### PR TITLE
fix: handle Microsoft multi-tenant issuer mismatch

### DIFF
--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -89,9 +89,17 @@ export const defaultCookiesOptions: (
 
 // Microsoft multi-tenant: aliases like "common", "organizations", "consumers"
 // discover issuer .../{alias}/v2.0 but tokens carry tenant-specific
-// iss claims (.../{tenantId}/v2.0). Use oauth4webapi's
-// _expectedIssuer extension to accept the token's own iss,
-// matching the approach used by @auth/core for Microsoft providers.
+// iss claims (.../{tenantId}/v2.0).
+//
+// oauth4webapi's processDiscoveryResponse validates that the ID token's
+// iss matches the discovered issuer, which fails for these aliases.
+// The library exports a _expectedIssuer Symbol as an extension point
+// specifically for this case — setting it to a function replaces the
+// default strict-equal check with custom validation. This is the same
+// approach used by @auth/core internally for Microsoft providers:
+//   https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/actions/callback/oauth/callback.ts
+//
+// The symbol is exported at runtime but not in the type declarations.
 // Only needed for multi-tenant aliases; tenant-specific endpoints
 // return exact issuer matches.
 function applyMultiTenantEntraFix(
@@ -104,8 +112,6 @@ function applyMultiTenantEntraFix(
     config.id === "microsoft-entra-id" &&
     /\/(common|organizations|consumers)\/v2\.0\/?$/.test(issuer);
   if (isMultiTenantEntra) {
-    // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,
-    // not yet in the type declarations.
     const expectedIssuer = (o as any)._expectedIssuer as symbol;
     (as as any)[expectedIssuer] = (result: any) => result.claims.iss;
   }

--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -120,11 +120,11 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
     // matching the approach used by @auth/core for Microsoft providers.
     // Only needed for multi-tenant aliases; tenant-specific endpoints
     // return exact issuer matches.
-    const issuer = discoveredAs.issuer ?? "";
+    const discoveredIssuer = discoveredAs.issuer ?? "";
     const isMultiTenantEntra =
       config.type === "oidc" &&
       config.id === "microsoft-entra-id" &&
-      /\/(common|organizations|consumers)\/v2\.0\/?$/.test(issuer);
+      /\/(common|organizations|consumers)\/v2\.0\/?$/.test(discoveredIssuer);
 
     if (isMultiTenantEntra) {
       // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,

--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -113,6 +113,17 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
         "TODO: Authorization server did not provide a token endpoint.",
       );
 
+    // Microsoft multi-tenant: the "common" endpoint discovers issuer .../common/v2.0
+    // but tokens carry tenant-specific iss claims (.../{tenantId}/v2.0).
+    // Use oauth4webapi's _expectedIssuer extension to accept the token's own iss,
+    // matching the approach used by @auth/core for Microsoft providers.
+    if (config.type === "oidc" && config.id === "microsoft-entra-id") {
+      // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,
+      // not yet in the type declarations.
+      const expectedIssuer = (o as any)._expectedIssuer as symbol;
+      (discoveredAs as any)[expectedIssuer] = (result: any) => result.claims.iss;
+    }
+
     const as: o.AuthorizationServer = discoveredAs;
     return {
       ...config,

--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -87,6 +87,30 @@ export const defaultCookiesOptions: (
   };
 };
 
+// Microsoft multi-tenant: aliases like "common", "organizations", "consumers"
+// discover issuer .../{alias}/v2.0 but tokens carry tenant-specific
+// iss claims (.../{tenantId}/v2.0). Use oauth4webapi's
+// _expectedIssuer extension to accept the token's own iss,
+// matching the approach used by @auth/core for Microsoft providers.
+// Only needed for multi-tenant aliases; tenant-specific endpoints
+// return exact issuer matches.
+function applyMultiTenantEntraFix(
+  as: o.AuthorizationServer,
+  config: OAuthConfig<any>,
+) {
+  const issuer = (as as any).issuer ?? as.issuer ?? "";
+  const isMultiTenantEntra =
+    config.type === "oidc" &&
+    config.id === "microsoft-entra-id" &&
+    /\/(common|organizations|consumers)\/v2\.0\/?$/.test(issuer);
+  if (isMultiTenantEntra) {
+    // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,
+    // not yet in the type declarations.
+    const expectedIssuer = (o as any)._expectedIssuer as symbol;
+    (as as any)[expectedIssuer] = (result: any) => result.claims.iss;
+  }
+}
+
 export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): Promise<InternalProvider<"oauth" | "oidc">> {
   // Only do service discovery if the provider does not have the required configuration
   if (!config.authorization || !config.token || !config.userinfo) {
@@ -113,25 +137,7 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
         "TODO: Authorization server did not provide a token endpoint.",
       );
 
-    // Microsoft multi-tenant: aliases like "common", "organizations", "consumers"
-    // discover issuer .../{alias}/v2.0 but tokens carry tenant-specific
-    // iss claims (.../{tenantId}/v2.0). Use oauth4webapi's
-    // _expectedIssuer extension to accept the token's own iss,
-    // matching the approach used by @auth/core for Microsoft providers.
-    // Only needed for multi-tenant aliases; tenant-specific endpoints
-    // return exact issuer matches.
-    const discoveredIssuer = discoveredAs.issuer ?? "";
-    const isMultiTenantEntra =
-      config.type === "oidc" &&
-      config.id === "microsoft-entra-id" &&
-      /\/(common|organizations|consumers)\/v2\.0\/?$/.test(discoveredIssuer);
-
-    if (isMultiTenantEntra) {
-      // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,
-      // not yet in the type declarations.
-      const expectedIssuer = (o as any)._expectedIssuer as symbol;
-      (discoveredAs as any)[expectedIssuer] = (result: any) => result.claims.iss;
-    }
+    applyMultiTenantEntraFix(discoveredAs, config);
 
     const as: o.AuthorizationServer = discoveredAs;
     return {
@@ -167,6 +173,13 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
   const userinfo = config.userinfo
     ? normalizeEndpoint(config.userinfo)
     : undefined;
+  const as: o.AuthorizationServer = {
+    issuer: config.issuer ?? "theremustbeastringhere.dev",
+    authorization_endpoint: authorization?.url.toString(),
+    token_endpoint: token?.url.toString(),
+    userinfo_endpoint: userinfo?.url.toString(),
+  };
+  applyMultiTenantEntraFix(as, config);
   return {
     ...config,
     checks: config.checks!,
@@ -177,12 +190,7 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
     authorization,
     token,
     userinfo,
-    as: {
-      issuer: config.issuer ?? "theremustbeastringhere.dev",
-      authorization_endpoint: authorization?.url.toString(),
-      token_endpoint: token?.url.toString(),
-      userinfo_endpoint: userinfo?.url.toString(),
-    },
+    as,
     configSource: "provided",
   };
 }

--- a/src/server/oauth/convexAuth.ts
+++ b/src/server/oauth/convexAuth.ts
@@ -113,11 +113,20 @@ export async function oAuthConfigToInternalProvider(config: OAuthConfig<any>): P
         "TODO: Authorization server did not provide a token endpoint.",
       );
 
-    // Microsoft multi-tenant: the "common" endpoint discovers issuer .../common/v2.0
-    // but tokens carry tenant-specific iss claims (.../{tenantId}/v2.0).
-    // Use oauth4webapi's _expectedIssuer extension to accept the token's own iss,
+    // Microsoft multi-tenant: aliases like "common", "organizations", "consumers"
+    // discover issuer .../{alias}/v2.0 but tokens carry tenant-specific
+    // iss claims (.../{tenantId}/v2.0). Use oauth4webapi's
+    // _expectedIssuer extension to accept the token's own iss,
     // matching the approach used by @auth/core for Microsoft providers.
-    if (config.type === "oidc" && config.id === "microsoft-entra-id") {
+    // Only needed for multi-tenant aliases; tenant-specific endpoints
+    // return exact issuer matches.
+    const issuer = discoveredAs.issuer ?? "";
+    const isMultiTenantEntra =
+      config.type === "oidc" &&
+      config.id === "microsoft-entra-id" &&
+      /\/(common|organizations|consumers)\/v2\.0\/?$/.test(issuer);
+
+    if (isMultiTenantEntra) {
       // _expectedIssuer is a runtime-exported Symbol from oauth4webapi,
       // not yet in the type declarations.
       const expectedIssuer = (o as any)._expectedIssuer as symbol;


### PR DESCRIPTION
## Problem

When using `MicrosoftEntraId` with the default multi-tenant ("common") endpoint, the OAuth callback fails. OIDC discovery returns `issuer: .../common/v2.0`, but ID tokens carry tenant-specific `iss` claims (`.../{tenantId}/v2.0`). `oauth4webapi`'s issuer validation rejects these tokens.

## Fix

Use `oauth4webapi`'s exported `_expectedIssuer` Symbol extension point on the discovered `AuthorizationServer` for `microsoft-entra-id` providers. This accepts the token's own `iss` claim while still validating the JWT signature — the same approach `@auth/core` (Auth.js) uses internally for Microsoft.

The fix only applies in the discovery code path (when `authorization`, `token`, or `userinfo` endpoints are not all explicitly provided), which is the common configuration for Microsoft Entra ID.

## Testing

- Multi-tenant Microsoft sign-in now succeeds (previously failed with issuer mismatch)
- Single-tenant (`tenantId: "..."`) continues to work — discovery returns the tenant-specific issuer which matches tokens
- Other OIDC providers unaffected — fix is scoped to `config.id === "microsoft-entra-id"`

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Microsoft Entra ID (Azure AD) OIDC sign-in: issuer matching now respects the token's reported issuer for multi-tenant alias endpoints.

* **Bug Fixes**
  * Fixed validation failures for sign-ins using common/organizations/consumers multi-tenant endpoints, reducing incorrect or failed sign-in validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->