### PR TITLE
Update reuse window implementation

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 import { SignInAction } from "../../server/implementation/index.js";
 import { getRequestCookies, getResponseCookies } from "./cookies.js";
 import {
+  getRedactedMessage,
   isCorsRequest,
   jsonResponse,
   logVerbose,
@@ -46,7 +47,10 @@ export async function proxyAuthActionToConvex(
     token = getRequestCookies().token ?? undefined;
   }
   logVerbose(
-    `Fetching action ${action} with args ${JSON.stringify(args)}`,
+    `Fetching action ${action} with args ${JSON.stringify({
+      ...args,
+      refreshToken: getRedactedMessage(args?.refreshToken ?? ""),
+    })}`,
     verbose,
   );
 

--- a/src/nextjs/server/utils.ts
+++ b/src/nextjs/server/utils.ts
@@ -62,3 +62,15 @@ export function logVerbose(message: string, verbose: boolean) {
     );
   }
 }
+
+export function getRedactedMessage(value: string) {
+  const length = 5;
+  if (value.length < length * 2) {
+    return "<redacted>";
+  }
+  return (
+    value.substring(0, length) +
+    "<redacted>" +
+    value.substring(value.length - length)
+  );
+}

--- a/src/server/implementation/refreshTokens.ts
+++ b/src/server/implementation/refreshTokens.ts
@@ -50,10 +50,12 @@ export const parseRefreshToken = (
 };
 
 /**
- * Mark all refresh tokens for a session as invalid. They will still be usable
- * for 10 seconds (the length of the reuse window).
+ * Mark all refresh tokens descending from the given refresh token as invalid immediately.
+ * This is used when we detect an invalid use of a refresh token, and want to revoke
+ * the entire tree.
+ *
  * @param ctx
- * @param sessionId
+ * @param refreshToken
  */
 export async function invalidateRefreshTokensInSubtree(
   ctx: MutationCtx,
@@ -144,17 +146,15 @@ export async function refreshTokenIfValid(
  *
  * @param ctx
  * @param sessionId
- * @returns
  */
 export async function loadActiveRefreshToken(
   ctx: QueryCtx,
   sessionId: GenericId<"authSessions">,
 ) {
-  const refreshTokenDoc = await ctx.db
+  return ctx.db
     .query("authRefreshTokens")
     .withIndex("sessionId", (q) => q.eq("sessionId", sessionId))
     .filter((q) => q.eq(q.field("firstUsedTime"), undefined))
     .order("desc")
     .first();
-  return refreshTokenDoc;
 }

--- a/src/server/implementation/types.ts
+++ b/src/server/implementation/types.ts
@@ -83,7 +83,14 @@ export const authTables = {
     sessionId: v.id("authSessions"),
     expirationTime: v.number(),
     firstUsedTime: v.optional(v.number()),
-  }).index("sessionId", ["sessionId"]),
+    parentRefreshTokenId: v.optional(v.id("authRefreshTokens")),
+  })
+    // Sort by creationTime
+    .index("sessionId", ["sessionId"])
+    .index("sessionIdAndParentRefreshTokenId", [
+      "sessionId",
+      "parentRefreshTokenId",
+    ]),
   /**
    * Verification codes:
    * - OTP tokens

--- a/src/server/implementation/types.ts
+++ b/src/server/implementation/types.ts
@@ -74,15 +74,21 @@ export const authTables = {
     .index("providerAndAccountId", ["provider", "providerAccountId"]),
   /**
    * Refresh tokens.
-   * Each session has only a single refresh token
-   * valid at a time. Refresh tokens are rotated
-   * and reuse is not allowed, except for within
-   * a 10 second window.
+   * Refresh tokens are generally meant to be used once, to be exchanged for another
+   * refresh token and a JWT access token, but with a few exceptions:
+   * - The "active refresh token" is the most recently created refresh token that has
+   *   not been used yet. The parent of the active refresh token can always be used to
+   *   obtain the active refresh token.
+   * - A refresh token can be used within a 10 second window ("reuse window") to
+   *   obtain a new refresh token.
+   * - On any invalid use of a refresh token, the token itself and all its descendants
+   *   are invalidated.
    */
   authRefreshTokens: defineTable({
     sessionId: v.id("authSessions"),
     expirationTime: v.number(),
     firstUsedTime: v.optional(v.number()),
+    // This is the ID of the refresh token that was exchanged to create this one.
     parentRefreshTokenId: v.optional(v.id("authRefreshTokens")),
   })
     // Sort by creationTime

