### PR TITLE
Updated core API with better type safety

### DIFF
--- a/examples/react-minimal/.gitignore
+++ b/examples/react-minimal/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-minimal/convex/_generated/api.d.ts
+++ b/examples/react-minimal/convex/_generated/api.d.ts
@@ -1,0 +1,53 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+};

--- a/examples/react-minimal/convex/_generated/api.js
+++ b/examples/react-minimal/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-minimal/convex/_generated/dataModel.d.ts
+++ b/examples/react-minimal/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-minimal/convex/_generated/server.d.ts
+++ b/examples/react-minimal/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-minimal/convex/_generated/server.js
+++ b/examples/react-minimal/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -1,13 +1,33 @@
+import { CompleteSignInFunc, defineProvider } from "../../../src/lib/types";
 import { components, internal } from "./_generated/api";
-import { setupCore } from "@convex-dev/auth/core/setup.js";
+import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
+
+const FooProvider = defineProvider({
+  name: "foo",
+  setup: (completeSignIn, options: { x: string }) => {
+    return {
+      login: () => null,
+    };
+  },
+});
 
 // The core owns sessions, accounts, and JWT minting. It calls back into our
 // `upsertFromAuth` on every sign-in; this example owns no users table and just
 // echoes the account id back as the app user id.
-const core = setupCore({
+export const { signOut, refreshSession, providers } = setupCore({
   component: components.core,
-  createOrUpdateUser: internal.users.upsertFromAuth,
-});
+  providers: [
+    provider(FooProvider, { x: "value" }),
+    provider(
+      {
+        name: "bar",
+        setup: (completeSignIn: CompleteSignInFunc, options: { x: number }) => {
+          return { x: "hi" };
+        },
+      },
+      { x: 2 },
+    ),
+  ],
+}).attachUserCallback(internal.users.upsertFromAuth);
 
-// A sign-in path (e.g. username/password) is wired in alongside a provider.
-export const { signOut, refreshSession } = core;
+const { foo, bar } = providers;

--- a/examples/react-minimal/convex/schema.ts
+++ b/examples/react-minimal/convex/schema.ts
@@ -9,4 +9,7 @@ export default defineSchema({
     authorName: v.string(),
     body: v.string(),
   }).index("by_author", ["authorId"]),
+  users: defineTable({
+    name: v.string(),
+  }),
 });

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -1,5 +1,5 @@
 import { internalMutation, query } from "./_generated/server";
