### PR TITLE
Update the lock file to point to a common @types/react version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,10 +1774,11 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
+      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@edge-runtime/vm": "^3.2.0",
         "@types/inquirer": "^9.0.7",
         "@types/node": "20.6.0",
-        "@types/react": "^18.3.3",
+        "@types/react": "^18.3.12",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "chalk": "^5.3.0",
         "convex-test": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@edge-runtime/vm": "^3.2.0",
     "@types/inquirer": "^9.0.7",
     "@types/node": "20.6.0",
-    "@types/react": "^18.3.3",
+    "@types/react": "^18.3.12",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "chalk": "^5.3.0",
     "convex-test": "^0.0.20",


### PR DESCRIPTION
Previously the root package and the test-nextjs package pointed at different versions and I think that was causing the following error:

```
% npm run build

> template-nextjs@0.1.0 build
> next build

  ▲ Next.js 14.2.5
  - Environments: .env.local

   Creating an optimized production build ...
 ⚠ Found lockfile missing swc dependencies, patching...
 ⚠ Found lockfile missing swc dependencies, patching...
 ⚠ Found lockfile missing swc dependencies, patching...
 ⚠ Lockfile was successfully patched, please run "npm install" to ensure @next/swc dependencies are downloaded
 ✓ Compiled successfully
   Linting and checking validity of types  ..Failed to compile.

./components/ui/toggle-group.tsx:28:7
Type error: Type 'React.ReactNode' is not assignable to type 'import("/Users/christian/Development/Convex/convex-auth/test-nextjs/node_modules/@types/react/index").ReactNode'.
  Type 'bigint' is not assignable to type 'ReactNode'.

  26 |   >
  27 |     <ToggleGroupContext.Provider value={{ variant, size }}>
> 28 |       {children}
     |       ^
  29 |     </ToggleGroupContext.Provider>
  30 |   </ToggleGroupPrimitive.Root>
  31 | ));
```

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
