### PR TITLE
Add @auth/core as a peer dependency to prevent version mismatches

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -22,7 +22,7 @@ Next.js or React Native [quickstart](https://docs.convex.dev/quickstarts) first.
 ### Install the NPM library
  
 ```sh
-npm install @convex-dev/auth @auth/core
+npm install @convex-dev/auth @auth/core@0.31.0
 ```
 
 This also installs `@auth/core`, which you will use during provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/auth",
-  "version": "0.0.61",
+  "version": "0.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/auth",
-      "version": "0.0.61",
+      "version": "0.0.71",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth/core": "^0.31.0",
@@ -43,6 +43,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
+        "@auth/core": "^0.31.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "server-only": "^0.0.1"
   },
   "peerDependencies": {
+    "@auth/core": "^0.31.0",
     "convex": "^1.14.4",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
We use some `@auth/core` types in our library, but also instruct developers to install `@auth/core`, ant the latest `@auth/core` version has slightly different types.

This adds `@auth/core` as a peer dependency tied to the `0.31` version. Upgrading to a newer `@auth/core` version is something I'll try next.