### PR TITLE
Enable manual redirect handling

### DIFF
--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -182,7 +182,7 @@ export function AuthProvider({
   );
 
   const signIn = useCallback(
-    async (provider?: string, args?: FormData | Record<string, Value>) => {
+    async (provider?: string, args?: FormData | Record<string, Value>, redirect: boolean = true) => {
       const params =
         args instanceof FormData
           ? Array.from(args.entries()).reduce(
@@ -204,7 +204,7 @@ export function AuthProvider({
         const url = new URL(result.redirect);
         await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
-        if (window.location !== undefined) {
+        if (redirect && window.location !== undefined) {
           window.location.href = url.toString();
         }
         return { signingIn: false, redirect: url };

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -11,10 +11,10 @@ import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
 import { Value } from "convex/values";
 import { ReactNode, useContext, useMemo } from "react";
 import {
-	AuthProvider,
-	ConvexAuthActionsContext,
-	ConvexAuthTokenContext,
-	useAuth,
+  AuthProvider,
+  ConvexAuthActionsContext,
+  ConvexAuthTokenContext,
+  useAuth,
 } from "./client.js";
 import { AuthClient } from "./clientType.js";
 
@@ -31,7 +31,7 @@ import { AuthClient } from "./clientType.js";
  * ```
  */
 export function useAuthActions() {
-	return useContext(ConvexAuthActionsContext);
+  return useContext(ConvexAuthActionsContext);
 }
 
 /**
@@ -50,88 +50,88 @@ export function useAuthActions() {
  * ```
  */
 export function ConvexAuthProvider(props: {
-	/**
-	 * Your [`ConvexReactClient`](https://docs.convex.dev/api/classes/react.ConvexReactClient).
-	 */
-	client: ConvexReactClient;
-	/**
-	 * Optional custom storage object that implements
-	 * the {@link TokenStorage} interface, otherwise
-	 * [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
-	 * is used.
-	 *
-	 * You must set this for React Native.
-	 */
-	storage?: TokenStorage;
-	/**
-	 * Optional namespace for keys used to store tokens. The keys
-	 * determine whether the tokens are shared or not.
-	 *
-	 * Any non-alphanumeric characters will be ignored (for RN compatibility).
-	 *
-	 * Defaults to the deployment URL, as configured in the given `client`.
-	 */
-	storageNamespace?: string;
-	/**
-	 * Provide this function if you're using a JS router (Expo router etc.)
-	 * and after OAuth or magic link sign-in the `code` param is not being
-	 * erased from the URL.
-	 *
-	 * The implementation will depend on your chosen router.
-	 */
-	replaceURL?: (
-		/**
-		 * The URL, always starting with '/' and include the path, query and
-		 * fragment components, that the window location should be set to.
-		 */
-		relativeUrl: string,
-	) => void | Promise<void>;
-	/**
-	 * Children components can call Convex hooks
-	 * and {@link useAuthActions}.
-	 */
-	children: ReactNode;
+  /**
+   * Your [`ConvexReactClient`](https://docs.convex.dev/api/classes/react.ConvexReactClient).
+   */
+  client: ConvexReactClient;
+  /**
+   * Optional custom storage object that implements
+   * the {@link TokenStorage} interface, otherwise
+   * [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+   * is used.
+   *
+   * You must set this for React Native.
+   */
+  storage?: TokenStorage;
+  /**
+   * Optional namespace for keys used to store tokens. The keys
+   * determine whether the tokens are shared or not.
+   *
+   * Any non-alphanumeric characters will be ignored (for RN compatibility).
+   *
+   * Defaults to the deployment URL, as configured in the given `client`.
+   */
+  storageNamespace?: string;
+  /**
+   * Provide this function if you're using a JS router (Expo router etc.)
+   * and after OAuth or magic link sign-in the `code` param is not being
+   * erased from the URL.
+   *
+   * The implementation will depend on your chosen router.
+   */
+  replaceURL?: (
+    /**
+     * The URL, always starting with '/' and include the path, query and
+     * fragment components, that the window location should be set to.
+     */
+    relativeUrl: string,
+  ) => void | Promise<void>;
+  /**
+   * Children components can call Convex hooks
+   * and {@link useAuthActions}.
+   */
+  children: ReactNode;
 }) {
-	const { client, storage, storageNamespace, replaceURL, children } = props;
-	const authClient = useMemo(
-		() =>
-			({
-				authenticatedCall(action, args) {
-					return client.action(action, args);
-				},
-				unauthenticatedCall(action, args) {
-					return new ConvexHttpClient((client as any).address).action(
-						action,
-						args,
-					);
-				},
-				verbose: (client as any).options?.verbose,
-			}) satisfies AuthClient,
-		[client],
-	);
-	return (
-		<AuthProvider
-			client={authClient}
-			storage={
-				storage ??
-				// Handle SSR, RN, Web, etc.
-				// Pretend we always have storage, the component checks
-				// it in first useEffect.
-				(typeof window === "undefined" ? undefined : window?.localStorage)!
-			}
-			storageNamespace={storageNamespace ?? (client as any).address}
-			replaceURL={
-				replaceURL ??
-				((url) => {
-					window.history.replaceState({}, "", url);
-				})
-			}
-		>
-			<ConvexProviderWithAuth client={client} useAuth={useAuth}>
-				{children}
-			</ConvexProviderWithAuth>
-		</AuthProvider>
-	);
+  const { client, storage, storageNamespace, replaceURL, children } = props;
+  const authClient = useMemo(
+    () =>
+      ({
+        authenticatedCall(action, args) {
+          return client.action(action, args);
+        },
+        unauthenticatedCall(action, args) {
+          return new ConvexHttpClient((client as any).address).action(
+            action,
+            args,
+          );
+        },
+        verbose: (client as any).options?.verbose,
+      }) satisfies AuthClient,
+    [client],
+  );
+  return (
+    <AuthProvider
+      client={authClient}
+      storage={
+        storage ??
+        // Handle SSR, RN, Web, etc.
+        // Pretend we always have storage, the component checks
+        // it in first useEffect.
+        (typeof window === "undefined" ? undefined : window?.localStorage)!
+      }
+      storageNamespace={storageNamespace ?? (client as any).address}
+      replaceURL={
+        replaceURL ??
+        ((url) => {
+          window.history.replaceState({}, "", url);
+        })
+      }
+    >
+      <ConvexProviderWithAuth client={client} useAuth={useAuth}>
+        {children}
+      </ConvexProviderWithAuth>
+    </AuthProvider>
+  );
 }
 
 /**
@@ -145,103 +145,97 @@ export function ConvexAuthProvider(props: {
  * In React Native we recommend wrapping `expo-secure-store`.
  */
 export interface TokenStorage {
-	/**
-	 * Read a value.
-	 * @param key Unique key.
-	 */
-	getItem: (
-		key: string,
-	) => string | undefined | null | Promise<string | undefined | null>;
-	/**
-	 * Write a value.
-	 * @param key Unique key.
-	 * @param value The value to store.
-	 */
-	setItem: (key: string, value: string) => void | Promise<void>;
-	/**
-	 * Remove a value.
-	 * @param key Unique key.
-	 */
-	removeItem: (key: string) => void | Promise<void>;
+  /**
+   * Read a value.
+   * @param key Unique key.
+   */
+  getItem: (
+    key: string,
+  ) => string | undefined | null | Promise<string | undefined | null>;
+  /**
+   * Write a value.
+   * @param key Unique key.
+   * @param value The value to store.
+   */
+  setItem: (key: string, value: string) => void | Promise<void>;
+  /**
+   * Remove a value.
+   * @param key Unique key.
+   */
+  removeItem: (key: string) => void | Promise<void>;
 }
 
 /**
  * The result of calling {@link useAuthActions}.
  */
 export type ConvexAuthActionsContext = {
-	/**
-	 * Sign in via one of your configured authentication providers.
-	 *
-	 * @returns Whether the user was immediately signed in (ie. the sign-in
-	 *          didn't trigger an additional step like email verification
-	 *          or OAuth signin).
-	 */
-	signIn(
-		this: void,
-		/**
-		 * The ID of the provider (lowercase version of the
-		 * provider name or a configured `id` option value).
-		 */
-		provider: string,
-		/**
-		 * Either a `FormData` object containing the sign-in
-		 *        parameters or a plain object containing them.
-		 *        The shape required depends on the chosen provider's
-		 *        implementation.
-		 *
-		 * Special fields:
-		 *  - `redirectTo`: If provided, customizes the destination the user is
-		 *     redirected to at the end of an OAuth flow or the magic link URL.
-		 *     See [redirect callback](https://labs.convex.dev/auth/api_reference/server#callbacksredirect).
-		 *  - `code`: OTP code for email or phone verification, or
-		 *     (used only in RN) the code from an OAuth flow or magic link URL.
-		 */
-		params?:
-			| FormData
-			| (Record<string, Value> & {
-					/**
-					 * If provided, customizes the destination the user is
-					 * redirected to at the end of an OAuth flow or the magic link URL.
-					 */
-					redirectTo?: string;
-					/**
-					 * OTP code for email or phone verification, or
-					 * (used only in RN) the code from an OAuth flow or magic link URL.
-					 */
-					code?: string;
-			  }),
-		/**
-		 * Whether to automatically perform the redirect to the OAuth provider.
-		 * If false, the URL will be returned in the response to be handled by the client.
-		 * Defaults to `true`.
-		 */
-		redirect?: boolean,
-	): Promise<{
-		/**
-		 * Whether the call led to an immediate successful sign-in.
-		 *
-		 * Note that there's a delay between the `signIn` function
-		 * returning and the client performing the handshake with
-		 * the server to confirm the sign-in.
-		 */
-		signingIn: boolean;
-		/**
-		 * If the sign-in started an OAuth flow, this is the URL
-		 * the browser should be redirected to.
-		 *
-		 * Useful in RN for opening the in-app browser to
-		 * this URL.
-		 */
-		redirect?: URL;
-	}>;
+  /**
+   * Sign in via one of your configured authentication providers.
+   *
+   * @returns Whether the user was immediately signed in (ie. the sign-in
+   *          didn't trigger an additional step like email verification
+   *          or OAuth signin).
+   */
+  signIn(
+    this: void,
+    /**
+     * The ID of the provider (lowercase version of the
+     * provider name or a configured `id` option value).
+     */
+    provider: string,
+    /**
+     * Either a `FormData` object containing the sign-in
+     *        parameters or a plain object containing them.
+     *        The shape required depends on the chosen provider's
+     *        implementation.
+     *
+     * Special fields:
+     *  - `redirectTo`: If provided, customizes the destination the user is
+     *     redirected to at the end of an OAuth flow or the magic link URL.
+     *     See [redirect callback](https://labs.convex.dev/auth/api_reference/server#callbacksredirect).
+     *  - `code`: OTP code for email or phone verification, or
+     *     (used only in RN) the code from an OAuth flow or magic link URL.
+     */
+    params?:
+      | FormData
+      | (Record<string, Value> & {
+          /**
+           * If provided, customizes the destination the user is
+           * redirected to at the end of an OAuth flow or the magic link URL.
+           */
+          redirectTo?: string;
+          /**
+           * OTP code for email or phone verification, or
+           * (used only in RN) the code from an OAuth flow or magic link URL.
+           */
+          code?: string;
+        }),
+  ): Promise<{
+    /**
+     * Whether the call led to an immediate successful sign-in.
+     *
+     * Note that there's a delay between the `signIn` function
+     * returning and the client performing the handshake with
+     * the server to confirm the sign-in.
+     */
+    signingIn: boolean;
+    /**
+     * If the sign-in started an OAuth flow, this is the URL
+     * the browser should be redirected to.
+     *
+     * Useful in RN for opening the in-app browser to
+     * this URL.
+     */
+    redirect?: URL;
+  }>;
 
-	/**
-	 * Sign out the current user.
-	 *
-	 * Calls the server to invalidate the server session
-	 * and deletes the locally stored JWT and refresh token.
-	 */
-	signOut(this: void): Promise<void>;
+  /**
+   * Sign out the current user.
+   *
+   * Calls the server to invalidate the server session
+   * and deletes the locally stored JWT and refresh token.
+   */
+  signOut(this: void): Promise<void>;
 };
 
 /**
@@ -268,5 +262,5 @@ export type ConvexAuthActionsContext = {
  * ```
  */
 export function useAuthToken() {
-	return useContext(ConvexAuthTokenContext);
+  return useContext(ConvexAuthTokenContext);
 }

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -11,10 +11,10 @@ import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
 import { Value } from "convex/values";
 import { ReactNode, useContext, useMemo } from "react";
 import {
-  AuthProvider,
-  ConvexAuthActionsContext,
-  ConvexAuthTokenContext,
-  useAuth,
+	AuthProvider,
+	ConvexAuthActionsContext,
+	ConvexAuthTokenContext,
+	useAuth,
 } from "./client.js";
 import { AuthClient } from "./clientType.js";
 
@@ -31,7 +31,7 @@ import { AuthClient } from "./clientType.js";
  * ```
  */
 export function useAuthActions() {
-  return useContext(ConvexAuthActionsContext);
+	return useContext(ConvexAuthActionsContext);
 }
 
 /**
@@ -50,88 +50,88 @@ export function useAuthActions() {
  * ```
  */
 export function ConvexAuthProvider(props: {
-  /**
-   * Your [`ConvexReactClient`](https://docs.convex.dev/api/classes/react.ConvexReactClient).
-   */
-  client: ConvexReactClient;
-  /**
-   * Optional custom storage object that implements
-   * the {@link TokenStorage} interface, otherwise
-   * [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
-   * is used.
-   *
-   * You must set this for React Native.
-   */
-  storage?: TokenStorage;
-  /**
-   * Optional namespace for keys used to store tokens. The keys
-   * determine whether the tokens are shared or not.
-   *
-   * Any non-alphanumeric characters will be ignored (for RN compatibility).
-   *
-   * Defaults to the deployment URL, as configured in the given `client`.
-   */
-  storageNamespace?: string;
-  /**
-   * Provide this function if you're using a JS router (Expo router etc.)
-   * and after OAuth or magic link sign-in the `code` param is not being
-   * erased from the URL.
-   *
-   * The implementation will depend on your chosen router.
-   */
-  replaceURL?: (
-    /**
-     * The URL, always starting with '/' and include the path, query and
-     * fragment components, that the window location should be set to.
-     */
-    relativeUrl: string,
-  ) => void | Promise<void>;
-  /**
-   * Children components can call Convex hooks
-   * and {@link useAuthActions}.
-   */
-  children: ReactNode;
+	/**
+	 * Your [`ConvexReactClient`](https://docs.convex.dev/api/classes/react.ConvexReactClient).
+	 */
+	client: ConvexReactClient;
+	/**
+	 * Optional custom storage object that implements
+	 * the {@link TokenStorage} interface, otherwise
+	 * [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+	 * is used.
+	 *
+	 * You must set this for React Native.
+	 */
+	storage?: TokenStorage;
+	/**
+	 * Optional namespace for keys used to store tokens. The keys
+	 * determine whether the tokens are shared or not.
+	 *
+	 * Any non-alphanumeric characters will be ignored (for RN compatibility).
+	 *
+	 * Defaults to the deployment URL, as configured in the given `client`.
+	 */
+	storageNamespace?: string;
+	/**
+	 * Provide this function if you're using a JS router (Expo router etc.)
+	 * and after OAuth or magic link sign-in the `code` param is not being
+	 * erased from the URL.
+	 *
+	 * The implementation will depend on your chosen router.
+	 */
+	replaceURL?: (
+		/**
+		 * The URL, always starting with '/' and include the path, query and
+		 * fragment components, that the window location should be set to.
+		 */
+		relativeUrl: string,
+	) => void | Promise<void>;
+	/**
+	 * Children components can call Convex hooks
+	 * and {@link useAuthActions}.
+	 */
+	children: ReactNode;
 }) {
-  const { client, storage, storageNamespace, replaceURL, children } = props;
-  const authClient = useMemo(
-    () =>
-      ({
-        authenticatedCall(action, args) {
-          return client.action(action, args);
-        },
-        unauthenticatedCall(action, args) {
-          return new ConvexHttpClient((client as any).address).action(
-            action,
-            args,
-          );
-        },
-        verbose: (client as any).options?.verbose,
-      }) satisfies AuthClient,
-    [client],
-  );
-  return (
-    <AuthProvider
-      client={authClient}
-      storage={
-        storage ??
-        // Handle SSR, RN, Web, etc.
-        // Pretend we always have storage, the component checks
-        // it in first useEffect.
-        (typeof window === "undefined" ? undefined : window?.localStorage)!
-      }
-      storageNamespace={storageNamespace ?? (client as any).address}
-      replaceURL={
-        replaceURL ??
-        ((url) => {
-          window.history.replaceState({}, "", url);
-        })
-      }
-    >
-      <ConvexProviderWithAuth client={client} useAuth={useAuth}>
-        {children}
-      </ConvexProviderWithAuth>
-    </AuthProvider>
-  );
+	const { client, storage, storageNamespace, replaceURL, children } = props;
+	const authClient = useMemo(
+		() =>
+			({
+				authenticatedCall(action, args) {
+					return client.action(action, args);
+				},
+				unauthenticatedCall(action, args) {
+					return new ConvexHttpClient((client as any).address).action(
+						action,
+						args,
+					);
+				},
+				verbose: (client as any).options?.verbose,
+			}) satisfies AuthClient,
+		[client],
+	);
+	return (
+		<AuthProvider
+			client={authClient}
+			storage={
+				storage ??
+				// Handle SSR, RN, Web, etc.
+				// Pretend we always have storage, the component checks
+				// it in first useEffect.
+				(typeof window === "undefined" ? undefined : window?.localStorage)!
+			}
+			storageNamespace={storageNamespace ?? (client as any).address}
+			replaceURL={
+				replaceURL ??
+				((url) => {
+					window.history.replaceState({}, "", url);
+				})
+			}
+		>
+			<ConvexProviderWithAuth client={client} useAuth={useAuth}>
+				{children}
+			</ConvexProviderWithAuth>
+		</AuthProvider>
+	);
 }
 
 /**
@@ -145,97 +145,103 @@ export function ConvexAuthProvider(props: {
  * In React Native we recommend wrapping `expo-secure-store`.
  */
 export interface TokenStorage {
-  /**
-   * Read a value.
-   * @param key Unique key.
-   */
-  getItem: (
-    key: string,
-  ) => string | undefined | null | Promise<string | undefined | null>;
-  /**
-   * Write a value.
-   * @param key Unique key.
-   * @param value The value to store.
-   */
-  setItem: (key: string, value: string) => void | Promise<void>;
-  /**
-   * Remove a value.
-   * @param key Unique key.
-   */
-  removeItem: (key: string) => void | Promise<void>;
+	/**
+	 * Read a value.
+	 * @param key Unique key.
+	 */
+	getItem: (
+		key: string,
+	) => string | undefined | null | Promise<string | undefined | null>;
+	/**
+	 * Write a value.
+	 * @param key Unique key.
+	 * @param value The value to store.
+	 */
+	setItem: (key: string, value: string) => void | Promise<void>;
+	/**
+	 * Remove a value.
+	 * @param key Unique key.
+	 */
+	removeItem: (key: string) => void | Promise<void>;
 }
 
 /**
  * The result of calling {@link useAuthActions}.
  */
 export type ConvexAuthActionsContext = {
-  /**
-   * Sign in via one of your configured authentication providers.
-   *
-   * @returns Whether the user was immediately signed in (ie. the sign-in
-   *          didn't trigger an additional step like email verification
-   *          or OAuth signin).
-   */
-  signIn(
-    this: void,
-    /**
-     * The ID of the provider (lowercase version of the
-     * provider name or a configured `id` option value).
-     */
-    provider: string,
-    /**
-     * Either a `FormData` object containing the sign-in
-     *        parameters or a plain object containing them.
-     *        The shape required depends on the chosen provider's
-     *        implementation.
-     *
-     * Special fields:
-     *  - `redirectTo`: If provided, customizes the destination the user is
-     *     redirected to at the end of an OAuth flow or the magic link URL.
-     *     See [redirect callback](https://labs.convex.dev/auth/api_reference/server#callbacksredirect).
-     *  - `code`: OTP code for email or phone verification, or
-     *     (used only in RN) the code from an OAuth flow or magic link URL.
-     */
-    params?:
-      | FormData
-      | (Record<string, Value> & {
-          /**
-           * If provided, customizes the destination the user is
-           * redirected to at the end of an OAuth flow or the magic link URL.
-           */
-          redirectTo?: string;
-          /**
-           * OTP code for email or phone verification, or
-           * (used only in RN) the code from an OAuth flow or magic link URL.
-           */
-          code?: string;
-        }),
-  ): Promise<{
-    /**
-     * Whether the call led to an immediate successful sign-in.
-     *
-     * Note that there's a delay between the `signIn` function
-     * returning and the client performing the handshake with
-     * the server to confirm the sign-in.
-     */
-    signingIn: boolean;
-    /**
-     * If the sign-in started an OAuth flow, this is the URL
-     * the browser should be redirected to.
-     *
-     * Useful in RN for opening the in-app browser to
-     * this URL.
-     */
-    redirect?: URL;
-  }>;
+	/**
+	 * Sign in via one of your configured authentication providers.
+	 *
+	 * @returns Whether the user was immediately signed in (ie. the sign-in
+	 *          didn't trigger an additional step like email verification
+	 *          or OAuth signin).
+	 */
+	signIn(
+		this: void,
+		/**
+		 * The ID of the provider (lowercase version of the
+		 * provider name or a configured `id` option value).
+		 */
+		provider: string,
+		/**
+		 * Either a `FormData` object containing the sign-in
+		 *        parameters or a plain object containing them.
+		 *        The shape required depends on the chosen provider's
+		 *        implementation.
+		 *
+		 * Special fields:
+		 *  - `redirectTo`: If provided, customizes the destination the user is
+		 *     redirected to at the end of an OAuth flow or the magic link URL.
+		 *     See [redirect callback](https://labs.convex.dev/auth/api_reference/server#callbacksredirect).
+		 *  - `code`: OTP code for email or phone verification, or
+		 *     (used only in RN) the code from an OAuth flow or magic link URL.
+		 */
+		params?:
+			| FormData
+			| (Record<string, Value> & {
+					/**
+					 * If provided, customizes the destination the user is
+					 * redirected to at the end of an OAuth flow or the magic link URL.
+					 */
+					redirectTo?: string;
+					/**
+					 * OTP code for email or phone verification, or
+					 * (used only in RN) the code from an OAuth flow or magic link URL.
+					 */
+					code?: string;
+			  }),
+		/**
+		 * Whether to automatically perform the redirect to the OAuth provider.
+		 * If false, the URL will be returned in the response to be handled by the client.
+		 * Defaults to `true`.
+		 */
+		redirect?: boolean,
+	): Promise<{
+		/**
+		 * Whether the call led to an immediate successful sign-in.
+		 *
+		 * Note that there's a delay between the `signIn` function
+		 * returning and the client performing the handshake with
+		 * the server to confirm the sign-in.
+		 */
+		signingIn: boolean;
+		/**
+		 * If the sign-in started an OAuth flow, this is the URL
+		 * the browser should be redirected to.
+		 *
+		 * Useful in RN for opening the in-app browser to
+		 * this URL.
+		 */
+		redirect?: URL;
+	}>;
 
-  /**
-   * Sign out the current user.
-   *
-   * Calls the server to invalidate the server session
-   * and deletes the locally stored JWT and refresh token.
-   */
-  signOut(this: void): Promise<void>;
+	/**
+	 * Sign out the current user.
+	 *
+	 * Calls the server to invalidate the server session
+	 * and deletes the locally stored JWT and refresh token.
+	 */
+	signOut(this: void): Promise<void>;
 };
 
 /**
@@ -262,5 +268,5 @@ export type ConvexAuthActionsContext = {
  * ```
  */
 export function useAuthToken() {
-  return useContext(ConvexAuthTokenContext);
+	return useContext(ConvexAuthTokenContext);
 }

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -210,6 +210,12 @@ export type ConvexAuthActionsContext = {
            */
           code?: string;
         }),
+    /** 
+     * Whether to automatically perform the redirect in OAuth flows.
+     * If false, the redirect URL will be returned to the client to handle.
+     * Defaults to true.
+     */
+    redirect?: boolean,
   ): Promise<{
     /**
      * Whether the call led to an immediate successful sign-in.


### PR DESCRIPTION
Adds an optional boolean parameter to the `signIn` method from the `useAuthActions` hook to disable the automatic redirect. Defaults to `true`, so existing uses should be unaffected, but if set to `false` then the `signIn` function will not redirect, instead only returning the URL to be handled by the client. Enables behavior similar to the React Native OAuth flow for other platforms with similar restrictions on redirects, such as applications built with Tauri.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
