### PR TITLE
Remove the dependency on `arctic`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
-        "arctic": "^1.2.0",
         "cookie": "^1.0.1",
         "cspell": "^8.17.2",
         "is-network-error": "^1.1.0",
@@ -3135,14 +3134,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/arctic": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/arctic/-/arctic-1.9.0.tgz",
-      "integrity": "sha512-5llm2EMDM4wYv9q20JG19qnNAzEZj68MTYmZvfyKRivTHZqpR2uYHmN6umcaZjURvaaukwm5W6K1KH++qcdDRg==",
-      "dependencies": {
-        "oslo": "1.2.0"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     }
   },
   "dependencies": {
-    "arctic": "^1.2.0",
     "cookie": "^1.0.1",
     "cspell": "^8.17.2",
     "is-network-error": "^1.1.0",

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -41,11 +41,12 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.80",
+      "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
-        "arctic": "^1.2.0",
         "cookie": "^1.0.1",
+        "cspell": "^8.17.2",
+        "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -44,7 +44,6 @@
       "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
-        "arctic": "^1.2.0",
         "cookie": "^1.0.1",
         "is-network-error": "^1.1.0",
         "jose": "^5.2.2",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -59,11 +59,11 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.80",
+      "version": "0.0.82",
       "license": "Apache-2.0",
       "dependencies": {
-        "arctic": "^1.2.0",
         "cookie": "^1.0.1",
+        "is-network-error": "^1.1.0",
         "jose": "^5.2.2",
         "jwt-decode": "^4.0.0",
         "lucia": "^3.2.0",
@@ -84,6 +84,7 @@
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "chalk": "^5.3.0",
         "convex-test": "^0.0.20",
+        "cspell": "^8.17.2",
         "dotenv": "^16.4.5",
         "eslint": "8.49.0",
         "inquirer": "^9.2.22",


### PR DESCRIPTION
We’re not using `arctic` so it’s safe to remove.
