### PR TITLE
Password provider: Improve error return values

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/argon2-wasm-setup
+
+      - name: Build argon2-wasm
+        working-directory: src/components/passwordProvider/argon2-wasm
+        run: just build
+
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/src/components/passwordProvider/argon2.ts
+++ b/src/components/passwordProvider/argon2.ts
@@ -10,7 +10,14 @@ import wasmModule from "./argon2-wasm/pkg/argon2_wasm_bg.wasm";
 // (This component doesn’t do concurrent WASM calls at the moment, but it’s still safer to do so.)
 let ready: Promise<unknown> | null = null;
 function ensureReady() {
-  if (!ready) ready = init({ module_or_path: wasmModule }); // WebAssembly.instantiate(module, imports)
+  if (!ready) {
+    ready = init({ module_or_path: wasmModule }).catch((cause) => {
+      // Reset so a later call can retry, and surface a clear error instead of
+      // the raw wasm-bindgen failure.
+      ready = null;
+      throw new Error(`Failed to initialize the argon2 WASM module: ${cause}`);
+    });
+  }
   return ready;
 }
 
@@ -18,7 +25,13 @@ function ensureReady() {
 export async function hashPassword(password: string): Promise<string> {
   await ensureReady();
   const salt = crypto.getRandomValues(new Uint8Array(16)); // randomness stays in JS
-  return hash_password(password, salt);
+  try {
+    return hash_password(password, salt);
+  } catch (cause) {
+    // Hashing shouldn't fail for a valid input; surface a clear error instead
+    // of the raw wasm-bindgen failure.
+    throw new Error(`Failed to hash password: ${cause}`);
+  }
 }
 
 /** Verify a password against a stored PHC string. */
@@ -27,5 +40,12 @@ export async function verifyPassword(
   phc: string,
 ): Promise<boolean> {
   await ensureReady();
-  return verify_password(password, phc);
+  try {
+    return verify_password(password, phc);
+  } catch (cause) {
+    // Thrown when the stored PHC string can't be parsed as an argon2 hash (it's
+    // always our own data, so this is unrecoverable). Surface a clear error
+    // instead of the raw wasm-bindgen failure.
+    throw new Error(`Failed to verify password against the stored hash: ${cause}`);
+  }
 }

--- a/src/components/passwordProvider/argon2.ts
+++ b/src/components/passwordProvider/argon2.ts
@@ -11,7 +11,7 @@ import wasmModule from "./argon2-wasm/pkg/argon2_wasm_bg.wasm";
 let ready: Promise<unknown> | null = null;
 function ensureReady() {
   if (!ready) {
-    ready = init({ module_or_path: wasmModule }).catch((cause) => {
+    ready = init({ module_or_path: wasmModule }).catch((cause: unknown) => {
       // Reset so a later call can retry, and surface a clear error instead of
       // the raw wasm-bindgen failure.
       ready = null;

--- a/src/components/passwordProvider/passwordProvider.test.ts
+++ b/src/components/passwordProvider/passwordProvider.test.ts
@@ -28,15 +28,16 @@ function setup() {
 describe("setPassword + verifyPassword", () => {
   test("verifies the correct password after setting it", async () => {
     const t = setup();
-    await t.mutation(api.public.setPassword, {
+    const setResult = await t.mutation(api.public.setPassword, {
       userId: "alice",
       password: PASSWORD,
     });
-    const ok = await t.mutation(api.public.verifyPassword, {
+    expect(setResult).toEqual({ success: true });
+    const result = await t.mutation(api.public.verifyPassword, {
       userId: "alice",
       password: PASSWORD,
     });
-    expect(ok).toBe(true);
+    expect(result).toEqual({ success: true });
   });
 
   test("rejects a wrong password", async () => {
@@ -45,20 +46,24 @@ describe("setPassword + verifyPassword", () => {
       userId: "alice",
       password: PASSWORD,
     });
-    const ok = await t.mutation(api.public.verifyPassword, {
+    const result = await t.mutation(api.public.verifyPassword, {
       userId: "alice",
       password: "wrong horse battery staple",
     });
-    expect(ok).toBe(false);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "INVALID_CREDENTIALS" },
+    });
   });
 
-  test("returns false for an unknown user id", async () => {
+  test("throws for an unknown user id", async () => {
     const t = setup();
-    const ok = await t.mutation(api.public.verifyPassword, {
-      userId: "nobody",
-      password: PASSWORD,
-    });
-    expect(ok).toBe(false);
+    await expect(
+      t.mutation(api.public.verifyPassword, {
+        userId: "nobody",
+        password: PASSWORD,
+      }),
+    ).rejects.toThrow();
   });
 
   test("upserts: setting a new password replaces the old one", async () => {
@@ -84,32 +89,42 @@ describe("setPassword + verifyPassword", () => {
         userId: "alice",
         password: newPassword,
       }),
-    ).toBe(true);
+    ).toEqual({ success: true });
     expect(
       await t.mutation(api.public.verifyPassword, {
         userId: "alice",
         password: PASSWORD,
       }),
-    ).toBe(false);
+    ).toEqual({
+      success: false,
+      userError: { error: "INVALID_CREDENTIALS" },
+    });
   });
 });
 
 describe("password validation (setPassword only)", () => {
   test("rejects a too-short password", async () => {
     const t = setup();
-    await expect(
-      t.mutation(api.public.setPassword, { userId: "alice", password: "short" }),
-    ).rejects.toThrow(/between 10 and 100/i);
+    const result = await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: "short",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
+    });
   });
 
   test("rejects a password with leading whitespace", async () => {
     const t = setup();
-    await expect(
-      t.mutation(api.public.setPassword, {
-        userId: "alice",
-        password: " leadingspace123",
-      }),
-    ).rejects.toThrow(/whitespace/i);
+    const result = await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: " leadingspace123",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_HAS_SURROUNDING_WHITESPACE" },
+    });
   });
 });
 
@@ -127,11 +142,11 @@ describe("Unicode normalization", () => {
       userId: "alice",
       password: composed,
     });
-    const ok = await t.mutation(api.public.verifyPassword, {
+    const result = await t.mutation(api.public.verifyPassword, {
       userId: "alice",
       password: decomposed,
     });
-    expect(ok).toBe(true);
+    expect(result).toEqual({ success: true });
   });
 });
 
@@ -152,7 +167,10 @@ describe("interoperability with hash-wasm", () => {
 
   test("hash-wasm rejects the wrong password against our crate's hash", async () => {
     const phc = await hashPassword(PASSWORD);
-    const ok = await argon2Verify({ password: "wrong password entirely", hash: phc });
+    const ok = await argon2Verify({
+      password: "wrong password entirely",
+      hash: phc,
+    });
     expect(ok).toBe(false);
   });
 
@@ -252,7 +270,7 @@ describe("verifyPassword is lenient about the stored PHC string", () => {
 });
 
 describe("rate limiting (verifyPassword only)", () => {
-  test("throws once the per-user bucket is exhausted", async () => {
+  test("returns RATE_LIMITED once the per-user bucket is exhausted", async () => {
     const t = setup();
     await t.mutation(api.public.setPassword, {
       userId: "alice",
@@ -267,11 +285,16 @@ describe("rate limiting (verifyPassword only)", () => {
         password: "wrong horse battery staple",
       });
     }
-    await expect(
-      t.mutation(api.public.verifyPassword, {
-        userId: "alice",
-        password: PASSWORD,
-      }),
-    ).rejects.toThrow();
+    const result = await t.mutation(api.public.verifyPassword, {
+      userId: "alice",
+      password: PASSWORD,
+    });
+    expect(result.success).toBe(false);
+    if (result.success === false) {
+      expect(result.userError.error).toBe("RATE_LIMITED");
+      if (result.userError.error === "RATE_LIMITED") {
+        expect(typeof result.userError.retryAfterMs).toBe("number");
+      }
+    }
   });
 });

--- a/src/components/passwordProvider/passwordProvider.test.ts
+++ b/src/components/passwordProvider/passwordProvider.test.ts
@@ -102,7 +102,7 @@ describe("setPassword + verifyPassword", () => {
   });
 });
 
-describe("password validation (setPassword only)", () => {
+describe("password validation (setPassword)", () => {
   test("rejects a too-short password", async () => {
     const t = setup();
     const result = await t.mutation(api.public.setPassword, {
@@ -118,6 +118,56 @@ describe("password validation (setPassword only)", () => {
   test("rejects a password with leading whitespace", async () => {
     const t = setup();
     const result = await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: " leadingspace123",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_HAS_SURROUNDING_WHITESPACE" },
+    });
+  });
+});
+
+describe("password validation (verifyPassword)", () => {
+  test("rejects a too-short password without touching the stored password", async () => {
+    const t = setup();
+    await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: PASSWORD,
+    });
+    const result = await t.mutation(api.public.verifyPassword, {
+      userId: "alice",
+      password: "short",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
+    });
+  });
+
+  test("rejects a too-long password", async () => {
+    const t = setup();
+    await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: PASSWORD,
+    });
+    const result = await t.mutation(api.public.verifyPassword, {
+      userId: "alice",
+      password: "a".repeat(101),
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_TOO_LONG", maximumLength: 100 },
+    });
+  });
+
+  test("rejects a password with surrounding whitespace", async () => {
+    const t = setup();
+    await t.mutation(api.public.setPassword, {
+      userId: "alice",
+      password: PASSWORD,
+    });
+    const result = await t.mutation(api.public.verifyPassword, {
       userId: "alice",
       password: " leadingspace123",
     });

--- a/src/components/passwordProvider/public.ts
+++ b/src/components/passwordProvider/public.ts
@@ -1,13 +1,17 @@
 import { mutation, QueryCtx } from "./_generated/server";
 import { Doc } from "./_generated/dataModel";
 import { components } from "./_generated/api";
-import { v } from "convex/values";
+import { Infer, v } from "convex/values";
 import { RateLimiter, MINUTE } from "@convex-dev/rate-limiter";
 import {
   hashPassword,
   verifyPassword as verifyPasswordHash,
 } from "./argon2.js";
-import { assertValidPassword, normalizePassword } from "./validation.js";
+import {
+  validatePassword,
+  normalizePassword,
+  setPasswordUserError,
+} from "./validation.js";
 
 // Throttle for password verification attempts.
 //
@@ -33,6 +37,12 @@ const rateLimiter = new RateLimiter(components.rateLimiter, {
   },
 });
 
+const setPasswordResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({ success: v.literal(false), userError: setPasswordUserError }),
+);
+type SetPasswordResult = Infer<typeof setPasswordResult>;
+
 /**
  * Set (or replace) a user's password.
  *
@@ -41,9 +51,13 @@ const rateLimiter = new RateLimiter(components.rateLimiter, {
  */
 export const setPassword = mutation({
   args: { userId: v.string(), password: v.string() },
-  returns: v.null(),
-  handler: async (ctx, { userId, password }) => {
-    assertValidPassword(password);
+  returns: setPasswordResult,
+  handler: async (ctx, { userId, password }): Promise<SetPasswordResult> => {
+    const userError = validatePassword(password);
+    if (userError !== null) {
+      return { success: false, userError };
+    }
+
     const passwordHashPHC = await hashPassword(normalizePassword(password));
     const existing = await passwordByUserId(ctx, userId);
     if (existing !== null) {
@@ -51,9 +65,21 @@ export const setPassword = mutation({
     } else {
       await ctx.db.insert("passwords", { userId, passwordHashPHC });
     }
-    return null;
+
+    return { success: true };
   },
 });
+
+const verifyPasswordUserError = v.union(
+  v.object({ error: v.literal("INVALID_CREDENTIALS") }),
+  v.object({ error: v.literal("RATE_LIMITED"), retryAfterMs: v.number() }),
+);
+
+const verifyPasswordResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({ success: v.literal(false), userError: verifyPasswordUserError }),
+);
+type VerifyPasswordResult = Infer<typeof verifyPasswordResult>;
 
 /**
  * Verify a user's password.
@@ -65,20 +91,32 @@ export const setPassword = mutation({
  */
 export const verifyPassword = mutation({
   args: { userId: v.string(), password: v.string() },
-  returns: v.boolean(),
-  handler: async (ctx, { userId, password }) => {
-    await rateLimiter.limit(ctx, "verifyPassword", {
+  returns: verifyPasswordResult,
+  handler: async (ctx, { userId, password }): Promise<VerifyPasswordResult> => {
+    const status = await rateLimiter.limit(ctx, "verifyPassword", {
       key: userId,
-      throws: true,
     });
+    if (!status.ok) {
+      return {
+        success: false,
+        userError: { error: "RATE_LIMITED", retryAfterMs: status.retryAfter },
+      };
+    }
+
     const row = await passwordByUserId(ctx, userId);
     if (row === null) {
-      return false;
+      // The app owns the user ↔ userId mapping, so an unknown userId is an
+      // unrecoverable programming error rather than a user-facing condition.
+      throw new Error(`No password stored for userId ${userId}.`);
     }
-    return await verifyPasswordHash(
+    const matches = await verifyPasswordHash(
       normalizePassword(password),
       row.passwordHashPHC,
     );
+    if (!matches) {
+      return { success: false, userError: { error: "INVALID_CREDENTIALS" } };
+    }
+    return { success: true };
   },
 });
 

--- a/src/components/passwordProvider/public.ts
+++ b/src/components/passwordProvider/public.ts
@@ -71,6 +71,15 @@ export const setPassword = mutation({
 });
 
 const verifyPasswordUserError = v.union(
+  v.object({
+    error: v.literal("PASSWORD_TOO_SHORT"),
+    minimumLength: v.number(),
+  }),
+  v.object({
+    error: v.literal("PASSWORD_TOO_LONG"),
+    maximumLength: v.number(),
+  }),
+  v.object({ error: v.literal("PASSWORD_HAS_SURROUNDING_WHITESPACE") }),
   v.object({ error: v.literal("INVALID_CREDENTIALS") }),
   v.object({ error: v.literal("RATE_LIMITED"), retryAfterMs: v.number() }),
 );
@@ -101,6 +110,22 @@ export const verifyPassword = mutation({
         success: false,
         userError: { error: "RATE_LIMITED", retryAfterMs: status.retryAfter },
       };
+    }
+
+    // We validate the input string before validating the password.
+    // This helps us to provide more user-friendly error messages
+    // (e.g. we can warn them than the password they’re trying
+    // is too short so it can’t be the right one), and is also
+    // useful from a security perspective (we avoid resource
+    // exhaustion attacks where an attacker makes us compute
+    // hashes of really long passwords).
+    //
+    // Note that if we ever change the default password validation rules,
+    // we need to make sure we edit the code so that validation here
+    // still accepts older passwords.
+    const userError = validatePasswordInputFormat(password);
+    if (userError !== null) {
+      return { success: false, userError };
     }
 
     const row = await passwordByUserId(ctx, userId);

--- a/src/components/passwordProvider/public.ts
+++ b/src/components/passwordProvider/public.ts
@@ -8,7 +8,7 @@ import {
   verifyPassword as verifyPasswordHash,
 } from "./argon2.js";
 import {
-  validatePassword,
+  validatePasswordInputFormat,
   normalizePassword,
   setPasswordUserError,
 } from "./validation.js";
@@ -53,7 +53,7 @@ export const setPassword = mutation({
   args: { userId: v.string(), password: v.string() },
   returns: setPasswordResult,
   handler: async (ctx, { userId, password }): Promise<SetPasswordResult> => {
-    const userError = validatePassword(password);
+    const userError = validatePasswordInputFormat(password);
     if (userError !== null) {
       return { success: false, userError };
     }

--- a/src/components/passwordProvider/validation.ts
+++ b/src/components/passwordProvider/validation.ts
@@ -1,27 +1,55 @@
-import { ConvexError } from "convex/values";
+import { Infer, v } from "convex/values";
 
 // Password requirements, following the NIST guidance summarized at
 // https://auth.pilcrowonpaper.com/passwords: 10–100 characters, any printable
 // Unicode, no leading/trailing whitespace.
-//
-// TODO(nicolas) Reorganize these requirements
-export function assertValidPassword(password: string): void {
+
+export const MIN_PASSWORD_LENGTH = 10;
+export const MAX_PASSWORD_LENGTH = 100;
+
+/**
+ * A user-facing error describing why a password was rejected. Safe to surface
+ * to the end user. The `error` field is both a machine-readable code and the
+ * discriminant of the union.
+ */
+export const setPasswordUserError = v.union(
+  v.object({
+    error: v.literal("PASSWORD_TOO_SHORT"),
+    minimumLength: v.number(),
+  }),
+  v.object({
+    error: v.literal("PASSWORD_TOO_LONG"),
+    maximumLength: v.number(),
+  }),
+  v.object({ error: v.literal("PASSWORD_HAS_SURROUNDING_WHITESPACE") }),
+);
+export type SetPasswordUserError = Infer<typeof setPasswordUserError>;
+
+/**
+ * Validate a password against the requirements. Returns a `SetPasswordUserError`
+ * describing the first violation, or `null` when the password is valid.
+ */
+export function validatePassword(
+  password: string,
+): SetPasswordUserError | null {
   // Length is measured in Unicode code points (`[...password].length`) rather
   // than UTF-16 units, so an astral character (e.g. an emoji) counts as one, per
   // NIST's "1 character" intent.
   const length = [...password].length;
 
-  // TODO(nicolas) Replace errors thrown by this message by typed error results
-
-  if (length < 10 || length > 100) {
-    throw new ConvexError("Password must be between 10 and 100 characters.");
+  if (length < MIN_PASSWORD_LENGTH) {
+    return { error: "PASSWORD_TOO_SHORT", minimumLength: MIN_PASSWORD_LENGTH };
+  }
+  if (length > MAX_PASSWORD_LENGTH) {
+    return { error: "PASSWORD_TOO_LONG", maximumLength: MAX_PASSWORD_LENGTH };
   }
   // Reject leading/trailing whitespace. `\s` with the `u` flag matches Unicode
   // whitespace (e.g. non-breaking space, ideographic space), which a plain
   // `password.trim()` comparison would miss.
   if (/^\s|\s$/u.test(password)) {
-    throw new ConvexError("Password must not start or end with whitespace.");
+    return { error: "PASSWORD_HAS_SURROUNDING_WHITESPACE" };
   }
+  return null;
 }
 
 // Normalize to NFC before hashing or verifying so that two inputs that a user

--- a/src/components/passwordProvider/validation.ts
+++ b/src/components/passwordProvider/validation.ts
@@ -29,7 +29,7 @@ export type SetPasswordUserError = Infer<typeof setPasswordUserError>;
  * Validate a password against the requirements. Returns a `SetPasswordUserError`
  * describing the first violation, or `null` when the password is valid.
  */
-export function validatePassword(
+export function validatePasswordInputFormat(
   password: string,
 ): SetPasswordUserError | null {
   // Length is measured in Unicode code points (`[...password].length`) rather


### PR DESCRIPTION
This changes how the password provider returns errors. The goal is to:
- Make sure the expected user errors (e.g. password is too long) does _not_ throw an error, in order to not clutter the app logs
- For errors that are unrecoverable (e.g. unexpected issue in WASM), throw a clear error that will appear in the user’s logs, and don’t return a value.
- Make user errors clear at the type level. This allows errors to be forwarded to the client. Doing this instead of hardcoding error messages in `ConvexError`s will make it easier for users to localize error messages, and customize to the application context.
- Make sure the ergonomics of error handling in `setup*` functions (especially if they’re customized by users) are good. With the return value format that I chose, it should be pretty straightforward:

```ts
const result = await ctx.runMutation(
  components.authPassword.validatePassword,
  { userId, password },
);

if (!result.success) {
  return result.userError; // e.g. { error: "PASSWORD_TOO_LONG", maximumLength: 100 }
}

// …
```