### PR TITLE
feat: should redirect param

### DIFF
--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -221,7 +221,7 @@ export function AuthProvider({
   );
 
   const signIn = useCallback(
-    async (provider?: string, args?: FormData | Record<string, Value>) => {
+    async (provider?: string, args?: FormData | Record<string, Value>, shouldRedirect: boolean = true) => {
       const params =
         args instanceof FormData
           ? Array.from(args.entries()).reduce(
@@ -243,7 +243,7 @@ export function AuthProvider({
         const url = new URL(result.redirect);
         await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
-        if (window.location !== undefined) {
+        if (window.location !== undefined && shouldRedirect) {
           window.location.href = url.toString();
         }
         return { signingIn: false, redirect: url };

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -210,6 +210,12 @@ export type ConvexAuthActionsContext = {
            */
           code?: string;
         }),
+    /**
+     * Whether to automatically redirect the user to the redirect URL.
+     *
+     * Defaults to `true`.
+     */
+    shouldRedirect?: boolean,
   ): Promise<{
     /**
      * Whether the call led to an immediate successful sign-in.


### PR DESCRIPTION
This PR aims to resolve issue #206.

Previously, the code attempted to detect a React Native environment by checking if `window.location === undefined`. However, this condition evaluates to `true` even in a React Native application (tested with Expo & Expo Router).

This PR introduces an optional `shouldRedirect` parameter, allowing it to be explicitly set to `false`. It defaults to `true`, ensuring this change is non-breaking.

This PR was trying to solve the problem some moths ago #160  (while adding some unwanted reformatting)

If someone could merge this ASAP would be great as the library is actually completely unusable on React Native for OAuth.

@thomasballinger @xixixao 