-import { v } from "convex/values";
+import { GenericId, v } from "convex/values";
 
 /**
  * The app's user create-or-update callback. The core invokes it (via a function
@@ -19,13 +19,19 @@ import { v } from "convex/values";
  */
 export const upsertFromAuth = internalMutation({
   args: {
-    provider: v.string(),
+    provider: v.union(v.literal("foo"), v.literal("bar")),
     providerAccountId: v.string(),
     profile: v.any(),
-    userId: v.optional(v.string()),
+    userId: v.union(v.string(), v.null()),
   },
-  returns: v.string(),
-  handler: async (_ctx, args) => args.userId ?? args.providerAccountId,
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    args.provider;
+    if (args.profile.name && typeof args.profile.name === "string") {
+      return ctx.db.insert("users", { name: args.profile.name });
+    }
+    throw Error("unable to add user; no name");
+  },
 });
 
 /**

--- a/examples/react-minimal/package-lock.json
+++ b/examples/react-minimal/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "^19.2.7"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.3.4",
+        "@vitejs/plugin-react": "^6.0.3",
         "typescript": "^6.0.3",
         "vite": "^8.0.16"
       }
@@ -43,7 +43,7 @@
         "@commander-js/extra-typings": "^15.0.0",
         "@edge-runtime/vm": "^5.0.0",
         "@types/inquirer": "^9.0.7",
-        "@types/node": "24.12.4",
+        "@types/node": "^24.12.4",
         "@types/react": "^18.3.12",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "chalk": "^5.3.0",
@@ -73,288 +73,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@convex-dev/auth": {
@@ -811,56 +529,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -1166,9 +834,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1183,146 +851,31 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
         },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
+        "babel-plugin-react-compiler": {
+          "optional": true
         }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convex": {
       "version": "1.41.0",
@@ -1362,24 +915,6 @@
         }
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1389,13 +924,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/esbuild": {
       "version": "0.27.0",
@@ -1438,16 +966,6 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1479,49 +997,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -1797,23 +1272,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -1831,16 +1289,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/picocolors": {
@@ -1928,16 +1376,6 @@
         "react": "^19.2.7"
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -1972,28 +1410,11 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2042,37 +1463,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/vite": {
@@ -2173,13 +1563,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/examples/react-minimal/package.json
+++ b/examples/react-minimal/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }

--- a/src/components/core/public.ts
+++ b/src/components/core/public.ts
@@ -138,9 +138,9 @@ async function issueSession(
 }
 
 type CreateOrUpdateUserFunctionHandle = FunctionHandle<
-  CreateOrUpdateUserFn["_type"],
-  CreateOrUpdateUserFn["_args"],
-  CreateOrUpdateUserFn["_returnType"]
+  CreateOrUpdateUserFn<string>["_type"],
+  CreateOrUpdateUserFn<string>["_args"],
+  CreateOrUpdateUserFn<string>["_returnType"]
 >;
 
 /**

--- a/src/components/core/setup.ts
+++ b/src/components/core/setup.ts
@@ -95,6 +95,31 @@ type AuthApi<T extends readonly ProviderWithOptions[]> = {
 // determined without typing the `createOrUpdateUser` argument. See the note
 // on `setupCore` for why that decoupling is required.
 type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
+  /**
+   * The `createOrUpdateUser` function passed in here represents the core
+   * entrypoint for an application to integrate its user model with Convex Auth.
+   *
+   * It will be called in two scenarios, both associated with a user signing in:
+   *
+   *  1. The first time a user signs in with an account from a provider.
+   *    * The `userId` argument will not be present in this case.
+   *    * The application should do one of:
+   *      a. Create a new user record and return its `_id`
+   *      b. Use trusted information in the `profile` (e.g. a verified email)
+   *         to associate the account with an existing user, and return its
+   *         `_id`
+   *  2. Subsequent sign ins from a provider
+   *    * The `userId` argument will be present.
+   *    * The application may use the data in `profile` to update or otherwise
+   *      modify the stored user record.
+   *    * The existing `userId` must be the return value.
+   *
+   * The application keeps ownership of its users table — the core only holds a
+   * reference to this one mutation.
+   *
+   * If an application wants to reject a sign in, it can throw a `ConvexError`
+   * and the entire sign in attempt will be blocked.
+   */
   attachUserCallback(
     createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
   ): AuthApi<T>;
@@ -120,8 +145,11 @@ type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
  *
  * Changes to token TTLs impact newly minted tokens, not ones that have
  * already been issued.
+ *
+ * @returns a builder object with an `attachUserCallback` function that
+ *          completes the configuration of Convex Auth.
  */
-// ## Why this is a two-step (`setupCore(...).attachUserCallback(...)`) API
+// Why this is a two-step (`setupCore(...).attachUserCallback(...)`) API
 //
 // The app's `createOrUpdateUser` is a reference into the app's *own* `internal`
 // API. But the module that calls `setupCore` also exports the handlers this

--- a/src/components/core/setup.ts
+++ b/src/components/core/setup.ts
@@ -1,28 +1,117 @@
 import {
   mutationGeneric,
   createFunctionHandle,
-  type GenericActionCtx,
+  RegisteredMutation,
 } from "convex/server";
 import { v } from "convex/values";
 import type { ComponentApi } from "./_generated/component.js";
 import {
   vTokenBundle,
   type TokenBundle,
-  type AuthClaims,
+  ProviderConfig,
+  CompleteSignInFunc,
 } from "../../lib/types.js";
 import { CreateOrUpdateUserFn } from "../../lib/types.js";
 
