### PR TITLE
Document the Sign In with Apple secret expiration

### DIFF
--- a/docs/pages/config/oauth/apple.mdx
+++ b/docs/pages/config/oauth/apple.mdx
@@ -160,6 +160,12 @@ Use the **Secret Key** value that was generated above and set it as the
 npx convex env set AUTH_APPLE_SECRET <yourapplesecret>
 ```
 
+<Callout type="warning">
+The client secret generated above is only valid for 6 months, which is the
+maximum time that Apple allows. After that, you'll need to generate a new secret
+and update your environment variables again.
+</Callout>
+
 ### Provider configuration in auth.ts
 
 Add the provider config to the `providers` array in `convex/auth.ts`. The


### PR DESCRIPTION
The client secret from Sign In with Apple is a JWT that must expire in less than 6 months. The
generator on the website generates tokens expiring in 6 months, but we’re not documenting it at
the moment. This can cause existing installations to break, so we should document it so that
users rotate their client secrets.