### PR TITLE
Updated core API with better type safety

### DIFF
--- a/examples/react-minimal/.gitignore
+++ b/examples/react-minimal/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-minimal/convex/_generated/api.d.ts
+++ b/examples/react-minimal/convex/_generated/api.d.ts
@@ -1,0 +1,53 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+};

--- a/examples/react-minimal/convex/_generated/api.js
+++ b/examples/react-minimal/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-minimal/convex/_generated/dataModel.d.ts
+++ b/examples/react-minimal/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-minimal/convex/_generated/server.d.ts
+++ b/examples/react-minimal/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-minimal/convex/_generated/server.js
+++ b/examples/react-minimal/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -1,13 +1,38 @@
+import { defineProvider } from "@convex-dev/auth/lib/types.js";
 import { components, internal } from "./_generated/api";
-import { setupCore } from "@convex-dev/auth/core/setup.js";
+import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
 
-// The core owns sessions, accounts, and JWT minting. It calls back into our
-// `upsertFromAuth` on every sign-in; this example owns no users table and just
-// echoes the account id back as the app user id.
-const core = setupCore({
-  component: components.core,
-  createOrUpdateUser: internal.users.upsertFromAuth,
+/**
+ * Documentation for the FakeProvider.
+ *
+ * Pair with {@link FakeOptions} when installing as a {@link provider}.
+ */
+// TODO: dowski - remove this when we have real providers to work with
+const FakeProvider = defineProvider({
+  name: "fake",
+  setup: (completeSignIn, options: FakeOptions) => {
+    return {
+      login: (arg1: string) => null,
+    };
+  },
 });
 
-// A sign-in path (e.g. username/password) is wired in alongside a provider.
-export const { signOut, refreshSession } = core;
+/**
+ * Docs for the FakeOptions.
+ */
+type FakeOptions = {
+  /**
+   * Docs for the exampleValue.
+   */
+  exampleValue: string;
+};
+
+// The core owns sessions, accounts, and JWT minting. It calls back into our
+// `upsertFromAuth` on every sign-in from a provider.
+export const { signOut, refreshSession, providers } = setupCore({
+  component: components.core,
+  providers: [
+    // TODO: dowski - remove this when we have real providers to work with
+    provider(FakeProvider, { exampleValue: "passed to FakeProvider.setup" }),
+  ],
+}).attachUserCallback(internal.users.upsertFromAuth);

--- a/examples/react-minimal/convex/schema.ts
+++ b/examples/react-minimal/convex/schema.ts
@@ -9,4 +9,7 @@ export default defineSchema({
     authorName: v.string(),
     body: v.string(),
   }).index("by_author", ["authorId"]),
+  users: defineTable({
+    name: v.string(),
+  }),
 });

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -1,39 +1,24 @@
-import { internalMutation, query } from "./_generated/server";
+import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
  * The app's user create-or-update callback. The core invokes it (via a function
  * handle) on every sign-in — without a `userId` the first time an identity is
  * seen, and with the resolved `userId` thereafter.
- *
- * This minimal example owns no users table. Instead of storing a row, it simply
- * echoes the provider-scoped account id back as the app's user id. The core
- * treats that value as an opaque string: it goes into the `accounts`/`sessions`
- * tables and becomes the JWT `subject`, so `ctx.auth.getUserIdentity().subject`
- * ends up being the provider account id. The (provider, providerAccountId) pair
- * is stable, so the subject stays the same across logins.
- *
- * The `userId` arg is part of the core's callback contract (it's set on a
- * returning sign-in, and when an existing user links another identity). With no
- * users table there's nothing to update, so we just honor it when present.
  */
 export const upsertFromAuth = internalMutation({
   args: {
-    provider: v.string(),
+    // TODO: dowski - remove this when we have real providers to work with
+    provider: v.union(v.literal("fake")),
     providerAccountId: v.string(),
     profile: v.any(),
-    userId: v.optional(v.string()),
+    userId: v.union(v.string(), v.null()),
   },
-  returns: v.string(),
-  handler: async (_ctx, args) => args.userId ?? args.providerAccountId,
-});
-
-/**
- * The signed-in identity, straight from the access token. There's no user row
- * to load — the subject is the provider account id the core minted into the
- * JWT. Returns null when no one is signed in.
- */
-export const loggedInUser = query({
-  args: {},
-  handler: async (ctx) => ctx.auth.getUserIdentity(),
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    if (args.profile.name && typeof args.profile.name === "string") {
+      return ctx.db.insert("users", { name: args.profile.name });
+    }
+    throw Error("unable to add user; no name");
+  },
 });

