### PR TITLE
Add optional calledBy + logging for signIn action

### DIFF
--- a/src/server/implementation/index.ts
+++ b/src/server/implementation/index.ts
@@ -354,6 +354,7 @@ export function convexAuth(config_: ConvexAuthConfig) {
         params: v.optional(v.any()),
         verifier: v.optional(v.string()),
         refreshToken: v.optional(v.string()),
+        calledBy: v.optional(v.string()),
       },
       handler: async (
         ctx,
@@ -364,6 +365,9 @@ export function convexAuth(config_: ConvexAuthConfig) {
         tokens?: Tokens | null;
         started?: boolean;
       }> => {
+        if (args.calledBy !== undefined) {
+          logWithLevel("INFO", `\`auth:signIn\` called by ${args.calledBy}`);
+        }
         const provider =
           args.provider !== undefined
             ? getProviderOrThrow(args.provider)

--- a/src/server/implementation/signIn.ts
+++ b/src/server/implementation/signIn.ts
@@ -36,6 +36,7 @@ export async function signInImpl(
     params?: Record<string, any>;
     verifier?: string;
     refreshToken?: string;
+    calledBy?: string;
   },
   options: {
     generateTokens: boolean;


### PR DESCRIPTION
This is part 1 of 2. I want to be able to see which functions are called from the ConvexReactClient vs. called from Next.js requests. I added this as optional, will do a release, and then will do another release where I start passing it in, so folks who care about version skew can upgrade in 2 stages if they want.

Other things I considered but did not do:
* Stick this in `params` and remove it in `signInImpl` -- seemed a little too gross + would squat on a potential param that a developer could use.
* Propagate this to `auth:store` calls -- I think the Convex request ID should be good enough to link things together there.