### PR TITLE
Add support for custom JWT claims

### DIFF
--- a/docs/pages/api_reference/nextjs/server.mdx
+++ b/docs/pages/api_reference/nextjs/server.mdx
@@ -457,8 +457,8 @@ Returns a function that accepts a `Request` object and returns whether the reque
 predefined routes that can be passed in as the first argument.
 
 You can use glob patterns to match multiple routes or a function to match against the request object.
-Path patterns and regular expressions are supported, for example: `['/foo', '/bar(.*)'] or `[/^/foo/.*$/]`
-For more information, see: https://github.com/pillarjs/path-to-regexp
+Path patterns and limited regular expressions are supported.
+For more information, see: https://www.npmjs.com/package/path-to-regexp/v/6.3.0
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Parameters</h3>
 

--- a/docs/pages/api_reference/server.mdx
+++ b/docs/pages/api_reference/server.mdx
@@ -8,6 +8,48 @@ and use the helpers it returns.
 
 Include [authTables](server.mdx#authtables) in your schema.
 
+## SignInAction
+
+
+The type of the signIn Convex Action returned from the auth() helper.
+
+This type is exported for implementors of other client integrations.
+However it is not stable, and may change until this library reaches 1.0.
+
+<h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
+
+[src/server/implementation/index.ts:65](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L65)
+
+***
+
+## SignOutAction
+
+
+The type of the signOut Convex Action returned from the auth() helper.
+
+This type is exported for implementors of other client integrations.
+However it is not stable, and may change until this library reaches 1.0.
+
+<h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
+
+[src/server/implementation/index.ts:74](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L74)
+
+***
+
+## IsAuthenticatedQuery
+
+
+The type of the isAuthenticated Convex Query returned from the auth() helper.
+
+This type is exported for implementors of other client integrations.
+However it is not stable, and may change until this library reaches 1.0.
+
+<h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
+
+[src/server/implementation/index.ts:83](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L83)
+
+***
+
 ## convexAuth()
 
 
@@ -139,7 +181,7 @@ based on credentials that they've supplied separately.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:91](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L91)
+[src/server/implementation/index.ts:103](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L103)
 
 ***
 
@@ -217,7 +259,7 @@ the user ID or `null` if the client isn't authenticated
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:479](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L479)
+[src/server/implementation/index.ts:493](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L493)
 
 ***
 
@@ -417,7 +459,7 @@ or throws an error.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:497](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L497)
+[src/server/implementation/index.ts:511](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L511)
 
 ***
 
@@ -560,7 +602,7 @@ secret does not match.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:557](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L557)
+[src/server/implementation/index.ts:571](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L571)
 
 ***
 
@@ -691,7 +733,7 @@ The new secret credential to store for this account.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:597](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L597)
+[src/server/implementation/index.ts:611](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L611)
 
 ***
 
@@ -763,7 +805,7 @@ Use this function to invalidate existing sessions.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:627](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L627)
+[src/server/implementation/index.ts:641](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L641)
 
 ***
 
@@ -853,7 +895,7 @@ or `null`.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/implementation/index.ts:649](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L649)
+[src/server/implementation/index.ts:663](https://github.com/get-convex/convex-auth/blob/main/src/server/implementation/index.ts#L663)
 
 ***
 
@@ -1534,6 +1576,95 @@ The `shouldLink` argument passed to `createAccount`.
 
 `Promise`\<`void`\>
 
+#### callbacks.addClaimsToJWT()?
+
+
+Add additional claims to the JWT.
+
+This callback is called before signing the JWT.
+
+<h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Parameters</h5>
+
+<table className="api_reference_table"><tbody>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+<tr>
+<td>
+
+`ctx`
+
+</td>
+<td>
+
+`GenericMutationCtx`\<`AnyDataModel`\>
+
+</td>
+<td>
+
+&hyphen;
+
+</td>
+</tr>
+<tr>
+<td>
+
+`args`
+
+</td>
+<td>
+
+`object`
+
+</td>
+<td>
+
+&hyphen;
+
+</td>
+</tr>
+<tr>
+<td>
+
+`args.userId`
+
+</td>
+<td>
+
+`GenericId`\<`"users"`\>
+
+</td>
+<td>
+
+The ID of the user to add custom JWT claims for.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`args.sessionId`
+
+</td>
+<td>
+
+`GenericId`\<`"authSessions"`\>
+
+</td>
+<td>
+
+The ID of the current session to add custom JWT claims for.
+
+</td>
+</tr>
+</tbody></table>
+
+<h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Returns</h5>
+
+`Promise`\<`object`\>
+
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
 [src/server/types.ts:22](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L22)
@@ -1549,7 +1680,7 @@ service.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:232](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L232)
+[src/server/types.ts:249](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L249)
 
 ***
 
@@ -1916,7 +2047,7 @@ The values passed to the `signIn` function.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:256](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L256)
+[src/server/types.ts:273](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L273)
 
 ***
 
@@ -1927,7 +2058,7 @@ Configurable options for an email provider config.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:268](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L268)
+[src/server/types.ts:285](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L285)
 
 ***
 
@@ -1944,14 +2075,14 @@ phone number instead of the email address.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:279](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L279)
+[src/server/types.ts:296](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L296)
 
 #### type
 
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:280](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L280)
+[src/server/types.ts:297](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L297)
 
 #### maxAge
 
@@ -1961,7 +2092,7 @@ Token expiration in seconds.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:284](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L284)
+[src/server/types.ts:301](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L301)
 
 #### sendVerificationRequest()
 
@@ -2067,7 +2198,7 @@ Send the phone number verification request.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:288](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L288)
+[src/server/types.ts:305](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L305)
 
 #### apiKey?
 
@@ -2077,7 +2208,7 @@ Defaults to `process.env.AUTH_<PROVIDER_ID>_KEY`.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:301](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L301)
+[src/server/types.ts:318](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L318)
 
 #### generateVerificationToken()?
 
@@ -2088,7 +2219,7 @@ Defaults to `process.env.AUTH_<PROVIDER_ID>_KEY`.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:310](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L310)
+[src/server/types.ts:327](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L327)
 
 #### normalizeIdentifier()?
 
@@ -2128,7 +2259,7 @@ The phone number used in `sendVerificationRequest`.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:316](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L316)
+[src/server/types.ts:333](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L333)
 
 #### authorize()?
 
@@ -2189,14 +2320,14 @@ The values passed to the `signIn` function.
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:324](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L324)
+[src/server/types.ts:341](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L341)
 
 #### options
 
 
 <h5 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-lg">Defined in</h5>
 
-[src/server/types.ts:331](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L331)
+[src/server/types.ts:348](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L348)
 
 ***
 
@@ -2207,7 +2338,7 @@ Configurable options for a phone provider config.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:337](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L337)
+[src/server/types.ts:354](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L354)
 
 ***
 
@@ -2227,7 +2358,7 @@ Similar to Auth.js Credentials config.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:344](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L344)
+[src/server/types.ts:361](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L361)
 
 ***
 
@@ -2247,7 +2378,7 @@ the config passed to `convexAuth`.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:353](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L353)
+[src/server/types.ts:370](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L370)
 
 ***
 
@@ -2270,7 +2401,7 @@ See [ConvexAuthConfig](server.mdx#convexauthconfig)
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:364](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L364)
+[src/server/types.ts:381](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L381)
 
 ***
 
@@ -2281,4 +2412,4 @@ Materialized Auth.js provider config.
 
 <h3 className="nx-font-semibold nx-tracking-tight nx-text-slate-900 dark:nx-text-slate-100 nx-mt-8 nx-text-2xl">Defined in</h3>
 
-[src/server/types.ts:372](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L372)
+[src/server/types.ts:389](https://github.com/get-convex/convex-auth/blob/main/src/server/types.ts#L389)

--- a/package.json
+++ b/package.json
@@ -63,20 +63,20 @@
     }
   },
   "dependencies": {
-    "arctic": "^1.2.0",
-    "cookie": "^1.0.1",
-    "cspell": "^8.17.2",
-    "jose": "^5.2.2",
+    "arctic": "^1.9.2",
+    "cookie": "^1.0.2",
+    "cspell": "^8.18.1",
+    "jose": "^5.10.0",
     "jwt-decode": "^4.0.0",
-    "lucia": "^3.2.0",
-    "oauth4webapi": "^3.1.2",
-    "oslo": "^1.1.2",
+    "lucia": "^3.2.2",
+    "oauth4webapi": "^3.3.2",
+    "oslo": "^1.2.1",
     "path-to-regexp": "^6.3.0",
     "server-only": "^0.0.1"
   },
   "peerDependencies": {
     "@auth/core": "^0.37.0",
-    "convex": "^1.17.0",
+    "convex": "^1.21.0",
     "react": "^18.2.0 || ^19.0.0-0"
   },
   "peerDependenciesMeta": {
@@ -93,20 +93,20 @@
     "@edge-runtime/vm": "^3.2.0",
     "@types/inquirer": "^9.0.7",
     "@types/node": "20.6.0",
-    "@types/react": "^18.3.12",
-    "@typescript-eslint/eslint-plugin": "^6.18.1",
-    "chalk": "^5.3.0",
+    "@types/react": "^19.0.12",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "chalk": "^5.4.1",
     "convex-test": "^0.0.20",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.4.7",
     "eslint": "8.49.0",
-    "inquirer": "^9.2.22",
-    "next": "^15.0.3",
+    "inquirer": "^9.3.7",
+    "next": "^15.2.4",
     "npm-run-all": "^4.1.5",
     "react-dom": "^18.3.1",
     "shelljs": "^0.8.5",
-    "tsup": "^8.0.1",
-    "typescript": "^5.5.2",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.2",
     "valibot": "^0.35.0",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.1"
   }
 }

--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -207,14 +207,14 @@ export function AuthProvider({
         if (window.location !== undefined) {
           window.location.href = url.toString();
         }
-        return { signingIn: false, redirect: url };
+        return { signingIn: false, redirect: url, error: result.error  };
       } else if (result.tokens !== undefined) {
         const { tokens } = result;
         logVerbose(`signed in and got tokens, is null: ${tokens === null}`);
         await setToken({ shouldStore: true, tokens });
-        return { signingIn: result.tokens !== null };
+        return { signingIn: result.tokens !== null, error: result.error };
       }
-      return { signingIn: false };
+      return { signingIn: false, error: result.error };
     },
     [client, setToken, storageGet],
   );

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -199,17 +199,17 @@ export type ConvexAuthActionsContext = {
     params?:
       | FormData
       | (Record<string, Value> & {
-          /**
-           * If provided, customizes the destination the user is
-           * redirected to at the end of an OAuth flow or the magic link URL.
-           */
-          redirectTo?: string;
-          /**
-           * OTP code for email or phone verification, or
-           * (used only in RN) the code from an OAuth flow or magic link URL.
-           */
-          code?: string;
-        }),
+        /**
+         * If provided, customizes the destination the user is
+         * redirected to at the end of an OAuth flow or the magic link URL.
+         */
+        redirectTo?: string;
+        /**
+         * OTP code for email or phone verification, or
+         * (used only in RN) the code from an OAuth flow or magic link URL.
+         */
+        code?: string;
+      }),
   ): Promise<{
     /**
      * Whether the call led to an immediate successful sign-in.
@@ -227,6 +227,10 @@ export type ConvexAuthActionsContext = {
      * this URL.
      */
     redirect?: URL;
+    /**
+     * 
+     */
+    error?: string;
   }>;
 
   /**
@@ -264,3 +268,5 @@ export type ConvexAuthActionsContext = {
 export function useAuthToken() {
   return useContext(ConvexAuthTokenContext);
 }
+
+export { useAuth }

--- a/src/server/implementation/index.ts
+++ b/src/server/implementation/index.ts
@@ -405,6 +405,7 @@ export function convexAuth(config_: ConvexAuthConfig) {
         verifier?: string;
         tokens?: Tokens | null;
         started?: boolean;
+        error?: string;
       }> => {
         if (args.calledBy !== undefined) {
           logWithLevel("INFO", `\`auth:signIn\` called by ${args.calledBy}`);
