### PR TITLE
Remove Resend version warning

### DIFF
--- a/docs/pages/config/otps.mdx
+++ b/docs/pages/config/otps.mdx
@@ -60,10 +60,7 @@ Create a custom provider config for sending an OTP.
 1. The Resend SDK (`resend` on NPM)
 2. `oslo`, a handy library which is part of the Lucia project
 
-You can install these with `npm i resend@3.2.0 oslo`.
-
-_Note: `resend` v3.3 and v3.4 is broken in Convex runtime, fix is coming in
-v3.5_
+You can install these with `npm i resend oslo`.
 
 </Aside>
 


### PR DESCRIPTION
Now that Resend 3.5 has been released more than 9 months ago, I think it’s fine just asking people to `npm i resend`.