### PR TITLE
Expose issueTokens helper and plumb runtime site URL

### DIFF
--- a/src/server/implementation/mutations/createAccountFromCredentials.ts
+++ b/src/server/implementation/mutations/createAccountFromCredentials.ts
@@ -5,6 +5,7 @@ import { ConvexCredentialsConfig } from "../../types.js";
 import { upsertUserAndAccount } from "../users.js";
 import { getAuthSessionId } from "../sessions.js";
 import { LOG_LEVELS, logWithLevel, maybeRedact } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const createAccountFromCredentialsArgs = v.object({
   provider: v.string(),
@@ -94,5 +95,6 @@ export const callCreateAccountFromCredentials = async (
       type: "createAccountFromCredentials",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/createVerificationCode.ts
+++ b/src/server/implementation/mutations/createVerificationCode.ts
@@ -5,6 +5,7 @@ import { EmailConfig, PhoneConfig } from "../../types.js";
 import { getAccountOrThrow, upsertUserAndAccount } from "../users.js";
 import { getAuthSessionId } from "../sessions.js";
 import { LOG_LEVELS, logWithLevel, sha256 } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const createVerificationCodeArgs = v.object({
   accountId: v.optional(v.id("authAccounts")),
@@ -80,6 +81,7 @@ export const callCreateVerificationCode = async (
       type: "createVerificationCode",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };
 

--- a/src/server/implementation/mutations/index.ts
+++ b/src/server/implementation/mutations/index.ts
@@ -117,6 +117,13 @@ export const storeImpl = async (
     config as any,
     fnArgs.env,
   );
+  if (process.env.AUTH_LOG_LEVEL === "DEBUG") {
+    console.debug("storeImpl runtimeEnv", {
+      pid: process.pid,
+      type: args.type,
+      runtimeEnv,
+    });
+  }
   logWithLevel(LOG_LEVELS.INFO, `\`auth:store\` type: ${args.type}`);
   switch (args.type) {
     case "signIn": {

--- a/src/server/implementation/mutations/invalidateSessions.ts
+++ b/src/server/implementation/mutations/invalidateSessions.ts
@@ -2,6 +2,7 @@ import { Infer, v } from "convex/values";
 import { deleteSession } from "../sessions.js";
 import { ActionCtx, MutationCtx } from "../types.js";
 import { LOG_LEVELS, logWithLevel } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const invalidateSessionsArgs = v.object({
   userId: v.id("users"),
@@ -17,6 +18,7 @@ export const callInvalidateSessions = async (
       type: "invalidateSessions",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };
 

--- a/src/server/implementation/mutations/modifyAccount.ts
+++ b/src/server/implementation/mutations/modifyAccount.ts
@@ -2,6 +2,7 @@ import { Infer, v } from "convex/values";
 import { ActionCtx, MutationCtx } from "../types.js";
 import { GetProviderOrThrowFunc, hash } from "../provider.js";
 import { LOG_LEVELS, logWithLevel, maybeRedact } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const modifyAccountArgs = v.object({
   provider: v.string(),
@@ -47,5 +48,6 @@ export const callModifyAccount = async (
       type: "modifyAccount",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/retrieveAccountWithCredentials.ts
+++ b/src/server/implementation/mutations/retrieveAccountWithCredentials.ts
@@ -7,6 +7,7 @@ import {
 } from "../rateLimit.js";
 import * as Provider from "../provider.js";
 import { LOG_LEVELS, logWithLevel, maybeRedact } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const retrieveAccountWithCredentialsArgs = v.object({
   provider: v.string(),
@@ -74,5 +75,6 @@ export const callRetreiveAccountWithCredentials = async (
       type: "retrieveAccountWithCredentials",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/signIn.ts
+++ b/src/server/implementation/mutations/signIn.ts
@@ -6,6 +6,10 @@ import {
   maybeGenerateTokensForSession,
 } from "../sessions.js";
 import { LOG_LEVELS, logWithLevel } from "../utils.js";
+import {
+  AuthRuntimeEnv,
+  collectRuntimeEnv,
+} from "../runtimeEnv.js";
 
 export const signInArgs = v.object({
   userId: v.id("users"),
@@ -19,6 +23,7 @@ export async function signInImpl(
   ctx: MutationCtx,
   args: Infer<typeof signInArgs>,
   config: Provider.Config,
+  runtimeEnv: AuthRuntimeEnv,
 ): Promise<ReturnType> {
   logWithLevel(LOG_LEVELS.DEBUG, "signInImpl args:", args);
   const { userId, sessionId: existingSessionId, generateTokens } = args;
@@ -28,6 +33,7 @@ export async function signInImpl(
   return await maybeGenerateTokensForSession(
     ctx,
     config,
+    runtimeEnv,
     userId,
     sessionId,
     generateTokens,
@@ -43,5 +49,6 @@ export const callSignIn = async (
       type: "signIn",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/signOut.ts
+++ b/src/server/implementation/mutations/signOut.ts
@@ -1,6 +1,7 @@
 import { GenericId } from "convex/values";
 import { ActionCtx, MutationCtx } from "../types.js";
 import { deleteSession, getAuthSessionId } from "../sessions.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 type ReturnType = {
   userId: GenericId<"users">;
@@ -24,5 +25,6 @@ export const callSignOut = async (ctx: ActionCtx): Promise<void> => {
     args: {
       type: "signOut",
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/userOAuth.ts
+++ b/src/server/implementation/mutations/userOAuth.ts
@@ -4,6 +4,7 @@ import * as Provider from "../provider.js";
 import { OAuthConfig } from "@auth/core/providers/oauth.js";
 import { upsertUserAndAccount } from "../users.js";
 import { generateRandomString, logWithLevel, sha256 } from "../utils.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 const OAUTH_SIGN_IN_EXPIRATION_MS = 1000 * 60 * 2; // 2 minutes
 
@@ -78,5 +79,6 @@ export const callUserOAuth = async (
       type: "userOAuth",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/verifier.ts
+++ b/src/server/implementation/mutations/verifier.ts
@@ -1,6 +1,7 @@
 import { GenericId } from "convex/values";
 import { ActionCtx, MutationCtx } from "../types.js";
 import { getAuthSessionId } from "../sessions.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 type ReturnType = GenericId<"authVerifiers">;
 
@@ -15,5 +16,6 @@ export const callVerifier = async (ctx: ActionCtx): Promise<ReturnType> => {
     args: {
       type: "verifier",
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/verifierSignature.ts
+++ b/src/server/implementation/mutations/verifierSignature.ts
@@ -1,5 +1,6 @@
 import { GenericId, Infer, v } from "convex/values";
 import { ActionCtx, MutationCtx } from "../types.js";
+import { collectRuntimeEnv } from "../runtimeEnv.js";
 
 export const verifierSignatureArgs = v.object({
   verifier: v.string(),
@@ -29,5 +30,6 @@ export const callVerifierSignature = async (
       type: "verifierSignature",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };

--- a/src/server/implementation/mutations/verifyCodeAndSignIn.ts
+++ b/src/server/implementation/mutations/verifyCodeAndSignIn.ts
@@ -14,6 +14,10 @@ import {
 import { ConvexAuthConfig } from "../../types.js";
 import { LOG_LEVELS, logWithLevel, sha256 } from "../utils.js";
 import { upsertUserAndAccount } from "../users.js";
+import {
+  AuthRuntimeEnv,
+  collectRuntimeEnv,
+} from "../runtimeEnv.js";
 
 export const verifyCodeAndSignInArgs = v.object({
   params: v.any(),
@@ -30,6 +34,7 @@ export async function verifyCodeAndSignInImpl(
   args: Infer<typeof verifyCodeAndSignInArgs>,
   getProviderOrThrow: Provider.GetProviderOrThrowFunc,
   config: Provider.Config,
+  runtimeEnv: AuthRuntimeEnv,
 ): Promise<ReturnType> {
   logWithLevel(LOG_LEVELS.DEBUG, "verifyCodeAndSignInImpl args:", {
     params: { email: args.params.email, phone: args.params.phone },
@@ -76,6 +81,7 @@ export async function verifyCodeAndSignInImpl(
   return await maybeGenerateTokensForSession(
     ctx,
     config,
+    runtimeEnv,
     userId,
     sessionId,
     generateTokens,
@@ -91,6 +97,7 @@ export const callVerifyCodeAndSignIn = async (
       type: "verifyCodeAndSignIn",
       ...args,
     },
+    env: collectRuntimeEnv(),
   });
 };
 

--- a/src/server/implementation/runtimeEnv.ts
+++ b/src/server/implementation/runtimeEnv.ts
@@ -8,6 +8,13 @@ export type AuthRuntimeEnv = {
 export function collectRuntimeEnv(): AuthRuntimeEnv | undefined {
   const siteUrl = process.env.CONVEX_SITE_URL;
   const customAuthSiteUrl = process.env.CUSTOM_AUTH_SITE_URL;
+  if (process.env.AUTH_LOG_LEVEL === "DEBUG") {
+    console.debug("collectRuntimeEnv", {
+      pid: process.pid,
+      siteUrl,
+      customAuthSiteUrl,
+    });
+  }
   if (siteUrl === undefined && customAuthSiteUrl === undefined) {
     return undefined;
   }
@@ -40,6 +47,15 @@ export function requireSiteUrl(
     config.siteUrl ??
     process.env.CONVEX_SITE_URL ??
     process.env.CUSTOM_AUTH_SITE_URL;
+  if (siteUrl === undefined && process.env.AUTH_LOG_LEVEL === "DEBUG") {
+    console.debug("requireSiteUrl missing", {
+      pid: process.pid,
+      runtime,
+      configSiteUrl: config.siteUrl,
+      envSiteUrl: process.env.CONVEX_SITE_URL,
+      envCustomAuthSiteUrl: process.env.CUSTOM_AUTH_SITE_URL,
+    });
+  }
   if (siteUrl === undefined) {
     throw new Error(
       "Missing environment variable `CONVEX_SITE_URL`. Set it in Convex or pass `siteUrl` to `convexAuth`.",

--- a/src/server/implementation/runtimeEnv.ts
+++ b/src/server/implementation/runtimeEnv.ts
@@ -1,0 +1,63 @@
+import { ConvexAuthMaterializedConfig } from "../types.js";
+
+export type AuthRuntimeEnv = {
+  siteUrl?: string;
+  customAuthSiteUrl?: string;
+};
+
+export function collectRuntimeEnv(): AuthRuntimeEnv | undefined {
+  const siteUrl = process.env.CONVEX_SITE_URL;
+  const customAuthSiteUrl = process.env.CUSTOM_AUTH_SITE_URL;
+  if (siteUrl === undefined && customAuthSiteUrl === undefined) {
+    return undefined;
+  }
+  return {
+    siteUrl: siteUrl ?? undefined,
+    customAuthSiteUrl: customAuthSiteUrl ?? undefined,
+  };
+}
+
+export function mergeRuntimeEnv(
+  config: Pick<ConvexAuthMaterializedConfig, "siteUrl" | "customAuthSiteUrl">,
+  runtime?: AuthRuntimeEnv,
+): AuthRuntimeEnv {
+  return {
+    siteUrl: runtime?.siteUrl ?? config.siteUrl,
+    customAuthSiteUrl:
+      runtime?.customAuthSiteUrl ??
+      config.customAuthSiteUrl ??
+      runtime?.siteUrl ??
+      config.siteUrl,
+  };
+}
+
+export function requireSiteUrl(
+  config: Pick<ConvexAuthMaterializedConfig, "siteUrl">,
+  runtime?: AuthRuntimeEnv,
+): string {
+  const siteUrl =
+    runtime?.siteUrl ??
+    config.siteUrl ??
+    process.env.CONVEX_SITE_URL ??
+    process.env.CUSTOM_AUTH_SITE_URL;
+  if (siteUrl === undefined) {
+    throw new Error(
+      "Missing environment variable `CONVEX_SITE_URL`. Set it in Convex or pass `siteUrl` to `convexAuth`.",
+    );
+  }
+  return siteUrl;
+}
+
+export function resolveAuthBaseUrl(
+  config: Pick<ConvexAuthMaterializedConfig, "siteUrl" | "customAuthSiteUrl">,
+  runtime?: AuthRuntimeEnv,
+): string {
+  return (
+    runtime?.customAuthSiteUrl ??
+    config.customAuthSiteUrl ??
+    runtime?.siteUrl ??
+    config.siteUrl ??
+    process.env.CUSTOM_AUTH_SITE_URL ??
+    requireSiteUrl(config, runtime)
+  );
+}

--- a/src/server/implementation/sessions.ts
+++ b/src/server/implementation/sessions.ts
@@ -15,12 +15,14 @@ import {
   formatRefreshToken,
   deleteAllRefreshTokens,
 } from "./refreshTokens.js";
+import { AuthRuntimeEnv } from "./runtimeEnv.js";
 
 const DEFAULT_SESSION_TOTAL_DURATION_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
 
 export async function maybeGenerateTokensForSession(
   ctx: MutationCtx,
   config: ConvexAuthConfig,
+  runtimeEnv: AuthRuntimeEnv,
   userId: GenericId<"users">,
   sessionId: GenericId<"authSessions">,
   generateTokens: boolean,
@@ -29,7 +31,7 @@ export async function maybeGenerateTokensForSession(
     userId,
     sessionId,
     tokens: generateTokens
-      ? await generateTokensForSession(ctx, config, {
+      ? await generateTokensForSession(ctx, config, runtimeEnv, {
           userId,
           sessionId,
           issuedRefreshTokenId: null,
@@ -57,6 +59,7 @@ export async function createNewAndDeleteExistingSession(
 export async function generateTokensForSession(
   ctx: MutationCtx,
   config: ConvexAuthConfig,
+  runtimeEnv: AuthRuntimeEnv,
   args: {
     userId: GenericId<"users">;
     sessionId: GenericId<"authSessions">;
@@ -74,7 +77,7 @@ export async function generateTokensForSession(
       args.parentRefreshTokenId,
     ));
   const result = {
-    token: await generateToken(ids, config),
+    token: await generateToken(ids, config, runtimeEnv),
     refreshToken: formatRefreshToken(refreshTokenId, args.sessionId),
   };
   logWithLevel(

--- a/src/server/implementation/signIn.ts
+++ b/src/server/implementation/signIn.ts
@@ -20,9 +20,9 @@ import {
   callVerifyCodeAndSignIn,
 } from "./mutations/index.js";
 import { redirectAbsoluteUrl, setURLSearchParam } from "./redirects.js";
-import { requireEnv } from "../utils.js";
 import { OAuth2Config, OIDCConfig } from "@auth/core/providers/oauth.js";
 import { generateRandomString } from "./utils.js";
+import { resolveAuthBaseUrl } from "./runtimeEnv.js";
 
 const DEFAULT_EMAIL_VERIFICATION_CODE_DURATION_S = 60 * 60 * 24; // 24 hours
 
@@ -237,7 +237,7 @@ async function handleOAuthProvider(
     };
   }
   const redirect = new URL(
-    (process.env.CUSTOM_AUTH_SITE_URL ?? requireEnv("CONVEX_SITE_URL")) + `/api/auth/signin/${provider.id}`,
+    resolveAuthBaseUrl(ctx.auth.config) + `/api/auth/signin/${provider.id}`,
   );
   const verifier = await callVerifier(ctx);
   redirect.searchParams.set("code", verifier);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ export {
   createAccount,
   retrieveAccount,
   signInViaProvider,
+  issueTokens,
   invalidateSessions,
   modifyAccountCredentials,
   Tokens,

--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -32,28 +32,31 @@ export function getAuthorizationSignature({
 function oauthStateCookieName(
   type: "state" | "pkce" | "nonce",
   providerId: string,
+  siteUrl?: string,
 ) {
-  return (!isLocalHost(process.env.CONVEX_SITE_URL) ? "__Host-" : "") + providerId + "OAuth" + type;
+  const host = siteUrl ?? process.env.CONVEX_SITE_URL;
+  return (!isLocalHost(host) ? "__Host-" : "") + providerId + "OAuth" + type;
 }
 
 export const defaultCookiesOptions: (
   providerId: string,
-) => Record<keyof CookiesOptions, CookieOption> = (providerId) => {
+  siteUrl?: string,
+) => Record<keyof CookiesOptions, CookieOption> = (providerId, siteUrl) => {
   return {
     pkceCodeVerifier: {
-      name: oauthStateCookieName("pkce", providerId),
+      name: oauthStateCookieName("pkce", providerId, siteUrl),
       options: {
         ...SHARED_COOKIE_OPTIONS,
       },
     },
     state: {
-      name: oauthStateCookieName("state", providerId),
+      name: oauthStateCookieName("state", providerId, siteUrl),
       options: {
         ...SHARED_COOKIE_OPTIONS,
       },
     },
     nonce: {
-      name: oauthStateCookieName("nonce", providerId),
+      name: oauthStateCookieName("nonce", providerId, siteUrl),
       options: {
         ...SHARED_COOKIE_OPTIONS,
       },

--- a/src/server/provider_utils.ts
+++ b/src/server/provider_utils.ts
@@ -43,6 +43,11 @@ export function configDefaults(config_: ConvexAuthConfig) {
     .map((p) => p.extraProviders)
     .flat()
     .filter((p) => p !== undefined);
+  const siteUrl = config_.siteUrl ?? process.env.CONVEX_SITE_URL ?? undefined;
+  const customAuthSiteUrl =
+    config_.customAuthSiteUrl ??
+    process.env.CUSTOM_AUTH_SITE_URL ??
+    siteUrl;
   return {
     ...config,
     extraProviders: materializeProviders(extraProviders),
@@ -52,6 +57,8 @@ export function configDefaults(config_: ConvexAuthConfig) {
       brandColor: "",
       buttonText: "",
     },
+    siteUrl,
+    customAuthSiteUrl,
   };
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -29,6 +29,17 @@ export type ConvexAuthConfig = {
    */
   providers: AuthProviderConfig[];
   /**
+   * Override the Convex site URL used when generating JWTs and exposing
+   * OpenID configuration. If not provided, the library falls back to the
+   * `CONVEX_SITE_URL` environment variable.
+   */
+  siteUrl?: string;
+  /**
+   * Override the URL used for OAuth callbacks and sign-in redirects.
+   * Defaults to `CUSTOM_AUTH_SITE_URL` (when set) or `siteUrl`.
+   */
+  customAuthSiteUrl?: string;
+  /**
    * Theme used for emails.
    * See [Auth.js theme docs](https://authjs.dev/reference/core/types#theme).
    */
@@ -364,7 +375,12 @@ export type GenericActionCtxWithAuthConfig<DataModel extends GenericDataModel> =
 export type ConvexAuthMaterializedConfig = {
   providers: AuthProviderMaterializedConfig[];
   theme: Theme;
-} & Pick<ConvexAuthConfig, "session" | "jwt" | "signIn" | "callbacks">;
+  siteUrl?: string;
+  customAuthSiteUrl?: string;
+} & Pick<
+  ConvexAuthConfig,
+  "session" | "jwt" | "signIn" | "callbacks"
+>;
 
 /**
  * Materialized Auth.js provider config.

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -5,8 +5,9 @@ import Resend from "@auth/core/providers/resend";
 import Apple from "@auth/core/providers/apple";
 import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
 import { Password } from "@convex-dev/auth/providers/Password";
-import { ConvexError } from "convex/values";
-import { convexAuth } from "@convex-dev/auth/server";
+import { ConvexError, v } from "convex/values";
+import { convexAuth, issueTokens as issueTokensHelper } from "@convex-dev/auth/server";
+import { action } from "./_generated/server";
 import { ResendOTP } from "./otp/ResendOTP";
 import { TwilioOTP } from "./otp/TwilioOTP";
 import { TwilioVerify } from "./otp/TwilioVerify";
@@ -70,4 +71,14 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
     Password({ id: "password-link", verify: Resend }),
     Anonymous,
   ],
+});
+
+export const issueTokens = action({
+  args: {
+    userId: v.id("users"),
+    sessionId: v.optional(v.id("authSessions")),
+  },
+  handler: async (ctx, args) => {
+    return await issueTokensHelper(ctx, args);
+  },
 });

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -60,7 +60,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.87",
+      "version": "0.0.90",
       "license": "Apache-2.0",
       "dependencies": {
         "@oslojs/crypto": "^1.0.1",

--- a/test/package.json
+++ b/test/package.json
@@ -11,8 +11,8 @@
     "build": "tsc && vite build",
     "lint": "tsc && tsc -p convex/tsconfig.json && eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:once": "vitest run",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage"
   },


### PR DESCRIPTION
Sorry to be that guy, but this is a mostly AI generated PR. I did review it though and it seems reasonable to me. At a minimum would like to get the conversation going

## Motivation
We rely on Convex Auth for passwordless flows where a user redeems a magic link and should land in the app already authenticated (think clinician emailing a patient an assessment link). In hosted/E2E setups the internal.auth.store mutation runs in a worker that never sees runtime process.env mutations, so token minting fails with “Missing environment variable CONVEX_SITE_URL.” That breaks the magic-link UX and forces clients to call internal APIs to work around it. Pushing the site URL through config and exposing a supported issueTokens helper keeps these flows working across environments without relying on internals.

## Summary
- fix auth:store workers skipping token minting when runtime processes can't see CONVEX_SITE_URL by threading site/custom auth url data through call stack
- normalize site URL handling so JWT issuer, OAuth redirects, and cookie names all use config overrides (or CUSTOM_AUTH_SITE_URL fallback) instead of direct process.env reads
- provide a public issueTokens(actionCtx, {userId, sessionId?}) helper so apps avoid internal.auth.store and still get tokens with the right issuer metadata; add the convex test hook covering it

## Testing
- not run
