### PR TITLE
Pass authUserId to createOrUpdateUser for secure account linking

### DIFF
--- a/docs/pages/advanced.mdx
+++ b/docs/pages/advanced.mdx
@@ -89,6 +89,12 @@ export const { auth, signIn, signOut, store, isAuthenticated } = {
         return args.existingUserId;
       }
 
+      if (args.authUserId) {
+        // During OAuth account linking, attach the new account to the
+        // currently authenticated user who started the flow.
+        return args.authUserId;
+      }
+
       // Implement your own account linking logic:
       const existingUser = await findUserByEmail(ctx, args.profile.email);
       if (existingUser) return existingUser._id;
@@ -101,6 +107,10 @@ export const { auth, signIn, signOut, store, isAuthenticated } = {
   },
 };
 ```
+
+`args.existingUserId` is the user already linked to the account being signed in,
+if one exists. `args.authUserId` identifies the currently authenticated user so
+you can link the new OAuth account to them. This is useful for OAuth flows started while signed in.
 
 When you provide this callback, the library doesn't create or update users at
 all. It is up to you to implement all the necessary logic for all providers you
@@ -123,7 +133,7 @@ import { MutationCtx } from "./_generated/server";
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [GitHub, Password],
   callbacks: {
-    // `args` are the same the as for `createOrUpdateUser` but include `userId`
+    // `args` are the same as for `createOrUpdateUser` but include `userId`
     async afterUserCreatedOrUpdated(ctx: MutationCtx, { userId }) {
       await ctx.db.insert("someTable", { userId, data: "some data" });
     },

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -207,6 +207,8 @@ export type ConvexAuthActionsContext = {
      *  - `redirectTo`: If provided, customizes the destination the user is
      *     redirected to at the end of an OAuth flow or the magic link URL.
      *     See [redirect callback](https://labs.convex.dev/auth/api_reference/server#callbacksredirect).
+     *  - `scope`: If provided for OAuth, overrides the provider's configured
+     *     authorization scopes for this sign-in.
      *  - `code`: OTP code for email or phone verification, or
      *     (used only in RN) the code from an OAuth flow or magic link URL.
      */
@@ -218,6 +220,11 @@ export type ConvexAuthActionsContext = {
            * redirected to at the end of an OAuth flow or the magic link URL.
            */
           redirectTo?: string;
+          /**
+           * If provided for OAuth, overrides the provider's configured
+           * authorization scopes for this sign-in.
+           */
+          scope?: string;
           /**
            * OTP code for email or phone verification, or
            * (used only in RN) the code from an OAuth flow or magic link URL.

--- a/src/server/implementation/index.ts
+++ b/src/server/implementation/index.ts
@@ -251,9 +251,18 @@ export function convexAuth(config_: ConvexAuthConfig) {
               const provider = getProviderOrThrow(
                 providerId,
               ) as OAuthConfig<any>;
+              const internalProvider =
+                await oAuthConfigToInternalProvider(provider);
+              const requestedScope = url.searchParams.get("scope");
+              if (requestedScope !== null) {
+                internalProvider.authorization?.url.searchParams.set(
+                  "scope",
+                  requestedScope,
+                );
+              }
               const { redirect, cookies, signature } =
                 await getAuthorizationUrl({
-                  provider: await oAuthConfigToInternalProvider(provider),
+                  provider: internalProvider,
                   cookies: defaultCookiesOptions(providerId),
                 });
 

--- a/src/server/implementation/signIn.ts
+++ b/src/server/implementation/signIn.ts
@@ -237,7 +237,8 @@ async function handleOAuthProvider(
     };
   }
   const redirect = new URL(
-    (process.env.CUSTOM_AUTH_SITE_URL ?? requireEnv("CONVEX_SITE_URL")) + `/api/auth/signin/${provider.id}`,
+    (process.env.CUSTOM_AUTH_SITE_URL ?? requireEnv("CONVEX_SITE_URL")) +
+      `/api/auth/signin/${provider.id}`,
   );
   const verifier = await callVerifier(ctx);
   redirect.searchParams.set("code", verifier);
@@ -248,6 +249,14 @@ async function handleOAuthProvider(
       );
     }
     redirect.searchParams.set("redirectTo", args.params.redirectTo);
+  }
+  if (args.params?.scope !== undefined) {
+    if (typeof args.params.scope !== "string") {
+      throw new Error(
+        `Expected \`scope\` to be a string, got ${args.params.scope}`,
+      );
+    }
+    redirect.searchParams.set("scope", args.params.scope);
   }
   return { kind: "redirect", redirect: redirect.toString(), verifier };
 }

