### PR TITLE
Upgrade to @auth/core 0.37.3

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -44,7 +44,7 @@ instructions above.
 ### Install the NPM library
  
 ```sh
-npm install @convex-dev/auth @auth/core@0.36.0
+npm install @convex-dev/auth @auth/core@0.37.0
 ```
 
 This also installs `@auth/core`, which you will use during provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.36.0",
+        "@auth/core": "^0.37.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },
@@ -57,18 +57,18 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.36.0.tgz",
-      "integrity": "sha512-tK+TEYHdM0nkW2uUxAZylpKk2nIf3jsAWzi920E5irxJlymihWzI8nQcz9McfmKux7lmtdpC6TiysayFP7sLYg==",
+      "version": "0.37.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.3.tgz",
+      "integrity": "sha512-qcffDLwxB9iUYH8GHq68w/KU8jtjAbjjk9xnpoKhjX3+QcntaQ2MKVSkTTocmA6ElpL5vK2xR9CXfQ98dvGnyg==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
-        "@types/cookie": "0.6.0",
-        "cookie": "0.7.1",
-        "jose": "^5.9.3",
-        "oauth4webapi": "^2.17.0",
-        "preact": "10.11.3",
-        "preact-render-to-string": "5.2.3"
+        "cookie": "1.0.1",
+        "jose": "^5.9.6",
+        "oauth4webapi": "^3.1.1",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
@@ -85,15 +85,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@auth/core/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -1742,12 +1733,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -4375,9 +4360,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
-      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5104,9 +5090,10 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
-      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.1.2.tgz",
+      "integrity": "sha512-KQZkNU+xn02lWrFu5Vjqg9E81yPtDSxUZorRHlLWVoojD+H/0GFbH59kcnz5Thdjj7c4/mYMBPj/mhvGe/kKXA==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5556,9 +5543,10 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -5566,13 +5554,11 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
-      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -5600,12 +5586,6 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "server-only": "^0.0.1"
   },
   "peerDependencies": {
-    "@auth/core": "^0.36.0",
+    "@auth/core": "^0.37.0",
     "convex": "^1.14.4",
     "react": "^18.2.0"
   },

--- a/src/server/oauth.ts
+++ b/src/server/oauth.ts
@@ -293,7 +293,7 @@ export async function handleOAuthCallback(
         }
       } catch {}
     }
-    
+
     tokens = result;
   } else {
     tokens = await o.processAuthorizationCodeResponse(

--- a/test/convex/test.helpers.ts
+++ b/test/convex/test.helpers.ts
@@ -62,7 +62,7 @@ export async function signInViaGitHub(
             access_token: issuedAccessToken,
             token_type: "bearer",
           }),
-          { status: 200 },
+          { status: 200, headers: { "Content-Type": "application/json" } },
         );
       } else if (
         input === "https://api.github.com/user" ||

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -63,6 +63,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "arctic": "^1.2.0",
+        "cookie": "^1.0.1",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
@@ -78,7 +79,7 @@
         "@edge-runtime/vm": "^3.2.0",
         "@types/inquirer": "^9.0.7",
         "@types/node": "20.6.0",
-        "@types/react": "^18.3.3",
+        "@types/react": "^18.3.12",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "chalk": "^5.3.0",
         "convex-test": "^0.0.20",
@@ -95,7 +96,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.36.0",
+        "@auth/core": "^0.37.0",
         "convex": "^1.14.4",
         "react": "^18.2.0"
       },


### PR DESCRIPTION
<!-- Describe your PR here. -->

This is a minimal approach to switching to `@auth/core` 0.37+. It pulls in a bit more code, but lets us run using the new 3.x version of `oauth4webapi` as well.

The test suites (`test/` and `test-nextjs/`) succeed. I plan on trying out a few providers manually with this change, but thought I'd put the code up for review in the meantime.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
