### PR TITLE
Added missing import in nextjs docs page

### DIFF
--- a/docs/pages/authz/nextjs.mdx
+++ b/docs/pages/authz/nextjs.mdx
@@ -127,6 +127,7 @@ and `POST` or `PUT`
 [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers).
 
 ```tsx filename="app/example/page.tsx"
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
 import { api } from "@/convex/_generated/api";
 import { fetchMutation, fetchQuery } from "convex/nextjs";
 import { revalidatePath } from "next/cache";


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixed a missing import in the [Next.js docs page](https://labs.convex.dev/auth/authz/nextjs#calling-authenticated-mutations-and-actions) under the 'Calling authenticated mutations and actions' section. Added the missing `convexAuthNextjsToken` import in the code example.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