--- a/src/server/implementation/users.ts
+++ b/src/server/implementation/users.ts
@@ -55,10 +55,15 @@ async function defaultCreateOrUpdateUser(
     args,
   });
   const existingUserId = existingAccount?.userId ?? null;
+  const authUserId =
+    existingSessionId !== null
+      ? (await ctx.db.get(existingSessionId))?.userId ?? null
+      : null;
   if (config.callbacks?.createOrUpdateUser !== undefined) {
     logWithLevel(LOG_LEVELS.DEBUG, "Using custom createOrUpdateUser callback");
     return await config.callbacks.createOrUpdateUser(ctx, {
       existingUserId,
+      authUserId,
       ...args,
     });
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -168,6 +168,14 @@ export type ConvexAuthConfig = {
          */
         existingUserId: GenericId<"users"> | null;
         /**
+         * If this OAuth flow was started while another user was already signed in,
+         * this is that authenticated user ID recovered from the saved session.
+         *
+         * This is distinct from `existingUserId`, which refers to the user already
+         * linked to the OAuth account being processed, if any.
+         */
+        authUserId: GenericId<"users"> | null;
+        /**
          * The provider type or "verification" if this callback is called
          * after an email or phone token verification.
          */

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -168,6 +168,11 @@ export type ConvexAuthConfig = {
          */
         existingUserId: GenericId<"users"> | null;
         /**
+         * If this OAuth flow was started while a user was already signed in,
+         * this is that authenticated user ID recovered from the saved session.
+         */
+        authUserId: GenericId<"users"> | null;
+        /**
          * The provider type or "verification" if this callback is called
          * after an email or phone token verification.
          */

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -168,11 +168,8 @@ export type ConvexAuthConfig = {
          */
         existingUserId: GenericId<"users"> | null;
         /**
-         * If this OAuth flow was started while another user was already signed in,
+         * If this OAuth flow was started while a user was already signed in,
          * this is that authenticated user ID recovered from the saved session.
-         *
-         * This is distinct from `existingUserId`, which refers to the user already
-         * linked to the OAuth account being processed, if any.
          */
         authUserId: GenericId<"users"> | null;
         /**

--- a/test/convex/createOrUpdateUser.test.ts
+++ b/test/convex/createOrUpdateUser.test.ts
@@ -92,6 +92,37 @@ test("createOrUpdateUser links a new OAuth account to the signed-in user via aut
   });
 });
 
+test("createOrUpdateUser creates a new user for unauthenticated OAuth sign-in", async () => {
+  setupEnv();
+  const modules = import.meta.glob("./**/*.*s");
+  const overriddenModules = {
+    ...modules,
+    "./auth.ts": async () => createOrUpdateUserAuth,
+  };
+  const t = convexTest(schema, overriddenModules);
+
+  const { tokens: oauthTokens } = await signInViaGitHub(t, "github", {
+    email: "unauthenticated@example.com",
+    name: "Unauthenticated User",
+    id: "anotherGitHubId",
+  });
+  expect(oauthTokens).not.toBeNull();
+
+  await t.run(async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    expect(users).toHaveLength(1);
+
+    const accounts = await ctx.db.query("authAccounts").collect();
+    expect(accounts).toHaveLength(1);
+    expect(accounts.find((account) => account.provider === "github")).toMatchObject({
+      userId: users[0]._id,
+    });
+
+    const messages = await ctx.db.query("messages").collect();
+    expect(messages).toEqual([]);
+  });
+});
+
 function setupEnv() {
   process.env.SITE_URL = "http://localhost:5173";
   process.env.CONVEX_SITE_URL = CONVEX_SITE_URL;

--- a/test/convex/createOrUpdateUser.test.ts
+++ b/test/convex/createOrUpdateUser.test.ts
@@ -1,0 +1,134 @@
+/// <reference types="vite/client" />
+import GitHub from "@auth/core/providers/github";
+import { convexTest } from "convex-test";
+import { decodeJwt } from "jose";
+import { Password } from "../../src/providers/Password";
+import { convexAuth } from "../../src/server";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import {
+  CONVEX_SITE_URL,
+  JWKS,
+  JWT_PRIVATE_KEY,
+  signInViaGitHub,
+} from "./test.helpers";
+
+const createOrUpdateUserAuth = convexAuth({
+  callbacks: {
+    async createOrUpdateUser(ctx, args) {
+      if (args.existingUserId) {
+        return args.existingUserId;
+      }
+
+      if (args.authUserId) {
+        await ctx.db.insert("messages", {
+          userId: args.authUserId,
+          body: JSON.stringify({
+            type: args.type,
+            authUserId: args.authUserId,
+            existingUserId: args.existingUserId,
+          }),
+        });
+        return args.authUserId;
+      }
+
+      return await ctx.db.insert("users", {
+        email: args.profile.email,
+        name:
+          typeof args.profile.name === "string" ? args.profile.name : undefined,
+      });
+    },
+  },
+  providers: [GitHub, Password],
+});
+
+test("createOrUpdateUser links a new OAuth account to the signed-in user via authUserId", async () => {
+  setupEnv();
+  const modules = import.meta.glob("./**/*.*s");
+  const overriddenModules = {
+    ...modules,
+    "./auth.ts": async () => createOrUpdateUserAuth,
+  };
+  const t = convexTest(schema, overriddenModules);
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    provider: "password",
+    params: { email: "sarah@gmail.com", password: "44448888", flow: "signUp" },
+  });
+  expect(tokens).not.toBeNull();
+
+  const claims = decodeJwt(tokens!.token);
+  const asSarah = t.withIdentity({ subject: claims.sub });
+
+  const { tokens: oauthTokens } = await signInViaGitHub(asSarah, "github", {
+    email: "github-only@example.com",
+    name: "Sarah From GitHub",
+    id: "someGitHubId",
+  });
+  expect(oauthTokens).not.toBeNull();
+
+  await t.run(async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    expect(users).toHaveLength(1);
+
+    const accounts = await ctx.db.query("authAccounts").collect();
+    expect(accounts).toHaveLength(2);
+    expect(accounts.find((account) => account.provider === "password")).toMatchObject({
+      userId: users[0]._id,
+    });
+    expect(accounts.find((account) => account.provider === "github")).toMatchObject({
+      userId: users[0]._id,
+    });
+
+    const messages = await ctx.db.query("messages").collect();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].userId).toEqual(users[0]._id);
+    expect(JSON.parse(messages[0].body)).toEqual({
+      type: "oauth",
+      authUserId: users[0]._id,
+      existingUserId: null,
+    });
+  });
+});
+
+test("createOrUpdateUser creates a new user for unauthenticated OAuth sign-in", async () => {
+  setupEnv();
+  const modules = import.meta.glob("./**/*.*s");
+  const overriddenModules = {
+    ...modules,
+    "./auth.ts": async () => createOrUpdateUserAuth,
+  };
+  const t = convexTest(schema, overriddenModules);
+
+  const { tokens: oauthTokens } = await signInViaGitHub(t, "github", {
+    email: "unauthenticated@example.com",
+    name: "Unauthenticated User",
+    id: "anotherGitHubId",
+  });
+  expect(oauthTokens).not.toBeNull();
+
+  await t.run(async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    expect(users).toHaveLength(1);
+
+    const accounts = await ctx.db.query("authAccounts").collect();
+    expect(accounts).toHaveLength(1);
+    expect(accounts.find((account) => account.provider === "github")).toMatchObject({
+      userId: users[0]._id,
+    });
+
+    const messages = await ctx.db.query("messages").collect();
+    expect(messages).toEqual([]);
+  });
+});
+
+function setupEnv() {
+  process.env.SITE_URL = "http://localhost:5173";
+  process.env.CONVEX_SITE_URL = CONVEX_SITE_URL;
+  process.env.JWT_PRIVATE_KEY = JWT_PRIVATE_KEY;
+  process.env.JWKS = JWKS;
+  process.env.AUTH_GITHUB_ID = "githubClientId";
+  process.env.AUTH_GITHUB_SECRET = "githubClientSecret";
+  process.env.AUTH_LOG_LEVEL = "ERROR";
+}