--- a/src/server/implementation/utils.ts
+++ b/src/server/implementation/utils.ts
@@ -56,17 +56,20 @@ export function logWithLevel(level: LogLevel, ...args: unknown[]) {
   }
 }
 
+const UNREDACTED_LENGTH = 5;
 export function maybeRedact(value: string) {
   if (value === "") {
     return "";
   }
   const shouldRedact = process.env.AUTH_LOG_SECRETS !== "true";
   if (shouldRedact) {
-    if (value.length < 6) {
+    if (value.length < UNREDACTED_LENGTH * 2) {
       return "<redacted>";
     }
     return (
-      value.substring(0, 3) + "<redacted>" + value.substring(value.length - 3)
+      value.substring(0, UNREDACTED_LENGTH) +
+      "<redacted>" +
+      value.substring(value.length - UNREDACTED_LENGTH)
     );
   } else {
     return value;

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -41,7 +41,7 @@
         "@vitest/coverage-v8": "^1.6.0",
         "autoprefixer": "^10.4.19",
         "cheerio": "^1.0.0-rc.12",
-        "convex-test": "^0.0.21",
+        "convex-test": "^0.0.32",
         "eslint": "^8.57.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -58,7 +58,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.70",
+      "version": "0.0.72-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@auth/core": "^0.31.0",
@@ -3857,9 +3857,9 @@
       "link": true
     },
     "node_modules/convex-test": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.21.tgz",
-      "integrity": "sha512-Wo21g77F4jpun3DqOK8kbVOFjYC5SkqcZQSZeQGW84sUaY6hloPqIR0rfyMwer/jiHEVzPBu/A9W6eu3dkKFxw==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.32.tgz",
+      "integrity": "sha512-RA4EEe2x+kEkoSBgG+aXT42co4LUSqkLVPq40edISVhlSwM8+xgPAYhjjDAySM06Jzdw/xomBMfvlDG0MrSe3Q==",
       "dev": true,
       "peerDependencies": {
         "convex": "^1.12.1"

--- a/test/package.json
+++ b/test/package.json
@@ -50,7 +50,7 @@
     "@vitest/coverage-v8": "^1.6.0",
     "autoprefixer": "^10.4.19",
     "cheerio": "^1.0.0-rc.12",
-    "convex-test": "^0.0.21",
+    "convex-test": "^0.0.32",
     "eslint": "^8.57.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
This updates our reuse detection for refresh tokens as follows:
* refresh tokens track their parent token
* the "active refresh token" is the most recently issued token that has never been used
* If a refresh token has never been used (its `firstUsedTime` is unset), issue a new token + update this tokens `firstUsedTime`
* If a refresh token is the parent of the active refresh token, return the active refresh token (regardless of when this refresh token was first used)
* If a refresh token has been used, but is within the allowed reuse token (10s), issue a new token
* Otherwise, this is an invalid reuse, so mark this token and all its descendants as usable (firstUsedTime 10+s ago)

This is more or less what supabase does for their refresh tokens with a pretty good write up of why [here](https://supabase.com/docs/guides/auth/sessions#what-is-refresh-token-reuse-detection-and-what-does-it-protect-from).

Some interesting effects:
* Once someone upgrades, they can't downgrade without migrating their data since I'm adding a column (we've done this before, and feels fine as long as we note it in our changelog)
* We don't clean up refresh tokens until we clean up the session (as opposed to previously we'd clean them up on each use). In the future, we'd perhaps want cron jobs to clean up stale sessions automatically.

Some other changes also in this PR:
* I added some more logging for my own sanity + ended up upgrading our version of convex-test so the new tests I wrote would work.
