### PR TITLE
Export useAuth hook for custom auth providers

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -18,6 +18,8 @@ import {
 } from "./client.js";
 import { AuthClient } from "./clientType.js";
 
+export { useAuth as useConvexAuth } from "./client.js";
+
 /**
  * Use this hook to access the `signIn` and `signOut` methods:
  *


### PR DESCRIPTION
Allow consumers to build their own auth providers.

We need that because our frontend is connecting to two different Convex instances, where one of them is the auth provider.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
