### PR TITLE
fix CryptoKey is not extractable

### DIFF
--- a/docs/pages/setup/manual.mdx
+++ b/docs/pages/setup/manual.mdx
@@ -56,7 +56,7 @@ Run the following script via `node generateKeys.mjs`:
 ```js filename="generateKeys.mjs"
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 
-const keys = await generateKeyPair("RS256");
+const keys = await generateKeyPair("RS256", { extractable: true });
 const privateKey = await exportPKCS8(keys.privateKey);
 const publicKey = await exportJWK(keys.publicKey);
 const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicKey }] });


### PR DESCRIPTION
# Fix Key Generation Script Error

## Description
This PR addresses an issue in the `generateKeys.mjs` script where the CryptoKey being generated was not extractable, causing the following error when attempting to export to PKCS8 format:
```
➜ node generateKeys.mjs
TypeError: CryptoKey is not extractable
    at genericExport (node_modules/jose/dist/webapi/lib/asn1.js:20:15)
    at toPKCS8 (node_modules/jose/dist/webapi/lib/asn1.js:31:12)
    at exportPKCS8 (node_modules/jose/dist/webapi/key/export.js:7:12)
    at generateKeys.mjs:4:26
```

## Changes
- Added `{ extractable: true }` to the `generateKeyPair` function options to ensure the generated keys can be properly exported
- This allows the script to successfully generate and export both the private key in PKCS8 format and the public key as JWK

## Testing
Tested the script with the fix and verified it now runs without errors and produces the expected JWT_PRIVATE_KEY and JWKS output.

<!-- The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore. -->
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
