### PR TITLE
Fix handling of URL with convex/nextjs functions

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 import { SignInAction } from "../../server/implementation/index.js";
 import { getRequestCookies, getResponseCookies } from "./cookies.js";
 import {
+  getConvexNextjsOptions,
   getRedactedMessage,
   isCorsRequest,
   jsonResponse,
@@ -69,7 +70,7 @@ export async function proxyAuthActionToConvex(
         : { token };
     try {
       result = await fetchAction(action, args, {
-        url: options?.convexUrl,
+        ...getConvexNextjsOptions(options),
         ...fetchActionAuthOptions,
       });
     } catch (error) {
@@ -110,7 +111,7 @@ export async function proxyAuthActionToConvex(
   } else {
     try {
       await fetchAction(action, args, {
-        url: options?.convexUrl,
+        ...getConvexNextjsOptions(options),
         token,
       });
     } catch (error) {

--- a/src/nextjs/server/utils.ts
+++ b/src/nextjs/server/utils.ts
@@ -3,6 +3,7 @@ import {
   getRequestCookiesInMiddleware,
   getResponseCookies,
 } from "./cookies.js";
+import { NextjsOptions } from "convex/nextjs";
 
 export function jsonResponse(body: any) {
   return new NextResponse(JSON.stringify(body), {
@@ -76,4 +77,21 @@ export function getRedactedMessage(value: string) {
     "<redacted>" +
     value.substring(value.length - length)
   );
+}
+/**
+ * @param options - a subset of ConvexAuthNextjsMiddlewareOptions
+ * @returns NextjsOptions
+ */
+export function getConvexNextjsOptions(options: {
+  convexUrl?: string;
+}): NextjsOptions {
+  // If `convexUrl` is provided (even if it's undefined), pass it as the `url` option.
+  // `convex/nextjs` has its own logic for falling back to `process.env.NEXT_PUBLIC_CONVEX_URL`
+  // and protecting against accidentally passing in `undefined` (e.g. { convexUrl: process.env.VAR_I_DIDNT_SET })
+  if (Object.hasOwn(options, "convexUrl")) {
+    return {
+      url: options.convexUrl,
+    };
+  }
+  return {};
 }


### PR DESCRIPTION
In https://github.com/get-convex/convex-js/commit/3183379af8bdc2a525877818b9198b4dee6955e3 we guard against passing `url: undefined` to a `convex/nextjs` function, primarily to guard against things like `{ url: process.env.VAR_I_DIDNT_SET }` quietly falling back on the default `NEXT_PUBLIC_CONVEX_URL`.

However, we were passing through the optional `convexUrl` property, resulting in `{ url: undefined }` and crashing the Convex Auth related Next.js functions.

This adds a `getConvexNextjsOptions` that takes the relevant configuration for Convex Auth + Next.js (right now just `convexUrl`) and transforms it into the options for `fetchQuery` and friends.

I searched for imports for `convex/nextjs` and updated all of these to use this helper (also fixing multiple spots where we weren't respecting the `convexUrl` override in the first place)