### PR TITLE
Fix the React (Vite) build when using Convex Auth

### DIFF
--- a/src/server/implementation/index.ts
+++ b/src/server/implementation/index.ts
@@ -27,7 +27,7 @@ import {
 } from "../types.js";
 import { requireEnv } from "../utils.js";
 import { ActionCtx, MutationCtx, Tokens } from "./types.js";
-export { authTables, Tokens } from "./types.js";
+export { authTables, Doc, Tokens } from "./types.js";
 import {
   LOG_LEVELS,
   TOKEN_SUB_CLAIM_DIVIDER,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,6 +20,8 @@ export {
   signInViaProvider,
   invalidateSessions,
   modifyAccountCredentials,
+  Tokens,
+  Doc,
 } from "./implementation/index.js";
 export type {
   ConvexAuthConfig,


### PR DESCRIPTION
Without this you'd hit an error like:

```
convex/auth.ts:7:39 - error TS2742: The inferred type of 'store' cannot be named without a reference to '../node_modules/@convex-dev/auth/dist/server/implementation/types'. This is likely not portable. A type annotation is necessary.
```

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
