### PR TITLE
Add beforeSessionCreation callback hook

### DIFF
--- a/src/server/implementation/sessions.ts
+++ b/src/server/implementation/sessions.ts
@@ -89,6 +89,9 @@ async function createSession(
   userId: GenericId<"users">,
   config: ConvexAuthConfig,
 ) {
+  if (config.callbacks?.beforeSessionCreation !== undefined) {
+    await config.callbacks.beforeSessionCreation(ctx, { userId });
+  }
   const expirationTime =
     Date.now() +
     (config.session?.totalDurationMs ??

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -167,6 +167,36 @@ export type ConvexAuthConfig = {
       },
     ) => Promise<GenericId<"users">>;
     /**
+     * Called before a new session is created for a user.
+     *
+     * This callback runs during every sign-in flow
+     * (credentials, OAuth, email, phone) right before the session
+     * is persisted. Throw an error to reject the sign-in.
+     *
+     * This is useful for checking whether a user is banned or
+     * otherwise disallowed from signing in:
+     *
+     * ```ts
+     * callbacks: {
+     *   async beforeSessionCreation(ctx, { userId }) {
+     *     const user = await ctx.db.get(userId);
+     *     if (user?.banned) {
+     *       throw new Error("Account is banned");
+     *     }
+     *   },
+     * }
+     * ```
+     */
+    beforeSessionCreation?: (
+      ctx: GenericMutationCtx<AnyDataModel>,
+      args: {
+        /**
+         * The ID of the user about to be signed in.
+         */
+        userId: GenericId<"users">;
+      },
+    ) => Promise<void>;
+    /**
      * Perform additional writes after a user is created.
      *
      * This callback is called during the sign-in process,


### PR DESCRIPTION
## Add `beforeSessionCreation` callback

### Problem

The `createOrUpdateUser` callback only fires during account creation (sign-up, OAuth, email/phone OTP). The credentials sign-in flow bypasses it entirely (`retrieveAccount` → `callSignIn` → `createSession`), so there's no hook to reject a returning user's login (e.g. banned users).

### Solution

New optional `beforeSessionCreation` callback that runs in `createSession()` before the session is persisted. Covers all sign-in flows. Throw to reject.

### Changes

- `src/server/types.ts` — callback type + JSDoc
- `src/server/implementation/sessions.ts` — 3-line guard in `createSession()`

### Usage

```ts
callbacks: {
  async beforeSessionCreation(ctx, { userId }) {
    const user = await ctx.db.get(userId);
    if (user?.banned) throw new Error("Account is banned");
  },
}
```


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pre-session creation callback that runs during all sign-in flows, enabling custom validation logic and the ability to reject sign-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->