### PR TITLE
add kid to custom JWT header

### DIFF
--- a/src/server/implementation/tokens.ts
+++ b/src/server/implementation/tokens.ts
@@ -14,13 +14,20 @@ export async function generateToken(
   config: ConvexAuthConfig,
 ) {
   const privateKey = await importPKCS8(requireEnv("JWT_PRIVATE_KEY"), "RS256");
+  let kid: string | undefined;
+  try {
+    const jwks = JSON.parse(requireEnv("JWKS"));
+    kid = jwks?.keys?.[0]?.kid;
+  } catch {
+    // ignore if JWKS is missing or invalid
+  }
   const expirationTime = new Date(
     Date.now() + (config.jwt?.durationMs ?? DEFAULT_JWT_DURATION_MS),
   );
   return await new SignJWT({
     sub: args.userId + TOKEN_SUB_CLAIM_DIVIDER + args.sessionId,
   })
-    .setProtectedHeader({ alg: "RS256" })
+    .setProtectedHeader(kid ? { alg: "RS256", kid } : { alg: "RS256" })
     .setIssuedAt()
     .setIssuer(requireEnv("CONVEX_SITE_URL"))
     .setAudience("convex")


### PR DESCRIPTION
## Context
Convex requires JWTs for customJwt providers to include a `kid` in the header so it can select the correct key from JWKS.

## Problem
`@convex-dev/auth` generates access tokens without `kid`. Convex then fails auth with:

> "Could not decode token. JWT may be missing a 'kid' (key ID) header."

## Fix
Read JWKS from env and include the first key's `kid` in the JWT protected header.

## Changes
- `src/server/implementation/tokens.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT token generation with optional key ID extraction from JWKS.
  * Enhanced JWT headers to include key ID when available, with graceful fallback if JWKS data is unavailable or invalid.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->