### PR TITLE
Update to auth/core 0.36

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -22,7 +22,7 @@ Next.js or React Native [quickstart](https://docs.convex.dev/quickstarts) first.
 ### Install the NPM library
  
 ```sh
-npm install @convex-dev/auth @auth/core@0.31.0
+npm install @convex-dev/auth @auth/core@0.36.0
 ```
 
 This also installs `@auth/core`, which you will use during provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.71",
       "license": "Apache-2.0",
       "dependencies": {
-        "@auth/core": "^0.31.0",
+        "@auth/core": "^0.36.0",
         "arctic": "^1.2.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
@@ -43,7 +43,6 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.31.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },
@@ -57,15 +56,15 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.31.0.tgz",
-      "integrity": "sha512-UKk3psvA1cRbk4/c9CkpWB8mdWrkKvzw0DmEYRsWolUQytQ2cRqx+hYuV6ZCsngw/xbj9hpmkZmAZEyq2g4fMg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.36.0.tgz",
+      "integrity": "sha512-tK+TEYHdM0nkW2uUxAZylpKk2nIf3jsAWzi920E5irxJlymihWzI8nQcz9McfmKux7lmtdpC6TiysayFP7sLYg==",
       "dependencies": {
-        "@panva/hkdf": "^1.1.1",
+        "@panva/hkdf": "^1.2.1",
         "@types/cookie": "0.6.0",
-        "cookie": "0.6.0",
-        "jose": "^5.1.3",
-        "oauth4webapi": "^2.4.0",
+        "cookie": "0.7.1",
+        "jose": "^5.9.3",
+        "oauth4webapi": "^2.17.0",
         "preact": "10.11.3",
         "preact-render-to-string": "5.2.3"
       },
@@ -1476,9 +1475,9 @@
       }
     },
     "node_modules/@panva/hkdf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.1.1.tgz",
-      "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2734,9 +2733,9 @@
       "peer": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4362,9 +4361,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.3.0.tgz",
-      "integrity": "sha512-IChe9AtAE79ru084ow8jzkN2lNrG3Ntfiv65Cvj9uOCE2m5LNsdHG+9EbxWxAoWRF9TgDOqLN5jm08++owDVRg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
+      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5091,9 +5090,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.10.4.tgz",
-      "integrity": "sha512-DSoj8QoChzOCQlJkRmYxAJCIpnXFW32R0Uq7avyghIeB6iJq0XAblOD7pcq3mx4WEBDwMuKr0Y1qveCBleG2Xw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     }
   },
   "dependencies": {
-    "@auth/core": "^0.31.0",
     "arctic": "^1.2.0",
     "jose": "^5.2.2",
     "jwt-decode": "^4.0.0",
@@ -71,7 +70,7 @@
     "server-only": "^0.0.1"
   },
   "peerDependencies": {
-    "@auth/core": "^0.31.0",
+    "@auth/core": "^0.36.0",
     "convex": "^1.14.4",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
Could not go all the way to latest (0.37) easily since it has a major version bump of `oauth4webapi` and requires some pretty non-trivial changes to the portions we forked.