### PR TITLE
Update docs to be more explicit about amount of support

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -213,7 +213,7 @@ export function convexAuthNextjsMiddleware(handler, options) {
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:111](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L111)
+[src/nextjs/server/index.tsx:112](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L112)
 
 ***
 
@@ -332,7 +332,7 @@ A Next.js middleware.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:122](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L122)
+[src/nextjs/server/index.tsx:123](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L123)
 
 ***
 
@@ -396,7 +396,7 @@ The route path to redirect to.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:241](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L241)
+[src/nextjs/server/index.tsx:244](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L244)
 
 ***
 

--- a/docs/pages/api_reference/server.mdx
+++ b/docs/pages/api_reference/server.mdx
@@ -211,7 +211,7 @@ the user ID or `null` if the client isn't authenticated
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:428](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L428)
+[src/server/implementation/index.ts:440](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L440)
 
 ***
 
@@ -411,7 +411,7 @@ or throws an error.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:446](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L446)
+[src/server/implementation/index.ts:458](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L458)
 
 ***
 
@@ -554,7 +554,7 @@ secret does not match.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:506](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L506)
+[src/server/implementation/index.ts:518](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L518)
 
 ***
 
@@ -685,7 +685,7 @@ The new secret credential to store for this account.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:546](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L546)
+[src/server/implementation/index.ts:558](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L558)
 
 ***
 
@@ -757,7 +757,7 @@ Use this function to invalidate existing sessions.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:576](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L576)
+[src/server/implementation/index.ts:588](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L588)
 
 ***
 
@@ -847,7 +847,7 @@ or `null`.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:598](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L598)
+[src/server/implementation/index.ts:610](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L610)
 
 ***
 
@@ -980,7 +980,8 @@ A single user can have multiple accounts linked.
 Refresh tokens.
 Each session has only a single refresh token
 valid at a time. Refresh tokens are rotated
-and reuse is not allowed.
+and reuse is not allowed, except for within
+a 10 second window.
 
 #### authVerificationCodes
 

--- a/docs/pages/authz.mdx
+++ b/docs/pages/authz.mdx
@@ -160,35 +160,6 @@ mutations.
 See [Customizing Schema](/setup/schema) for guidance on attaching additional
 information to users and sessions.
 
-### Detecting anonymous users
-
-If you enabled [anonymous sign-in](/config/anonymous), the user ID returned by
-`getAuthUserId` might belong to an anonymous user. You might want to restrict
-what anonymous users can do compared to authenticated users. To do this, load
-the current user and check the `isAnonymous` field:
-
-```ts filename="convex/myFunctions.tsx"
-import { mutation } from "./_generated/server";
-import { auth } from "./auth";
-
-export const doSomethingAfterProperSignIn = mutation({
-  args: {
-    /* ... */
-  },
-  handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (userId === null) {
-      throw new Error("Client is not authenticated!");
-    }
-    const user = await ctx.db.get(userId);
-    if (user.isAnonymous) {
-      throw new Error("User must sign in with an authentication method!");
-    }
-    // ...
-  },
-});
-```
-
 ## Server-side authentication in Next.js
 
 You can set up your Next.js App Router app to have access to the authentication

--- a/docs/pages/config.mdx
+++ b/docs/pages/config.mdx
@@ -26,9 +26,6 @@ follow the method specific guide:
 3. [Passwords](/config/passwords) (including password reset flow and optional
    email verification)
 
-Your app can also store user data before the actual sign-up with the
-[Anonymous](/config/anonymous) sign-in method.
-
 ## Understand the tradeoffs
 
 There are DX, UX and security tradeoffs between these methods, and you have to

