### PR TITLE
Update to latest path-to-regexp

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -407,7 +407,7 @@ See [createRouteMatcher](server.mdx#createroutematcher) for more information.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/routeMatcher.ts:44](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L44)
+[src/nextjs/server/routeMatcher.ts:40](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L40)
 
 ***
 
@@ -418,7 +418,7 @@ Returns a function that accepts a `Request` object and returns whether the reque
 predefined routes that can be passed in as the first argument.
 
 You can use glob patterns to match multiple routes or a function to match against the request object.
-Path patterns are supported, for example: `['/foo', '/bar{/*extra}'].
+Path patterns are supported, for example: `['/foo', '/bar{/*extra}']`.
 
 Note: regular expressions are not supported in path patterns.
 
@@ -476,4 +476,4 @@ For more information, see: https://github.com/pillarjs/path-to-regexp
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/routeMatcher.ts:61](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L61)
+[src/nextjs/server/routeMatcher.ts:56](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L56)

--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -418,7 +418,10 @@ Returns a function that accepts a `Request` object and returns whether the reque
 predefined routes that can be passed in as the first argument.
 
 You can use glob patterns to match multiple routes or a function to match against the request object.
-Path patterns and regular expressions are supported, for example: `['/foo', '/bar(.*)'] or `[/^/foo/.*$/]`
+Path patterns are supported, for example: `['/foo', '/bar{/*extra}'].
+
+Note: regular expressions are not supported in path patterns.
+
 For more information, see: https://github.com/pillarjs/path-to-regexp
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Parameters</h3>
@@ -473,4 +476,4 @@ For more information, see: https://github.com/pillarjs/path-to-regexp
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/routeMatcher.ts:58](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L58)
+[src/nextjs/server/routeMatcher.ts:61](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/routeMatcher.ts#L61)

--- a/docs/pages/api_reference/server.mdx
+++ b/docs/pages/api_reference/server.mdx
@@ -1569,9 +1569,9 @@ For example if it's "Google", the corresponding button will say:
 
 [node\_modules/@auth/core/providers/email.d.ts:16](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L16)
 
-#### from
+#### from?
 
-> **from**: `string`
+> `optional` **from**: `string`
 
 ##### Inherited from
 
@@ -1581,9 +1581,9 @@ For example if it's "Google", the corresponding button will say:
 
 [node\_modules/@auth/core/providers/email.d.ts:17](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L17)
 
-#### maxAge
+#### maxAge?
 
-> **maxAge**: `number`
+> `optional` **maxAge**: `number`
 
 ##### Inherited from
 
@@ -1806,9 +1806,9 @@ Used with SMTP-based email providers.
 
 [node\_modules/@auth/core/providers/email.d.ts:35](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L35)
 
-#### options
+#### options?
 
-> **options**: `EmailUserConfig`
+> `optional` **options**: `EmailUserConfig`
 
 ##### Inherited from
 

--- a/docs/pages/authz/nextjs.mdx
+++ b/docs/pages/authz/nextjs.mdx
@@ -23,7 +23,7 @@ import {
 } from "@convex-dev/auth/nextjs/server";
 
 const isSignInPage = createRouteMatcher(["/signin"]);
-const isProtectedRoute = createRouteMatcher(["/product(.*)"]);
+const isProtectedRoute = createRouteMatcher(["/product{/*extra}"]);
 
 export default convexAuthNextjsMiddleware((request, { convexAuth }) => {
   if (isSignInPage(request) && convexAuth.isAuthenticated()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "0.0.71",
       "license": "Apache-2.0",
       "dependencies": {
-        "@auth/core": "^0.36.0",
         "arctic": "^1.2.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oslo": "^1.1.2",
-        "path-to-regexp": "^7.1.0",
+        "path-to-regexp": "^8.2.0",
         "server-only": "^0.0.1"
       },
       "bin": {
@@ -43,6 +42,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
+        "@auth/core": "^0.36.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },
@@ -59,6 +59,7 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.36.0.tgz",
       "integrity": "sha512-tK+TEYHdM0nkW2uUxAZylpKk2nIf3jsAWzi920E5irxJlymihWzI8nQcz9McfmKux7lmtdpC6TiysayFP7sLYg==",
+      "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
         "@types/cookie": "0.6.0",
@@ -1478,6 +1479,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1734,7 +1736,8 @@
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -2736,6 +2739,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5093,6 +5097,7 @@
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
       "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5378,9 +5383,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.1.0.tgz",
-      "integrity": "sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
@@ -5544,6 +5550,7 @@
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
       "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5553,6 +5560,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
       "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -5587,7 +5595,8 @@
     "node_modules/pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jwt-decode": "^4.0.0",
     "lucia": "^3.2.0",
     "oslo": "^1.1.2",
-    "path-to-regexp": "^7.1.0",
+    "path-to-regexp": "^8.2.0",
     "server-only": "^0.0.1"
   },
   "peerDependencies": {

--- a/src/nextjs/server/routeMatcher.ts
+++ b/src/nextjs/server/routeMatcher.ts
@@ -52,7 +52,10 @@ export type RouteMatcherParam =
  * predefined routes that can be passed in as the first argument.
  *
  * You can use glob patterns to match multiple routes or a function to match against the request object.
- * Path patterns and regular expressions are supported, for example: `['/foo', '/bar(.*)'] or `[/^\/foo\/.*$/]`
+ * Path patterns are supported, for example: `['/foo', '/bar{/*extra}'].
+ * 
+ * Note: regular expressions are not supported in path patterns.
+ * 
  * For more information, see: https://github.com/pillarjs/path-to-regexp
  */
 export const createRouteMatcher = (routes: RouteMatcherParam) => {
@@ -74,7 +77,7 @@ const precomputePathRegex = (patterns: Array<string | RegExp>) => {
 
 function pathStringToRegExp(path: string) {
   try {
-    return pathToRegexp(path);
+    return pathToRegexp(path).regexp;
   } catch (e: any) {
     throw new Error(
       `Invalid path: ${path}.\nConsult the documentation of path-to-regexp here: https://github.com/pillarjs/path-to-regexp\n${e.message}`,

--- a/src/nextjs/server/routeMatcher.ts
+++ b/src/nextjs/server/routeMatcher.ts
@@ -26,24 +26,19 @@ import { pathToRegexp } from "path-to-regexp";
 import type Link from "next/link";
 import type { NextRequest } from "next/server";
 
-type WithPathPatternWildcard<T> = `${T & string}(.*)`;
 type NextTypedRoute<T = Parameters<typeof Link>["0"]["href"]> = T extends string
   ? T
   : never;
 
 type Autocomplete<U extends T, T = string> = U | (T & Record<never, never>);
 
-type RouteMatcherWithNextTypedRoutes = Autocomplete<
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-  WithPathPatternWildcard<NextTypedRoute> | NextTypedRoute
->;
+type RouteMatcherWithNextTypedRoutes = Autocomplete<NextTypedRoute>;
 
 /**
  * See {@link createRouteMatcher} for more information.
  */
 export type RouteMatcherParam =
-  | Array<RegExp | RouteMatcherWithNextTypedRoutes>
-  | RegExp
+  | Array<RouteMatcherWithNextTypedRoutes>
   | RouteMatcherWithNextTypedRoutes
   | ((req: NextRequest) => boolean);
 
@@ -53,9 +48,9 @@ export type RouteMatcherParam =
  *
  * You can use glob patterns to match multiple routes or a function to match against the request object.
  * Path patterns are supported, for example: `['/foo', '/bar{/*extra}'].
- * 
+ *
  * Note: regular expressions are not supported in path patterns.
- * 
+ *
  * For more information, see: https://github.com/pillarjs/path-to-regexp
  */
 export const createRouteMatcher = (routes: RouteMatcherParam) => {

--- a/src/nextjs/server/routeMatcher.ts
+++ b/src/nextjs/server/routeMatcher.ts
@@ -47,7 +47,7 @@ export type RouteMatcherParam =
  * predefined routes that can be passed in as the first argument.
  *
  * You can use glob patterns to match multiple routes or a function to match against the request object.
- * Path patterns are supported, for example: `['/foo', '/bar{/*extra}'].
+ * Path patterns are supported, for example: `['/foo', '/bar{/*extra}']`.
  *
  * Note: regular expressions are not supported in path patterns.
  *

--- a/test-nextjs/middleware.ts
+++ b/test-nextjs/middleware.ts
@@ -5,7 +5,7 @@ import {
 } from "@convex-dev/auth/nextjs/server";
 
 const isSignInPage = createRouteMatcher(["/signin"]);
-const isProtectedRoute = createRouteMatcher(["/product(.*)"]);
+const isProtectedRoute = createRouteMatcher(["/product{/*extra}"]);
 
 export default convexAuthNextjsMiddleware((request, { convexAuth }) => {
   if (isSignInPage(request) && convexAuth.isAuthenticated()) {


### PR DESCRIPTION
This resolve a vulnerability present in the old version.

Required a slight API tweak as the pathToRegexp function now returns a different type.

https://github.com/advisories/GHSA-9wv6-86v2-598j

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
