### PR TITLE
add useState and fix type in docs

### DIFF
--- a/docs/pages/authz.mdx
+++ b/docs/pages/authz.mdx
@@ -58,9 +58,9 @@ Sometimes your React frontend might need to call your Convex backend via HTTP,
 usually to stream data, such as when uploading files or when loading a slowly
 generated AI response.
 
-To authenticate HTTP actions you will need to access the JWT token the
-client uses for authenticating with the backend, which you get from the
-`useAuthToken` hook:
+To authenticate HTTP actions you will need to access the JWT token the client
+uses for authenticating with the backend, which you get from the `useAuthToken`
+hook:
 
 ```tsx
 import { useAuthToken } from "@convex-dev/auth/react";
@@ -71,7 +71,7 @@ function SomeComponent() {
     // You might need to set up `VITE_CONVEX_SITE_URL`
     const response = await fetch(
       `${process.env.VITE_CONVEX_SITE_URL!}/someEndpoint`,
-      { headers: { Authorization: `Bearer ${token}` } },
+      { headers: { Authorization: `Bearer ${token}` } }
     );
     // ...
   };
@@ -125,7 +125,7 @@ export const currentUser = query({
 });
 ```
 
-The function returns `Id<"users">` (or `null` when the client isn't
+The function returns `Doc<"users">` (or `null` when the client isn't
 authenticated).
 
 ### Get current session ID
@@ -149,7 +149,7 @@ export const currentSession = query({
 });
 ```
 
-The function returns `Id<"authSessions">` (or `null` when the client isn't
+The function returns `Doc<"authSessions">` (or `null` when the client isn't
 authenticated).
 
 ### Loading users and sessions

--- a/docs/pages/config/otps.mdx
+++ b/docs/pages/config/otps.mdx
@@ -126,6 +126,7 @@ For example for the custom `ResendOTP` provider:
 
 ```tsx filename="src/SignIn.tsx"
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useState } from "react";
 
 export function SignIn() {
   const { signIn } = useAuthActions();
@@ -136,7 +137,7 @@ export function SignIn() {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
         void signIn("resend-otp", formData).then(() =>
-          setStep({ email: formData.get("email") as string }),
+          setStep({ email: formData.get("email") as string })
         );
       }}
     >

--- a/docs/pages/config/passwords.mdx
+++ b/docs/pages/config/passwords.mdx
@@ -57,6 +57,7 @@ errors - and indicated via the `flow` field.
 
 ```tsx filename="src/SignIn.tsx"
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useState } from "react";
 
 export function SignIn() {
   const { signIn } = useAuthActions();
@@ -228,6 +229,7 @@ user provides the new password.
 
 ```tsx filename="src/PasswordReset.tsx"
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useState } from "react";
 
 export function PasswordReset() {
   const { signIn } = useAuthActions();
@@ -238,7 +240,7 @@ export function PasswordReset() {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
         void signIn("password", formData).then(() =>
-          setStep({ email: formData.get("email") as string }),
+          setStep({ email: formData.get("email") as string })
         );
       }}
     >
@@ -351,11 +353,12 @@ that the whole `SignIn` component will be unmounted when the user is signed-in.
 
 ```tsx filename="src/SignIn.tsx"
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useState } from "react";
 
 export function SignIn() {
   const { signIn } = useAuthActions();
   const [step, setStep] = useState<"signIn" | "signUp" | { email: string }>(
-    "signIn",
+    "signIn"
   );
   return step === "signIn" || step === "signUp" ? (
     <form
@@ -363,7 +366,7 @@ export function SignIn() {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
         void signIn("password", formData).then(() =>
-          setStep({ email: formData.get("email") as string }),
+          setStep({ email: formData.get("email") as string })
         );
       }}
     >
@@ -450,9 +453,9 @@ export default Password({
 Use the `validatePasswordRequirements` option to `Password` to invoke password
 validation logic.
 
-If you don't supply custom validation, the default behavior simply requires
-that a password is 8 or more characters. If you do supply custom validation,
-the default validation is not used.
+If you don't supply custom validation, the default behavior simply requires that
+a password is 8 or more characters. If you do supply custom validation, the
+default validation is not used.
 
 This example requires a certain password length and contents:
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add missing `import { useState } from "react";`
and `db.get` returns `Doc` type.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