--- a/docs/pages/config/oauth.mdx
+++ b/docs/pages/config/oauth.mdx
@@ -22,12 +22,9 @@ Convex Auth implements configuration via [Auth.js](https://authjs.dev)
 "provider" configs. These JS objects define how the library interfaces with an
 OAuth provider.
 
-You can use any of the 80 OAuth providers preconfigured by Auth.js, including
-GitHub, Google, Apple, Facebook, etc.
-
-You can find the list of available providers and more details about each
-configuration in the sidebar of
-[Auth.js docs](https://authjs.dev/getting-started/providers/github).
+We recommend using GitHub, Google, or Apple as an OAuth provider. You can also
+try any of the 80 OAuth providers preconfigured by Auth.js (see the list in the
+sidebar of [Auth.js docs](https://authjs.dev/getting-started/providers/github)).
 
 Choose an OAuth provider (for example _GitHub_) and follow the guide below.
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -46,3 +46,8 @@ See [issues on Github](https://github.com/get-convex/convex-auth/issues).
 
 - Lucia is oriented towards traditional servers that host a website.
 - The previous Convex+Lucia integrations are now deprecated.
+
+## Can I use Convex Auth if I'm not using React?
+
+We currently only have Convex Auth client libraries for React. Contributions to
+add a client implementation for another framework are welcome!

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -9,7 +9,7 @@ application can be:
 - a full-stack Next.js app
 - a React Native mobile app
 
-**NOTE:** Convex Auth is very new. Please share any feedback you have on
+**NOTE:** Convex Auth is in beta. Please share any feedback you have on
 [Discord](https://convex.dev/community).
 
 Convex Auth enables you to implement the following authentication methods:

--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -3,20 +3,42 @@ import { Tabs } from "nextra-theme-docs";
 
 # Set Up Convex Auth
 
+## Creating a new project
+
+<Tabs items={['React (Vite)', 'Next.js', 'React Native']}>
+<Tabs.Tab>
+
 To start a new project from scratch with Convex and Convex Auth, run
 
 ```sh
 npm create convex@latest
 ```
 
-and choose `React (Vite)` or `Next.js` and then `Convex Auth`.
+and choose `React (Vite)` and then `Convex Auth`.
 
-Otherwise follow the guide below.
+</Tabs.Tab>
+<Tabs.Tab>
+**NOTE:** Convex Auth support for Next.js with server-side authentication (SSA) is experimental.
+
+To start a new project from scratch with Convex and Convex Auth, run
+
+```sh
+npm create convex@latest
+```
+
+and choose `Next.js` and then `Convex Auth`.
+
+</Tabs.Tab>
+<Tabs.Tab>
+Follow the Convex [React Native quickstart](https://docs.convex.dev/quickstart/react-native)
+to create an app with Convex. Then follow the instructions below to finish setting up Convex Auth.
+</Tabs.Tab>
+</Tabs>
 
 ---
 
-This guide assumes you have a working Convex app. If not, follow our React,
-Next.js or React Native [quickstart](https://docs.convex.dev/quickstarts) first.
+This guide assumes you already have a working Convex app from following the
+instructions above.
 
 <Steps>
 ### Install the NPM library
@@ -60,7 +82,7 @@ export default schema;
 
 ### Set up the React provider
 
-<Tabs items={['Vite', 'Next.js', 'React Native']}>
+<Tabs items={['React (Vite)', 'Next.js', 'React Native']}>
 <Tabs.Tab>
 
 Replace `ConvexProvider` from `convex/react` with `ConvexAuthProvider` from
@@ -88,11 +110,18 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 </Tabs.Tab>
 <Tabs.Tab>
 
-Convex Auth currently only supports server-side authentication (**SSA**) on the
-Next.js server with App Router.
+Convex Auth has support for both App Router and Pages Router without any
+server-side authentication **(SSA)**.
+
+There is experimental support for SSA on the Next.js server with App Router. SSA
+with the Pages Router is currently unsupported.
 
 <Tabs items={['App Router with SSA', 'App Router without SSA', 'Pages Router without SSA']}>
 <Tabs.Tab>
+
+<Steps>
+
+### Server provider
 
 Wrap your app in `ConvexAuthNextjsServerProvider` from
 `@convex-dev/auth/nextjs/server`:
@@ -115,7 +144,10 @@ export default function RootLayout({
 }
 ```
 
-And in your client provider file replace `ConvexProvider` from `convex/react`
+### Client provider
+
+In your client provider file, replace `ConvexProvider` from `convex/react`
+
 with `ConvexAuthNextjsProvider` from `@convex-dev/auth/nextjs`:
 
 ```tsx filename="app/ConvexClientProvider.tsx" {3,11,13}
@@ -162,7 +194,9 @@ export default function RootLayout({
 }
 ```
 
-Finally add a `middleware.ts` file using `convexAuthNextjsMiddleware`:
+### Middleware
+
+Finally, add a `middleware.ts` file using `convexAuthNextjsMiddleware`:
 
 ```tsx filename="middleware.ts"
 import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
@@ -175,6 +209,8 @@ export const config = {
   matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
 };
 ```
+
+</Steps>
 
 Note that the React examples in this documentation are all Client Components
 unless noted otherwise, so you might need to add `"use client"` to their source.

--- a/docs/pages/setup/manual.mdx
+++ b/docs/pages/setup/manual.mdx
@@ -16,14 +16,13 @@ For code changes you can also refer to the
 The `SITE_URL` environment variable is used when redirecting back to your site
 during OAuth sign-in and for magic links sent via email.
 
-You don't need to configure this variable for React Native or if you're only
-using passwords.
+You don't need to configure this variable if you're only using passwords.
 
 [Setting environment variables Convex docs](https://docs.convex.dev/production/environment-variables#setting-environment-variables).
 
 For local development you can run (adjust the port number as needed!):
 
-<Tabs items={['Vite', 'Next.js']}>
+<Tabs items={['React (Vite)', 'Next.js', 'React Native']}>
 <Tabs.Tab>
 
 ```sh
@@ -32,6 +31,16 @@ npx convex env set SITE_URL http://localhost:5173
 
 </Tabs.Tab>
 <Tabs.Tab>
+
+```sh
+npx convex env set SITE_URL http://localhost:3000
+```
+
+</Tabs.Tab>
+
+<Tabs.Tab>
+OTP providers require a `SITE_URL` variable even though the value is not used.
+Set this to a placeholder value if using OTPs with React Native:
 
 ```sh
 npx convex env set SITE_URL http://localhost:3000

--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -107,6 +107,7 @@ export function isAuthenticatedNextjs() {
  *     }
  *   };
  * }
+ * ```
  */
 export type ConvexAuthNextjsMiddlewareContext = {
   getToken: () => string | undefined;


### PR DESCRIPTION
Changes included in here:
* Remove references to anonymous auth because I believe we launched without this
* Recommend Github, Google, and Apple as OAuth providers we know work with Convex Auth, and soften the claim that we work with any Auth.js OAuth provider.
* Add a note in the FAQ that we currently just have the client library for React
* Add a note that Next.js SSA support is experimental -- I'm down to say "beta" too, but given that we're still pretty actively squashing bugs here, "experimental" seemed fair
* Do a little bit of doc restructuring -- I want to do a fuller pass here at some point. In particular, I want to split out a few recommended configurations into their own guides + organize some of the more "advanced" cases to be in another section.