### PR TITLE
Use a version of path-to-regexp that isn't vulnerable to REDoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
         "oslo": "^1.1.2",
-        "path-to-regexp": "^7.1.0",
+        "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },
       "bin": {
@@ -3183,7 +3183,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.1.tgz",
       "integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5861,12 +5860,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.1.0.tgz",
-      "integrity": "sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==",
-      "engines": {
-        "node": ">=16"
-      }
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jwt-decode": "^4.0.0",
     "lucia": "^3.2.0",
     "oslo": "^1.1.2",
-    "path-to-regexp": "^7.1.0",
+    "path-to-regexp": "^6.3.0",
     "server-only": "^0.0.1",
     "oauth4webapi": "^3.1.2"
   },

--- a/src/nextjs/server/routeMatcher.ts
+++ b/src/nextjs/server/routeMatcher.ts
@@ -52,8 +52,8 @@ export type RouteMatcherParam =
  * predefined routes that can be passed in as the first argument.
  *
  * You can use glob patterns to match multiple routes or a function to match against the request object.
- * Path patterns and regular expressions are supported, for example: `['/foo', '/bar(.*)'] or `[/^\/foo\/.*$/]`
- * For more information, see: https://github.com/pillarjs/path-to-regexp
+ * Path patterns and limited regular expressions are supported.
+ * For more information, see: https://www.npmjs.com/package/path-to-regexp/v/6.3.0
  */
 export const createRouteMatcher = (routes: RouteMatcherParam) => {
   if (typeof routes === "function") {

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -49,8 +49,9 @@
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
+        "oauth4webapi": "^3.1.2",
         "oslo": "^1.1.2",
-        "path-to-regexp": "^7.1.0",
+        "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },
       "bin": {
@@ -78,7 +79,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.36.0",
+        "@auth/core": "^0.37.0",
         "convex": "^1.17.0",
         "react": "^18.2.0 || ^19.0.0-0"
       },


### PR DESCRIPTION
Fixes #107.

https://github.com/pillarjs/path-to-regexp/releases/tag/v6.3.0

We'll want to include that this is a potentially breaking change in our release notes, as the version 7.x path-to-regexp that we were using supported more regular expressions in path patterns.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
