### PR TITLE
[cli] Run without prompts if in a non-interactive environment

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -745,31 +745,45 @@ async function promptForConfirmation(
   message: string,
   options: { default?: boolean } = {},
 ) {
-  const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
-    {
-      type: "confirm",
-      name: "confirmed",
-      message,
-      default: options.default ?? true,
-    },
-  ]);
-  return confirmed;
+  if (process.stdout.isTTY) {
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message,
+        default: options.default ?? true,
+      },
+    ]);
+    return confirmed;
+  } else {
+    return options.default ?? true;
+  }
 }
 
 async function promptForInput(
   message: string,
   options: { default?: string; validate?: (input: string) => true | string },
 ) {
-  const { input } = await inquirer.prompt<{ input: string }>([
-    {
-      type: "input",
-      name: "input",
-      message,
-      default: options.default,
-      validate: options.validate,
-    },
-  ]);
-  return input;
+  if (process.stdout.isTTY) {
+    const { input } = await inquirer.prompt<{ input: string }>([
+      {
+        type: "input",
+        name: "input",
+        message,
+        default: options.default,
+        validate: options.validate,
+      },
+    ]);
+    return input;
+  } else {
+    if (options.default !== undefined) {
+      return options.default;
+    } else {
+      logErrorAndExit(
+        "Run this command in an interactive terminal to provide input.",
+      );
+    }
+  }
 }
 
 function logErrorAndExit(message: string, error?: string): never {

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -1,4 +1,4 @@
-import { INVALID_PASSWORD } from "./errors.js"
+import { INVALID_PASSWORD } from "./errors.js";
 import GitHub from "@auth/core/providers/github";
 import Google from "@auth/core/providers/google";
 import Resend from "@auth/core/providers/resend";


### PR DESCRIPTION
If this is run in a non-interactive terminal, accept the defaults (or crash if there's no safe default) instead of just hanging.
