### PR TITLE
Improve Custom User Schema Creation Docs

### DIFF
--- a/docs/pages/config/passwords.mdx
+++ b/docs/pages/config/passwords.mdx
@@ -495,7 +495,7 @@ import { Password } from "@convex-dev/auth/providers/Password";
 import { DataModel } from "./_generated/dataModel";
 
 export default Password<DataModel>({
-  profile(params) {
+  profile(params, ctx) {
     return {
       email: params.email as string,
       name: params.name as string,
@@ -504,6 +504,8 @@ export default Password<DataModel>({
   },
 });
 ```
+
+Replace the built-in `Password` provider with the one we've defined above. 
 
 Parametrizing `Password` with your `DataModel` gives you strict type checking
 for the return value of `profile`.


### PR DESCRIPTION
The `profile`  function takes a second ctx parameter which the docs did not include.

Additionally, it was not clear what to do with this new `Password` object, I added a line to make that clearer.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
