### PR TITLE
Fix header propagation in Next.js middleware

### DIFF
--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -212,7 +212,9 @@ export function convexAuthNextjsMiddleware(
     if (handler === undefined) {
       logVerbose(`No custom handler`, verbose);
       response = NextResponse.next({
-        headers: request.headers,
+        request: {
+          headers: request.headers,
+        },
       });
     } else {
       // Call the custom handler
@@ -232,7 +234,9 @@ export function convexAuthNextjsMiddleware(
           },
         })) ??
         NextResponse.next({
-          headers: request.headers,
+          request: {
+            headers: request.headers,
+          },
         });
     }
 


### PR DESCRIPTION
`NextResponse.next({ request: { headers } })` allows overriding headers on the request. `NextResponse.next({ headers })` initializes those headers on the response itself.

I intended the former but wrote the latter. Amongst other things, I believe this'll fix https://github.com/get-convex/convex-auth/issues/92 for folks with middleware that handles the redirect.