+// Helper: pairs a `ProviderConfig` with its options, preserving `Name`, `Options` and `Api` individually.
+export function provider<Name extends string, Options, Api>(
+  config: ProviderConfig<Name, Options, Api>,
+  options: Options,
+): readonly [ProviderConfig<Name, Options, Api>, Options] {
+  return [config, options] as const;
+}
+
+// An explicitly loosley typed tuple of [ProviderConfig, Options].
+type ProviderWithOptions = readonly [ProviderConfig<any, any, any>, any];
+
+// Maps a tuple of entries to
+// { [ProviderConfig.name]: ReturnType<ProviderConfig.setup> } by distributing
+// over the tuple's union.
+type ProviderApis<T extends readonly ProviderWithOptions[]> = {
+  [K in T[number] as K[0]["name"]]: ReturnType<K[0]["setup"]>;
+};
+
+/**
+ * Refreshes a session using the given token, rotating the refresh token.
+ *
+ * A successful refresh returns a new token bundle. A failed refresh (an
+ * unknown or expired token) returns `null` and leaves no usable session
+ * behind (an expired session is deleted as part of the same call). Callers,
+ * including the client, should treat a `null` result as signed-out and clear
+ * any stored session.
+ */
+type RefreshSessionFunc = RegisteredMutation<
+  "public",
+  {
+    refreshToken: string;
+  },
+  Promise<TokenBundle | null>
+>;
+
+/**
+ * Signs out of the current session.
+ *
+ * After this the refresh token is no longer valid.
+ */
+type SignOutFunc = RegisteredMutation<
+  "public",
+  {
+    refreshToken: string;
+  },
+  Promise<null>
+>;
+
+// The app-facing handlers that `attachUserCallback` produces once the
+// create-or-update-user callback is supplied.
+type AuthApi<T extends readonly ProviderWithOptions[]> = {
+  /**
+   * Signs out of the current session.
+   *
+   * After this the refresh token is no longer valid.
+   */
+  signOut: SignOutFunc;
+  /**
+   * Refreshes a session using the given token, rotating the refresh token.
+   *
+   * A successful refresh returns a new token bundle. A failed refresh (an
+   * unknown or expired token) returns `null` and leaves no usable session
+   * behind (an expired session is deleted as part of the same call). Callers,
+   * including the client, should treat a `null` result as signed-out and clear
+   * any stored session.
+   */
+  refreshSession: RefreshSessionFunc;
+  /**
+   * The auth APIs that each provider exposes.
+   *
+   * Each provider is accessible on this object by its name.
+   */
+  providers: ProviderApis<T>;
+};
+
+// Intermediate builder returned by `setupCore` before the app's user callback
+// is known. Its sole method, `attachUserCallback`, is deliberately
+// *non-generic* in the provider tuple `T`: `T` is already fixed by the time
+// `attachUserCallback` is called, so its return type `AuthApi<T>` is fully
+// determined without typing the `createOrUpdateUser` argument. See the note
+// on `setupCore` for why that decoupling is required.
+type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
+  attachUserCallback(
+    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
+  ): AuthApi<T>;
+};
+
 /**
  * Build the app-facing auth-core handlers from the mounted `core` component
- * reference and the app's user create-or-update callback. Returns ready-to-export
- * `signOut`/`refreshSession` mutations plus `completeSignIn`, which the provider
- * factories use to turn provider claims into a session.
+ * reference and the auth providers that the app will use. Returns
+ * ready-to-export `signOut`/`refreshSession` mutations plus a typesafe
+ * `providers` object keyed by provider name and containing its API.
  *
  * The core never triggers a sign-in itself: it has no idea how any given
  * provider authenticates a user. *Triggering `signIn` is each provider's
- * responsibility*: a provider verifies the user its own way (checking a
- * password, say), produces the standard claims, and then calls `completeSignIn`
- * to exchange them for a session. The core only supplies that exchange.
+ * responsibility* and should be part of its returned API. A provider verifies
+ * the user its own way (checking a password, say), produces the standard
+ * claims, and then calls a `completeSignIn` function that the core makes
+ * available to each provider to allow them to exchange claims for a session.
  *
  * Token lifetimes are configurable here and default to 1m (access) and 30d
  * (refresh). The access-token TTL must be shorter than the refresh-token TTL,
@@ -32,9 +121,33 @@ import { CreateOrUpdateUserFn } from "../../lib/types.js";
  * Changes to token TTLs impact newly minted tokens, not ones that have
  * already been issued.
  */
