### PR TITLE
Export type referenced in signIn + fix downstream errors

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -59,7 +59,7 @@ export async function proxyAuthActionToConvex(
     if (result.redirect !== undefined) {
       const { redirect } = result;
       const response = jsonResponse({ redirect });
-      getResponseCookies(response).verifier = result.verifier;
+      getResponseCookies(response).verifier = result.verifier!;
       logVerbose(`Redirecting to ${redirect}`, verbose);
       return response;
     } else if (result.tokens !== undefined) {

--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -202,7 +202,7 @@ export function AuthProvider({
       );
       if (result.redirect !== undefined) {
         const url = new URL(result.redirect);
-        await storageSet(VERIFIER_STORAGE_KEY, result.verifier);
+        await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
         if (window.location !== undefined) {
           window.location.href = url.toString();

--- a/src/server/implementation/index.ts
+++ b/src/server/implementation/index.ts
@@ -26,8 +26,8 @@ import {
   GenericActionCtxWithAuthConfig,
 } from "../types.js";
 import { requireEnv } from "../utils.js";
-import { ActionCtx, MutationCtx } from "./types.js";
-export { authTables } from "./types.js";
+import { ActionCtx, MutationCtx, Tokens } from "./types.js";
+export { authTables, Tokens } from "./types.js";
 import {
   LOG_LEVELS,
   TOKEN_SUB_CLAIM_DIVIDER,
@@ -355,7 +355,15 @@ export function convexAuth(config_: ConvexAuthConfig) {
         verifier: v.optional(v.string()),
         refreshToken: v.optional(v.string()),
       },
-      handler: async (ctx, args) => {
+      handler: async (
+        ctx,
+        args,
+      ): Promise<{
+        redirect?: string;
+        verifier?: string;
+        tokens?: Tokens | null;
+        started?: boolean;
+      }> => {
         const provider =
           args.provider !== undefined
             ? getProviderOrThrow(args.provider)


### PR DESCRIPTION
`signIn` references the type `Tokens` that wasn't exported (reported [here](https://discord.com/channels/1019350475847499849/1286561479247794206/1286561479247794206)).

This adds an explicit type annotation + exports the type referenced. The type annotation is a little broader than necessary (in my ideal world, this would return a discriminated union so we could type narrow). There were a couple spots where I had to assert that `result.verifier` was defined when `result.redirect` was defined, which is clear from reading the code but not clear from the type.
