### PR TITLE
fix module resolution error for checks import

### DIFF
--- a/src/server/oauth/callback.ts
+++ b/src/server/oauth/callback.ts
@@ -1,6 +1,6 @@
 // This maps to packages/core/src/lib/actions/callback/oauth/callback.ts in the @auth/core package (commit 5af1f30a32e64591abc50ae4d2dba4682e525431)
 
-import * as checks from "./checks";
+import * as checks from "./checks.js";
 import * as o from "oauth4webapi";
 import { InternalOptions } from "./types.js";
 import { fetchOpt } from "./lib/utils/customFetch.js";


### PR DESCRIPTION
<!-- Describe your PR here. -->
A module resolution error occurs due to no extension on an import from convex-test. Not certain why this is required, but adding an extension to align with the other imports fixes the issue.

Reference discord post: https://discord.com/channels/1019350475847499849/1317446619775373393

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
