### PR TITLE
Fix Auth v2 CI

### DIFF
--- a/.github/workflows/test-v2.yml
+++ b/.github/workflows/test-v2.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, reboot]
   pull_request:
-    branches: [main, reboot]
 
 permissions: {}
 
@@ -25,9 +24,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: |
-          npm ci
-          cd test; npm ci
+        run: npm ci
 
       - name: test
-        run: npm run test:once
+        run: npx vitest run

--- a/src/components/test.test.ts
+++ b/src/components/test.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+
+// TODO(nicolas) Remove this when we have v2 tests
+test("adds 1 + 2 to equal 3", () => {
+  expect(1 + 2).toBe(3);
+});


### PR DESCRIPTION
- Making sure the v2 CI also runs when pushing stacked PRs
- Fix the tests that are run: we want to run the Vitest tests, not `test:once` (which runs the v1 tests in `/test`)