### PR TITLE
[Next.js] Propagate auth cookies in middleware (take 2)

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -137,7 +137,7 @@ and [useAuthActions](/api_reference/react#useauthactions).
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:23](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L23)
+[src/nextjs/server/index.tsx:27](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L27)
 
 ***
 
@@ -155,7 +155,7 @@ The token if the the client is authenticated, otherwise `undefined`.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:78](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L78)
+[src/nextjs/server/index.tsx:82](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L82)
 
 ***
 
@@ -174,7 +174,45 @@ since they won't stop nested pages from rendering.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:89](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L89)
+[src/nextjs/server/index.tsx:93](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L93)
+
+***
+
+## ConvexAuthNextjsMiddlewareContext
+
+
+In `convexAuthNextjsMiddleware`, you can use this context
+to get the token and check if the client is authenticated in place of
+`convexAuthNextjsToken` and `isAuthenticatedNextjs`.
+
+```ts
+export function convexAuthNextjsMiddleware(handler, options) {
+  return async (request, event, convexAuth) => {
+    if (!convexAuth.isAuthenticated()) {
+      return nextjsMiddlewareRedirect(request, "/login");
+    }
+  };
+}
+
+<h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Type declaration</h3>
+
+#### getToken()
+
+
+<h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Returns</h5>
+
+`string` \| `undefined`
+
+#### isAuthenticated()
+
+
+<h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Returns</h5>
+
+`boolean`
+
+<h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
+
+[src/nextjs/server/index.tsx:111](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L111)
 
 ***
 
@@ -200,7 +238,7 @@ Convex Auth for authentication on the server.
 </td>
 <td>
 
-(`request`, `event`) => `NextMiddlewareResult` \| `Promise`\<`NextMiddlewareResult`\>
+(`request`, `ctx`) => `NextMiddlewareResult` \| `Promise`\<`NextMiddlewareResult`\>
 
 </td>
 <td>
@@ -293,7 +331,7 @@ A Next.js middleware.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:99](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L99)
+[src/nextjs/server/index.tsx:122](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L122)
 
 ***
 
@@ -357,7 +395,7 @@ The route path to redirect to.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:194](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L194)
+[src/nextjs/server/index.tsx:241](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L241)
 
 ***
 

--- a/docs/pages/authz/nextjs.mdx
+++ b/docs/pages/authz/nextjs.mdx
@@ -19,18 +19,17 @@ which routes require authentication in your `middleware.ts`:
 import {
   convexAuthNextjsMiddleware,
   createRouteMatcher,
-  isAuthenticatedNextjs,
   nextjsMiddlewareRedirect,
 } from "@convex-dev/auth/nextjs/server";
 
 const isSignInPage = createRouteMatcher(["/signin"]);
 const isProtectedRoute = createRouteMatcher(["/product(.*)"]);
 
-export default convexAuthNextjsMiddleware((request) => {
-  if (isSignInPage(request) && isAuthenticatedNextjs()) {
+export default convexAuthNextjsMiddleware((request, { convexAuth }) => {
+  if (isSignInPage(request) && convexAuth.isAuthenticated()) {
     return nextjsMiddlewareRedirect(request, "/product");
   }
-  if (isProtectedRoute(request) && !isAuthenticatedNextjs()) {
+  if (isProtectedRoute(request) && !convexAuth.isAuthenticated()) {
     return nextjsMiddlewareRedirect(request, "/signin");
   }
 });
@@ -48,6 +47,12 @@ access a route that requires authentication.
 To do this, you can pass a function to `convexAuthNextjsMiddleware`. This
 function can also be used to compose other middleware behaviors.
 
+This function has as arguments the `NextRequest`, the `NextFetchEvent`, and the
+`ConvexAuthNextjsContext`. `convexAuth.isAuthenticated()` and
+`convexAuth.getToken()` function similarly to `isAuthenticatedNextjs` and
+`convexAuthNextjsToken`, but should be used in middleware to ensure they reflect
+any updates to the request context from `convexAuthNextjsMiddleware`.
+
 Convex Auth provides an API and helper functions for implementing your
 middleware:
 
@@ -55,11 +60,6 @@ middleware:
   [syntax](https://github.com/pillarjs/path-to-regexp) as the middleware
   `config`. You call it with a list of glob patterns, and it returns a function
   that given the `NextRequest` returns whether the route matches.
-
-- `isAuthenticatedNextjs` function returns whether the current request is
-  authenticated or not. When using `ConvexAuthNextjsServerProvider`,
-  authentication state is stored both in http-only cookies and on the client, so
-  this state is also available during page requests.
 
 - `nextjsMiddlewareRedirect` is a simple shortcut for triggering redirects:
 

--- a/test-nextjs/middleware.ts
+++ b/test-nextjs/middleware.ts
@@ -1,18 +1,17 @@
 import {
   convexAuthNextjsMiddleware,
   createRouteMatcher,
-  isAuthenticatedNextjs,
   nextjsMiddlewareRedirect,
 } from "@convex-dev/auth/nextjs/server";
 
 const isSignInPage = createRouteMatcher(["/signin"]);
 const isProtectedRoute = createRouteMatcher(["/product(.*)"]);
 
-export default convexAuthNextjsMiddleware((request) => {
-  if (isSignInPage(request) && isAuthenticatedNextjs()) {
+export default convexAuthNextjsMiddleware((request, { convexAuth }) => {
+  if (isSignInPage(request) && convexAuth.isAuthenticated()) {
     return nextjsMiddlewareRedirect(request, "/product");
   }
-  if (isProtectedRoute(request) && !isAuthenticatedNextjs()) {
+  if (isProtectedRoute(request) && !convexAuth.isAuthenticated()) {
     return nextjsMiddlewareRedirect(request, "/signin");
   }
 });


### PR DESCRIPTION
Follow up to [this PR](https://github.com/get-convex/convex-auth/pull/70).

I wasn't propagating these headers properly in all places. Notably, for the handler passed in to `convexAuthNextjsMiddleware`, while the `request` passed in will have headers that reflect any updated cookies, `headers()` and `cookies()` from `next/headers` will not.

So if we refetch tokens as part of a request, we won't read those new values (or lack of values if refetching failed) in the handler. One way of producing buggy behavior was by having an expired token + invalid refresh token, where instead of the middleware clearing cookies and redirecting to sign in (because it can't fetch a new token), it would attempt to render the page and error.

We want `convexAuthNextjsToken()` and `isAuthenticatedNextjs()` to be free-standing functions that can be imported in server components / server routes without always needing access to a request, but at the same time, we want these functions when called in the middleware handler to read off of our mutated request instead of the original request.

I'm replacing these in the context of middleware with `convexAuth.getToken()` and `convexAuth.isAuthenticated()` where `convexAuth` is injected into the handler and reads from the mutated request. It means there are seemingly valid syntaxes for getting a token and checking authentication, where the original `convexAuthNextjsToken()` won't always work properly in middleware. However, I don't have a better idea for alternatives.