### PR TITLE
Move users table out of auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:bin": "esbuild src/cli/index.ts --bundle --platform=node --format=cjs --outfile=dist/bin.cjs",
     "build:server": "tsc --project tsconfig.server.json",
     "build:react": "tsc --project tsconfig.react.json && mkdir -p dist && rm -rf dist/react && mv distreact/react dist/react && rm -r distreact",
-    "build": "rm -r dist && npm run build:bin && npm run build:server && npm run build:react",
+    "build": "rm -rf dist && npm run build:bin && npm run build:server && npm run build:react",
     "docs": "cd docs && npm run dev",
     "lint": "tsc && eslint . && cd test && npm run lint",
     "prepublishOnly": "npm run build",

--- a/src/providers/ConvexCredentials.ts
+++ b/src/providers/ConvexCredentials.ts
@@ -40,7 +40,7 @@ export interface ConvexCredentialsConfig<
      */
     credentials: Partial<Record<string, unknown>>,
     ctx: GenericActionCtxWithAuthConfig<DataModel>,
-  ) => Promise<{ id: GenericId<"users"> } | null>;
+  ) => Promise<{ id: string } | null>;
   /**
    * Provide hashing and verification functions if you're
    * storing account secrets and want to control
@@ -78,7 +78,7 @@ export interface ConvexCredentialsConfig<
      */
     credentials: Partial<Record<string, unknown>>,
     verified: {
-      userId: GenericId<"users">;
+      userId: string;
       providerAccountId: string;
       sessionId: GenericId<"sessions">;
     },

--- a/src/server/implementation.ts
+++ b/src/server/implementation.ts
@@ -277,10 +277,6 @@ export function convexAuth<
     args: {
       userId: UserId | null;
       profile: {
-        name?: string | null;
-        email: string;
-        email_verified?: boolean;
-        image?: string | null;
         [key: string]: unknown;
       };
       provider: AuthProviderMaterializedConfig;
@@ -622,7 +618,7 @@ export function convexAuth<
                     type: "userOAuth",
                     provider: providerId,
                     providerAccountId: id,
-                    profile: { ...profile, ...profileFromCallback },
+                    profile: profileFromCallback,
                     state,
                   },
                 },

