### PR TITLE
Add configuration for cookie expiration for Next.js

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -308,6 +308,45 @@ Defaults to `/api/auth`.
 <tr>
 <td>
 
+`options.cookieConfig`?
+
+</td>
+<td>
+
+`object`
+
+</td>
+<td>
+
+The cookie config to use for the auth cookies.
+
+`maxAge` is the number of seconds the cookie will be valid for. If this is not set, the cookie will be a session cookie.
+
+See [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#defining_the_lifetime_of_a_cookie)
+for more information.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`options.cookieConfig.maxAge`?
+
+</td>
+<td>
+
+`null` \| `number`
+
+</td>
+<td>
+
+&hyphen;
+
+</td>
+</tr>
+<tr>
+<td>
+
 `options.verbose`?
 
 </td>
@@ -396,7 +435,7 @@ The route path to redirect to.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/nextjs/server/index.tsx:244](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L244)
+[src/nextjs/server/index.tsx:261](https://github.com/get-convex/convex-auth/blob/main/src/nextjs/server/index.tsx#L261)
 
 ***
 

--- a/docs/pages/api_reference/server.mdx
+++ b/docs/pages/api_reference/server.mdx
@@ -1569,9 +1569,9 @@ For example if it's "Google", the corresponding button will say:
 
 [node\_modules/@auth/core/providers/email.d.ts:16](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L16)
 
-#### from
+#### from?
 
-> **from**: `string`
+> `optional` **from**: `string`
 
 ##### Inherited from
 
@@ -1581,9 +1581,9 @@ For example if it's "Google", the corresponding button will say:
 
 [node\_modules/@auth/core/providers/email.d.ts:17](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L17)
 
-#### maxAge
+#### maxAge?
 
-> **maxAge**: `number`
+> `optional` **maxAge**: `number`
 
 ##### Inherited from
 
@@ -1806,9 +1806,9 @@ Used with SMTP-based email providers.
 
 [node\_modules/@auth/core/providers/email.d.ts:35](https://github.com/get-convex/convex-auth/blob/main/node_modules/@auth/core/providers/email.d.ts#L35)
 
-#### options
+#### options?
 
-> **options**: `EmailUserConfig`
+> `optional` **options**: `EmailUserConfig`
 
 ##### Inherited from
 

--- a/docs/pages/authz/nextjs.mdx
+++ b/docs/pages/authz/nextjs.mdx
@@ -76,6 +76,24 @@ middleware:
 
   You can inline this code if you need more control over the target URL.
 
+## Configure cookie expiration
+
+You can configure the expiration of the authentication cookie by passing a
+`cookieConfig` option to `convexAuthNextjsMiddleware`.
+
+```ts filename="middleware.ts"
+export default convexAuthNextjsMiddleware(
+  (request, { convexAuth }) => {
+    // ...
+  },
+  { cookieConfig: { maxAge: 60 * 60 * 24 * 30 } },
+); // 30 days
+```
+
+If you don't set this option, the cookie will be considered a "session cookie"
+and be deleted when the browser session ends, which depends from browser to
+browser.
+
 ## Preloading and loading data
 
 To preload or load data on your Next.js server from your Convex backend, you can

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@convex-dev/auth",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/auth",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "license": "Apache-2.0",
       "dependencies": {
-        "@auth/core": "^0.36.0",
         "arctic": "^1.2.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
@@ -43,6 +42,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
+        "@auth/core": "^0.36.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },
@@ -59,6 +59,7 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.36.0.tgz",
       "integrity": "sha512-tK+TEYHdM0nkW2uUxAZylpKk2nIf3jsAWzi920E5irxJlymihWzI8nQcz9McfmKux7lmtdpC6TiysayFP7sLYg==",
+      "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
         "@types/cookie": "0.6.0",
@@ -1478,6 +1479,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1734,7 +1736,8 @@
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -2736,6 +2739,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5093,6 +5097,7 @@
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
       "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5544,6 +5549,7 @@
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
       "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5553,6 +5559,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
       "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -5587,7 +5594,8 @@
     "node_modules/pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/src/nextjs/server/cookies.ts
+++ b/src/nextjs/server/cookies.ts
@@ -2,10 +2,14 @@ import { cookies, headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export function getRequestCookies() {
+  // maxAge doesn't matter for request cookies since they're only relevant for the
+  // length of the request
   return getCookieStore(headers(), cookies(), { maxAge: null });
 }
 
 export function getRequestCookiesInMiddleware(request: NextRequest) {
+  // maxAge doesn't matter for request cookies since they're only relevant for the
+  // length of the request
   return getCookieStore(headers(), request.cookies, { maxAge: null });
 }
 

--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -163,6 +163,12 @@ export function convexAuthNextjsMiddleware(
 ): NextMiddleware {
   return async (request, event) => {
     const verbose = options.verbose ?? false;
+    const cookieConfig = options.cookieConfig ?? { maxAge: null };
+    if (cookieConfig.maxAge !== null && cookieConfig.maxAge <= 0) {
+      throw new Error(
+        "cookieConfig.maxAge must be null or a positive number of seconds",
+      );
+    }
     logVerbose(`Begin middleware for request with URL ${request.url}`, verbose);
     const requestUrl = new URL(request.url);
     // Proxy signIn and signOut actions to Convex backend
@@ -182,7 +188,7 @@ export function convexAuthNextjsMiddleware(
     const authResult = await handleAuthenticationInRequest(
       request,
       verbose,
-      options.cookieConfig ?? { maxAge: null },
+      cookieConfig,
     );
 
     // If redirecting, proceed, the middleware will run again on next request
@@ -236,11 +242,7 @@ export function convexAuthNextjsMiddleware(
       authResult.refreshTokens !== undefined
     ) {
       const nextResponse = NextResponse.next(response);
-      setAuthCookies(
-        nextResponse,
-        authResult.refreshTokens,
-        options.cookieConfig ?? { maxAge: null },
-      );
+      setAuthCookies(nextResponse, authResult.refreshTokens, cookieConfig);
       return nextResponse;
     }
 

--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -147,6 +147,15 @@ export function convexAuthNextjsMiddleware(
      */
     apiRoute?: string;
     /**
+     * The cookie config to use for the auth cookies.
+     *
+     * `maxAge` is the number of seconds the cookie will be valid for. If this is not set, the cookie will be a session cookie.
+     *
+     * See [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#defining_the_lifetime_of_a_cookie)
+     * for more information.
+     */
+    cookieConfig?: { maxAge: number | null };
+    /**
      * Turn on debugging logs.
      */
     verbose?: boolean;
@@ -170,7 +179,11 @@ export function convexAuthNextjsMiddleware(
       verbose,
     );
     // Refresh tokens, handle code query param
-    const authResult = await handleAuthenticationInRequest(request, verbose);
+    const authResult = await handleAuthenticationInRequest(
+      request,
+      verbose,
+      options.cookieConfig ?? { maxAge: null },
+    );
 
     // If redirecting, proceed, the middleware will run again on next request
     if (authResult.kind === "redirect") {
@@ -223,7 +236,11 @@ export function convexAuthNextjsMiddleware(
       authResult.refreshTokens !== undefined
     ) {
       const nextResponse = NextResponse.next(response);
-      setAuthCookies(nextResponse, authResult.refreshTokens);
+      setAuthCookies(
+        nextResponse,
+        authResult.refreshTokens,
+        options.cookieConfig ?? { maxAge: null },
+      );
       return nextResponse;
     }
 

--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -13,9 +13,13 @@ import {
 
 export async function proxyAuthActionToConvex(
   request: NextRequest,
-  options: { convexUrl?: string; verbose?: boolean; cookieMaxAge?: number },
+  options: {
+    convexUrl?: string;
+    verbose?: boolean;
+    cookieConfig?: { maxAge: number | null };
+  },
 ) {
-  const cookieMaxAge = options?.cookieMaxAge ?? null;
+  const cookieConfig = options?.cookieConfig ?? { maxAge: null };
   const verbose = options?.verbose ?? false;
   if (request.method !== "POST") {
     return new Response("Invalid method", { status: 405 });
@@ -69,13 +73,13 @@ export async function proxyAuthActionToConvex(
       console.error(error);
       logVerbose(`Clearing auth cookies`, verbose);
       const response = jsonResponse(null);
-      setAuthCookies(response, null);
+      setAuthCookies(response, null, cookieConfig);
       return response;
     }
     if (result.redirect !== undefined) {
       const { redirect } = result;
       const response = jsonResponse({ redirect });
-      getResponseCookies(response).verifier = result.verifier!;
+      getResponseCookies(response, cookieConfig).verifier = result.verifier!;
       logVerbose(`Redirecting to ${redirect}`, verbose);
       return response;
     } else if (result.tokens !== undefined) {
@@ -94,7 +98,7 @@ export async function proxyAuthActionToConvex(
             ? { token: result.tokens.token, refreshToken: "dummy" }
             : null,
       });
-      setAuthCookies(response, result.tokens);
+      setAuthCookies(response, result.tokens, cookieConfig);
       return response;
     }
     return jsonResponse(result);
@@ -110,7 +114,7 @@ export async function proxyAuthActionToConvex(
     }
     logVerbose(`Clearing auth cookies`, verbose);
     const response = jsonResponse(null);
-    setAuthCookies(response, null);
+    setAuthCookies(response, null, cookieConfig);
     return response;
   }
 }

--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -13,8 +13,9 @@ import {
 
 export async function proxyAuthActionToConvex(
   request: NextRequest,
-  options: { convexUrl?: string; verbose?: boolean },
+  options: { convexUrl?: string; verbose?: boolean; cookieMaxAge?: number },
 ) {
+  const cookieMaxAge = options?.cookieMaxAge ?? null;
   const verbose = options?.verbose ?? false;
   if (request.method !== "POST") {
     return new Response("Invalid method", { status: 405 });

--- a/src/nextjs/server/request.ts
+++ b/src/nextjs/server/request.ts
@@ -8,6 +8,7 @@ import { isCorsRequest, logVerbose, setAuthCookies } from "./utils.js";
 export async function handleAuthenticationInRequest(
   request: NextRequest,
   verbose: boolean,
+  cookieConfig: { maxAge: number | null },
 ): Promise<
   | { kind: "redirect"; response: NextResponse }
   | {
@@ -44,7 +45,7 @@ export async function handleAuthenticationInRequest(
         throw new Error("Invalid `signIn` action result for code exchange");
       }
       const response = NextResponse.redirect(redirectUrl);
-      setAuthCookies(response, result.tokens);
+      setAuthCookies(response, result.tokens, cookieConfig);
       logVerbose(
         `Successfully validated code, redirecting to ${redirectUrl.toString()} with auth cookies`,
         verbose,
@@ -57,7 +58,7 @@ export async function handleAuthenticationInRequest(
         verbose,
       );
       const response = NextResponse.redirect(redirectUrl);
-      setAuthCookies(response, null);
+      setAuthCookies(response, null, cookieConfig);
       return { kind: "redirect", response };
     }
   }

--- a/src/nextjs/server/utils.ts
+++ b/src/nextjs/server/utils.ts
@@ -13,8 +13,11 @@ export function jsonResponse(body: any) {
 export function setAuthCookies(
   response: NextResponse,
   tokens: { token: string; refreshToken: string } | null,
+  cookieConfig: {
+    maxAge: number | null;
+  },
 ) {
-  const responseCookies = getResponseCookies(response);
+  const responseCookies = getResponseCookies(response, cookieConfig);
   if (tokens === null) {
     responseCookies.token = null;
     responseCookies.refreshToken = null;


### PR DESCRIPTION
In the current implementation, the cookies we use for Next.js have no expiration which means they're deleted at the end of the browser session (for Chrome, this seems like whenever you quit your browser). A use case where this was particularly disruptive was with mobile web, where closing the app (or maybe even just backgrounding it for long enough) would clear out the cookies.

This PR makes it configurable via an option in `convexAuthNextjsMiddleware`.

In an ideal world, all the configurations would live in one spot (like `auth.ts`), but this is hard in practice since some of the configuration is deployed to Convex while some is deployed to Next.js. It could also be nice to be able to configure this based on a parameter in the sign in request (like the "remember me" check box), but offering this basic configuration is a good start.