### PR TITLE
Extract users table

### DIFF
--- a/src/server/implementation/types.ts
+++ b/src/server/implementation/types.ts
@@ -11,6 +11,19 @@ import { GenericId, v } from "convex/values";
 import { GenericDoc } from "../convex_types.js";
 
 /**
+ * Users.
+ */
+export usersTable {
+  name: v.optional(v.string()),
+  image: v.optional(v.string()),
+  email: v.optional(v.string()),
+  emailVerificationTime: v.optional(v.number()),
+  phone: v.optional(v.string()),
+  phoneVerificationTime: v.optional(v.number()),
+  isAnonymous: v.optional(v.boolean()),
+}
+
+/**
  * The table definitions required by the library.
  *
  * Your schema must include these so that the indexes
@@ -37,15 +50,7 @@ export const authTables = {
   /**
    * Users.
    */
-  users: defineTable({
-    name: v.optional(v.string()),
-    image: v.optional(v.string()),
-    email: v.optional(v.string()),
-    emailVerificationTime: v.optional(v.number()),
-    phone: v.optional(v.string()),
-    phoneVerificationTime: v.optional(v.number()),
-    isAnonymous: v.optional(v.boolean()),
-  })
+  users: defineTable(usersTable)
     .index("email", ["email"])
     .index("phone", ["phone"]),
   /**


### PR DESCRIPTION
<!-- Describe your PR here. -->

Extract users table into an object of its own, this makes it easier for users to extend the table if they need to.

Allow us to do:
```ts
import { usersTable, authTables } from '@convex-dev/auth/server'
import { stripeTables } from '@raideno/convex-stripe/server'
import { defineSchema, defineTable } from 'convex/server'
import { v } from 'convex/values'

export default defineSchema({
  ...authTables,
  ...stripeTables,
  users: defineTable({
    ...usersTable,
    myNewField: v.optional(v.string()),
  }),
});
```

Instead of

```ts
import { authTables } from '@convex-dev/auth/server'
import { stripeTables } from '@raideno/convex-stripe/server'
import { defineSchema, defineTable } from 'convex/server'
import { v } from 'convex/values'

export default defineSchema({
  ...authTables,
  ...stripeTables,
  users: defineTable({
    name: v.optional(v.string()),
    image: v.optional(v.string()),
    email: v.optional(v.string()),
    emailVerificationTime: v.optional(v.number()),
    phone: v.optional(v.string()),
    phoneVerificationTime: v.optional(v.number()),
    isAnonymous: v.optional(v.boolean()),
    // ...authTables.users,
    myNewField: v.optional(v.string()),
  }),
});
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