--- a/examples/react-minimal/package.json
+++ b/examples/react-minimal/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "eslint": "^10.6.0",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.62.1"
+    "typescript-eslint": "^8.62.1",
+    "vite": "^8.1.2",
+    "vitest": "^4.1.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -138,9 +138,9 @@ async function issueSession(
 }
 
 type CreateOrUpdateUserFunctionHandle = FunctionHandle<
-  CreateOrUpdateUserFn["_type"],
-  CreateOrUpdateUserFn["_args"],
-  CreateOrUpdateUserFn["_returnType"]
+  CreateOrUpdateUserFn<string>["_type"],
+  CreateOrUpdateUserFn<string>["_args"],
+  CreateOrUpdateUserFn<string>["_returnType"]
 >;
 
 /**

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -1,29 +1,147 @@
 import {
   mutationGeneric,
   createFunctionHandle,
-  type GenericActionCtx,
-  type GenericDataModel,
+  RegisteredMutation,
 } from "convex/server";
 import { v } from "convex/values";
 import type { ComponentApi } from "./_generated/component";
 import {
   vTokenBundle,
   type TokenBundle,
-  type AuthClaims,
-} from "../../lib/types";
-import { CreateOrUpdateUserFn } from "../../lib/types";
+  ProviderConfig,
+  CompleteSignInFunc,
+  CreateOrUpdateUserFn,
+} from "../../lib/types.js";
+
+// Helper: pairs a `ProviderConfig` with its options, preserving `Name`, `Options` and `Api` individually.
+// TODO: dowski - consider whether this function should exist, or whether defineProvider
+// should return a function that's callable with the options.
+export function provider<Name extends string, Options, Api>(
+  config: ProviderConfig<Name, Options, Api>,
+  options: Options,
+): readonly [ProviderConfig<Name, Options, Api>, Options] {
+  return [config, options] as const;
+}
+
+// An explicitly loosley typed tuple of [ProviderConfig, Options].
+type ProviderWithOptions = readonly [ProviderConfig<any, any, any>, any];
+
+// Maps a tuple of entries to
+// { [ProviderConfig.name]: ReturnType<ProviderConfig.setup> } by distributing
+// over the tuple's union.
+type ProviderApis<T extends readonly ProviderWithOptions[]> = {
+  [K in T[number]as K[0]["name"]]: ReturnType<K[0]["setup"]>;
+};
+
+/**
+ * Refreshes a session using the given token, rotating the refresh token.
+ *
+ * A successful refresh returns a new token bundle. A failed refresh (an
+ * unknown or expired token) returns `null` and leaves no usable session
+ * behind (an expired session is deleted as part of the same call). Callers,
+ * including the client, should treat a `null` result as signed-out and clear
+ * any stored session.
+ */
+type RefreshSessionFunc = RegisteredMutation<
+  "public",
+  {
+    refreshToken: string;
+  },
+  Promise<TokenBundle | null>
+>;
+
+/**
+ * Signs out of the current session.
+ *
+ * After this the refresh token is no longer valid.
+ */
+type SignOutFunc = RegisteredMutation<
+  "public",
+  {
+    refreshToken: string;
+  },
+  Promise<null>
+>;
+
+// The app-facing handlers that `attachUserCallback` produces once the
+// create-or-update-user callback is supplied.
+type AuthApi<T extends readonly ProviderWithOptions[]> = {
+  /**
+   * Signs out of the current session.
+   *
+   * After this the refresh token is no longer valid.
+   */
+  signOut: SignOutFunc;
+  /**
+   * Refreshes a session using the given token, rotating the refresh token.
+   *
+   * A successful refresh returns a new token bundle. A failed refresh (an
+   * unknown or expired token) returns `null` and leaves no usable session
+   * behind (an expired session is deleted as part of the same call). Callers,
+   * including the client, should treat a `null` result as signed-out and clear
+   * any stored session.
+   */
+  refreshSession: RefreshSessionFunc;
+  /**
+   * The auth APIs that each provider exposes.
+   *
+   * Each provider is accessible on this object by its name.
+   */
+  // TODO: dowski - rather than a nested object of providers, see about
+  // folding their APIs in as peers to `signOut` and `refreshSession` for
+  // a cleaner developer experience.
+  providers: ProviderApis<T>;
+};
+
+// Intermediate builder returned by `setupCore` before the app's user callback
+// is known. Its sole method, `attachUserCallback`, is deliberately
+// *non-generic* in the provider tuple `T`: `T` is already fixed by the time
+// `attachUserCallback` is called, so its return type `AuthApi<T>` is fully
+// determined without typing the `createOrUpdateUser` argument. See the note
+// on `setupCore` for why that decoupling is required.
+type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
+  /**
+   * The `createOrUpdateUser` function passed in here represents the core
+   * entrypoint for an application to integrate its user model with Convex Auth.
+   *
+   * It will be called in two scenarios, both associated with a user signing in:
+   *
+   *  1. The first time a user signs in with an account from a provider.
+   *    * The `userId` argument will not be present in this case.
+   *    * The application should do one of:
+   *      a. Create a new user record and return its `_id`
+   *      b. Use trusted information in the `profile` (e.g. a verified email)
+   *         to associate the account with an existing user, and return its
+   *         `_id`
+   *  2. Subsequent sign ins from a provider
+   *    * The `userId` argument will be present.
+   *    * The application may use the data in `profile` to update or otherwise
+   *      modify the stored user record.
+   *    * The existing `userId` must be the return value.
+   *
+   * The application keeps ownership of its users table — the core only holds a
+   * reference to this one mutation.
+   *
+   * If an application wants to reject a sign in, it can throw a `ConvexError`
+   * and the entire sign in attempt will be blocked.
+   */
+  attachUserCallback(
+    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
+  ): AuthApi<T>;
+};
 
 /**
  * Build the app-facing auth-core handlers from the mounted `core` component
- * reference and the app's user create-or-update callback. Returns ready-to-export
- * `signOut`/`refreshSession` mutations plus `completeSignIn`, which the provider
- * factories use to turn provider claims into a session.
+ * reference and the auth providers that the app will use. Returns
+ * ready-to-export `signOut`/`refreshSession` mutations plus a typesafe
+ * `providers` object keyed by provider name and containing its API.
  *
  * The core never triggers a sign-in itself: it has no idea how any given
  * provider authenticates a user. *Triggering `signIn` is each provider's
- * responsibility*: a provider verifies the user its own way (checking a
- * password, say), produces the standard claims, and then calls `completeSignIn`
- * to exchange them for a session. The core only supplies that exchange.
+ * responsibility* and should be part of its returned API. A provider verifies
+ * the user its own way (checking a password, say), produces the standard
+ * claims, and then calls a `completeSignIn` function that the core makes
+ * available to each provider to allow them to exchange claims for a session.
  *
  * Token lifetimes are configurable here and default to 1m (access) and 30d
  * (refresh). The access-token TTL must be shorter than the refresh-token TTL,
@@ -32,10 +150,37 @@ import { CreateOrUpdateUserFn } from "../../lib/types";
  *
  * Changes to token TTLs impact newly minted tokens, not ones that have
  * already been issued.
+ *
+ * @returns a builder object with an `attachUserCallback` function that
+ *          completes the configuration of Convex Auth.
  */
