### PR TITLE
Build argon2-wasm before running the v2 CI

### DIFF
--- a/.github/actions/argon2-wasm-setup/action.yml
+++ b/.github/actions/argon2-wasm-setup/action.yml
@@ -1,0 +1,24 @@
+name: argon2-wasm setup
+description: Install just, the pinned Rust toolchain, and cache cargo artifacts for argon2-wasm
+
+runs:
+  using: composite
+  steps:
+    - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+
+    # Reads rust-toolchain.toml and installs the pinned toolchain + targets.
+    - name: Install pinned Rust toolchain
+      shell: bash
+      working-directory: src/components/passwordProvider/argon2-wasm
+      run: rustup toolchain install
+
+    - name: Cache cargo registry and build artifacts
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          src/components/passwordProvider/argon2-wasm/target
+        key: ${{ runner.os }}-cargo-argon2-wasm-${{ hashFiles('src/components/passwordProvider/argon2-wasm/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-argon2-wasm-

--- a/.github/workflows/argon2-wasm.yml
+++ b/.github/workflows/argon2-wasm.yml
@@ -24,22 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
-
-      # Reads rust-toolchain.toml and installs the pinned toolchain + targets.
-      - name: Install pinned Rust toolchain
-        run: rustup toolchain install
-
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src/components/passwordProvider/argon2-wasm/target
-          key: ${{ runner.os }}-cargo-argon2-wasm-${{ hashFiles('src/components/passwordProvider/argon2-wasm/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-argon2-wasm-
+      - uses: ./.github/actions/argon2-wasm-setup
 
       - name: cargo fmt
         run: just fmt

--- a/.github/workflows/test-v2.yml
+++ b/.github/workflows/test-v2.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/argon2-wasm-setup
+
+      - name: Build argon2-wasm
+        working-directory: src/components/passwordProvider/argon2-wasm
+        run: just build
+
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
Starting from #360, the v2 code will depend on the WASM-compiled Rust crate added in #362. I’m making sure that we build the Rust project before running the v2 CI so that it can succeed.