### PR TITLE
Make isAuthenticated in middleware fail more loudly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Next.js middleware function `isAuthenticated` fails more loudly; previously it
+  returned false in the case of a Convex backend that didn't expose an endpoint
+  called `auth:isAuthenticated`, now it throws an error. This should help people
+  with the migration required for 0.0.76.
+
 ## 0.0.78
 
 - Add support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
   called `auth:isAuthenticated`, now it throws an error. This should help people
   with the migration required for 0.0.76.
 
-- Export `SignInAction` and `SignOutAction` types.
-
 ## 0.0.77
 
 - Fix syntax of an import to work with convex-test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
+- Add support for
+  [custom OAuth callback and sign-in URLs](https://labs.convex.dev/auth/advanced#custom-callback-and-sign-in-urls)
+
 - Next.js middleware function `isAuthenticated` fails more loudly; previously it
   returned false in the case of a Convex backend that didn't expose an endpoint
   called `auth:isAuthenticated`, now it throws an error. This should help people
   with the migration required for 0.0.76.
 
-## 0.0.78
-
-- Add support for
-  [custom OAuth callback and sign-in URLs](https://labs.convex.dev/auth/advanced#custom-callback-and-sign-in-urls)
+- Export `SignInAction` and `SignOutAction` types.
 
 ## 0.0.77
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@convex-dev/auth",
-  "version": "0.0.75",
+  "version": "0.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@convex-dev/auth",
-      "version": "0.0.75",
+      "version": "0.0.77",
       "license": "Apache-2.0",
       "dependencies": {
         "arctic": "^1.2.0",

--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -313,7 +313,9 @@ async function isAuthenticated(token: string | null): Promise<boolean> {
       throw new Error(
         "Server Error: could not find api.auth.isAuthenticated. convex-auth 0.0.76 introduced a new export in convex/auth.ts. Add `isAuthenticated` to the list of functions returned from convexAuth(). See convex-auth changelog for more https://github.com/get-convex/convex-auth/blob/main/CHANGELOG.md",
       );
+    } else {
+      console.log("Returning false from isAuthenticated because", e);
     }
-    throw e;
+    return false;
   }
 }

--- a/src/nextjs/server/index.tsx
+++ b/src/nextjs/server/index.tsx
@@ -308,7 +308,12 @@ async function isAuthenticated(token: string | null): Promise<boolean> {
       {},
       { token: token },
     );
-  } catch {
-    return false;
+  } catch (e: any) {
+    if (e.message.includes("Could not find public function")) {
+      throw new Error(
+        "Server Error: could not find api.auth.isAuthenticated. convex-auth 0.0.76 introduced a new export in convex/auth.ts. Add `isAuthenticated` to the list of functions returned from convexAuth(). See convex-auth changelog for more https://github.com/get-convex/convex-auth/blob/main/CHANGELOG.md",
+      );
+    }
+    throw e;
   }
 }

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.75",
+      "version": "0.0.77",
       "license": "Apache-2.0",
       "dependencies": {
         "arctic": "^1.2.0",


### PR DESCRIPTION
Make the Next.js middleware function `isAuthenticated` fail more loudly. Previously it returned false in the case of a Convex backend that didn't expose an endpoint called `auth:isAuthenticated`, now it throws an error. This should help people with the migration required for 0.0.76.