### PR TITLE
add explicit react native check

### DIFF
--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -243,7 +243,10 @@ export function AuthProvider({
         const url = new URL(result.redirect);
         await storageSet(VERIFIER_STORAGE_KEY, result.verifier!);
         // Do not redirect in React Native
-        if (window.location?.href !== undefined) {
+        // Using a deprecated property because it's the only explicit check
+        // available, and they set it explicitly and intentionally for this
+        // purpose.
+        if (navigator.product !== "ReactNative") {
           window.location.href = url.toString();
         }
         return { signingIn: false, redirect: url };


### PR DESCRIPTION
Despite being deprecated and defined in specs as "returning 'Gecko' in all browsers", going with checking `navigator.product`.

- It's the only explicit way to check for the RN/Expo environment
- The React Native devs have kept this defined consistently since at least 2018 ([source](https://github.com/facebook/react-native/blob/a7810f6995f72f86605f8661992557f295146af6/packages/react-native/Libraries/Core/setUpNavigator.js#L18))
- Expo co-founder James Ide backed it ([source](https://github.com/facebook/react-native/issues/10881#issuecomment-261392494))
- Axios uses it ([source](https://github.com/axios/axios/blob/c7e0fea78716e86694d5023f8f17d174bf064e8a/lib/platform/common/utils.js#L5-L23))

There's no right way to do this, but I really don't want devs to have to go set a prop for this thing that no one should need to think about.

Fixes #206
Fixes #214

Replaces #216