--- a/test/convex/createOrUpdateUser.test.ts
+++ b/test/convex/createOrUpdateUser.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="vite/client" />
+import GitHub from "@auth/core/providers/github";
+import { convexTest } from "convex-test";
+import { decodeJwt } from "jose";
+import { Password } from "../../src/providers/Password";
+import { convexAuth } from "../../src/server";
+import { expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import {
+  CONVEX_SITE_URL,
+  JWKS,
+  JWT_PRIVATE_KEY,
+  signInViaGitHub,
+} from "./test.helpers";
+
+const createOrUpdateUserAuth = convexAuth({
+  callbacks: {
+    async createOrUpdateUser(ctx, args) {
+      if (args.existingUserId) {
+        return args.existingUserId;
+      }
+
+      if (args.authUserId) {
+        await ctx.db.insert("messages", {
+          userId: args.authUserId,
+          body: JSON.stringify({
+            type: args.type,
+            authUserId: args.authUserId,
+            existingUserId: args.existingUserId,
+          }),
+        });
+        return args.authUserId;
+      }
+
+      return await ctx.db.insert("users", {
+        email: args.profile.email,
+        name:
+          typeof args.profile.name === "string" ? args.profile.name : undefined,
+      });
+    },
+  },
+  providers: [GitHub, Password],
+});
+
+test("createOrUpdateUser links a new OAuth account to the signed-in user via authUserId", async () => {
+  setupEnv();
+  const modules = import.meta.glob("./**/*.*s");
+  const overriddenModules = {
+    ...modules,
+    "./auth.ts": async () => createOrUpdateUserAuth,
+  };
+  const t = convexTest(schema, overriddenModules);
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    provider: "password",
+    params: { email: "sarah@gmail.com", password: "44448888", flow: "signUp" },
+  });
+  expect(tokens).not.toBeNull();
+
+  const claims = decodeJwt(tokens!.token);
+  const asSarah = t.withIdentity({ subject: claims.sub });
+
+  const { tokens: oauthTokens } = await signInViaGitHub(asSarah, "github", {
+    email: "github-only@example.com",
+    name: "Sarah From GitHub",
+    id: "someGitHubId",
+  });
+  expect(oauthTokens).not.toBeNull();
+
+  await t.run(async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    expect(users).toHaveLength(1);
+
+    const accounts = await ctx.db.query("authAccounts").collect();
+    expect(accounts).toHaveLength(2);
+    expect(accounts.find((account) => account.provider === "password")).toMatchObject({
+      userId: users[0]._id,
+    });
+    expect(accounts.find((account) => account.provider === "github")).toMatchObject({
+      userId: users[0]._id,
+    });
+
+    const messages = await ctx.db.query("messages").collect();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].userId).toEqual(users[0]._id);
+    expect(JSON.parse(messages[0].body)).toEqual({
+      type: "oauth",
+      authUserId: users[0]._id,
+      existingUserId: null,
+    });
+  });
+});
+
+function setupEnv() {
+  process.env.SITE_URL = "http://localhost:5173";
+  process.env.CONVEX_SITE_URL = CONVEX_SITE_URL;
+  process.env.JWT_PRIVATE_KEY = JWT_PRIVATE_KEY;
+  process.env.JWKS = JWKS;
+  process.env.AUTH_GITHUB_ID = "githubClientId";
+  process.env.AUTH_GITHUB_SECRET = "githubClientSecret";
+  process.env.AUTH_LOG_LEVEL = "ERROR";
+}