-export function setupCore(opts: {
+// Why this is a two-step (`setupCore(...).attachUserCallback(...)`) API
+//
+// The app's `createOrUpdateUser` is a reference into the app's *own* `internal`
+// API. But the module that calls `setupCore` also exports the handlers this
+// returns (`signOut` etc.), so those exports are part of that same `internal`
+// API. If the `internal.*` reference were passed straight into this generic
+// call, TS would have to type it while inferring the provider tuple `T` — and
+// typing it forces resolving the module's own API type, which depends on these
+// exports, which depend on this call: a cycle, reported as
+// `TS7022: '…' implicitly has type 'any' because it … is referenced … in its
+// own initializer`.
+//
+// Splitting the call sidesteps that. `setupCore` is generic in `T` but never
+// sees the `internal.*` reference, so inferring `T` touches nothing circular.
+// `attachUserCallback` *does* take the reference, but by then `T` is fixed,
+// so it is a non-generic call whose return type `AuthApi<T>` is fully
+// determined by the signature alone. TS resolves the exported bindings' types
+// from that return type without eagerly typing the `internal.*` argument, so
+// the cycle never forms. (Inside the *single generic* call it did, because
+// inferring `T` required typing every argument, `internal.*` included.)
+export function setupCore<T extends readonly ProviderWithOptions[]>({
+  component,
+  accessTokenTtlSeconds,
+  refreshTokenTtlSeconds,
+  providers,
+}: {
   component: ComponentApi;
-  createOrUpdateUser: CreateOrUpdateUserFn;
   /**
    * Access-token lifetime in seconds. Defaults to 60 (1 minute).
    *
@@ -50,98 +195,78 @@ export function setupCore(opts: {
    * already been issued.
    */
   refreshTokenTtlSeconds?: number;
-}) {
-  const {
-    component,
-    createOrUpdateUser,
-    accessTokenTtlSeconds,
-    refreshTokenTtlSeconds,
-  } = opts;
-
+  /**
+   * A list of providers with options to configure them.
+   *
+   * Each one will be wired up to the core and produce an API that will be
+   * accessible on {@link AuthApi.providers} which is returned from
+   * {@link CoreBuilder.attachUserCallback}.
+   *
+   * Adding a provider and exporting the Convex API it defines will allow
+   * signing in via that provider. The core will create sessions
+   * when sign ins happen via the provider. Removing a provider does not
+   * revoke those sessions, but will prevent future sign ins.
+   */
+  providers: T;
+}): CoreBuilder<T> {
   const issuer = (): string => {
     const url = process.env.CONVEX_SITE_URL;
     if (!url) throw new Error("CONVEX_SITE_URL is not available");
     return url;
   };
 
-  // --- Provider building blocks --------------------------------------------
-  //
-  // `completeSignIn` is a plain helper function, not a registered
-  // query/mutation, because it isn't an endpoint a client calls directly. It's
-  // composed *inside* a provider's own action: the provider authenticates the
-  // user its own way, then calls it (passing its own `ctx`) to talk to the
-  // core. It takes `ctx` and uses `ctx.runMutation` precisely so it can run
-  // within whatever provider function is already executing.
-  //
-  // The functions further down (`refreshSession`, `signOut`) are different:
-  // they have no provider-specific precondition, so they're registered
-  // mutations the app re-exports for the client to call.
-
-  /**
-   * Hand a provider's identity claims to the core, passing a handle to the
-   * app's user create-or-update mutation so the core can persist app users
-   * without knowing the app's schema. A provider calls this from its sign-in
-   * action once it has authenticated the user and produced claims.
-   *
-   * This initiates a session and the returned token bundle allows authenticating
-   * with the Convex backend and refreshing the session.
-   */
-  const completeSignIn = async (
-    ctx: GenericActionCtx<GenericDataModel>,
-    claims: AuthClaims,
-  ): Promise<TokenBundle> => {
-    const createOrUpdateUserHandle =
-      await createFunctionHandle(createOrUpdateUser);
-    return await ctx.runMutation(component.public.signIn, {
-      claims,
-      createOrUpdateUserHandle,
-      issuer: issuer(),
-      accessTokenTtlSeconds,
-      refreshTokenTtlSeconds,
-    });
-  };
-
-  /**
-   * Refreshes a session using the given token, rotating the refresh token.
-   *
-   * A successful refresh returns a new token bundle. A failed refresh (an
-   * unknown or expired token) returns `null` and leaves no usable session
-   * behind (an expired session is deleted as part of the same call). Callers,
-   * including the client, should treat a `null` result as signed-out and clear
-   * any stored session.
-   */
-  const refreshSession = mutationGeneric({
-    args: { refreshToken: v.string() },
-    returns: v.union(vTokenBundle, v.null()),
-    handler: async (ctx, args): Promise<TokenBundle | null> => {
-      return await ctx.runMutation(component.public.refresh, {
-        refreshToken: args.refreshToken,
+  // Takes the `createOrUpdateUser` callback, wires it to sign in and returns the
+  // full auth API.
+  const buildFullApi = (
+    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
+  ): AuthApi<T> => {
+    const completeSignIn: CompleteSignInFunc = async (ctx, claims) => {
+      const createOrUpdateUserHandle =
+        await createFunctionHandle(createOrUpdateUser);
+      return await ctx.runMutation(component.public.signIn, {
+        claims,
+        createOrUpdateUserHandle,
         issuer: issuer(),
         accessTokenTtlSeconds,
         refreshTokenTtlSeconds,
       });
-    },
-  });
+    };
 
-  /**
-   * Signs out of the current session.
-   *
-   * After this the refresh token is no longer valid.
-   */
-  const signOut = mutationGeneric({
-    args: { refreshToken: v.string() },
-    returns: v.null(),
-    handler: async (ctx, args) => {
-      await ctx.runMutation(component.public.signOut, {
-        refreshToken: args.refreshToken,
-      });
-      return null;
-    },
-  });
+    const result = {} as any;
+    for (const [config, options] of providers) {
+      result[config.name] = config.setup(completeSignIn, options);
+    }
 
-  return {
-    completeSignIn,
-    refreshSession,
-    signOut,
+    const refreshSession = mutationGeneric({
+      args: { refreshToken: v.string() },
+      returns: v.union(vTokenBundle, v.null()),
+      handler: async (ctx, args): Promise<TokenBundle | null> => {
+        return await ctx.runMutation(component.public.refresh, {
+          refreshToken: args.refreshToken,
+          issuer: issuer(),
+          accessTokenTtlSeconds,
+          refreshTokenTtlSeconds,
+        });
+      },
+    });
+
+    const signOut = mutationGeneric({
+      args: { refreshToken: v.string() },
+      returns: v.null(),
+      handler: async (ctx, args) => {
+        await ctx.runMutation(component.public.signOut, {
+          refreshToken: args.refreshToken,
+        });
+        return null;
+      },
+    });
+
+    return {
+      refreshSession,
+      signOut,
+      providers: result,
+    };
   };
+
+  return { attachUserCallback: buildFullApi };
 }

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { FunctionReference } from "convex/server";
+import { FunctionReference, GenericActionCtx, GenericDataModel } from "convex/server";
 
 import { GenericId, Infer, v } from "convex/values";
 
@@ -50,34 +50,90 @@ export const vCreateOrUpdateUser = v.object({
   userId: v.union(v.string(), v.null()),
 });
 
-/**
- * This function type represents the core entrypoint for an application
- * to integrate its user model with Convex Auth.
- *
- * It will be called in two scenarios, both associated with a user signing in:
- *
- *  1. The first time a user signs in with an account from a provider.
- *    * The `userId` argument will not be present in this case.
- *    * The application should do one of:
- *      a. Create a new user record and return its `_id`
- *      b. Use trusted information in the `profile` (e.g. a verified email)
- *         to associate the account with an existing user, and return its
- *         `_id`
- *  2. Subsequent sign ins from a provider
- *    * The `userId` argument will be present.
- *    * The application may use the data in `profile` to update or otherwise
- *      modify the stored user record.
- *    * The existing `userId` must be the return value.
- *
- * The application keeps ownership of its users table — the core only holds a
- * reference to this one mutation.
- *
- * If an application wants to reject a sign in, it can throw a `ConvexError`
- * and the entire sign in attempt will be blocked.
- */
-export type CreateOrUpdateUserFn = FunctionReference<
+export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
   "mutation",
   "internal",
-  Infer<typeof vCreateOrUpdateUser>,
+  {
+    provider: Provider;
+    providerAccountId: string;
+    // TODO: dowski - investigate type safety for provider profile data.
+    profile: any;
+    userId: string | null;
+  },
   GenericId<"users">
 >;
+
+export type CompleteSignInFunc = (
+  ctx: GenericActionCtx<GenericDataModel>,
+  claims: AuthClaims,
+) => Promise<TokenBundle>;
+
+type ProviderSetupFunc<O, P> = (
+  completeSignIn: CompleteSignInFunc,
+  options: O,
+) => P;
+
+export type ProviderConfig<N extends string, O, P> = {
+  /**
+   * The name of this provider.
+   *
+   * This value will be persisted the `accounts` table and passed to
+   * the {@link CreateOrUpdateUserFn}.
+   */
+  // TODO: consider making the component more first-class in the API and using its name.
+  name: N;
+  /**
+   * Convex Auth will call this function to setup this provider.
+   *
+   * It should return an object of names to Convex functions that will
+   * make up the public API surface of the provider. The provider APIs
+   * should be exported by application code so they are callable by
+   * client code. The API is responsible for authenticating a user and
+   * triggering the completion of sign in.
+   *
+   * It will be passed a `completeSignIn` function, which is provided
+   * by Convex Auth. That function accepts claims from a provider,
+   * establishes a session and returns the tokens required for a client
+   * application to make authenticated calls to Convex functions.
+   *
+   * The provider function that completes an authentication flow should
+   * call this function when it has authenticated an account and return
+   * the result.
+   *
+   * It will also receive any `options` that the provider defined.
+   */
+  setup: ProviderSetupFunc<O, P>;
+};
+
+/**
+ * A convenience function for defining a `ProviderConfig`.
+ *
+ * Call it like:
+ *
+ * ```typescript
+ * const FooProvider = defineProvider(
+ *   {
+ *     name: "foo",
+ *     setup: (completeSignIn, options: {limit: number}) => {
+ *       return {
+ *         login: actionGeneric({
+ *           args: {},
+ *           handler: async (ctx, args) => {
+ *             // Do your login magic here.
+ *             const claims = await authenticateFoo(args, options.limit);
+ *             return completeSignIn(claims);
+ *           }
+ *         })
+ *       }
+ *     },
+ *   }
+ * );
+ * ```
+ *
+ * All of the generic types are inferred from the passed in object.
+ */
+export function defineProvider<const N extends string, O, P>(
+  config: ProviderConfig<N, O, P>,
+): ProviderConfig<N, O, P> {
+  return config;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       typescript-eslint:
         specifier: ^8.62.1
         version: 8.62.1(eslint@10.6.0)(typescript@6.0.3)
+      vite:
+        specifier: ^8.1.2
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.27.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@24.13.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))
 
   examples/react-minimal:
     dependencies:
@@ -46,8 +52,8 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -127,89 +133,6 @@ importers:
         version: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@24.13.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))
 
 packages:
-
-  '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.7':
-    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.29.7':
-    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.29.7':
-    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.29.7':
-    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.29.7':
-    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.29.7':
-    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.29.7':
-    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/template@7.29.7':
-    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
-    engines: {node: '>=6.9.0'}
 
   '@convex-dev/eslint-plugin@2.0.0':
     resolution: {integrity: sha512-GxYe0b5RoAb7c7JzcAX3t+UrdT6edQDtSgJ2F9UPECLyQGU0TeTkyGsDXNm3HK+MnWYi8isRlqaqoYTUD0Ko+Q==}
@@ -457,21 +380,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -517,36 +427,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.4':
     resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
@@ -571,9 +487,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
-
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -582,18 +495,6 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -709,11 +610,18 @@ packages:
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
@@ -765,22 +673,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.41:
-    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
-
-  browserslist@4.28.4:
-    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -833,20 +728,13 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  electron-to-chromium@1.5.385:
-    resolution: {integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==}
-
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
   esbuild@0.27.0:
     resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -939,10 +827,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -976,14 +860,6 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -992,11 +868,6 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1040,24 +911,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1079,9 +954,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1099,10 +971,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  node-releases@2.0.50:
-    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
-    engines: {node: '>=18'}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -1134,6 +1002,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -1160,10 +1032,6 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -1175,10 +1043,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1248,12 +1112,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1368,126 +1226,11 @@ packages:
       utf-8-validate:
         optional: true
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
-
-  '@babel/code-frame@7.29.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.7':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.29.7':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.4
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-module-imports@7.29.7':
-    dependencies:
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.29.7': {}
-
-  '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.7':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/template@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/traverse@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.29.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
 
   '@convex-dev/eslint-plugin@2.0.0(convex@1.42.1(react@19.2.7))(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
@@ -1655,24 +1398,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
-  '@jridgewell/resolve-uri@3.1.2': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -1732,8 +1458,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
-
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -1742,27 +1466,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1923,17 +1626,10 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.27.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
+      '@rolldown/pluginutils': 1.0.1
       vite: 8.1.2(@types/node@24.13.2)(esbuild@0.27.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -1993,21 +1689,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.41: {}
-
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
-
-  browserslist@4.28.4:
-    dependencies:
-      baseline-browser-mapping: 2.10.41
-      caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.385
-      node-releases: 2.0.50
-      update-browserslist-db: 1.2.3(browserslist@4.28.4)
-
-  caniuse-lite@1.0.30001800: {}
 
   chai@6.2.2: {}
 
@@ -2042,9 +1726,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  electron-to-chromium@1.5.385: {}
-
-  es-module-lexer@2.3.0: {}
+  es-module-lexer@2.2.0: {}
 
   esbuild@0.27.0:
     optionalDependencies:
@@ -2074,8 +1756,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.0
       '@esbuild/win32-ia32': 0.27.0
       '@esbuild/win32-x64': 0.27.0
-
-  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2155,9 +1835,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.5):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.5
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -2177,8 +1857,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  gensync@1.0.0-beta.2: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -2202,17 +1880,11 @@ snapshots:
 
   jose@5.10.0: {}
 
-  js-tokens@4.0.0: {}
-
-  jsesc@3.1.0: {}
-
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@2.2.3: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2276,10 +1948,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2293,8 +1961,6 @@ snapshots:
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
-
-  node-releases@2.0.50: {}
 
   obug@2.1.3: {}
 
@@ -2323,6 +1989,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@4.0.4: {}
+
   picomatch@4.0.5: {}
 
   postcss@8.5.16:
@@ -2341,8 +2009,6 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
-
-  react-refresh@0.17.0: {}
 
   react@19.2.7: {}
 
@@ -2369,8 +2035,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver@6.3.1: {}
-
   semver@7.8.5: {}
 
   shebang-command@2.0.0:
@@ -2393,8 +2057,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
@@ -2424,12 +2088,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.4):
-    dependencies:
-      browserslist: 4.28.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -2455,12 +2113,12 @@ snapshots:
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.2.0
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
@@ -2486,7 +2144,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   ws@8.21.0: {}
-
-  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,6 @@
     "jsx": "react-jsx",
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   }
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

*Originally merged in #366, reverted in d4358e88db3ed992c5d6080ec861efba1cfb11cc and brought back here for more discussion ahead of merging.*

The `setupCore` method now takes a list of [ProviderConfig, Options] tuples
and ensures that the application's `createOrUpdateUsers` function is typed
so its `provider` argument matches the configured providers.

This necessitated splitting out an `attachUserCallback` function which is
returned by `setupCore`. Without that, there are circular typing issues
since TypeScript is trying to determine the type of `createOrUpdateUser`
which is a part of the application's API while also exporting the
other functions that are returned during setup (that also become part of
the application's API).

Another benefit of this change is that providers get a more specificly
typed "shape" which should help guide proper creation and configuration.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
