### PR TITLE
added null checks for result properties.

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -12,6 +12,7 @@ import {
   logVerbose,
   setAuthCookies,
 } from "./utils.js";
+import { ConvexError } from "convex/values";
 
 export async function proxyAuthActionToConvex(
   request: NextRequest,
@@ -77,7 +78,10 @@ export async function proxyAuthActionToConvex(
       console.error(`Hit error while running \`auth:signIn\`:`);
       console.error(error);
       let response;
-      if (error instanceof Error && error.message) {
+
+      if (error instanceof ConvexError) {
+        response = jsonResponse({ error });
+      } else if (error instanceof Error && error.message) {
         response = jsonResponse({
           error: {
             name: error.name,
@@ -114,7 +118,7 @@ export async function proxyAuthActionToConvex(
       const response = jsonResponse({
         tokens:
           result.tokens !== null
-            ? { token: result.tokens.token, refreshToken: "dummy" }
+            ? { token: result.tokens?.token, refreshToken: "dummy" }
             : null,
       });
       await setAuthCookies(response, result.tokens, cookieConfig);

--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -76,19 +76,32 @@ export async function proxyAuthActionToConvex(
     } catch (error) {
       console.error(`Hit error while running \`auth:signIn\`:`);
       console.error(error);
+      let response;
+      if (error instanceof Error && error.message) {
+        response = jsonResponse({
+          error: {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+            cause: error.cause,
+          },
+        });
+      } else {
+        response = jsonResponse({ error });
+      }
       logVerbose(`Clearing auth cookies`, verbose);
-      const response = jsonResponse(null);
       await setAuthCookies(response, null, cookieConfig);
       return response;
     }
-    if (result.redirect !== undefined) {
+    if (result?.redirect !== undefined) {
       const { redirect } = result;
       const response = jsonResponse({ redirect });
       (await getResponseCookies(response, cookieConfig)).verifier =
         result.verifier!;
       logVerbose(`Redirecting to ${redirect}`, verbose);
       return response;
-    } else if (result.tokens !== undefined) {
+    }
+    if (result?.tokens !== undefined) {
       // The server doesn't share the refresh token with the client
       // for added security - the client has to use the server
       // to refresh the access token via cookies.

--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -1,4 +1,4 @@
-import { Value } from "convex/values";
+import { ConvexError, Value } from "convex/values";
 import {
   ReactNode,
   createContext,
@@ -240,7 +240,7 @@ export function AuthProvider({
         { provider, params, verifier },
       );
 
-      if ("error" in result) throw result.error;
+      if ("error" in result) throw new ConvexError(result.error);
 
       if (result?.redirect !== undefined) {
         const url = new URL(result.redirect);

--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -237,7 +237,10 @@ export function AuthProvider({
         "auth:signIn" as unknown as SignInAction,
         { provider, params, verifier },
       );
-      if (result.redirect !== undefined) {
+
+      if ("error" in result) throw result.error;
+
+      if (result?.redirect !== undefined) {
         const url = new URL(result.redirect);
         await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
@@ -245,7 +248,8 @@ export function AuthProvider({
           window.location.href = url.toString();
         }
         return { signingIn: false, redirect: url };
-      } else if (result.tokens !== undefined) {
+      }
+      if (result?.tokens !== undefined) {
         const { tokens } = result;
         logVerbose(`signed in and got tokens, is null: ${tokens === null}`);
         await setToken({ shouldStore: true, tokens });


### PR DESCRIPTION
## Brief description: 
optional chaining added on property accessors, passing errors from proxy, allowing handling them on client side in nextjs

<!-- Describe your PR here. -->
Bunch of folks (including me) were running into issues with error on accessing property on null object. 
#103 
When addressed by adding optional chaining it turned out that when authentication is unsuccessful, the error was the one providing feedback to the client side of the app, and by resolving issue auth errors were only visible on server end. 
Added trivial passing errors in the response from nextjs proxy. This looks like a small can of worms as proper error handling should probably be introduced. 
Since unsure on how maintainers would see best implementation of that, I left the fix at simplest possible implementation that can be built upon by adding matching type declarations on return type of signIn method of the convexAuth function 
https://github.com/get-convex/convex-auth/blob/ffba54c0b3bd9d98ebde75df149eba3de0aafab2/src/server/implementation/index.ts#L403

Errors themselves can look a bit rough as well and properly distinguishing between them is currently a little clunky as requires few splits and manual parsing of the message to get to the actual error type
### example:
`Error: [Request ID: 7a4755d4241579bb] Server Error\nUncaught Error: Could not verify code\n`

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
