### PR TITLE
[Next.js] Propagate auth cookies in request to subsequent handlers in middleware

### DIFF
--- a/src/nextjs/server/utils.ts
+++ b/src/nextjs/server/utils.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getResponseCookies } from "./cookies.js";
+import {
+  getRequestCookiesInMiddleware,
+  getResponseCookies,
+} from "./cookies.js";
 
 export function jsonResponse(body: any) {
   return new NextResponse(JSON.stringify(body), {
@@ -20,6 +23,26 @@ export function setAuthCookies(
     responseCookies.refreshToken = tokens.refreshToken;
   }
   responseCookies.verifier = null;
+}
+
+/**
+ * Forward on any auth cookies in the request to the next handler.
+ *
+ * @param request
+ * @param tokens
+ */
+export function setAuthCookiesInMiddleware(
+  request: NextRequest,
+  tokens: { token: string; refreshToken: string } | null,
+) {
+  const requestCookies = getRequestCookiesInMiddleware(request);
+  if (tokens === null) {
+    requestCookies.token = null;
+    requestCookies.refreshToken = null;
+  } else {
+    requestCookies.token = tokens.token;
+    requestCookies.refreshToken = tokens.refreshToken;
+  }
 }
 
 export function isCorsRequest(request: NextRequest) {


### PR DESCRIPTION
I was able to reproduce [this bug](https://discord.com/channels/1019350475847499849/1279823393125961748) whenever the client failed to proactively fetch the new access token before it expired, and the server ended up fetching a new token instead.

We'd successfully fetch the token on the server, but we weren't consistently propagating it on to the next handler, which meant that SSR that relied on auth would be reading a stale value.

In particular, I think we should never be calling `NextResponse.next()` until we've mutated our request to reflect any auth we've fetched on the server.
