### PR TITLE
Allow Convex Auth to work with local deployments when using a single page app

### DIFF
--- a/src/nextjs/server/cookies.ts
+++ b/src/nextjs/server/cookies.ts
@@ -1,5 +1,6 @@
 import { cookies, headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import * as utils from "../../server/utils.js";
 
 export function getRequestCookies() {
   // maxAge doesn't matter for request cookies since they're only relevant for the
@@ -51,8 +52,8 @@ function getCookieStore(
     maxAge: number | null;
   },
 ) {
-  const isLocalhost = /(localhost|127\.0\.0\.1):\d+/.test(
-    requestHeaders.get("Host") ?? "",
+  const isLocalhost = utils.isLocalHost(
+    requestHeaders.get("Host") ?? ""
   );
   const prefix = isLocalhost ? "" : "__Host-";
   const tokenName = prefix + "__convexAuthJWT";

--- a/src/server/checks.ts
+++ b/src/server/checks.ts
@@ -19,6 +19,7 @@
 import { generateState } from "arctic";
 import * as o from "oauth4webapi";
 import { InternalProvider } from "./oauth.js";
+import { isLocalHost } from "./utils.js";
 
 const SHARED_COOKIE_OPTIONS = {
   httpOnly: true,
@@ -168,5 +169,5 @@ function oauthStateCookieName(
   type: "state" | "pkce" | "nonce",
   providerId: string,
 ) {
-  return "__Host-" + providerId + "OAuth" + type;
+  return (!isLocalHost(process.env.CONVEX_SITE_URL) ? "__Host-" : "") + providerId + "OAuth" + type;
 }

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -5,3 +5,8 @@ export function requireEnv(name: string) {
   }
   return value;
 }
+
+export function isLocalHost(host?: string) {
+  return /(localhost|127\.0\.0\.1):\d+/.test(
+  host ?? "");
+}


### PR DESCRIPTION
This already worked for Next.js, but for SPAs the auth cookies were getting the __Host- prefix applied which is only compatible with cookies served via HTTPS.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
