### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/test-nextjs/README.md
+++ b/test-nextjs/README.md
@@ -21,7 +21,7 @@ npm run dev
 If you're reading this README on GitHub and want to use this template, run:
 
 ```
-npx create-convex@latest  -t nextjs-shadcn
+npx create-convex@latest -t nextjs-shadcn
 ```
 
 ## Learn more


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README bootstrap command to use npx (adjusted invocation and package name) for initializing the template, improving setup clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->