### PR TITLE
Core: add getUserIdByAccount query

### DIFF
--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -24,6 +24,13 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     public: {
+      getUserIdByAccount: FunctionReference<
+        "query",
+        "internal",
+        { provider: string; providerAccountId: string },
+        string | null,
+        Name
+      >;
       refresh: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -309,3 +309,37 @@ describe("token lifetime configuration", () => {
     ).rejects.toThrow(/shorter than the refresh-token TTL/i);
   });
 });
+
+describe("getUserIdByAccount", () => {
+  test("returns null for an unknown identity", async () => {
+    const t = setup();
+    const userId = await t.query(api.public.getUserIdByAccount, {
+      provider: "password",
+      providerAccountId: "alice",
+    });
+    expect(userId).toBeNull();
+  });
+
+  test("returns the user id after the account is created by signIn", async () => {
+    const t = setup();
+    const bundle = await signIn(t, claims());
+    const userId = await t.query(api.public.getUserIdByAccount, {
+      provider: "password",
+      providerAccountId: "alice",
+    });
+    expect(userId).toBe(bundle.userId);
+  });
+
+  test("does not confuse identities across providers", async () => {
+    const t = setup();
+    await signIn(
+      t,
+      claims({ provider: "password", providerAccountId: "alice" }),
+    );
+    const other = await t.query(api.public.getUserIdByAccount, {
+      provider: "google",
+      providerAccountId: "alice",
+    });
+    expect(other).toBeNull();
+  });
+});

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -1,4 +1,10 @@
-import { mutation, MutationCtx, QueryCtx, env } from "./_generated/server";
+import {
+  mutation,
+  query,
+  MutationCtx,
+  QueryCtx,
+  env,
+} from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { FunctionHandle } from "convex/server";
@@ -228,6 +234,30 @@ export const signIn = mutation({
       args.createOrUpdateUserHandle as CreateOrUpdateUserFunctionHandle,
     );
     return await issueSession(ctx, accountId, userId, args.issuer, ttl);
+  },
+});
+
+/**
+ * Resolve a provider identity to its app user id without minting a session.
+ *
+ * Providers use this (via the `resolveUserId` helper the core hands them) to look
+ * up the user behind a `(provider, providerAccountId)` pair before authenticating
+ * — e.g. a password provider needs the user id to verify a stored password *before*
+ * a session is issued. Returns `null` when no account exists for the identity.
+ *
+ * This is a component-internal function (callable by the app, not by end-user
+ * clients), so it does not expose account existence to the outside world; the
+ * provider's own public API decides what, if anything, to reveal.
+ */
+export const getUserIdByAccount = query({
+  args: { provider: v.string(), providerAccountId: v.string() },
+  returns: v.union(v.string(), v.null()),
+  handler: async (
+    ctx,
+    { provider, providerAccountId },
+  ): Promise<string | null> => {
+    const account = await accountByIdentity(ctx, provider, providerAccountId);
+    return account?.userId ?? null;
   },
 });
 


### PR DESCRIPTION
Adds a core component function to look up an account by provider + provider account ID.

This will be used in the implementation of `setUsernamePassword`.