@@ -598,7 +599,7 @@ export async function retrieveAccount<
   const actionCtx = ctx as unknown as ActionCtx;
   const result = await callRetreiveAccountWithCredentials(actionCtx, args);
   if (typeof result === "string") {
-    throw new Error(result);
+    throw new ConvexError(result);
   }
   return result;
 }

--- a/src/server/implementation/mutations/createAccountFromCredentials.ts
+++ b/src/server/implementation/mutations/createAccountFromCredentials.ts
@@ -1,4 +1,4 @@
-import { Infer, v } from "convex/values";
+import { ConvexError, Infer, v } from "convex/values";
 import { ActionCtx, Doc, MutationCtx } from "../types.js";
 import * as Provider from "../provider.js";
 import { ConvexCredentialsConfig } from "../../types.js";
@@ -44,21 +44,22 @@ export async function createAccountFromCredentialsImpl(
     )
     .unique();
   if (existingAccount !== null) {
-    if (
-      account.secret !== undefined &&
-      !(await Provider.verify(
-        provider,
-        account.secret,
-        existingAccount.secret ?? "",
-      ))
-    ) {
-      throw new Error(`Account ${account.id} already exists`);
-    }
-    return {
-      account: existingAccount,
-      // TODO: Ian removed this,
-      user: (await ctx.db.get(existingAccount.userId))!,
-    };
+    // if (
+    //   account.secret !== undefined &&
+    //   !(await Provider.verify(
+    //     provider,
+    //     account.secret,
+    //     existingAccount.secret ?? "",
+    //   ))
+    // ) {
+    //   throw new ConvexError(`Account ${account.id} already exists`);
+    // }
+    // return {
+    //   account: existingAccount,
+    //   // TODO: Ian removed this,
+    //   user: (await ctx.db.get(existingAccount.userId))!,
+    // };
+    throw new ConvexError(`Account ${account.id} already exists`);
   }
 
   const secret =

