### PR TITLE
Support auth-less PKCE OAuth providers such as Lichess

### DIFF
--- a/src/server/oauth/callback.ts
+++ b/src/server/oauth/callback.ts
@@ -139,16 +139,8 @@ export async function handleOAuth(
       // TODO: move away from allowing insecure HTTP requests
       [o.allowInsecureRequests]: true,
       [o.customFetch]: (...args) => {
-        const [url, init] = args;
-        // Drop code_verifier if PKCE not used (existing behavior)
         if (!provider.checks.includes("pkce")) {
-          init?.body?.delete?.("code_verifier");
-        }
-        // Lichess public client: add client_id to token request body
-        if (String(url) === as.token_endpoint && client.token_endpoint_auth_method === "none") {
-          const body = init?.body;
-          // oauth4webapi uses URLSearchParams here, so we can safely set()
-          body?.set?.("client_id", String(client.client_id));
+          args[1].body.delete("code_verifier");
         }
         return fetchOpt(provider)[o.customFetch](...args);
       },


### PR DESCRIPTION
Some PKCE OAuth providers work without passing any secrets, notably Lichess.org ([see relevant docs](https://lichess.org/api#tag/OAuth)). This patch allows for simply omitting auth for such public implementations.

In case you'd like to see this in practice, here is an example Lichess provider configuration:

```ts
const Lichess: OAuthConfig<any> = {
  id: "lichess",
  name: "Lichess",
  type: "oauth",

  // PKCE is default, but we make it explicit and add CSRF 'state'
  checks: ["pkce", "state"],

  // Lichess OAuth endpoints
  authorization: {
    url: "https://lichess.org/oauth",
    params: {
      scope: "email:read",
    },
  },
  token: "https://lichess.org/api/token",
  userinfo: "https://lichess.org/api/account",

  // Public client (no client_secret)
  client: {
    token_endpoint_auth_method: "none",
  },

  // Lichess doesn't return OIDC claims; map to Auth.js User
  async profile(profile, tokens) {
    // profile from /api/account includes username; email requires a second call
    let email: string | undefined;
    try {
      const r = await fetch("https://lichess.org/api/account/email", {
        headers: {
          Authorization: `Bearer ${tokens.access_token}`,
          "Content-Type": "application/json",
        },
      });
      if (r.ok) {
        const data = await r.json();
        email = data?.email?.trim();
      }
    } catch {}

    return {
      id: profile.id,
      name: profile.username,
      email,
    };
  },

  // Configure your public client id. Lichess doesn’t have app registration; pick a stable string.
  clientId: process.env.LICHESS_CLIENT_ID!,
};
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
