### PR TITLE
docs: use named imports in provider JSDoc examples

### DIFF
--- a/docs/pages/advanced.mdx
+++ b/docs/pages/advanced.mdx
@@ -75,7 +75,7 @@ providing the
 
 ```ts
 import GitHub from "@auth/core/providers/github";
-import Password from "@convex-dev/auth/providers/Password";
+import { Password } from "@convex-dev/auth/providers/Password";
 import { MutationCtx } from "./_generated/server";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = {
@@ -117,7 +117,7 @@ you can still perform additional writes to the database with the
 
 ```ts
 import GitHub from "@auth/core/providers/github";
-import Password from "@convex-dev/auth/providers/Password";
+import { Password } from "@convex-dev/auth/providers/Password";
 import { MutationCtx } from "./_generated/server";
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({

--- a/src/providers/ConvexCredentials.ts
+++ b/src/providers/ConvexCredentials.ts
@@ -5,7 +5,7 @@
  * use the [`Password`](https://labs.convex.dev/auth/api_reference/providers/Password) provider instead.
  *
  * ```ts
- * import ConvexCredentials from "@convex-dev/auth/providers/ConvexCredentials";
+ * import { ConvexCredentials } from "@convex-dev/auth/providers/ConvexCredentials";
  * import { convexAuth } from "@convex-dev/auth/server";
  *
  * export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({

--- a/src/providers/Email.ts
+++ b/src/providers/Email.ts
@@ -19,7 +19,7 @@ import { EmailConfig, EmailUserConfig } from "../server/types.js";
  * you can override the `authorize` method to skip the check:
  *
  * ```ts
- * import Email from "@convex-dev/auth/providers/Email";
+ * import { Email } from "@convex-dev/auth/providers/Email";
  * import { convexAuth } from "@convex-dev/auth/server";
  *
  * export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({

--- a/src/providers/Password.ts
+++ b/src/providers/Password.ts
@@ -12,7 +12,7 @@
  *    included in params, verify an OTP.
  *
  * ```ts
- * import Password from "@convex-dev/auth/providers/Password";
+ * import { Password } from "@convex-dev/auth/providers/Password";
  * import { convexAuth } from "@convex-dev/auth/server";
  *
  * export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({


### PR DESCRIPTION
## Summary

All Convex Auth providers are **named** exports, but several JSDoc and docs examples showed a **default** import (`import Password from …`) that doesn't work when copied. This aligns them with the correct named form already used by `Anonymous` and the website docs.

- `src/providers/Password.ts`, `Email.ts`, `ConvexCredentials.ts` — JSDoc `@example` imports.
- `docs/pages/advanced.mdx` — two code samples.

Pure documentation/comment change; no code or behavior changes.

This is the base of a two-PR stack — the passkey feature builds on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)