--- a/src/server/implementation.ts
+++ b/src/server/implementation.ts
@@ -146,7 +146,7 @@ const storeArgs = {
   args: v.union(
     v.object({
       type: v.literal("signIn"),
-      userId: v.id("users"),
+      userId: v.string(),
     }),
     v.object({
       type: v.literal("signOut"),
@@ -159,7 +159,7 @@ const storeArgs = {
     }),
     v.object({
       type: v.literal("getProviderAccountId"),
-      userId: v.id("users"),
+      userId: v.string(),
       provider: v.string(),
     }),
     v.object({
@@ -1263,9 +1263,9 @@ export async function modifyAccountCredentials<
       secret: string;
     };
   },
-): Promise<GenericDoc<DataModel, "users">> {
+): Promise<void> {
   const actionCtx = ctx as unknown as GenericActionCtx<AuthDataModel>;
-  return await actionCtx.runMutation(internal.auth.store, {
+  await actionCtx.runMutation(internal.auth.store, {
     args: {
       type: "modifyAccount",
       ...args,
@@ -1284,9 +1284,9 @@ export async function invalidateSessions<
     userId: string;
     except?: GenericId<"sessions">[];
   },
-): Promise<GenericDoc<DataModel, "users">> {
+): Promise<void> {
   const actionCtx = ctx as unknown as GenericActionCtx<AuthDataModel>;
-  return await actionCtx.runMutation(internal.auth.store, {
+  await actionCtx.runMutation(internal.auth.store, {
     args: {
       type: "invalidateSessions",
       ...args,

--- a/src/server/implementation.ts
+++ b/src/server/implementation.ts
@@ -1607,7 +1607,7 @@ function convertErrorsToResponse(
       if (error instanceof ConvexError) {
         return new Response(null, {
           status: errorStatusCode,
-          statusText: (error as any).data,
+          statusText: error.data,
         });
       } else {
         console.error((error as Error).message ?? error);

--- a/src/server/implementation.ts
+++ b/src/server/implementation.ts
@@ -112,7 +112,7 @@ export const authTables = {
     secret: v.optional(v.string()),
     emailVerified: v.boolean(),
   })
-    .index("providerAndUserId", ["provider", "userId"])
+    .index("userIdAndProvider", ["userId", "provider"])
     .index("providerAndAccountId", ["provider", "providerAccountId"]),
   /**
    * Refresh tokens.
@@ -814,8 +814,8 @@ export function convexAuth(config_: ConvexAuthConfig) {
             const { userId, provider } = args;
             const account = await ctx.db
               .query("accounts")
-              .withIndex("providerAndUserId", (q) =>
-                q.eq("provider", provider).eq("userId", userId),
+              .withIndex("userIdAndProvider", (q) =>
+                q.eq("userId", userId).eq("provider", provider),
               )
               .unique();
             if (account === null) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ export {
   retrieveAccount,
 } from "./implementation";
 export type {
+  OnSignIn,
   ConvexAuthConfig,
   GenericActionCtxWithAuthConfig,
   AuthProviderMaterializedConfig,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -6,8 +6,14 @@ import {
   OIDCConfig,
 } from "@auth/core/providers";
 import { WebAuthnConfig } from "@auth/core/providers/webauthn";
-import { Theme } from "@auth/core/types";
-import { GenericActionCtx, GenericDataModel } from "convex/server";
+import { Theme, User } from "@auth/core/types";
+import {
+  AnyDataModel,
+  GenericActionCtx,
+  GenericDataModel,
+  GenericMutationCtx,
+} from "convex/server";
+import { GenericId } from "convex/values";
 
 /**
  * The config for the Convex Auth library, passed to `convexAuth`.
@@ -54,7 +60,21 @@ export type ConvexAuthConfig = {
      */
     durationMs?: number;
   };
+  onSignIn?: OnSignIn<any, any, any>;
 };
+
+export type OnSignIn<
+  Profile = User,
+  UserId extends string = GenericId<"users">,
+  DataModel extends GenericDataModel = AnyDataModel,
+> = (
+  ctx: GenericMutationCtx<DataModel>,
+  args: {
+    userId: UserId | null;
+    profile: Profile;
+    provider: AuthProviderMaterializedConfig;
+  },
+) => Promise<UserId>;
 
 /**
  * Your `ActionCtx` enriched with `ctx.auth.config` field with

--- a/test/convex/accounts.test.ts
+++ b/test/convex/accounts.test.ts
@@ -60,7 +60,7 @@ test("automatic linking for signin via email", async () => {
   await t.run(async (ctx) => {
     const users = await ctx.db.query("users").collect();
     expect(users).toHaveLength(1);
-    expect(users[0].emailVerificationTime).not.toBeUndefined();
+    expect(users[0].emailVerified).toEqual(true);
   });
 });
 
@@ -82,7 +82,7 @@ test("automatic linking for signin via verified OAuth", async () => {
   await t.run(async (ctx) => {
     const users = await ctx.db.query("users").collect();
     expect(users).toHaveLength(1);
-    expect(users[0].emailVerificationTime).not.toBeUndefined();
+    expect(users[0].emailVerified).toEqual(true);
   });
 });
 
@@ -110,7 +110,7 @@ test("automatic linking for password email verification", async () => {
   await t.run(async (ctx) => {
     const users = await ctx.db.query("users").collect();
     expect(users).toHaveLength(1);
-    expect(users[0].emailVerificationTime).not.toBeUndefined();
+    expect(users[0].emailVerified).toEqual(true);
   });
 });
 

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -6,7 +6,6 @@ import { ResendOTP } from "./otp/ResendOTP";
 import Password from "@xixixao/convex-auth/providers/Password";
 import { ResendOTPPasswordReset } from "./passwordReset/ResendOTPPasswordReset";
 import type { DataModel, Doc, Id } from "./_generated/dataModel";
-import { WithoutSystemFields } from "convex/server";
 
 export const { auth, signIn, verifyCode, signOut, store } = convexAuth<
   DataModel,

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -9,7 +9,6 @@ import { ResendOTPPasswordReset } from "./passwordReset/ResendOTPPasswordReset";
 export const { auth, signIn, verifyCode, signOut, store } = convexAuth({
   providers: [
     GitHub,
-    GitHub({ id: "github-verified", allowDangerousEmailAccountLinking: true }),
     Google,
     Resend,
     ResendOTP,

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -36,16 +36,17 @@ export const { auth, signIn, verifyCode, signOut, store } = convexAuth<
   },
   async (ctx, { profile, provider, userId }) => {
     const fields: Partial<Doc<"users">> = {};
-    let emailVerified = profile.email_verified ?? false;
+    if (profile.name) fields.name = profile.name;
+    let emailVerified = !!profile.email_verified;
     switch (provider.id) {
       case "github":
-        fields.bio = (profile as GitHubProfile).bio ?? undefined;
         // GitHub oauth requires verifying email
         emailVerified = true;
         break;
       case "google":
         fields.phone = (profile as GoogleProfile).phone ?? undefined;
         break;
+      case "resend":
       case "resend-otp":
       case "password-code":
       case "password-link":

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -1,30 +1,89 @@
-import GitHub from "@auth/core/providers/github";
-import Google from "@auth/core/providers/google";
+import GitHub, { GitHubProfile } from "@auth/core/providers/github";
+import Google, { GoogleProfile } from "@auth/core/providers/google";
 import Resend from "@auth/core/providers/resend";
 import { convexAuth } from "@xixixao/convex-auth/server";
 import { ResendOTP } from "./otp/ResendOTP";
 import Password from "@xixixao/convex-auth/providers/Password";
 import { ResendOTPPasswordReset } from "./passwordReset/ResendOTPPasswordReset";
+import type { DataModel, Doc, Id } from "./_generated/dataModel";
+import { WithoutSystemFields } from "convex/server";
 
-export const { auth, signIn, verifyCode, signOut, store } = convexAuth({
-  providers: [
-    GitHub,
-    Google,
-    Resend,
-    ResendOTP,
-    Password,
-    Password({ id: "password-with-reset", reset: ResendOTPPasswordReset }),
-    Password({
-      id: "password-code",
-      reset: ResendOTPPasswordReset,
-      verify: ResendOTP,
-    }),
-    Password({ id: "password-link", verify: Resend }),
-  ],
-  // session: {
-  //   inactiveDurationMs: 1000 * 60 * 1, // 1 minute
-  // },
-  // jwt: {
-  //   durationMs: 1000 * 20, // 20 seconds
-  // },
-});
+export const { auth, signIn, verifyCode, signOut, store } = convexAuth<
+  DataModel,
+  Id<"users">
+>(
+  {
+    providers: [
+      GitHub,
+      Google,
+      Resend,
+      ResendOTP,
+      Password,
+      Password({ id: "password-with-reset", reset: ResendOTPPasswordReset }),
+      Password({
+        id: "password-code",
+        reset: ResendOTPPasswordReset,
+        verify: ResendOTP,
+      }),
+      Password({ id: "password-link", verify: Resend }),
+    ],
+    // session: {
+    //   inactiveDurationMs: 1000 * 60 * 1, // 1 minute
+    // },
+    // jwt: {
+    //   durationMs: 1000 * 20, // 20 seconds
+    // },
+  },
+  async (ctx, { profile, provider, userId }) => {
+    const fields: Partial<Doc<"users">> = {};
+    let emailVerified = profile.email_verified ?? false;
+    switch (provider.id) {
+      case "github":
+        fields.bio = (profile as GitHubProfile).bio ?? undefined;
+        // GitHub oauth requires verifying email
+        emailVerified = true;
+        break;
+      case "google":
+        fields.phone = (profile as GoogleProfile).phone ?? undefined;
+        break;
+      case "resend-otp":
+      case "password-code":
+      case "password-link":
+        // The email will be verified before the user is logged in
+        // so let's treat it as such..
+        emailVerified = true;
+        break;
+    }
+    // Check for an existing user with the same email to merge
+    const existingUserById = userId && (await ctx.db.get(userId));
+    if (emailVerified) {
+      const userWithVerifiedEmail = await ctx.db
+        .query("users")
+        .withIndex("email", (q) => q.eq("email", profile.email))
+        .filter((q) => q.eq(q.field("emailVerified"), true))
+        .unique();
+      if (userWithVerifiedEmail && userWithVerifiedEmail._id !== userId) {
+        // patch any fields that might be useful from the new signin
+        await ctx.db.patch(userWithVerifiedEmail._id, fields);
+        if (existingUserById) {
+          // merge accounts: assign anything from the old account to the new one
+          // then get rid of this one that just verified email.
+          await ctx.db.delete(userId);
+        }
+        return userWithVerifiedEmail?._id;
+      }
+    }
+    // Update the existing user or create a new one
+    if (existingUserById) {
+      await ctx.db.patch(userId, { ...fields, emailVerified });
+      return userId;
+    }
+    return ctx.db.insert("users", {
+      name: profile.name ?? undefined,
+      image: profile.image ?? undefined,
+      email: profile.email,
+      emailVerified,
+      ...fields,
+    });
+  },
+);

--- a/test/convex/schema.ts
+++ b/test/convex/schema.ts
@@ -4,6 +4,14 @@ import { authTables } from "@xixixao/convex-auth/server";
 
 export default defineSchema({
   ...authTables,
+  users: defineTable({
+    name: v.optional(v.string()),
+    email: v.string(),
+    emailVerified: v.boolean(),
+    image: v.optional(v.string()),
+    phone: v.optional(v.string()), // from google
+    bio: v.optional(v.string()), // from github
+  }).index("email", ["email"]),
   numbers: defineTable({
     userId: v.id("users"),
     value: v.number(),

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@xixixao/convex-auth",
-      "version": "0.0.9",
+      "version": "0.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth/core": "^0.31.0",


### PR DESCRIPTION
<!-- Describe your PR here. -->

Move the user creation/ update out of convex-auth, and provide a callback `onSignIn` that creates / updates the user record

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
