### PR TITLE
Add missing Platform import for React Native setup

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -280,6 +280,7 @@ Then replace `ConvexProvider` from `convex/react` with `ConvexAuthProvider` from
 Provide a `storage` implementation using `expo-secure-store` as shown:
 
 ```tsx filename="app/_layout.tsx" {1,2,4,10-14,18,22}
+import { Platform } from 'react-native'
 import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ConvexReactClient } from "convex/react";
 import { Stack } from "expo-router";

--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -279,7 +279,7 @@ Then replace `ConvexProvider` from `convex/react` with `ConvexAuthProvider` from
 
 Provide a `storage` implementation using `expo-secure-store` as shown:
 
-```tsx filename="app/_layout.tsx" {1,2,4,10-14,18,22}
+```tsx filename="app/_layout.tsx" {1-3,5,11-15,19,23}
 import { Platform } from 'react-native'
 import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ConvexReactClient } from "convex/react";


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adding missing impor for react native setup in the `setup.mdx` file

This pull request updates the documentation to reflect the correct usage of the `ConvexAuthProvider` component from the `@convex-dev/auth/react` package, replacing the older `ConvexProvider` from `convex/react`.

Documentation updates:

* [`docs/pages/setup.mdx`](diffhunk://#diff-3c922c2063f438e0a8a6e8e6e44a9e4a24fd0522f6c0886f85d93efe404fd17fR283): Updated the example code to import `ConvexAuthProvider` instead of `ConvexProvider` and added an import for `Platform` from `react-native` to align with the updated example.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
