### PR TITLE
fix(oauth): drop `partitioned: true` and use `sameSite: "lax"` cookies

### DIFF
--- a/src/server/cookies.ts
+++ b/src/server/cookies.ts
@@ -1,11 +1,26 @@
 import { isLocalHost } from "./utils.js";
 
+// These options apply to every cookie Convex Auth sets during OAuth flows
+// (PKCE code_verifier, state, nonce, redirectTo). They must be carried back
+// from the OAuth provider callback to the Convex callback endpoint on the
+// same convex.site origin.
+//
+// Why `sameSite: "lax"` and no `partitioned`:
+// - `sameSite: "lax"` still sends the cookie on the top-level navigation
+//   initiated by the OAuth provider redirecting back to `/api/auth/callback/*`,
+//   which is what all of these cookies need.
+// - `sameSite: "none" + partitioned: true` was failing under iOS
+//   `ASWebAuthenticationSession` (especially with `preferEphemeralSession:
+//   true`) — Safari would not replay the cookie on the return leg after
+//   Google, dropping the PKCE verifier, state, nonce, and redirectTo. That
+//   manifested as `checkOAuthBodyError` during the Google token exchange and
+//   as a fallthrough to `SITE_URL` in the redirect callback. See
+//   https://github.com/get-convex/convex-auth/issues/218.
 export const SHARED_COOKIE_OPTIONS = {
   httpOnly: true,
-  sameSite: "none" as const,
+  sameSite: "lax" as const,
   secure: true,
   path: "/",
-  partitioned: true,
 };
 
 const REDIRECT_MAX_AGE = 60 * 15; // 15 minutes in seconds


### PR DESCRIPTION
## Summary

Fixes #218.

The cookies Convex Auth sets during OAuth flows (PKCE `code_verifier`, `state`, `nonce`, `redirectToParam`) are dropped by iOS `ASWebAuthenticationSession` on the return leg from the OAuth provider, because of the `sameSite: "none" + partitioned: true` combo in `SHARED_COOKIE_OPTIONS`. Switching to `sameSite: "lax"` and dropping `partitioned` restores the flow on native without breaking web.

## Repro

1. Expo / React Native app using `@convex-dev/auth` with the Google provider.
2. Open the OAuth flow via `expo-web-browser`:
   ```ts
   const { redirect } = await signIn('google', { redirectTo });
   const result = await WebBrowser.openAuthSessionAsync(
     redirect.toString(),
     redirectTo,
     { preferEphemeralSession: true },
   );
   ```
3. Sign in with Google.

**Observed before this PR:**
- `checkOAuthBodyError` from `processAuthorizationCodeOpenIDResponse` during the Google token exchange — the PKCE cookie is missing on the callback leg, so `handleOAuth` sends the `"decoy"` verifier and Google rejects the exchange.
- `Uncaught Error: Invalid state` from `userOAuthImpl` for providers that rely on the `state` cookie (another user reports this on GitHub OAuth in the linked issue).
- On providers where the token exchange does succeed, the final redirect uses `SITE_URL` instead of the mobile scheme because the `redirectToParam` cookie is also missing — the user lands on the web homepage instead of being deep-linked back into the app.

## Root cause

`ASWebAuthenticationSession` (especially with `preferEphemeralSession: true`, which is the recommended setting for OAuth flows because it forces an account picker) runs the OAuth flow in an isolated Safari browsing context. WebKit treats the `partitioned` cookie as belonging to a different partition when the top-level origin flips from `<convex-site>` → `accounts.google.com` → `<convex-site>`, so cookies set on the outbound leg are dropped on the return leg.

`sameSite: "none"` + `partitioned: true` is the combination specifically required for iframe-embedded cross-site flows (e.g. a cross-domain auth widget embedded in another site). Convex Auth's OAuth flow is not an iframe flow — it's a full-page top-level navigation from the callback URL. `sameSite: "lax"` is the correct and safer default for that, and it's what most OAuth state cookie implementations use.

## Change

One file: `src/server/cookies.ts`.

```diff
 export const SHARED_COOKIE_OPTIONS = {
   httpOnly: true,
-  sameSite: "none" as const,
+  sameSite: "lax" as const,
   secure: true,
   path: "/",
-  partitioned: true,
 };
```

## Compatibility

- **Native (Expo / React Native):** Fixes the issue.
- **Standard web (Next.js, SPA, SSR):** No regression. The OAuth callback is a top-level navigation, which `sameSite: "lax"` permits; `partitioned: true` was never required here.
- **Cross-domain iframe embedding:** If anyone is embedding Convex Auth UI inside another site's iframe and relying on `SameSite=None; Partitioned` for that case, they would be affected. This seems extremely unlikely for an OAuth state cookie flow, but maintainers should confirm whether that use case is supported.

## Test plan

- [x] Verified fix locally in a production Expo app against a real Google OAuth flow (staging Convex deployment) — sign-in now completes end-to-end, the mobile deep link fires correctly, and the second `signIn('google', { code })` call succeeds.
- [ ] Repo CI (upstream tests) — pending PR checks.

## Notes

Happy to iterate on the approach if maintainers would prefer:
1. Making `SHARED_COOKIE_OPTIONS` user-configurable via the `convexAuth()` config (opt-in behavior change), or
2. Providing a separate set of cookie options specifically for the OAuth flow while keeping the main cookies as-is.

But `sameSite: "lax"` is the genuinely correct default for OAuth state cookies, and the current defaults are broken on mobile today, so I'd lean toward just landing the change as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth authentication security by adjusting cookie handling during the sign-in process for improved reliability and cross-site request protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->