### PR TITLE
Bump `@auth/core` peer dependency

### DIFF
--- a/docs/pages/setup.mdx
+++ b/docs/pages/setup.mdx
@@ -44,7 +44,7 @@ instructions above.
 ### Install the NPM library
 
 ```sh
-npm install @convex-dev/auth @auth/core@0.37.0
+npm install @convex-dev/auth @auth/core@0.41.1
 ```
 
 This also installs `@auth/core`, which you will use during provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.37.0",
+        "@auth/core": "^0.41.1",
         "convex": "^1.17.0",
         "react": "^18.2.0 || ^19.0.0-0"
       },
@@ -59,22 +59,22 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.37.3",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.3.tgz",
-      "integrity": "sha512-qcffDLwxB9iUYH8GHq68w/KU8jtjAbjjk9xnpoKhjX3+QcntaQ2MKVSkTTocmA6ElpL5vK2xR9CXfQ98dvGnyg==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
-        "cookie": "1.0.1",
-        "jose": "^5.9.6",
-        "oauth4webapi": "^3.1.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
         "preact": "10.24.3",
         "preact-render-to-string": "6.5.11"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
+        "nodemailer": "^7.0.7"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -86,6 +86,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@auth/core/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@commander-js/extra-typings": {
@@ -6533,9 +6543,9 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.1.2.tgz",
-      "integrity": "sha512-KQZkNU+xn02lWrFu5Vjqg9E81yPtDSxUZorRHlLWVoojD+H/0GFbH59kcnz5Thdjj7c4/mYMBPj/mhvGe/kKXA==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "server-only": "^0.0.1"
   },
   "peerDependencies": {
-    "@auth/core": "^0.37.0",
+    "@auth/core": "^0.41.1",
     "convex": "^1.17.0",
     "react": "^18.2.0 || ^19.0.0-0"
   },

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -80,10 +80,10 @@
         "tsup": "^8.0.1",
         "typescript": "^5.5.2",
         "valibot": "^0.35.0",
-        "vitest": "^1.6.0"
+        "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.37.0",
+        "@auth/core": "^0.41.1",
         "convex": "^1.17.0",
         "react": "^18.2.0 || ^19.0.0-0"
       },

--- a/test-router/package-lock.json
+++ b/test-router/package-lock.json
@@ -100,10 +100,10 @@
         "tsup": "^8.0.1",
         "typescript": "^5.5.2",
         "valibot": "^0.35.0",
-        "vitest": "^1.6.0"
+        "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.37.0",
+        "@auth/core": "^0.41.1",
         "convex": "^1.17.0",
         "react": "^18.2.0 || ^19.0.0-0"
       },

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -62,7 +62,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.91",
+      "version": "0.0.93",
       "license": "Apache-2.0",
       "dependencies": {
         "@oslojs/crypto": "^1.0.1",
@@ -80,20 +80,20 @@
         "auth": "dist/bin.cjs"
       },
       "devDependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
+        "@commander-js/extra-typings": "^15.0.0",
         "@edge-runtime/vm": "^5.0.0",
         "@types/inquirer": "^9.0.7",
-        "@types/node": "20.6.0",
+        "@types/node": "24.12.4",
         "@types/react": "^18.3.12",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "chalk": "^5.3.0",
         "convex-test": "^0.0.20",
-        "cspell": "^9.0.0",
+        "cspell": "^10.0.0",
         "dotenv": "^17.0.0",
         "eslint": "8.49.0",
-        "inquirer": "^13.0.0",
+        "inquirer": "^14.0.0",
         "next": "^15.2.5",
-        "npm-run-all": "^4.1.5",
+        "npm-run-all2": "^9.0.0",
         "prettier": "^3.2.5",
         "react-dom": "^18.3.1",
         "shelljs": "^0.8.5",
@@ -101,10 +101,10 @@
         "tsup": "^8.0.1",
         "typescript": "^5.5.2",
         "valibot": "^0.35.0",
-        "vitest": "^1.6.0"
+        "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@auth/core": "^0.37.0",
+        "@auth/core": "^0.41.1",
         "convex": "^1.17.0",
         "react": "^18.2.0 || ^19.0.0-0"
       },


### PR DESCRIPTION
<!-- Describe your PR here. -->
The latest version of `@auth/core` is `0.41.1` but it's currently specified as `^0.37.0` in `package.json`.
When `pnpm` links a newer version of `@auth/core` (such as `0.41.1`), it works correctly but emits a warning:
```
.
└─┬ @convex-dev/auth 0.0.91
  └── ✕ unmet peer @auth/core@^0.37.0: found 0.41.1
```
This change fixes the warning.

Alternatively, `>=` could be used if the Convex team doesn't plan to update the peer dependencies often.
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.