### PR TITLE
fix: close unclosed TypeScript code block

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -193,6 +193,7 @@ export function convexAuthNextjsMiddleware(handler, options) {
     }
   };
 }
+```
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Type declaration</h3>
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
This pull request fixes a documentation issue where a TypeScript code block was not properly closed with the correct ``` syntax. This caused formatting problems on the rendered page.
The changes made ensure that the code is properly formatted and displayed as TypeScript. 
No functional code changes were made; this is strictly a documentation fix.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
