### PR TITLE
match Convex Action error handling in nextjs api proxy

### DIFF
--- a/src/nextjs/client.tsx
+++ b/src/nextjs/client.tsx
@@ -29,6 +29,10 @@ export function ConvexAuthNextjsClientProvider({
         body: JSON.stringify(params),
         method: "POST",
       });
+      // Match error handling of Convex Actions
+      if (response.status >= 400) {
+        throw new Error((await response.json()).error);
+      }
       return await response.json();
     },
     [apiRoute],

--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -77,7 +77,8 @@ export async function proxyAuthActionToConvex(
       console.error(`Hit error while running \`auth:signIn\`:`);
       console.error(error);
       logVerbose(`Clearing auth cookies`, verbose);
-      const response = jsonResponse(null);
+      // Send raw error message to client, just like Convex Action would
+      const response = jsonResponse({ error: (error as Error).message }, 400);
       await setAuthCookies(response, null, cookieConfig);
       return response;
     }

--- a/src/nextjs/server/utils.ts
+++ b/src/nextjs/server/utils.ts
@@ -5,9 +5,10 @@ import {
 } from "./cookies.js";
 import { NextjsOptions } from "convex/nextjs";
 
-export function jsonResponse(body: any) {
+export function jsonResponse(body: any, status = 200) {
   return new NextResponse(JSON.stringify(body), {
     headers: { "Content-Type": "application/json" },
+    status,
   });
 }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes #103

Smaller scope alternative to #194

When Convex Auth runs from a react client (non-server), the sign in action throws on invalid input, eg., missing or invalid password. The nextjs auth api proxy swallows the error and returns a 200 response with a null body.

This solution:
- Returns a 400 with an `error` key in the body containing the error message (complete with stack trace, mirroring the non-next react behavior)
- Parses and throws the error in the nextjs authenticated function, which is only used for signIn and signOut
- Avoids changes outside of the immediately affected code paths (no react client changes)

Should we be throwing a stack trace? Maybe not. But the current nextjs behavior is a bug, and this solution matches what we already do intentionally for non nextjs apps.

Recommend improvements to this approach be split to a separate issue, the only proposal here is fixing the bug and aligning with existing working behavior.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
