### PR TITLE
Fix broken links in api_reference.mdx

### DIFF
--- a/docs/pages/api_reference.mdx
+++ b/docs/pages/api_reference.mdx
@@ -1,9 +1,9 @@
 # @convex-dev/auth
 
-- [providers/Anonymous](docs/providers/Anonymous.mdx)
-- [providers/ConvexCredentials](docs/providers/ConvexCredentials.mdx)
-- [providers/Email](docs/providers/Email.mdx)
-- [providers/Password](docs/providers/Password.mdx)
-- [providers/Phone](docs/providers/Phone.mdx)
-- [react](docs/react.mdx)
-- [server](docs/server.mdx)
+- [providers/Anonymous](api_reference/providers/Anonymous.mdx)
+- [providers/ConvexCredentials](api_reference/providers/ConvexCredentials.mdx)
+- [providers/Email](api_reference/providers/Email.mdx)
+- [providers/Password](api_reference/providers/Password.mdx)
+- [providers/Phone](api_reference/providers/Phone.mdx)
+- [react](api_reference/react.mdx)
+- [server](api_reference/server.mdx)


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR fixes broken/dead links in the `api_reference.mdx` file found at the page for [API Reference](https://labs.convex.dev/auth/api_reference) in the docs. 




<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