-export function setupCore(opts: {
+// ## Why this is a two-step (`setupCore(...).attachUserCallback(...)`) API
+//
+// The app's `createOrUpdateUser` is a reference into the app's *own* `internal`
+// API. But the module that calls `setupCore` also exports the handlers this
+// returns (`signOut` etc.), so those exports are part of that same `internal`
+// API. If the `internal.*` reference were passed straight into this generic
+// call, TS would have to type it while inferring the provider tuple `T` — and
+// typing it forces resolving the module's own API type, which depends on these
+// exports, which depend on this call: a cycle, reported as
+// `TS7022: '…' implicitly has type 'any' because it … is referenced … in its
+// own initializer`.
+//
+// Splitting the call sidesteps that. `setupCore` is generic in `T` but never
+// sees the `internal.*` reference, so inferring `T` touches nothing circular.
+// `attachUserCallback` *does* take the reference, but by then `T` is fixed,
+// so it is a non-generic call whose return type `AuthApi<T>` is fully
+// determined by the signature alone. TS resolves the exported bindings' types
+// from that return type without eagerly typing the `internal.*` argument, so
+// the cycle never forms. (Inside the *single generic* call it did, because
+// inferring `T` required typing every argument, `internal.*` included.)
+export function setupCore<T extends readonly ProviderWithOptions[]>({
+  component,
+  accessTokenTtlSeconds,
+  refreshTokenTtlSeconds,
+  providers,
+}: {
   component: ComponentApi;
-  createOrUpdateUser: CreateOrUpdateUserFn;
   /**
    * Access-token lifetime in seconds. Defaults to 60 (1 minute).
    *
@@ -49,98 +162,66 @@ export function setupCore(opts: {
    * already been issued.
    */
   refreshTokenTtlSeconds?: number;
-}) {
-  const {
-    component,
-    createOrUpdateUser,
-    accessTokenTtlSeconds,
-    refreshTokenTtlSeconds,
-  } = opts;
-
+  providers: T;
+}): CoreBuilder<T> {
   const issuer = (): string => {
     const url = process.env.CONVEX_SITE_URL;
     if (!url) throw new Error("CONVEX_SITE_URL is not available");
     return url;
   };
 
-  // --- Provider building blocks --------------------------------------------
-  //
-  // `completeSignIn` is a plain helper function, not a registered
-  // query/mutation, because it isn't an endpoint a client calls directly. It's
-  // composed *inside* a provider's own action: the provider authenticates the
-  // user its own way, then calls it (passing its own `ctx`) to talk to the
-  // core. It takes `ctx` and uses `ctx.runMutation` precisely so it can run
-  // within whatever provider function is already executing.
-  //
-  // The functions further down (`refreshSession`, `signOut`) are different:
-  // they have no provider-specific precondition, so they're registered
-  // mutations the app re-exports for the client to call.
-
-  /**
-   * Hand a provider's identity claims to the core, passing a handle to the
-   * app's user create-or-update mutation so the core can persist app users
-   * without knowing the app's schema. A provider calls this from its sign-in
-   * action once it has authenticated the user and produced claims.
-   *
-   * This initiates a session and the returned token bundle allows authenticating
-   * with the Convex backend and refreshing the session.
-   */
-  const completeSignIn = async (
-    ctx: GenericActionCtx<any>,
-    claims: AuthClaims,
-  ): Promise<TokenBundle> => {
-    const createOrUpdateUserHandle =
-      await createFunctionHandle(createOrUpdateUser);
-    return await ctx.runMutation(component.public.signIn, {
-      claims,
-      createOrUpdateUserHandle,
-      issuer: issuer(),
-      accessTokenTtlSeconds,
-      refreshTokenTtlSeconds,
-    });
-  };
-
-  /**
-   * Refreshes a session using the given token, rotating the refresh token.
-   *
-   * A successful refresh returns a new token bundle. A failed refresh (an
-   * unknown or expired token) returns `null` and leaves no usable session
-   * behind (an expired session is deleted as part of the same call). Callers,
-   * including the client, should treat a `null` result as signed-out and clear
-   * any stored session.
-   */
-  const refreshSession = mutationGeneric({
-    args: { refreshToken: v.string() },
-    returns: v.union(vTokenBundle, v.null()),
-    handler: async (ctx, args): Promise<TokenBundle | null> => {
-      return await ctx.runMutation(component.public.refresh, {
-        refreshToken: args.refreshToken,
+  // Takes the `createOrUpdateUser` callback, wires it to sign in and returns the
+  // full auth API.
+  const buildFullApi = (
+    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
+  ): AuthApi<T> => {
+    const completeSignIn: CompleteSignInFunc = async (ctx, claims) => {
+      const createOrUpdateUserHandle =
+        await createFunctionHandle(createOrUpdateUser);
+      return await ctx.runMutation(component.public.signIn, {
+        claims,
+        createOrUpdateUserHandle,
         issuer: issuer(),
         accessTokenTtlSeconds,
         refreshTokenTtlSeconds,
       });
-    },
-  });
+    };
 
-  /**
-   * Signs out of the current session.
-   *
-   * After this the refresh token is no longer valid.
-   */
-  const signOut = mutationGeneric({
-    args: { refreshToken: v.string() },
-    returns: v.null(),
-    handler: async (ctx, args) => {
-      await ctx.runMutation(component.public.signOut, {
-        refreshToken: args.refreshToken,
-      });
-      return null;
-    },
-  });
+    const result = {} as any;
+    for (const [config, options] of providers) {
+      result[config.name] = config.setup(completeSignIn, options);
+    }
 
-  return {
-    completeSignIn,
-    refreshSession,
-    signOut,
+    const refreshSession = mutationGeneric({
+      args: { refreshToken: v.string() },
+      returns: v.union(vTokenBundle, v.null()),
+      handler: async (ctx, args): Promise<TokenBundle | null> => {
+        return await ctx.runMutation(component.public.refresh, {
+          refreshToken: args.refreshToken,
+          issuer: issuer(),
+          accessTokenTtlSeconds,
+          refreshTokenTtlSeconds,
+        });
+      },
+    });
+
+    const signOut = mutationGeneric({
+      args: { refreshToken: v.string() },
+      returns: v.null(),
+      handler: async (ctx, args) => {
+        await ctx.runMutation(component.public.signOut, {
+          refreshToken: args.refreshToken,
+        });
+        return null;
+      },
+    });
+
+    return {
+      refreshSession,
+      signOut,
+      providers: result,
+    };
   };
+
+  return { attachUserCallback: buildFullApi };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,31 +50,6 @@ export const vCreateOrUpdateUser = v.object({
   userId: v.union(v.string(), v.null()),
 });
 
-/**
- * This function type represents the core entrypoint for an application
- * to integrate its user model with Convex Auth.
- *
- * It will be called in two scenarios, both associated with a user signing in:
- *
- *  1. The first time a user signs in with an account from a provider.
- *    * The `userId` argument will not be present in this case.
- *    * The application should do one of:
- *      a. Create a new user record and return its `_id`
- *      b. Use trusted information in the `profile` (e.g. a verified email)
- *         to associate the account with an existing user, and return its
- *         `_id`
- *  2. Subsequent sign ins from a provider
- *    * The `userId` argument will be present.
- *    * The application may use the data in `profile` to update or otherwise
- *      modify the stored user record.
- *    * The existing `userId` must be the return value.
- *
- * The application keeps ownership of its users table — the core only holds a
- * reference to this one mutation.
- *
- * If an application wants to reject a sign in, it can throw a `ConvexError`
- * and the entire sign in attempt will be blocked.
- */
 export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
   "mutation",
   "internal",
@@ -98,12 +73,59 @@ type ProviderSetupFunc<O, P> = (
 ) => P;
 
 export type ProviderConfig<N extends string, O, P> = {
+  /**
+   * The name of this provider.
+   *
+   * This value will be persisted the `accounts` table and passed to
+   * the {@link CreateOrUpdateUserFn}.
+   */
   name: N;
+  /**
+   * Convex Auth will call this function to setup this provider.
+   *
+   * It should return an object of names to `actionGeneric` Convex
+   * functions that will make up the public API surface of the provider.
+   * The API is responsible for authenticating a user and triggering
+   * the completion of sign in.
+   *
+   * It will be passed a `completeSignIn` function, which is provided
+   * by Convex Auth. That function accepts claims from a provider,
+   * establishes a session and returns the tokens required for a client
+   * application to make authenticated calls to Convex functions.
+   *
+   * The provider function that completes an authentication flow should
+   * call this function when it has authenticated an account and return
+   * the result.
+   *
+   * It will also receive any `options` that the provider defined.
+   */
   setup: ProviderSetupFunc<O, P>;
 };
 
 /**
  * A convenience function for defining a `ProviderConfig`.
+ *
+ * Call it like:
+ *
+ * ```typescript
+ * const FooProvider = defineProvider(
+ *   {
+ *     name: "foo",
+ *     setup: (completeSignIn, options: {limit: number}) => {
+ *       return {
+ *         login: actionGeneric({
+ *           args: {},
+ *           handler: async (ctx, args) => {
+ *             // Do your login magic here.
+ *             const claims = await authenticateFoo(args, options.limit);
+ *             return completeSignIn(claims);
+ *           }
+ *         })
+ *       }
+ *     },
+ *   }
+ * );
+ * ```
  *
  * All of the generic types are inferred from the passed in object.
  */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { FunctionReference } from "convex/server";
+import { FunctionReference, GenericActionCtx } from "convex/server";
 
 import { GenericId, Infer, v } from "convex/values";
 
@@ -75,9 +75,40 @@ export const vCreateOrUpdateUser = v.object({
  * If an application wants to reject a sign in, it can throw a `ConvexError`
  * and the entire sign in attempt will be blocked.
  */
-export type CreateOrUpdateUserFn = FunctionReference<
+export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
   "mutation",
   "internal",
-  Infer<typeof vCreateOrUpdateUser>,
+  {
+    provider: Provider;
+    providerAccountId: string;
+    profile: any;
+    userId: string | null;
+  },
   GenericId<"users">
 >;
+
+export type CompleteSignInFunc = (
+  ctx: GenericActionCtx<any>,
+  claims: AuthClaims,
+) => Promise<TokenBundle>;
+
+type ProviderSetupFunc<O, P> = (
+  completeSignIn: CompleteSignInFunc,
+  options: O,
+) => P;
+
+export type ProviderConfig<N extends string, O, P> = {
+  name: N;
+  setup: ProviderSetupFunc<O, P>;
+};
+
+/**
+ * A convenience function for defining a `ProviderConfig`.
+ *
+ * All of the generic types are inferred from the passed in object.
+ */
+export function defineProvider<const N extends string, O, P>(
+  config: ProviderConfig<N, O, P>,
+): ProviderConfig<N, O, P> {
+  return config;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,11 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/lib/**/*", "src/components/**/*"],
+  "include": ["src/lib/**/*", "src/components/**/*", "examples/**/*"],
   "exclude": [
     "node_modules",
     "dist",
     "prototype",
-    "examples",
     "docs",
     "test",
     "test-router",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,11 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/lib/**/*", "src/components/**/*", "examples/**/*"],
+  "include": ["src/lib/**/*", "src/components/**/*"],
   "exclude": [
     "node_modules",
     "dist",
+    "examples",
     "prototype",
     "docs",
     "test",


### PR DESCRIPTION
<!-- Describe your PR here. -->

The `setupCore` method now takes a list of [ProviderConfig, Options] tuples
and ensures that the application's `createOrUpdateUsers` function is typed
so its `provider` argument matches the configured providers[^1].

This necessitated splitting out an `attachUserCallback` function which is
returned by `setupCore`. Without that, there are circular typing issues
since TypeScript is trying to determine the type of `createOrUpdateUser`
which is a part of the application's API while also exporting the
other functions that are returned during setup (that also become part of
the application's API).

Another benefit of this change is that providers get a more specificly
typed "shape" which should help guide proper creation and configuration.

I took a pass over the documentation too and expanded/moved some
to where it would be more accessible. If you check out the PR and
look at the `examples/react-minimal/auth.ts` you should see helpful
docs on most of the key symbols that are used when creating and
configuring providers. 

You can see an example of usage of the API here: https://github.com/get-convex/convex-auth/pull/367

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[^1]: The matching is a little backward compared to regular TS function references though - it will catch a `createOrUpdateUser` function that supports too many providers, not too few.