### PR TITLE
Add `kid` to JWKs

### DIFF
--- a/docs/pages/setup/manual.mdx
+++ b/docs/pages/setup/manual.mdx
@@ -61,7 +61,8 @@ const keys = await generateKeyPair("RS256", {
 });
 const privateKey = await exportPKCS8(keys.privateKey);
 const publicKey = await exportJWK(keys.publicKey);
-const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicKey }] });
+const kid = crypto.randomUUID();
+const jwks = JSON.stringify({ keys: [{ use: "sig", kid, ...publicKey }] });
 
 process.stdout.write(
   `JWT_PRIVATE_KEY="${privateKey.trimEnd().replace(/\n/g, " ")}"`,
@@ -127,5 +128,5 @@ export default http;
 
 </Steps>
 
-Continue to [Step 3](/setup#add-authentication-tables-to-your-schema) in
-the Setup guide.
+Continue to [Step 3](/setup#add-authentication-tables-to-your-schema) in the
+Setup guide.

--- a/src/cli/generateKeys.ts
+++ b/src/cli/generateKeys.ts
@@ -5,7 +5,8 @@ export async function generateKeys() {
     const keys = await generateKeyPair("RS256");
     const privateKey = await exportPKCS8(keys.privateKey);
     const publicKey = await exportJWK(keys.publicKey);
-    const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicKey }] });
+    const kid = crypto.randomUUID();
+    const jwks = JSON.stringify({ keys: [{ use: "sig", kid, ...publicKey }] });
     return {
       JWT_PRIVATE_KEY: `${privateKey.trimEnd().replace(/\n/g, " ")}`,
       JWKS: jwks,


### PR DESCRIPTION
Use 'latest' JWK's kid in the signing headers. This is used by clients to efficiently find the right JWK from the list

I noticed this was missing when trying to use hono/jwk middleware

<!-- Describe your PR here. -->
Add `kid` to the JWKS and the signing headers so that clients can use it to find the JWK from the list to verify.

I choose, (maybe wrongly) that the 'latest' key it the first one in the list. Could go either way. 

While trying to use the convex auth supplied access token from a Hono api with their jwk middleware, I got an error about the `kid` field missing. 

I learned that it is to uniquely identify the JWK so the client does not have to check every key in the list from the endpoint. 

I check on how Openauth does this [here](https://github.com/toolbeam/openauth/blob/98dc59625e656eace1d7be165500af8ec351be41/packages/openauth/src/issuer.ts#L699)

I found that the Convex Backend uses the Biscuit library to decode the jwks [here](https://github.com/get-convex/convex-backend/blob/3726bd854526e2adc4529c8081bf75d5bdfe290b/crates/authentication/src/lib.rs#L506)


However, after checking on the source for the Biscuit `decode_with_jwks` I am not sure how it does not throw a similar error due to the missing `kid`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
