### PR TITLE
Migrate from `oslo` to `@oslojs`

### DIFF
--- a/docs/pages/config/otps.mdx
+++ b/docs/pages/config/otps.mdx
@@ -58,9 +58,9 @@ Create a custom provider config for sending an OTP.
 <Aside title="This example uses additional dependencies">
 
 1. The Resend SDK (`resend` on NPM)
-2. `oslo`, a handy library which is part of the Lucia project
+2. `@oslojs/crypto`, a handy library with cryptographic primitives used for auth
 
-You can install these with `npm i resend@3.2.0 oslo`.
+You can install these with `npm i resend@3.2.0 @oslojs/crypto`.
 
 _Note: `resend` v3.3 and v3.4 is broken in Convex runtime, fix is coming in
 v3.5_
@@ -70,15 +70,21 @@ v3.5_
 ```ts filename="convex/ResendOTP.ts"
 import { Email } from "@convex-dev/auth/providers/Email";
 import { Resend as ResendAPI } from "resend";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 export const ResendOTP = Email({
   id: "resend-otp",
   apiKey: process.env.AUTH_RESEND_KEY,
   maxAge: 60 * 15, // 15 minutes
-  // This function can be asynchronous
-  generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+  async generateVerificationToken() {
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    return generateRandomString(random, alphabet, 8);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);

--- a/docs/pages/config/otps.mdx
+++ b/docs/pages/config/otps.mdx
@@ -84,7 +84,8 @@ export const ResendOTP = Email({
     };
 
     const alphabet = "0123456789";
-    return generateRandomString(random, alphabet, 8);
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);

--- a/docs/pages/config/passwords.mdx
+++ b/docs/pages/config/passwords.mdx
@@ -193,7 +193,8 @@ export const ResendOTPPasswordReset = Resend({
     };
 
     const alphabet = "0123456789";
-    return generateRandomString(random, alphabet, 8);
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);
@@ -320,7 +321,8 @@ export const ResendOTP = Resend({
     };
 
     const alphabet = "0123456789";
-    return generateRandomString(random, alphabet, 8);
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);

--- a/docs/pages/config/passwords.mdx
+++ b/docs/pages/config/passwords.mdx
@@ -171,22 +171,29 @@ First, create a custom email provider.
 <Aside title="This example sends an OTP and uses additional dependencies">
 
 1. The Resend SDK (`resend` on NPM)
-2. `oslo`, a handy library which is part of the Lucia project
+2. `@oslojs/crypto`, a handy library with cryptographic primitives used for auth
 
-You can install these with `npm i resend oslo`.
+You can install these with `npm i resend @oslojs/crypto`.
 
 </Aside>
 
 ```ts filename="convex/ResendOTPPasswordReset.ts"
 import Resend from "@auth/core/providers/resend";
 import { Resend as ResendAPI } from "resend";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 export const ResendOTPPasswordReset = Resend({
   id: "resend-otp",
   apiKey: process.env.AUTH_RESEND_KEY,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    return generateRandomString(random, alphabet, 8);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);
@@ -291,22 +298,29 @@ First, create a custom email provider.
 <Aside title="This example sends an OTP and uses additional dependencies">
 
 1. Resend and its SDK
-2. Oslo, a handy library which is part of the Lucia project
+2. `@oslojs/crypto`, a handy library with cryptographic primitives used for auth
 
-You can install these with `npm i resend oslo`.
+You can install these with `npm i resend @oslojs/crypto`.
 
 </Aside>
 
 ```ts filename="convex/ResendOTP.ts"
 import Resend from "@auth/core/providers/resend";
 import { Resend as ResendAPI } from "resend";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 export const ResendOTP = Resend({
   id: "resend-otp",
   apiKey: process.env.AUTH_RESEND_KEY,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    return generateRandomString(random, alphabet, 8);
   },
   async sendVerificationRequest({ identifier: email, provider, token }) {
     const resend = new ResendAPI(provider.apiKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "cookie": "^1.0.1",
         "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
-        "oslo": "^1.1.2",
         "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },
@@ -2393,6 +2394,37 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "arctic": "^1.2.0",
         "cookie": "^1.0.1",
         "cspell": "^8.17.2",
@@ -18,7 +19,6 @@
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
-        "oslo": "^1.1.2",
         "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },
@@ -2352,6 +2352,12 @@
         "@oslojs/asn1": "1.0.0",
         "@oslojs/binary": "1.0.0"
       }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.81",
       "license": "Apache-2.0",
       "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
         "arctic": "^1.2.0",
         "cookie": "^1.0.1",
         "cspell": "^8.17.2",
@@ -2325,6 +2326,31 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
       }
     },
     "node_modules/@panva/hkdf": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     }
   },
   "dependencies": {
+    "@oslojs/crypto": "^1.0.1",
     "arctic": "^1.2.0",
     "cookie": "^1.0.1",
     "cspell": "^8.17.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@oslojs/crypto": "^1.0.1",
+    "@oslojs/encoding": "^1.1.0",
     "arctic": "^1.2.0",
     "cookie": "^1.0.1",
     "cspell": "^8.17.2",
@@ -72,7 +73,6 @@
     "jwt-decode": "^4.0.0",
     "lucia": "^3.2.0",
     "oauth4webapi": "^3.1.2",
-    "oslo": "^1.1.2",
     "path-to-regexp": "^6.3.0",
     "server-only": "^0.0.1"
   },

--- a/src/server/implementation/mutations/userOAuth.ts
+++ b/src/server/implementation/mutations/userOAuth.ts
@@ -48,7 +48,7 @@ export async function userOAuthImpl(
     config,
   );
 
-  const code = generateRandomString("0123456789", 8);
+  const code = generateRandomString(8, "0123456789");
   await ctx.db.delete(verifier._id);
   const existingVerificationCode = await ctx.db
     .query("authVerificationCodes")

--- a/src/server/implementation/mutations/userOAuth.ts
+++ b/src/server/implementation/mutations/userOAuth.ts
@@ -3,8 +3,7 @@ import { ActionCtx, MutationCtx } from "../types.js";
 import * as Provider from "../provider.js";
 import { OAuthConfig } from "@auth/core/providers/oauth.js";
 import { upsertUserAndAccount } from "../users.js";
-import { logWithLevel, sha256 } from "../utils.js";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { generateRandomString, logWithLevel, sha256 } from "../utils.js";
 
 const OAUTH_SIGN_IN_EXPIRATION_MS = 1000 * 60 * 2; // 2 minutes
 
@@ -49,7 +48,7 @@ export async function userOAuthImpl(
     config,
   );
 
-  const code = generateRandomString(8, alphabet("0-9"));
+  const code = generateRandomString("0123456789", 8);
   await ctx.db.delete(verifier._id);
   const existingVerificationCode = await ctx.db
     .query("authVerificationCodes")

--- a/src/server/implementation/signIn.ts
+++ b/src/server/implementation/signIn.ts
@@ -19,10 +19,10 @@ import {
   callVerifier,
   callVerifyCodeAndSignIn,
 } from "./mutations/index.js";
-import { alphabet, generateRandomString } from "oslo/crypto";
 import { redirectAbsoluteUrl, setURLSearchParam } from "./redirects.js";
 import { requireEnv } from "../utils.js";
 import { OAuth2Config, OIDCConfig } from "@auth/core/providers/oauth.js";
+import { generateRandomString } from "./utils.js";
 
 const DEFAULT_EMAIL_VERIFICATION_CODE_DURATION_S = 60 * 60 * 24; // 24 hours
 
@@ -121,9 +121,11 @@ async function handleEmailAndPhoneProvider(
     };
   }
 
+  const alphabet =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   const code = provider.generateVerificationToken
     ? await provider.generateVerificationToken()
-    : generateRandomString(32, alphabet("0-9", "A-Z", "a-z"));
+    : generateRandomString(alphabet, 32);
   const expirationTime =
     Date.now() +
     (provider.maxAge ?? DEFAULT_EMAIL_VERIFICATION_CODE_DURATION_S) * 1000;

--- a/src/server/implementation/signIn.ts
+++ b/src/server/implementation/signIn.ts
@@ -125,7 +125,7 @@ async function handleEmailAndPhoneProvider(
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
   const code = provider.generateVerificationToken
     ? await provider.generateVerificationToken()
-    : generateRandomString(alphabet, 32);
+    : generateRandomString(32, alphabet);
   const expirationTime =
     Date.now() +
     (provider.maxAge ?? DEFAULT_EMAIL_VERIFICATION_CODE_DURATION_S) * 1000;

--- a/src/server/implementation/utils.ts
+++ b/src/server/implementation/utils.ts
@@ -16,7 +16,7 @@ export async function sha256(input: string) {
   return encodeHexLowerCase(rawSha256(new TextEncoder().encode(input)));
 }
 
-export function generateRandomString(alphabet: string, length: number) {
+export function generateRandomString(length: number, alphabet: string) {
   const random: RandomReader = {
     read(bytes) {
       crypto.getRandomValues(bytes);

--- a/src/server/implementation/utils.ts
+++ b/src/server/implementation/utils.ts
@@ -1,5 +1,9 @@
 import { sha256 as rawSha256 } from "oslo/crypto";
 import { encodeHex } from "oslo/encoding";
+import {
+  RandomReader,
+  generateRandomString as osloGenerateRandomString,
+} from "@oslojs/crypto/random";
 
 export const TOKEN_SUB_CLAIM_DIVIDER = "|";
 export const REFRESH_TOKEN_DIVIDER = "|";
@@ -10,6 +14,16 @@ export function stringToNumber(value: string | undefined) {
 
 export async function sha256(input: string) {
   return encodeHex(await rawSha256(new TextEncoder().encode(input)));
+}
+
+export function generateRandomString(alphabet: string, length: number) {
+  const random: RandomReader = {
+    read(bytes) {
+      crypto.getRandomValues(bytes);
+    },
+  };
+
+  return osloGenerateRandomString(random, alphabet, length);
 }
 
 export function logError(error: unknown) {

--- a/src/server/implementation/utils.ts
+++ b/src/server/implementation/utils.ts
@@ -1,5 +1,5 @@
-import { sha256 as rawSha256 } from "oslo/crypto";
-import { encodeHex } from "oslo/encoding";
+import { sha256 as rawSha256 } from "@oslojs/crypto/sha2";
+import { encodeHexLowerCase } from "@oslojs/encoding";
 import {
   RandomReader,
   generateRandomString as osloGenerateRandomString,
@@ -13,7 +13,7 @@ export function stringToNumber(value: string | undefined) {
 }
 
 export async function sha256(input: string) {
-  return encodeHex(await rawSha256(new TextEncoder().encode(input)));
+  return encodeHexLowerCase(rawSha256(new TextEncoder().encode(input)));
 }
 
 export function generateRandomString(alphabet: string, length: number) {

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -44,13 +44,14 @@
       "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "cookie": "^1.0.1",
         "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
-        "oslo": "^1.1.2",
         "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -5861,6 +5861,126 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.0.3.tgz",
+      "integrity": "sha512-s3Q/NOorCsLYdCKvQlWU+a+GeAd3C8Rb3L1YnetsgwXzhc3UTWrtQpB/3eCjFOdGUj5QmXfRak12uocd1ZiiQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.0.3.tgz",
+      "integrity": "sha512-Zxl/TwyXVZPCFSf0u2BNj5sE0F2uR6iSKxWpq4Wlk/Sv9Ob6YCKByQTkV2y6BCic+fkabp9190hyrDdPA/dNrw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.0.3.tgz",
+      "integrity": "sha512-T5+gg2EwpsY3OoaLxUIofmMb7ohAUlcNZW0fPQ6YAutaWJaxt1Z1h+8zdl4FRIOr5ABAAhXtBcpkZNwUcKI2fw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.0.3.tgz",
+      "integrity": "sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.0.3.tgz",
+      "integrity": "sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.0.3.tgz",
+      "integrity": "sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.0.3.tgz",
+      "integrity": "sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.0.3.tgz",
+      "integrity": "sha512-VNAz+HN4OGgvZs6MOoVfnn41kBzT+M+tB+OK4cww6DNyWS6wKaDpaAm/qLeOUbnMh0oVx1+mg0uoYARF69dJyA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/test-router/convex/otp/FakePhone.ts
+++ b/test-router/convex/otp/FakePhone.ts
@@ -1,5 +1,5 @@
 import { PhoneConfig, PhoneUserConfig } from "@convex-dev/auth/server";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 export function FakePhone(config: PhoneUserConfig): PhoneConfig {
   return {
@@ -7,7 +7,15 @@ export function FakePhone(config: PhoneUserConfig): PhoneConfig {
     type: "phone",
     maxAge: 60 * 20, // 20 minutes
     async generateVerificationToken() {
-      return generateRandomString(6, alphabet("0-9"));
+      const random: RandomReader = {
+        read(bytes) {
+          crypto.getRandomValues(bytes);
+        },
+      };
+
+      const alphabet = "0123456789";
+      const length = 6;
+      return generateRandomString(random, alphabet, length);
     },
     async sendVerificationRequest({ identifier: phone, provider, token }) {
       const response = await fetch("https://api.sms.com", {

--- a/test-router/convex/otp/ResendOTP.ts
+++ b/test-router/convex/otp/ResendOTP.ts
@@ -1,5 +1,5 @@
 import Resend from "@auth/core/providers/resend";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 import { Resend as ResendAPI } from "resend";
 import { VerificationCodeEmail } from "./VerificationCodeEmail";
 
@@ -8,7 +8,15 @@ export const ResendOTP = Resend({
   apiKey: process.env.AUTH_RESEND_KEY,
   maxAge: 60 * 20,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({
     identifier: email,

--- a/test-router/convex/passwordReset/ResendOTPPasswordReset.ts
+++ b/test-router/convex/passwordReset/ResendOTPPasswordReset.ts
@@ -1,5 +1,5 @@
 import Resend from "@auth/core/providers/resend";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 import { Resend as ResendAPI } from "resend";
 import { PasswordResetEmail } from "./PasswordResetEmail";
 
@@ -7,7 +7,15 @@ export const ResendOTPPasswordReset = Resend({
   id: "resend-otp-password-reset",
   apiKey: process.env.AUTH_RESEND_KEY,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({
     identifier: email,

--- a/test-router/package.json
+++ b/test-router/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@convex-dev/auth": "file:..",
+    "@oslojs/crypto": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",

--- a/test/convex/otp/FakePhone.ts
+++ b/test/convex/otp/FakePhone.ts
@@ -1,13 +1,21 @@
 import { Phone } from "@convex-dev/auth/providers/Phone";
 import { PhoneUserConfig } from "@convex-dev/auth/server";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 export function FakePhone(config: PhoneUserConfig) {
   return Phone({
     id: "fake-phone",
     maxAge: 60 * 20, // 20 minutes
     async generateVerificationToken() {
-      return generateRandomString(6, alphabet("0-9"));
+      const random: RandomReader = {
+        read(bytes) {
+          crypto.getRandomValues(bytes);
+        },
+      };
+
+      const alphabet = "0123456789";
+      const length = 6;
+      return generateRandomString(random, alphabet, length);
     },
     async sendVerificationRequest({ identifier: phone, provider, token }) {
       const response = await fetch("https://api.sms.com", {

--- a/test/convex/otp/ResendOTP.ts
+++ b/test/convex/otp/ResendOTP.ts
@@ -1,5 +1,5 @@
 import { Email } from "@convex-dev/auth/providers/Email";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 import { Resend as ResendAPI } from "resend";
 import { VerificationCodeEmail } from "./VerificationCodeEmail";
 
@@ -8,7 +8,15 @@ export const ResendOTP = Email({
   apiKey: process.env.AUTH_RESEND_KEY,
   maxAge: 60 * 20,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({
     identifier: email,

--- a/test/convex/otp/TwilioOTP.ts
+++ b/test/convex/otp/TwilioOTP.ts
@@ -1,6 +1,6 @@
 import { Phone } from "@convex-dev/auth/providers/Phone";
 import { internal } from "../_generated/api";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 
 /**
  * Uses Twilio messaging to send an OTP code.
@@ -18,7 +18,15 @@ export const TwilioOTP = Phone({
   id: "twilio-otp",
   maxAge: 60 * 20, // 20 minutes
   async generateVerificationToken() {
-    return generateRandomString(6, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    const length = 6;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({ identifier: phone, token }, ctx) {
     if (process.env.AUTH_TWILIO_FROM_NUMBER === undefined) {

--- a/test/convex/passwordReset/ResendOTPPasswordReset.ts
+++ b/test/convex/passwordReset/ResendOTPPasswordReset.ts
@@ -1,5 +1,5 @@
 import { Email } from "@convex-dev/auth/providers/Email";
-import { alphabet, generateRandomString } from "oslo/crypto";
+import { RandomReader, generateRandomString } from "@oslojs/crypto/random";
 import { Resend as ResendAPI } from "resend";
 import { PasswordResetEmail } from "./PasswordResetEmail";
 
@@ -7,7 +7,15 @@ export const ResendOTPPasswordReset = Email({
   id: "resend-otp-password-reset",
   apiKey: process.env.AUTH_RESEND_KEY,
   async generateVerificationToken() {
-    return generateRandomString(8, alphabet("0-9"));
+    const random: RandomReader = {
+      read(bytes) {
+        crypto.getRandomValues(bytes);
+      },
+    };
+
+    const alphabet = "0123456789";
+    const length = 8;
+    return generateRandomString(random, alphabet, length);
   },
   async sendVerificationRequest({
     identifier: email,

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/auth": "file:..",
+        "@oslojs/crypto": "^1.0.1",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
@@ -1347,6 +1348,31 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/auth": "file:..",
+        "@oslojs/crypto": "^1.0.1",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
@@ -26,7 +27,7 @@
         "react": "file:../node_modules/react",
         "react-colorful": "^5.6.1",
         "react-dom": "file:../node_modules/react-dom",
-        "resend": "3.2.0",
+        "resend": "^4.3.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "twilio": "^5.2.0"
@@ -62,13 +63,14 @@
       "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "cookie": "^1.0.1",
         "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
-        "oslo": "^1.1.2",
         "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },
@@ -1347,6 +1349,31 @@
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
     },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2467,40 +2494,36 @@
       }
     },
     "node_modules/@react-email/render": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-0.0.12.tgz",
-      "integrity": "sha512-S8WRv/PqECEi6x0QJBj0asnAb5GFtJaHlnByxLETLkgJjc76cxMYDH4r9wdbuJ4sjkcbpwP3LPnVzwS+aIjT7g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.6.tgz",
+      "integrity": "sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==",
+      "license": "MIT",
       "dependencies": {
         "html-to-text": "9.0.5",
-        "js-beautify": "^1.14.11",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "prettier": "3.5.3",
+        "react-promise-suspense": "0.3.4"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@react-email/render/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@react-email/render/node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render/node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@react-email/row": {
@@ -7409,11 +7432,12 @@
       "dev": true
     },
     "node_modules/resend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-3.2.0.tgz",
-      "integrity": "sha512-lDHhexiFYPoLXy7zRlJ8D5eKxoXy6Tr9/elN3+Vv7PkUoYuSSD1fpiIfa/JYXEWyiyN2UczkCTLpkT8dDPJ4Pg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.4.0.tgz",
+      "integrity": "sha512-SmVI3JCpgPNt4/m3Uy403LjoSeeleUE2X+KwPYQZcw+jiBCFsqL6vdf1r/XuQ7yOjvxYmlI8GD/oIWonFF9t9w==",
+      "license": "MIT",
       "dependencies": {
-        "@react-email/render": "0.0.12"
+        "@react-email/render": "1.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -7602,14 +7626,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scmp": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -26,7 +26,7 @@
         "react": "file:../node_modules/react",
         "react-colorful": "^5.6.1",
         "react-dom": "file:../node_modules/react-dom",
-        "resend": "3.2.0",
+        "resend": "^4.3.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "twilio": "^5.2.0"
@@ -59,11 +59,13 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "license": "Apache-2.0",
       "dependencies": {
         "arctic": "^1.2.0",
         "cookie": "^1.0.1",
+        "cspell": "^8.17.2",
+        "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
@@ -2466,40 +2468,36 @@
       }
     },
     "node_modules/@react-email/render": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-0.0.12.tgz",
-      "integrity": "sha512-S8WRv/PqECEi6x0QJBj0asnAb5GFtJaHlnByxLETLkgJjc76cxMYDH4r9wdbuJ4sjkcbpwP3LPnVzwS+aIjT7g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.6.tgz",
+      "integrity": "sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==",
+      "license": "MIT",
       "dependencies": {
         "html-to-text": "9.0.5",
-        "js-beautify": "^1.14.11",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "prettier": "3.5.3",
+        "react-promise-suspense": "0.3.4"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@react-email/render/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@react-email/render/node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render/node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@react-email/row": {
@@ -7408,11 +7406,12 @@
       "dev": true
     },
     "node_modules/resend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-3.2.0.tgz",
-      "integrity": "sha512-lDHhexiFYPoLXy7zRlJ8D5eKxoXy6Tr9/elN3+Vv7PkUoYuSSD1fpiIfa/JYXEWyiyN2UczkCTLpkT8dDPJ4Pg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.4.0.tgz",
+      "integrity": "sha512-SmVI3JCpgPNt4/m3Uy403LjoSeeleUE2X+KwPYQZcw+jiBCFsqL6vdf1r/XuQ7yOjvxYmlI8GD/oIWonFF9t9w==",
+      "license": "MIT",
       "dependencies": {
-        "@react-email/render": "0.0.12"
+        "@react-email/render": "1.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -7601,14 +7600,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scmp": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -60,7 +60,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.83",
+      "version": "0.0.87",
       "license": "Apache-2.0",
       "dependencies": {
         "@oslojs/crypto": "^1.0.1",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -60,9 +60,11 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.81",
+      "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "arctic": "^1.2.0",
         "cookie": "^1.0.1",
         "cspell": "^8.17.2",
@@ -71,7 +73,6 @@
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
         "oauth4webapi": "^3.1.2",
-        "oslo": "^1.1.2",
         "path-to-regexp": "^6.3.0",
         "server-only": "^0.0.1"
       },

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -27,7 +27,7 @@
         "react": "file:../node_modules/react",
         "react-colorful": "^5.6.1",
         "react-dom": "file:../node_modules/react-dom",
-        "resend": "^4.3.0",
+        "resend": "3.2.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "twilio": "^5.2.0"
@@ -2494,36 +2494,43 @@
       }
     },
     "node_modules/@react-email/render": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.6.tgz",
-      "integrity": "sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-0.0.12.tgz",
+      "integrity": "sha512-S8WRv/PqECEi6x0QJBj0asnAb5GFtJaHlnByxLETLkgJjc76cxMYDH4r9wdbuJ4sjkcbpwP3LPnVzwS+aIjT7g==",
       "license": "MIT",
       "dependencies": {
         "html-to-text": "9.0.5",
-        "prettier": "3.5.3",
-        "react-promise-suspense": "0.3.4"
+        "js-beautify": "^1.14.11",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
-    "node_modules/@react-email/render/node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+    "node_modules/@react-email/render/node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-email/render/node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
       },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
+      "peerDependencies": {
+        "react": "^18.2.0"
       }
     },
     "node_modules/@react-email/row": {
@@ -7432,12 +7439,12 @@
       "dev": true
     },
     "node_modules/resend": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-4.4.0.tgz",
-      "integrity": "sha512-SmVI3JCpgPNt4/m3Uy403LjoSeeleUE2X+KwPYQZcw+jiBCFsqL6vdf1r/XuQ7yOjvxYmlI8GD/oIWonFF9t9w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-3.2.0.tgz",
+      "integrity": "sha512-lDHhexiFYPoLXy7zRlJ8D5eKxoXy6Tr9/elN3+Vv7PkUoYuSSD1fpiIfa/JYXEWyiyN2UczkCTLpkT8dDPJ4Pg==",
       "license": "MIT",
       "dependencies": {
-        "@react-email/render": "1.0.6"
+        "@react-email/render": "0.0.12"
       },
       "engines": {
         "node": ">=18"
@@ -7626,6 +7633,15 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scmp": {

--- a/test/package.json
+++ b/test/package.json
@@ -36,7 +36,7 @@
     "react": "file:../node_modules/react",
     "react-colorful": "^5.6.1",
     "react-dom": "file:../node_modules/react-dom",
-    "resend": "^4.3.0",
+    "resend": "3.2.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "twilio": "^5.2.0"

--- a/test/package.json
+++ b/test/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@convex-dev/auth": "file:..",
+    "@oslojs/crypto": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",

--- a/test/package.json
+++ b/test/package.json
@@ -35,7 +35,7 @@
     "react": "file:../node_modules/react",
     "react-colorful": "^5.6.1",
     "react-dom": "file:../node_modules/react-dom",
-    "resend": "3.2.0",
+    "resend": "^4.3.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "twilio": "^5.2.0"


### PR DESCRIPTION
This removes our usage of the [deprecated](https://www.npmjs.com/package/oslo) `oslo/*` packages and replaces them with their `@oslojs/*` alternatives.