### PR TITLE
Gracefully handle errors thrown during /api/auth

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -52,9 +52,16 @@ export async function proxyAuthActionToConvex(
 
   if (action === "auth:signIn") {
     let result: SignInAction["_returnType"];
+    // Do not require auth when refreshing tokens or validating a code since they
+    // are steps in the auth flow.
+    const fetchActionAuthOptions =
+      args.refreshToken !== undefined || args.params?.code !== undefined
+        ? {}
+        : { token };
     try {
       result = await fetchAction(action, args, {
         url: options?.convexUrl,
+        ...fetchActionAuthOptions,
       });
     } catch (error) {
       console.error(`Hit error while running \`auth:signIn\`: ${error}`);


### PR DESCRIPTION
If talking to Convex fails for any reason (even though it shouldn't), I believe we end up sending a 500 with a generic Next.js error and fail to reset any state (i.e. clear cookies).

I've witnessed this hitting an error refreshing the session, and instead of clearing the cookies, we error and the client continues to have a useless refresh token in its cookies.

This also fixes an issue where we were requiring a valid auth token for `signIn`, when really we should just require one for `signOut`