### PR TITLE
Fix error in manual setup steps for JWT keys

### DIFF
--- a/docs/pages/setup/manual.mdx
+++ b/docs/pages/setup/manual.mdx
@@ -56,7 +56,7 @@ Run the following script via `node generateKeys.mjs`:
 ```js filename="generateKeys.mjs"
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 
-const keys = await generateKeyPair("RS256");
+const keys = await generateKeyPair("RS256", { extractable: true });
 const privateKey = await exportPKCS8(keys.privateKey);
 const publicKey = await exportJWK(keys.publicKey);
 const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicKey }] });


### PR DESCRIPTION
In the latest version of `jose` (v6), `exportPKCS8()` throws the error `TypeError: CryptoKey is not extractable` unless the option `{ extractable: true }` is set when creating the keypair with `generateKeyPair()`.

The code snippet works when this option is set and Convex auth functions normally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