--- a/src/server/implementation/sessions.ts
+++ b/src/server/implementation/sessions.ts
@@ -74,7 +74,7 @@ export async function generateTokensForSession(
       args.parentRefreshTokenId,
     ));
   const result = {
-    token: await generateToken(ids, config),
+    token: await generateToken(ctx, ids, config),
     refreshToken: formatRefreshToken(refreshTokenId, args.sessionId),
   };
   logWithLevel(

--- a/src/server/implementation/tokens.ts
+++ b/src/server/implementation/tokens.ts
@@ -1,12 +1,14 @@
 import { GenericId } from "convex/values";
+import { importPKCS8, SignJWT } from "jose";
 import { ConvexAuthConfig } from "../index.js";
-import { SignJWT, importPKCS8 } from "jose";
 import { requireEnv } from "../utils.js";
+import { MutationCtx } from "./types.js";
 import { TOKEN_SUB_CLAIM_DIVIDER } from "./utils.js";
 
 const DEFAULT_JWT_DURATION_MS = 1000 * 60 * 60; // 1 hour
 
 export async function generateToken(
+  ctx: MutationCtx,
   args: {
     userId: GenericId<"users">;
     sessionId: GenericId<"authSessions">;
@@ -17,10 +19,12 @@ export async function generateToken(
   const expirationTime = new Date(
     Date.now() + (config.jwt?.durationMs ?? DEFAULT_JWT_DURATION_MS),
   );
-  return await new SignJWT({
-    sub: args.userId + TOKEN_SUB_CLAIM_DIVIDER + args.sessionId,
-  })
+  const jwtPayload = config.callbacks?.addClaimsToJWT ?
+    await config.callbacks.addClaimsToJWT(ctx, args) : undefined;
+
+  return await new SignJWT(jwtPayload)
     .setProtectedHeader({ alg: "RS256" })
+    .setSubject(args.userId + TOKEN_SUB_CLAIM_DIVIDER + args.sessionId)
     .setIssuedAt()
     .setIssuer(requireEnv("CONVEX_SITE_URL"))
     .setAudience("convex")

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -221,6 +221,23 @@ export type ConvexAuthConfig = {
         shouldLink?: boolean;
       },
     ) => Promise<void>;
+    /**
+     * Add additional claims to the JWT.
+     *
+     * This callback is called before signing the JWT.
+     */
+    addClaimsToJWT?: (
+      ctx: GenericMutationCtx<AnyDataModel>,
+      args: {
+        /**
+         * The ID of the user to add custom JWT claims for.
+         */
+        userId: GenericId<"users">;
+        /**
+         * The ID of the current session to add custom JWT claims for.
+         */
+        sessionId: GenericId<"authSessions">;
+      }) => Promise<{ [name: string]: unknown }>;
   };
 };
 
@@ -231,9 +248,9 @@ export type ConvexAuthConfig = {
  */
 export type AuthProviderConfig =
   | Exclude<
-      AuthjsProviderConfig,
-      CredentialsConfig | ((...args: any) => CredentialsConfig)
-    >
+    AuthjsProviderConfig,
+    CredentialsConfig | ((...args: any) => CredentialsConfig)
+  >
   | ConvexCredentialsConfig
   | ((...args: any) => ConvexCredentialsConfig)
   | PhoneConfig


### PR DESCRIPTION
<!-- Describe your PR here. -->
Add support for custom JWT claims.

This allows adding additional claims to the JWT generated by Convex Auth.

To add some context on the use case. This make it possible to verify and use claims in the auth middleware, or other services. 

```ts
// middleware.ts

import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
import { jwtVerify } from "jose";
import { NextResponse } from "next/server";

export default convexAuthNextjsMiddleware(async (request, { convexAuth }) => {
  const token = await convexAuth.getToken()
  if (token) {
    const { payload } = await jwtVerify(
      token,
      pubKey, // jwks
      { issuer: "..." } // convex site url
    )
    // use payload...
  }

  return NextResponse.next()
});

export const config = {
  // The following matcher runs middleware on all routes
  // except static assets.
  matcher: [
    "/((?!.*\\..*|_next).*)",
    "/",
    "/(api|trpc)(.*)",
  ],
};
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
