### PR TITLE
Increase window location check specificity for Expo 53+

### DIFF
--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -243,7 +243,7 @@ export function AuthProvider({
         const url = new URL(result.redirect);
         await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
-        if (window.location !== undefined) {
+        if (window.location?.href !== undefined) {
           window.location.href = url.toString();
         }
         return { signingIn: false, redirect: url };
@@ -359,7 +359,7 @@ export function AuthProvider({
         return;
       }
       const code =
-        typeof window?.location !== "undefined"
+        typeof window?.location?.search !== "undefined"
           ? new URLSearchParams(window.location.search).get("code")
           : null;
       // code from URL is only consumed initially,


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes #206

Expo runtime introduced a default polyfill to metro runtime, making `window.location` no longer undefined. This breaks some of our client checks for the RN environment.

This fix makes checks more specific and looks for the actual property we're interacting with to be undefined.

#207 addresses this by adding an explicit prop, which definitely works, but I'd like to avoid adding more props. The library should just handle this for users.

A patch in #206 used `navigator.product` as a reference, which does appear to be reliably set to `ReactNative` ([source](https://github.com/facebook/react-native/blob/ca764bb5115d2e7baa6e07c49e64d4806f5b3d4a/packages/react-native/Libraries/Core/setUpNavigator.js#L18)). This is an option for the future if more changes in platforms make checking location object properties a dubious practice.
