### PR TITLE
Set cookies correctly on Next.js response

### DIFF
--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -221,7 +221,9 @@ export function convexAuthNextjsMiddleware(
       authResult.kind === "refreshTokens" &&
       authResult.refreshTokens !== undefined
     ) {
-      setAuthCookies(NextResponse.next(response), authResult.refreshTokens);
+      const nextResponse = NextResponse.next(response);
+      setAuthCookies(nextResponse, authResult.refreshTokens);
+      return nextResponse;
     }
 
     return response;

--- a/src/nextjs/server/request.ts
+++ b/src/nextjs/server/request.ts
@@ -122,7 +122,10 @@ async function getRefreshedTokens(verbose: boolean) {
     if (result.tokens === undefined) {
       throw new Error("Invalid `signIn` action result for token refresh");
     }
-    logVerbose(`Successfully refreshed tokens`, verbose);
+    logVerbose(
+      `Successfully refreshed tokens: is null? ${result.tokens === null}`,
+      verbose,
+    );
     return result.tokens;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
I inadvertently broke this in a previous refactor -- `setAuthCookies` mutates the response, I was using `NextResponse.next` to wrap a plain `Response`, but then still returning the original `Response` which empirically does not seem to reflect the cookies.