### PR TITLE
Re-run OIDC discovery after token exchange for Microsoft Entra ID

### DIFF
--- a/src/server/oauth/callback.ts
+++ b/src/server/oauth/callback.ts
@@ -220,9 +220,17 @@ export async function handleOAuth(
         }
         const { tid } = decodeJwt(responseJson.id_token);
         if (typeof tid === "string") {
-          const tenantRe = /microsoftonline\.com\/(\w+)\/v2\.0/;
-          const tenantId = as.issuer?.match(tenantRe)?.[1] ?? "common";
-          const issuer = new URL(as.issuer.replace(tenantId, tid));
+          // Match any URL path segment so we cover both authority names like
+          // `common`/`organizations`/`consumers` and hyphenated tenant GUIDs.
+          // Rewrite via the segment-anchored regex (not a substring replace)
+          // so we can't accidentally clobber an unrelated part of the URL.
+          const tenantSegmentRe = /microsoftonline\.com\/[^/]+\/v2\.0/;
+          const issuer = new URL(
+            as.issuer.replace(
+              tenantSegmentRe,
+              `microsoftonline.com/${tid}/v2.0`,
+            ),
+          );
           // ConvexAuth: Rewrite the `{tenantid}` placeholder Microsoft returns
           // in the discovery document's `issuer` field using the real `tid`
           // from the ID token. The provider's own `customFetch` hook (in

--- a/src/server/oauth/callback.ts
+++ b/src/server/oauth/callback.ts
@@ -12,9 +12,35 @@ import {
   callbackUrl,
   getAuthorizationSignature,
 } from "./convexAuth.js";
+import { decodeJwt } from "jose";
 
 function formUrlEncode(token: string) {
   return encodeURIComponent(token).replace(/%20/g, "+");
+}
+
+/**
+ * ConvexAuth: Detect `@auth/core`'s internal `conformInternal` symbol on a
+ * provider config without importing it. The symbol is marked `@internal` and
+ * is not exposed by the package's `exports` map, so any direct import from
+ * `@auth/core/lib/symbols.js` breaks under bundlers that enforce package
+ * exports (e.g. Vite during `vitest`).
+ *
+ * Providers that opt into core conformance logic (currently
+ * `microsoft-entra-id`, `azure-ad`, `apple`) set
+ * `[conformInternal]: true` using a `Symbol("conform-internal")` instance
+ * from `@auth/core`'s internal module. We identify that same symbol on the
+ * provider by description and read its value.
+ */
+function hasConformInternalSymbol(provider: object): boolean {
+  for (const sym of Object.getOwnPropertySymbols(provider)) {
+    if (
+      sym.description === "conform-internal" &&
+      (provider as Record<symbol, unknown>)[sym] === true
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -52,7 +78,11 @@ export async function handleOAuth(
   const { provider } = options;
 
   // ConvexAuth: The `token` property is not used here
-  const { userinfo, as } = provider;
+  // ConvexAuth: `as` is `let` because some providers (e.g. Microsoft Entra ID
+  // multi-tenant) require re-running OIDC discovery after the token exchange
+  // using a claim from the ID token. See the `conformInternal` block below.
+  const { userinfo } = provider;
+  let { as } = provider;
 
   const client: o.Client = {
     client_id: provider.clientId,
@@ -150,6 +180,97 @@ export async function handleOAuth(
   }
 
   let profile: Profile = {};
+
+  // ConvexAuth: Ported from @auth/core's `handleOAuth`
+  // (packages/core/src/lib/actions/callback/oauth/callback.ts).
+  // Some providers (currently Microsoft Entra ID / Azure AD) need the
+  // authorization server metadata to be re-processed after the token exchange
+  // because the initial discovery document uses a placeholder issuer (e.g.
+  // `https://login.microsoftonline.com/{tenantid}/v2.0`) and the real tenant id
+  // is only known once we have the ID token. Without this, `validateIssuer`
+  // inside `processAuthorizationCodeResponse` rejects the ID token whenever the
+  // app is configured as multi-tenant (`/common`, `/organizations`, `/consumers`).
+  //
+  // `@auth/core` gates this on its internal `conformInternal` symbol, but that
+  // symbol is not exported from the package's public entry points (it lives in
+  // `@auth/core/lib/symbols.js`, which is not listed in the package's `exports`
+  // map). To avoid relying on a deep import that breaks bundlers / Vite, we
+  // detect the symbol structurally by description on the provider object.
+  if (hasConformInternalSymbol(provider)) {
+    switch (provider.id) {
+      case "microsoft-entra-id":
+      case "azure-ad": {
+        /**
+         * These providers return errors in the response body and
+         * need the authorization server metadata to be re-processed
+         * based on the `id_token`'s `tid` claim.
+         * @see: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#error-response-1
+         */
+        const responseJson = await codeGrantResponse.clone().json();
+        if (responseJson.error) {
+          const cause = {
+            providerId: provider.id,
+            ...responseJson,
+          };
+          logWithLevel("DEBUG", "OAuthCallbackError", cause);
+          throw new Error(
+            `OAuth Provider returned an error: ${responseJson.error}`,
+            { cause },
+          );
+        }
+        const { tid } = decodeJwt(responseJson.id_token);
+        if (typeof tid === "string") {
+          const tenantRe = /microsoftonline\.com\/(\w+)\/v2\.0/;
+          const tenantId = as.issuer?.match(tenantRe)?.[1] ?? "common";
+          const issuer = new URL(as.issuer.replace(tenantId, tid));
+          // ConvexAuth: Rewrite the `{tenantid}` placeholder Microsoft returns
+          // in the discovery document's `issuer` field using the real `tid`
+          // from the ID token. The provider's own `customFetch` hook (in
+          // `@auth/core@0.37.x`) derives the replacement from `config.issuer`
+          // captured at construction, so it can't see the per-tenant authority
+          // during this re-discovery. The upstream fix at
+          // https://github.com/nextauthjs/next-auth/pull/13440 derives the
+          // tenant from the request URL instead; once an `@auth/core` release
+          // including it is pinned, this wrapper can defer to
+          // `provider[customFetch]`.
+          const discoveryResponse = await o.discoveryRequest(issuer, {
+            [o.customFetch]: async (
+              ...args: Parameters<typeof fetch>
+            ) => {
+              const response = await fetch(...args);
+              const first = args[0];
+              const requestUrl =
+                typeof first === "string"
+                  ? first
+                  : first instanceof URL
+                    ? first.toString()
+                    : first.url;
+              if (
+                !requestUrl.endsWith(".well-known/openid-configuration")
+              ) {
+                return response;
+              }
+              const json = await response.clone().json();
+              if (
+                typeof json?.issuer === "string" &&
+                json.issuer.includes("{tenantid}")
+              ) {
+                return Response.json({
+                  ...json,
+                  issuer: json.issuer.replace("{tenantid}", tid),
+                });
+              }
+              return response;
+            },
+          });
+          as = await o.processDiscoveryResponse(issuer, discoveryResponse);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
 
   // ConvexAuth: We use the value of the nonce later, aside from feeding it into the
   // `processAuthorizationCodeResponse` function.

--- a/test/convex/auth.ts
+++ b/test/convex/auth.ts
@@ -3,6 +3,7 @@ import GitHub from "@auth/core/providers/github";
 import Google from "@auth/core/providers/google";
 import Resend from "@auth/core/providers/resend";
 import Apple from "@auth/core/providers/apple";
+import MicrosoftEntraID from "@auth/core/providers/microsoft-entra-id";
 import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
 import { Password } from "@convex-dev/auth/providers/Password";
 import { ConvexError } from "convex/values";
@@ -44,6 +45,20 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         token_endpoint_auth_method: "client_secret_post",
       },
       profile: undefined,
+    }),
+    MicrosoftEntraID({
+      clientId: process.env.AUTH_MICROSOFT_ENTRA_ID_ID,
+      clientSecret: process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET,
+      // Skip the profile-photo fetch in tests; the default `profile` callback
+      // calls `https://graph.microsoft.com/...` which our test fetch mocks
+      // don't expect.
+      profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+        };
+      },
     }),
     Resend({
       from: process.env.AUTH_EMAIL ?? "My App <onboarding@resend.dev>",

--- a/test/convex/microsoftEntra.test.ts
+++ b/test/convex/microsoftEntra.test.ts
@@ -1,0 +1,347 @@
+import { convexTest } from "convex-test";
+import { SignJWT, importPKCS8 } from "jose";
+import { describe, expect, test, vi } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import {
+  CONVEX_SITE_URL,
+  JWKS,
+  JWT_PRIVATE_KEY,
+} from "./test.helpers";
+
+// Microsoft Entra ID's discovery document returns the literal string
+// `{tenantid}` as the issuer for multi-tenant authorities (`/common`,
+// `/organizations`, `/consumers`). The `@auth/core` Microsoft Entra ID provider
+// rewrites that placeholder via a `customFetch` hook so the initial issuer
+// validation succeeds, but the real per-tenant issuer is only known after the
+// token exchange, when we can read `tid` from the `id_token`.
+//
+// Before the fix, `@convex-dev/auth`'s callback handler skipped the
+// post-token-exchange re-discovery that `@auth/core` performs for these
+// providers. As a result, multi-tenant tokens were rejected by
+// `processAuthorizationCodeResponse`'s issuer check, since the AS metadata
+// still claimed `/common/v2.0` as the issuer while the `id_token` carried the
+// per-tenant URL.
+//
+// These tests exercise the ported re-discovery block.
+
+const TENANT_ID = "11111111-2222-3333-4444-555555555555";
+const SPOOFED_TENANT_ID = "99999999-9999-9999-9999-999999999999";
+const SHARED_AUTHORITY = "https://login.microsoftonline.com/common/v2.0";
+
+type DiscoveryDoc = {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+  id_token_signing_alg_values_supported: string[];
+  response_types_supported: string[];
+  subject_types_supported: string[];
+  code_challenge_methods_supported: string[];
+};
+
+function discoveryDocFor(authorityUrl: string): DiscoveryDoc {
+  const baseAuthority = "https://login.microsoftonline.com";
+  // Microsoft returns `{tenantid}` as a placeholder for the issuer field on
+  // the multi-tenant authorities. The provider's `customFetch` hook rewrites
+  // it to whatever segment is in the request URL. We mimic that response
+  // shape verbatim so the provider can do its replacement.
+  return {
+    issuer: `${baseAuthority}/{tenantid}/v2.0`,
+    authorization_endpoint: `${authorityUrl}/oauth2/v2.0/authorize`,
+    token_endpoint: `${authorityUrl}/oauth2/v2.0/token`,
+    userinfo_endpoint: "https://graph.microsoft.com/oidc/userinfo",
+    jwks_uri: `${authorityUrl}/discovery/v2.0/keys`,
+    id_token_signing_alg_values_supported: ["RS256"],
+    response_types_supported: ["code", "id_token"],
+    subject_types_supported: ["pairwise"],
+    code_challenge_methods_supported: ["S256"],
+  };
+}
+
+async function signIdToken(args: {
+  issuer: string;
+  audience: string;
+  tid: string;
+  sub: string;
+  email: string;
+  name: string;
+}) {
+  const privateKey = await importPKCS8(JWT_PRIVATE_KEY, "RS256");
+  return await new SignJWT({
+    tid: args.tid,
+    email: args.email,
+    name: args.name,
+  })
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuer(args.issuer)
+    .setAudience(args.audience)
+    .setSubject(args.sub)
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(privateKey);
+}
+
+function getJwks() {
+  return JSON.parse(JWKS) as {
+    keys: Array<Record<string, unknown>>;
+  };
+}
+
+async function driveSignInUpTo(t: ReturnType<typeof convexTest>) {
+  // Stub fetch for the *initial* OIDC discovery that runs lazily when
+  // convex-auth materializes the provider config inside `t.fetch`.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (
+        url ===
+        `${SHARED_AUTHORITY}/.well-known/openid-configuration`
+      ) {
+        return new Response(JSON.stringify(discoveryDocFor(SHARED_AUTHORITY)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch (init): ${url}`);
+    }),
+  );
+
+  const { redirect, verifier } = await t.action(api.auth.signIn, {
+    provider: "microsoft-entra-id",
+    params: {},
+  });
+  vi.unstubAllGlobals();
+
+  expect(redirect).toEqual(
+    expect.stringContaining(
+      CONVEX_SITE_URL + "/api/auth/signin/microsoft-entra-id",
+    ),
+  );
+
+  const url = new URL(redirect!);
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL) => {
+      const u = typeof input === "string" ? input : input.toString();
+      if (
+        u ===
+        `${SHARED_AUTHORITY}/.well-known/openid-configuration`
+      ) {
+        return new Response(JSON.stringify(discoveryDocFor(SHARED_AUTHORITY)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected fetch (redirect): ${u}`);
+    }),
+  );
+  const response = await t.fetch(`${url.pathname}${url.search}`);
+  vi.unstubAllGlobals();
+
+  expect(response.status).toBe(302);
+  const redirectedTo = response.headers.get("Location")!;
+  const cookies = response.headers.get("Set-Cookie")!;
+  const redirectedToParams = new URL(redirectedTo).searchParams;
+
+  return { verifier, cookies, redirectedToParams };
+}
+
+async function driveCallback(
+  t: ReturnType<typeof convexTest>,
+  ctx: {
+    verifier: string | undefined;
+    cookies: string;
+    redirectedToParams: URLSearchParams;
+  },
+  opts: {
+    idTokenIssuerTenantId: string;
+    idTokenTidClaim: string;
+    rediscoveryReturnsTenant?: string;
+  },
+) {
+  const callbackUrl = ctx.redirectedToParams.get("redirect_uri")!;
+  const state = ctx.redirectedToParams.get("state") ?? undefined;
+  const codeChallenge = ctx.redirectedToParams.get("code_challenge") ?? undefined;
+
+  const issuedCode = "ms-entra-code";
+  const issuedAccessToken = "ms-entra-access";
+  const expectedTenantAuthority = `https://login.microsoftonline.com/${opts.rediscoveryReturnsTenant ?? opts.idTokenTidClaim}/v2.0`;
+
+  // The id_token's issuer is constructed from `idTokenIssuerTenantId` so we
+  // can simulate both legitimate and spoofed tokens.
+  const idTokenIssuer = `https://login.microsoftonline.com/${opts.idTokenIssuerTenantId}/v2.0`;
+  const audience = process.env.AUTH_MICROSOFT_ENTRA_ID_ID!;
+
+  const idToken = await signIdToken({
+    issuer: idTokenIssuer,
+    audience,
+    tid: opts.idTokenTidClaim,
+    sub: "ms-user-1",
+    email: "user@contoso.example",
+    name: "Contoso User",
+  });
+
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const u =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    // The initial discovery may be re-run here because the callback action
+    // also lazily materializes the provider.
+    if (u === `${SHARED_AUTHORITY}/.well-known/openid-configuration`) {
+      return new Response(JSON.stringify(discoveryDocFor(SHARED_AUTHORITY)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Token exchange.
+    if (u === `${SHARED_AUTHORITY}/oauth2/v2.0/token`) {
+      return new Response(
+        JSON.stringify({
+          access_token: issuedAccessToken,
+          token_type: "Bearer",
+          expires_in: 3600,
+          id_token: idToken,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // Re-discovery (the bit this PR is about).
+    if (
+      u === `${expectedTenantAuthority}/.well-known/openid-configuration`
+    ) {
+      return new Response(
+        JSON.stringify(discoveryDocFor(expectedTenantAuthority)),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // JWKS for either authority.
+    if (
+      u === `${SHARED_AUTHORITY}/discovery/v2.0/keys` ||
+      u === `${expectedTenantAuthority}/discovery/v2.0/keys`
+    ) {
+      return new Response(JSON.stringify(getJwks()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    throw new Error(`Unexpected fetch (callback): ${u}`);
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+
+  // `Set-Cookie` values returned by `Headers.get` are joined with `, ` but
+  // commas also appear inside `Expires=...` dates. Split on the cookie
+  // boundary (`,` followed by a space and a token character) instead of just
+  // `,` so we don't mangle the nonce cookie.
+  const cookieHeader = ctx.cookies
+    .split(/,(?=\s*[A-Za-z0-9_-]+=)/)
+    .map((cookie) => {
+      const [name, value] = cookie.split(";")[0].split("=");
+      return `${name.trim()}=${value};`;
+    })
+    .join(" ");
+
+  const callbackParams = new URLSearchParams({ code: issuedCode });
+  if (state) callbackParams.set("state", state);
+  if (codeChallenge) callbackParams.set("code_challenge", codeChallenge);
+
+  const callbackResponse = await t.fetch(
+    `${new URL(callbackUrl).pathname}?${callbackParams.toString()}`,
+    {
+      headers: { Cookie: cookieHeader },
+    },
+  );
+
+  vi.unstubAllGlobals();
+
+  return { callbackResponse, fetchMock, verifier: ctx.verifier };
+}
+
+function setupEnv() {
+  process.env.SITE_URL = "http://localhost:5173";
+  process.env.CONVEX_SITE_URL = CONVEX_SITE_URL;
+  process.env.JWT_PRIVATE_KEY = JWT_PRIVATE_KEY;
+  process.env.JWKS = JWKS;
+  process.env.AUTH_MICROSOFT_ENTRA_ID_ID = "ms-entra-client-id";
+  process.env.AUTH_MICROSOFT_ENTRA_ID_SECRET = "ms-entra-client-secret";
+  process.env.AUTH_LOG_LEVEL = "ERROR";
+}
+
+describe("microsoft entra id multi-tenant issuer re-discovery", () => {
+  test("accepts an id_token whose issuer matches the tid claim", async () => {
+    setupEnv();
+    const t = convexTest(schema);
+    const ctx = await driveSignInUpTo(t);
+
+    const { callbackResponse, fetchMock } = await driveCallback(
+      t,
+      ctx,
+      {
+        idTokenIssuerTenantId: TENANT_ID,
+        idTokenTidClaim: TENANT_ID,
+      },
+    );
+
+    expect(callbackResponse.status).toBe(302);
+
+    // The re-discovery endpoint for the real tenant must have been hit.
+    const requestedUrls = fetchMock.mock.calls.map((c) => {
+      const input = c[0];
+      return typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    });
+    expect(requestedUrls).toContain(
+      `https://login.microsoftonline.com/${TENANT_ID}/v2.0/.well-known/openid-configuration`,
+    );
+
+    const finalRedirectedTo = callbackResponse.headers.get("Location")!;
+    // The callback redirected the browser back to the app with an auth code.
+    // Before the fix, this redirect would have included an `error=` query
+    // string instead (because the issuer mismatch made the token exchange
+    // throw). Asserting on the presence of a non-null `code` query param is
+    // sufficient to demonstrate the re-discovery succeeded.
+    const code = new URL(finalRedirectedTo).searchParams.get("code");
+    expect(code).not.toBeNull();
+  });
+
+  test("rejects an id_token whose issuer does not match the tid claim", async () => {
+    setupEnv();
+    const t = convexTest(schema);
+    const ctx = await driveSignInUpTo(t);
+
+    // The id_token claims `tid=TENANT_ID`, so we re-discover against
+    // `TENANT_ID/v2.0`, but the token itself was issued by the spoofed tenant.
+    const { callbackResponse } = await driveCallback(t, ctx, {
+      idTokenIssuerTenantId: SPOOFED_TENANT_ID,
+      idTokenTidClaim: TENANT_ID,
+    });
+
+    // The callback handler turns the OAuth error into a redirect with an
+    // `error` query param rather than throwing, but importantly the response
+    // is NOT a successful 302 to the SITE_URL with a code.
+    expect(callbackResponse.status).toBe(302);
+    const location = callbackResponse.headers.get("Location")!;
+    expect(location).not.toContain("?code=");
+  });
+});


### PR DESCRIPTION
# Fix Microsoft Entra ID multi-tenant issuer validation

## Summary

`@convex-dev/auth` rejects every Microsoft Entra ID sign-in whenever the Entra
app is registered against a multi-tenant authority (`/common`,
`/organizations`, or `/consumers`). The callback fails inside
`processAuthorizationCodeResponse` with an `unexpected JWT "iss" (issuer) claim
value` error, because the authorization-server metadata still claims
`https://login.microsoftonline.com/common/v2.0` as the issuer while the
`id_token` Microsoft returns is signed with the *per-tenant* issuer (e.g.
`https://login.microsoftonline.com/<real-tenant-guid>/v2.0`).

This PR ports the per-tenant re-discovery step that `@auth/core` runs after
the token exchange (its `conformInternal` block in
`packages/core/src/lib/actions/callback/oauth/callback.ts`) into convex-auth's
own `handleOAuth`, so the bug is fixed in convex-auth's callback flow
independently of next-auth's release schedule.

## Root cause

Microsoft's discovery endpoint at
`https://login.microsoftonline.com/{authority}/v2.0/.well-known/openid-configuration`
returns the literal string `{tenantid}` in the `issuer` field for the shared
multi-tenant authorities (see
[MicrosoftDocs/azure-docs#113944](https://github.com/MicrosoftDocs/azure-docs/issues/113944)).
The `@auth/core` Microsoft Entra ID provider rewrites that placeholder via a
`customFetch` hook so that the initial discovery succeeds, but the real
per-tenant issuer that ends up inside the signed `id_token` is only knowable
after the token exchange, when we can read the `tid` claim.

`@auth/core`'s `handleOAuth` handles this by re-running OIDC discovery for the
per-tenant authority once it has the `tid`, before calling
`processAuthorizationCodeResponse`. `@convex-dev/auth`'s `handleOAuth` was
ported from a snapshot of `@auth/core` that pre-dates this block (the comment
at the top of the file pins commit `5af1f30a`), so it skipped that step
entirely — which is why issuer validation tripped here.

## Changes

### `src/server/oauth/callback.ts`
- Allow `as` (the authorization server metadata used by `oauth4webapi`) to be
  reassigned later in `handleOAuth`.
- After the token-exchange request, if the provider opted into core
  conformance (i.e. it set the `@auth/core` internal `conformInternal` symbol),
  decode the returned `id_token`, derive the per-tenant authority from `tid`,
  re-fetch the discovery document for that authority, and replace `as`
  before `processAuthorizationCodeResponse` runs.
- Because `@auth/core`'s `conformInternal` symbol is marked `@internal` and
  is **not** listed in the package's `exports` map (so importing it from
  `@auth/core/lib/symbols.js` breaks under bundlers that enforce package
  exports — including Vite/vitest), the new `hasConformInternalSymbol` helper
  detects the symbol structurally by description (`Symbol("conform-internal")`)
  on the provider object instead of importing it. This keeps the gate
  functionally identical to upstream's symbol-based check without taking on
  a fragile deep import.
- The re-discovery uses a small inline `customFetch` wrapper that rewrites the
  `{tenantid}` placeholder in the discovery document's `issuer` field with the
  real `tid` from the ID token. Bypassing `provider[customFetch]` here is
  deliberate: the upstream provider's hook captures `config.issuer` at
  construction time (`/common/v2.0`), so it would rewrite `{tenantid}` to
  `common` and we'd still hit an issuer mismatch. By doing the rewrite
  locally with the real `tid`, this fix works against the currently shipped
  `@auth/core@0.37.x` and does not require waiting for the parallel
  `nextauthjs/next-auth` fix at https://github.com/nextauthjs/next-auth/pull/13440 to release.

### `test/convex/auth.ts`
- Register the Microsoft Entra ID provider with a no-op `profile` callback so
  the tests don't try to hit `https://graph.microsoft.com/...` for the user's
  profile photo.

### `test/convex/microsoftEntra.test.ts` (new)
Two tests exercise the new code path through the real Convex HTTP callback
flow, with `fetch` stubbed to simulate Microsoft's discovery + token endpoints
and a signed `id_token` produced from the same RSA key pair already used by
the test suite:

- **`accepts an id_token whose issuer matches the tid claim`** — drives a full
  multi-tenant sign-in through `/api/auth/signin/microsoft-entra-id` and the
  callback handler; asserts the re-discovery endpoint for the real tenant
  GUID is hit and the callback redirects back to the app with an auth code.
- **`rejects an id_token whose issuer does not match the tid claim`** —
  same flow, but signs the `id_token` with a different (spoofed) issuer than
  the `tid` claim; asserts the callback does *not* succeed (oauth4webapi's
  issuer validation rejects the token, the catch in `signIn` redirects without
  a `code`).

The existing GitHub `oauth.test.ts` suite continues to pass, exercising the
non-Microsoft path unchanged.

## Before / after

Before:
```
[microsoft-entra-id callback] OperationProcessingError:
  unexpected JWT "iss" (issuer) claim value
  expected: "https://login.microsoftonline.com/common/v2.0"
  actual:   "https://login.microsoftonline.com/<tenant-guid>/v2.0"
```

After: multi-tenant sign-ins complete successfully; spoofed-issuer tokens
remain rejected by `processAuthorizationCodeResponse`.

## Related

- Parallel `@auth/core` fix that updates the provider's `customFetch` to look
  at the request URL before falling back to `config.issuer`:
  https://github.com/nextauthjs/next-auth/pull/13440
- Upstream `conformInternal` block this is ported from:
  [`packages/core/src/lib/actions/callback/oauth/callback.ts#L188-L224`](https://github.com/nextauthjs/next-auth/blob/main/packages/core/src/lib/actions/callback/oauth/callback.ts#L188-L224)
- Microsoft docs for the multi-tenant authority issuer placeholder:
  [`microsoftonline.com/{tenantid}/v2.0`](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow)
- [MicrosoftDocs/azure-docs#113944](https://github.com/MicrosoftDocs/azure-docs/issues/113944)

## Test plan

- [x] `cd test && npm run test:once` — 14 files / 42 tests pass (including 2
      new Microsoft Entra ID tests).
- [x] `npx tsc --project tsconfig.server.json --noEmit` — clean.
- [x] `npx eslint src` — clean.
- [x] `cd test && npm run lint` — clean.
- [x] Existing GitHub `oauth.test.ts` continues to pass (non-Microsoft
      regression coverage).
