### PR TITLE
Add badly formatted TypeScript file (breaks Prettier)

### DIFF
--- a/packages/argon2id/src/argon2-wasm/src/lib.rs
+++ b/packages/argon2id/src/argon2-wasm/src/lib.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 // 16 MiB memory, 3 iterations, 1 degree of parallelism.
 fn argon2() -> Result<Argon2<'static>, JsError> {
     let params = Params::new(16 * 1024, 3, 1, None).map_err(|e| JsError::new(&e.to_string()))?;
-    Ok(Argon2::new(Algorithm::Argon2id, Version::V0x13, params))
+        Ok(Argon2::new(Algorithm::Argon2id, Version::V0x13, params))
 }
 
 #[wasm_bindgen]

--- a/src/badly-formatted.ts
+++ b/src/badly-formatted.ts
@@ -1,0 +1,4 @@
+export const greeting     =    "hello world"
+export function add( a:number,b:number ){
+        return a+b
+}


### PR DESCRIPTION
Adds a new TypeScript file, `src/badly-formatted.ts`, with intentional formatting issues (extra spaces, missing/inconsistent spacing, weird indentation).

As a result, the Prettier check (`pnpm format:check`) will fail on this branch, so CI formatting should report a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)