### PR TITLE
Latest version of Jose fails with this example code

### DIFF
--- a/docs/pages/setup/manual.mdx
+++ b/docs/pages/setup/manual.mdx
@@ -56,7 +56,9 @@ Run the following script via `node generateKeys.mjs`:
 ```js filename="generateKeys.mjs"
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 
-const keys = await generateKeyPair("RS256");
+const keys = await generateKeyPair("RS256", {
+  extractable: true,
+});
 const privateKey = await exportPKCS8(keys.privateKey);
 const publicKey = await exportJWK(keys.publicKey);
 const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicKey }] });


### PR DESCRIPTION
when following the guide, I got this error:

```
webdevcody:~/Workspace/site-sensei$ node generateKeys.mjs
file:///Users/webdevcody/Workspace/site-sensei/node_modules/jose/dist/webapi/lib/asn1.js:20
        throw new TypeError('CryptoKey is not extractable');
              ^

TypeError: CryptoKey is not extractable
    at genericExport (file:///Users/webdevcody/Workspace/site-sensei/node_modules/jose/dist/webapi/lib/asn1.js:20:15)
    at toPKCS8 (file:///Users/webdevcody/Workspace/site-sensei/node_modules/jose/dist/webapi/lib/asn1.js:31:12)
    at exportPKCS8 (file:///Users/webdevcody/Workspace/site-sensei/node_modules/jose/dist/webapi/key/export.js:7:12)
    at file:///Users/webdevcody/Workspace/site-sensei/generateKeys.mjs:4:26

Node.js v20.16.0
```

adding this to the generateKeyPair method seemed to fix it... I'm guessing Jose has a new version.
```
{
  extractable: true,
}
```

so that this script doesn't fail when ran with latest jose version

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
