### PR TITLE
Fix broken links

### DIFF
--- a/docs/pages/api_reference.mdx
+++ b/docs/pages/api_reference.mdx
@@ -1,9 +1,9 @@
 # @convex-dev/auth
 
-- [providers/Anonymous](docs/providers/Anonymous.mdx)
-- [providers/ConvexCredentials](docs/providers/ConvexCredentials.mdx)
-- [providers/Email](docs/providers/Email.mdx)
-- [providers/Password](docs/providers/Password.mdx)
-- [providers/Phone](docs/providers/Phone.mdx)
-- [react](docs/react.mdx)
-- [server](docs/server.mdx)
+- [providers/Anonymous](/api_reference/providers/Anonymous)
+- [providers/ConvexCredentials](/api_reference/providers/Conve)
+- [providers/Email](/api_reference/providers/Email)
+- [providers/Password](/api_reference/providers/Password)
+- [providers/Phone](/api_reference/providers/Phone)
+- [react](/api_reference/react)
+- [server](/api_reference/server)

--- a/docs/pages/authz.mdx
+++ b/docs/pages/authz.mdx
@@ -64,7 +64,7 @@ The `auth.getUserId` and `auth.getSessionId` methods use the Convex-built-in
 ### Data model
 
 Convex Auth defines [`users`](/api_reference/server#users) and
-[`authSessions`](<(/api_reference/server#authsessions)>) tables for you.
+[`authSessions`](/api_reference/server#authsessions) tables for you.
 
 When a user first signs up, a document is created in the `users` table.
 

--- a/docs/pages/config/email.mdx
+++ b/docs/pages/config/email.mdx
@@ -15,7 +15,7 @@ Your database keeps track of the issued link "token" that was sent which allows
 for secure verification and expiration.
 
 For React Native or to improve the user experience use the slightly more
-advanced [OTP method](/config/email/otps).
+advanced [OTP method](/config/otps).
 
 ## Email providers
 

--- a/docs/pages/config/oauth.mdx
+++ b/docs/pages/config/oauth.mdx
@@ -275,4 +275,4 @@ To implement the `profile` method correctly you must understand the profile
 information the particular OAuth provider returns. Consult their documentation.
 
 The method must return an `id` field with a unique ID, which is used to identify
-the [account](/auth/advanced#account-linking).
+the [account](/advanced#account-linking).


### PR DESCRIPTION
This PR fixes some broken links in the documentation. I wasn't able to test it locally (running into a build error) but the fixes are simple and I've double-checked the URLs.