### PR TITLE
Added --non-interactive flag

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ new Command()
     "Configure additional variables for interactive configuration.",
   )
   .option("--skip-git-check", "Don't warn when running outside a Git checkout.")
+  .option("--non-interactive", "Automatically answer 'yes' to all prompts and use defaults for input.")
   .addDeploymentSelectionOptions(
     actionDescription("Set environment variables on"),
   )
@@ -52,6 +53,7 @@ new Command()
       convexFolderPath,
       deployment,
       step: 1,
+      nonInteractive: options.nonInteractive,
     };
 
     // Step 1: Configure SITE_URL
@@ -743,8 +745,11 @@ async function promptForConfirmationOrExit(
 
 async function promptForConfirmation(
   message: string,
-  options: { default?: boolean } = {},
+  options: { default?: boolean, nonInteractive?: boolean } = {},
 ) {
+  if (options.nonInteractive) {
+    return true;
+  }
   if (process.stdout.isTTY) {
     const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
       {
@@ -762,8 +767,11 @@ async function promptForConfirmation(
 
 async function promptForInput(
   message: string,
-  options: { default?: string; validate?: (input: string) => true | string },
+  options: { default?: string; validate?: (input: string) => true | string, nonInteractive?: boolean },
 ) {
+  if (options.nonInteractive) {
+    return options.default;
+  }
   if (process.stdout.isTTY) {
     const { input } = await inquirer.prompt<{ input: string }>([
       {


### PR DESCRIPTION
This pull request introduces a new `--non-interactive` option to the CLI, enabling automated workflows by bypassing interactive prompts and using default values where applicable. The changes ensure that the CLI can operate seamlessly in non-interactive environments.

### Addition of `--non-interactive` option:

* [`src/cli/index.ts`](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R25): Added a `--non-interactive` flag to the CLI options, allowing users to automatically answer 'yes' to all prompts and use default values for inputs.

### Integration of `--non-interactive` functionality:

* [`src/cli/index.ts`](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R56): Passed the `nonInteractive` flag to the deployment configuration options, ensuring it propagates correctly through the CLI workflow.
* [`src/cli/index.ts`](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L746-R752): Updated `promptForConfirmation` to return `true` immediately when `nonInteractive` is enabled, bypassing the confirmation prompt.
* [`src/cli/index.ts`](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L765-R774): Updated `promptForInput` to return the default value immediately when `nonInteractive` is enabled, bypassing the input prompt.<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
