### PR TITLE
Fix Playwright install hang on Node 24, add CI test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/test-nextjs/package-lock.json
+++ b/test-nextjs/package-lock.json
@@ -26,7 +26,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.48.1",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@convex-dev/auth",
-      "version": "0.0.92",
+      "version": "0.0.93",
       "license": "Apache-2.0",
       "dependencies": {
         "@oslojs/crypto": "^1.0.1",
@@ -489,12 +489,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
-      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4183,12 +4184,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
-      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4201,10 +4203,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
-      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/test-nextjs/package.json
+++ b/test-nextjs/package.json
@@ -32,7 +32,7 @@
     "adm-zip": "0.5.14"
   },
   "devDependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
- Bump test-nextjs Playwright to v1.60.0. `playwright install` deterministically hangs right after the Chromium download on Node ≥24.16 (a yauzl extraction regression in Playwright <1.60.0). This is what stalls #321's Node 18→24 bump for 6h.
- Add `timeout-minutes: 20` to the test job so a hung step fails fast instead of running to GitHub's 6h default.

Note: unblocks the install step for #321, but the downstream Next.js e2e step on Node 24 is still unverified (see the existing TODO in test.yml).