### PR TITLE
Fix error in password reset form

### DIFF
--- a/docs/pages/config/passwords.mdx
+++ b/docs/pages/config/passwords.mdx
@@ -261,7 +261,7 @@ export function PasswordReset() {
       <input name="email" value={step.email} type="hidden" />
       <input name="flow" value="reset-verification" type="hidden" />
       <button type="submit">Continue</button>
-      <button type="button" onClick={() => setStep("signIn")}>
+      <button type="button" onClick={() => setStep("forgot")}>
         Cancel
       </button>
     </form>


### PR DESCRIPTION
`setStep` is defined like this:

```
const [step, setStep] = useState<"forgot" | { email: string }>("forgot");
```
But we try to set the step to `signIn` like this:
```
<button type="button" onClick={() => setStep("signIn")}>
```
And we get this error:
```
Argument of type '"signIn"' is not assignable to parameter of type 'SetStateAction<"forgot" | { email: string; }>'
```

So I just fixed the small mistake by changing `setStep("signIn")` to `setStep("forgot")`.
Hope this helps :)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
