### PR TITLE
Add platform check for ConvexAuthProvider's storage

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -42,7 +42,7 @@ instructions above.
 
 <Steps>
 ### Install the NPM library
- 
+
 ```sh
 npm install @convex-dev/auth @auth/core@0.37.0
 ```
@@ -297,7 +297,14 @@ const secureStorage = {
 
 export default function RootLayout() {
   return (
-    <ConvexAuthProvider client={convex} storage={secureStorage}>
+    <ConvexAuthProvider
+      client={convex}
+      storage={
+        Platform.OS === "android" || Platform.OS === "ios"
+          ? secureStorage
+          : undefined
+      }
+    >
       <Stack>
         <Stack.Screen name="index" />
       </Stack>


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes #114 

In Expo (React Native), providing `storage={secureStorage}` to `ConvexAuthProvider` makes the web version of the app crashes (see #114). Checking the platform and only assign `secureStorage` on Android and iOS fixes this issue.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
