### PR TITLE
fix auth refresh silent failure for react native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 /dist
 /distreact
+/distnextjs
 /publish-example
 
 # dependencies

--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -471,6 +471,7 @@ async function enqueueCallbackForMutex(
     setMutexValue(key, {
       currentlyRunning: callback().finally(() => {
         const nextCb = getMutexValue(key).waiting.shift();
+        getMutexValue(key).currentlyRunning = null;
         setMutexValue(key, {
           ...getMutexValue(key),
           currentlyRunning:


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes #147 

### Problem
When running Convex Auth in a React Native app, when the app is in the background for a long enough period of time, upon reopening:
- the app is in the same visual state it was when backgrounded
- it is no longer connected to Convex
- `isAuthenticated` is true and `<Authenticated>` renders children
- there are no signs of errors, except new or modified queries fail to load and mutations do nothing, although optimistic updates apply and stay in place indefinitely

### Minimal repro steps
- Run Convex Auth in an Expo app (I've only tried with iOS on device, not certain about Android or simulator)
- After loading app, move it to the background
- Wait for the minimum JWT duration to pass (an hour by default, I dropped to 10s for testing)
- Bring app back to foreground

### Root cause
Convex Auth uses a mutex to run authentication requests serially. The manual mutex, used when `window.navigator.locks` is undefined (so any non-browser context), has a bug when used while a callback is already running. Specifically in `enqueueCallbackForMutex()`.

https://github.com/get-convex/convex-auth/blob/882f6651bac4e0aed347487cecc47481c0d93ea9/src/react/client.tsx#L465-L488

- `enqueueCallbackForMutex` will run a received callback if none is running (by checking for the mutex `currentlyRunning` property to be `null`)
- if one is already running, the callback is added to the queue
- when the running callback completes, the next item is pulled from the queue via `.shift()` and passed  via recursion to `enqueueCallbackForMutex`
- at the time of this call, the value of `mutex.currentlyRunning` is still the previous promise - the value is never reset to `null`
- because `mutex.currentlyRunning` is not null, the next callback is re-added to the queue instead of being executed
- all subsequent callbacks are also added to the queue

This only happens in the repro conditions described above because the first auth attempt fails, ostensibly due to the websocket connection not being immediately available based on logs. It doesn't fail quickly, and the second attempt fires before it finishes, leading to the queueing attempt, which causes no further auth requests to run.

I decided not to dig further into nailing down why exactly the first auth attempt fails because:
- it seems highly likely to be as described
- the auth code is resilient against this sort of thing anyway, just needed this small bug fixed



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
