### PR TITLE
allow overriding the audience

### DIFF
--- a/src/server/implementation.ts
+++ b/src/server/implementation.ts
@@ -1972,7 +1972,7 @@ async function generateToken(
     .setProtectedHeader({ alg: "RS256" })
     .setIssuedAt()
     .setIssuer(process.env.CONVEX_SITE_URL!)
-    .setAudience("convex")
+    .setAudience(config.audience ?? "convex")
     .setExpirationTime(expirationTime)
     .sign(privateKey);
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -145,6 +145,11 @@ export type ConvexAuthConfig = {
       },
     ) => Promise<GenericId<"users">>;
   };
+  /**
+   * Control the audience of the JWT token.
+   * This should match the applicationID in your auth.config.ts file.
+   */
+  audience?: string;
 };
 
 /**


### PR DESCRIPTION
Allow non-convex audience so it can live side-by-side with a clerk provider (which afaik has to be convex at this point?)


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