--- a/test/convex/oauth.test.ts
+++ b/test/convex/oauth.test.ts
@@ -82,6 +82,21 @@ test("redirectTo with oauth", async () => {
   );
 });
 
+test("custom scope with oauth", async () => {
+  setupEnv();
+  const t = convexTest(schema);
+  await signInViaGitHub(
+    t,
+    "github",
+    {
+      email: "tom@gmail.com",
+      name: "Tom",
+      id: "someGitHubId",
+    },
+    { scope: "read:user repo" },
+  );
+});
+
 function setupEnv() {
   process.env.SITE_URL = "http://localhost:5173";
   process.env.CONVEX_SITE_URL = CONVEX_SITE_URL;

--- a/test/convex/test.helpers.ts
+++ b/test/convex/test.helpers.ts
@@ -17,6 +17,7 @@ export async function signInViaGitHub(
   githubProfile: Record<string, unknown>,
   params: {
     redirectTo?: string;
+    scope?: string;
   } = {},
 ) {
   const { redirect, verifier } = await t.action(api.auth.signIn, {
@@ -41,6 +42,9 @@ export async function signInViaGitHub(
   expect(cookies).not.toBeNull();
 
   const redirectedToParams = new URL(redirectedTo!).searchParams;
+  if (params.scope !== undefined) {
+    expect(redirectedToParams.get("scope")).toBe(params.scope);
+  }
 
   const callbackUrl = redirectedToParams.get("redirect_uri");
 
@@ -62,7 +66,7 @@ export async function signInViaGitHub(
             access_token: issuedAccessToken,
             token_type: "bearer",
           }),
-          { status: 200, headers: { "Content-Type": "application/json" }  },
+          { status: 200, headers: { "Content-Type": "application/json" } },
         );
       } else if (
         input === "https://api.github.com/user" ||


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Problem

In `createOrUpdateUser` it's not currently possible to know who the currently logged in user is.

Given an app with Github auth and Google auth, without customisation if you first log in with Github and then Google, the Google signin creates a second user and the session becomes that. Therefore we need custom account linking logic. 

Current docs for account linking: https://labs.convex.dev/auth/advanced#controlling-user-creation-and-account-linking-behavior

However, although the docs recommend using `createOrUpdateUser(ctx, args)` the ctx does not have the current session because it's being ran from a convex HTTP `*.site` URL which doesn't have the cookies. Therefore the following code prints "my user id is null" while having clicked "connect Google" even though we are logged in already.

```ts
export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
  providers: [
    GitHubProvider(),
    GoogleProvider(),
  ],
  callbacks: {
    async createOrUpdateUser(ctx, args) {
      const userId = await getAuthUserId(ctx);
      console.log("my user id is ", userId)
    }
  }
})
```

Email based account linking is not good enough.

- it's insecure
- also people often have accounts they want to link that have different emails
- some services don't provide user email in the OAuth profile [for example ;)](https://docs.convex.dev/platform-apis/oauth-applications)

## Solution

- Pass `authUserId` to the `createOrUpdateUser` callback when an OAuth flow is started while another user is already signed in.
- Update the advanced docs example to show how to use `authUserId` for OAuth account linking, fix a small typo in the callback docs.

## Why

Custom account-linking logic needs access to the currently authenticated user during signed-in OAuth flows. Without that, `createOrUpdateUser` callbacks can't reliably attach a new OAuth account to the existing logged in user who initiated the flow.

- `authUserId` is distinct from `existingUserId`
  - `existingUserId: Id<"users"> | null` refers to the user that may already be linked to the account being processed
  - `authUserId: Id<"users"> | null` **NEW** refers to the user who may currently be logged in.

## Test plan

- [ ] Verify the `createOrUpdateUser` callback receives `authUserId` during an OAuth flow started while signed in
- [ ] Verify `authUserId` is `null` for flows without an authenticated session

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.