### PR TITLE
Match with and without trailing slash in Next.js middleware

### DIFF
--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -13,7 +13,7 @@ import {
   ConvexAuthServerState,
 } from "../client.js";
 import { getRequestCookies } from "./cookies.js";
-import { proxyAuthActionToConvex } from "./proxy.js";
+import { proxyAuthActionToConvex, shouldProxyAuthAction } from "./proxy.js";
 import { handleAuthenticationInRequest } from "./request.js";
 import { logVerbose } from "./utils.js";
 
@@ -131,9 +131,9 @@ export function convexAuthNextjsMiddleware(
     const requestUrl = new URL(request.url);
     // Proxy signIn and signOut actions to Convex backend
     const apiRoute = options?.apiRoute ?? "/api/auth";
-    if (requestUrl.pathname === apiRoute) {
+    if (shouldProxyAuthAction(request, apiRoute)) {
       logVerbose(
-        `Proxying auth action to Convex, path matches ${apiRoute}`,
+        `Proxying auth action to Convex, path matches ${apiRoute} with or without trailing slash`,
         verbose,
       );
       return await proxyAuthActionToConvex(request, options);

--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -89,3 +89,19 @@ export async function proxyAuthActionToConvex(
     return response;
   }
 }
+
+export function shouldProxyAuthAction(request: NextRequest, apiRoute: string) {
+  // Handle both with and without trailing slash since this could be configured either way.
+  // https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash
+  const requestUrl = new URL(request.url);
+  if (apiRoute.endsWith("/")) {
+    return (
+      requestUrl.pathname === apiRoute ||
+      requestUrl.pathname === apiRoute.slice(0, -1)
+    );
+  } else {
+    return (
+      requestUrl.pathname === apiRoute || requestUrl.pathname === apiRoute + "/"
+    );
+  }
+}


### PR DESCRIPTION
Surfaced [here](https://discord.com/channels/1019350475847499849/1281663493648547905). Matching both seems fairly harmless.
