### PR TITLE
Update OTP Documentation

### DIFF
--- a/docs/pages/config/otps.mdx
+++ b/docs/pages/config/otps.mdx
@@ -76,7 +76,8 @@ export const ResendOTP = Email({
   id: "resend-otp",
   apiKey: process.env.AUTH_RESEND_KEY,
   maxAge: 60 * 15, // 15 minutes
-  async generateVerificationToken() {
+  // This function can be asynchronous
+  generateVerificationToken() {
     return generateRandomString(8, alphabet("0-9"));
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {


### PR DESCRIPTION
On strict type checking with a tool like Biome, the presence of `async` keyword results in an error

`This async function lacks an await expression`

This happens because of the `async` keyword in `async generateVerificationToken()`;

The `generateRandomString` from `oslo/crypto` package is not asynchronous.

