### PR TITLE
Add 10s reuse window for refresh tokens

### DIFF
--- a/src/server/implementation/sessions.ts
+++ b/src/server/implementation/sessions.ts
@@ -77,7 +77,7 @@ export async function deleteSession(
   session: Doc<"authSessions">,
 ) {
   await ctx.db.delete(session._id);
-  await deleteRefreshTokens(ctx, session._id);
+  await deleteRefreshTokens(ctx, session._id, null);
 }
 
 /**

--- a/src/server/implementation/types.ts
+++ b/src/server/implementation/types.ts
@@ -76,11 +76,13 @@ export const authTables = {
    * Refresh tokens.
    * Each session has only a single refresh token
    * valid at a time. Refresh tokens are rotated
-   * and reuse is not allowed.
+   * and reuse is not allowed, except for within
+   * a 10 second window.
    */
   authRefreshTokens: defineTable({
     sessionId: v.id("authSessions"),
     expirationTime: v.number(),
+    firstUsedTime: v.optional(v.number()),
   }).index("sessionId", ["sessionId"]),
   /**
    * Verification codes:

--- a/test/convex/sessions.test.ts
+++ b/test/convex/sessions.test.ts
@@ -68,6 +68,19 @@ test("refresh token reuse detection", async () => {
   });
   expect(newTokens).not.toBeNull();
 
+  // Advance time within the reuse window (10 seconds)
+  vi.advanceTimersByTime(5000);
+
+  const { tokens: newTokens2 } = await t.action(api.auth.signIn, {
+    refreshToken,
+    params: {},
+  });
+  expect(newTokens2).not.toBeNull();
+  expect(newTokens2).not.toEqual(newTokens);
+
+  // Advance time again to be outside of the reuse window
+  vi.advanceTimersByTime(5001);
+
   const { tokens: reuseResponse } = await t.action(api.auth.signIn, {
     refreshToken,
     params: {},


### PR DESCRIPTION
Without this diff, refresh tokens are single use. This can be problematic for Next.js where two requests can race each other and use the same refresh token, resulting in one of them failing + invalidating the entire session.

The example I was testing with was loading the same app twice in two separate tabs, with some injected latency to make them actually race. One tab would lose the race to use the refresh token, and result in clearing out the cookies for both tabs and not so gracefully logging out.

With the 10s window for reuse, when two requests race, both will end up receiving tokens (in this implementation, they're different, but I don't think it matters), so both tabs will stay logged in. A refresh token will live in the database until the next token exchange for the session. There's an invariant that there is only ever one refresh token in a reuse window per session (but there can be multiple refresh tokens that have yet to be used).

Folks upgrading to this version should be fine (the new property is optional), but downgrading would require a migration (removing the newly added property). I'll document this when releasing.