### PR TITLE
Framework agnostic client APIs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,8 @@
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",
     "./providers/password/convex.config.js": "./src/components/password/convex.config.ts",
     "./providers/password/*": "./src/components/password/*.ts",
-    "./providers/testing/*": "./src/components/testing/*.ts"
+    "./providers/testing/*": "./src/components/testing/*.ts",
+    "./browser": "./src/browser/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Framework-agnostic browser building blocks for Convex Auth clients: a token
+ * storage abstraction, a cross-tab refresh mutex, and the session manager that
+ * ties them together. The React bindings (`@convex-dev/auth/react`) build on
+ * these, and other client libraries can too.
+ */
+
+export {
+  type TokenStorage,
+  InMemoryStorage,
+  NamespacedStorage,
+  defaultStorage,
+  JWT_STORAGE_KEY,
+  REFRESH_TOKEN_STORAGE_KEY,
+} from "./storage";
+export { browserMutex } from "./mutex";
+export {
+  AuthClient,
+  type AuthApi,
+  type AuthClientOptions,
+  type AuthState,
+} from "./sessionManager";

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -13,10 +13,10 @@ export {
   JWT_STORAGE_KEY,
   REFRESH_TOKEN_STORAGE_KEY,
 } from "./storage";
-export { browserMutex } from "./mutex";
+export { runWithMutex } from "./mutex";
 export {
   AuthClient,
   type AuthApi,
-  type AuthClientOptions,
+  type AuthClientConfig,
   type AuthState,
 } from "./sessionManager";

--- a/packages/core/src/browser/mutex.ts
+++ b/packages/core/src/browser/mutex.ts
@@ -32,13 +32,10 @@ type MutexState = {
 
 const mutexes = new Map<string, MutexState>();
 
-function getMutex(key: string): MutexState {
-  let mutex = mutexes.get(key);
-  if (mutex === undefined) {
-    mutex = { currentlyRunning: null, waiting: [] };
-    mutexes.set(key, mutex);
-  }
-  return mutex;
+function manualMutex<T>(key: string, callback: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    enqueue(key, () => callback().then(resolve, reject));
+  });
 }
 
 function enqueue(key: string, callback: () => Promise<void>) {
@@ -56,8 +53,11 @@ function enqueue(key: string, callback: () => Promise<void>) {
   }
 }
 
-function manualMutex<T>(key: string, callback: () => Promise<T>): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    enqueue(key, () => callback().then(resolve, reject));
-  });
+function getMutex(key: string): MutexState {
+  let mutex = mutexes.get(key);
+  if (mutex === undefined) {
+    mutex = { currentlyRunning: null, waiting: [] };
+    mutexes.set(key, mutex);
+  }
+  return mutex;
 }

--- a/packages/core/src/browser/mutex.ts
+++ b/packages/core/src/browser/mutex.ts
@@ -11,6 +11,20 @@
  * window, which forgives the residual cross-tab race the fallback can't cover.
  */
 
+/**
+ * Run `callback` while holding the lock named `key`, resolving to its result.
+ * Only one callback per key runs at a time.
+ */
+export async function runWithMutex<T>(
+  key: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const locks = typeof navigator !== "undefined" ? navigator.locks : undefined;
+  return locks !== undefined
+    ? await locks.request(key, callback)
+    : await manualMutex(key, callback);
+}
+
 type MutexState = {
   currentlyRunning: Promise<void> | null;
   waiting: Array<() => Promise<void>>;
@@ -46,18 +60,4 @@ function manualMutex<T>(key: string, callback: () => Promise<T>): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     enqueue(key, () => callback().then(resolve, reject));
   });
-}
-
-/**
- * Run `callback` while holding the lock named `key`, resolving to its result.
- * Only one callback per key runs at a time.
- */
-export async function browserMutex<T>(
-  key: string,
-  callback: () => Promise<T>,
-): Promise<T> {
-  const locks = typeof navigator !== "undefined" ? navigator.locks : undefined;
-  return locks !== undefined
-    ? await locks.request(key, callback)
-    : await manualMutex(key, callback);
 }

--- a/packages/core/src/browser/mutex.ts
+++ b/packages/core/src/browser/mutex.ts
@@ -1,0 +1,63 @@
+/**
+ * A cross-context mutex used to serialize token refreshes so that concurrent
+ * callers (multiple tabs, or several components racing on mount) collapse to a
+ * single refresh instead of each rotating the refresh token and fighting over
+ * the result.
+ *
+ * When the browser exposes the Web Locks API (`navigator.locks`) it is a true
+ * cross-tab lock. Otherwise we fall back to an in-process queue, which still
+ * serializes callers within a single JS realm (enough for tests and runtimes
+ * without Web Locks). It composes with the server's short refresh-token grace
+ * window, which forgives the residual cross-tab race the fallback can't cover.
+ */
+
+type MutexState = {
+  currentlyRunning: Promise<void> | null;
+  waiting: Array<() => Promise<void>>;
+};
+
+const mutexes = new Map<string, MutexState>();
+
+function getMutex(key: string): MutexState {
+  let mutex = mutexes.get(key);
+  if (mutex === undefined) {
+    mutex = { currentlyRunning: null, waiting: [] };
+    mutexes.set(key, mutex);
+  }
+  return mutex;
+}
+
+function enqueue(key: string, callback: () => Promise<void>) {
+  const mutex = getMutex(key);
+  if (mutex.currentlyRunning === null) {
+    mutex.currentlyRunning = callback().finally(() => {
+      mutex.currentlyRunning = null;
+      const next = mutex.waiting.shift();
+      if (next !== undefined) {
+        enqueue(key, next);
+      }
+    });
+  } else {
+    mutex.waiting.push(callback);
+  }
+}
+
+function manualMutex<T>(key: string, callback: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    enqueue(key, () => callback().then(resolve, reject));
+  });
+}
+
+/**
+ * Run `callback` while holding the lock named `key`, resolving to its result.
+ * Only one callback per key runs at a time.
+ */
+export async function browserMutex<T>(
+  key: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const locks = typeof navigator !== "undefined" ? navigator.locks : undefined;
+  return locks !== undefined
+    ? await locks.request(key, callback)
+    : await manualMutex(key, callback);
+}

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { TokenBundle } from "../lib/types";
+import { AuthClient, AuthApi } from "./sessionManager";
+import {
+  InMemoryStorage,
+  JWT_STORAGE_KEY,
+  REFRESH_TOKEN_STORAGE_KEY,
+} from "./storage";
+
+const NAMESPACE = "https://happy-animal-123.convex.cloud";
+// Matches NamespacedStorage's `replace(/[^a-zA-Z0-9]/g, "")`.
+const SUFFIX = "httpshappyanimal123convexcloud";
+
+function bundle(n: number): TokenBundle {
+  return {
+    accessToken: `access-${n}`,
+    accessTokenExpiresAt: 0,
+    refreshToken: `refresh-${n}`,
+    refreshTokenExpiresAt: 0,
+    userId: "user-1",
+  };
+}
+
+/** A resolvable promise, to control refresh timing in the concurrency test. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function makeClient(
+  authApi: Partial<AuthApi> = {},
+  storage = new InMemoryStorage(),
+) {
+  const client = new AuthClient({
+    authApi: {
+      refreshSession: async () => null,
+      signOut: async () => {},
+      ...authApi,
+    },
+    storage,
+    storageNamespace: NAMESPACE,
+  });
+  return { client, storage };
+}
+
+describe("AuthClient", () => {
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test("starts unauthenticated with an empty store", async () => {
+    const { client } = makeClient();
+    expect(client.getSnapshot()).toMatchObject({ isLoading: true });
+    await client.init();
+    expect(client.getSnapshot()).toEqual({
+      isLoading: false,
+      isAuthenticated: false,
+      token: null,
+    });
+  });
+
+  test("setSession authenticates and persists under namespaced keys", async () => {
+    const { client, storage } = makeClient();
+    await client.init();
+    await client.setSession(bundle(1));
+
+    expect(client.getSnapshot()).toEqual({
+      isLoading: false,
+      isAuthenticated: true,
+      token: "access-1",
+    });
+    expect(client.getAccessToken()).toBe("access-1");
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-1");
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-1",
+    );
+  });
+
+  test("hydrates a persisted session on init", async () => {
+    const storage = new InMemoryStorage();
+    storage.setItem(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
+    storage.setItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`, "refresh-1");
+    const { client } = makeClient({}, storage);
+    await client.init();
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: true,
+      token: "access-1",
+    });
+  });
+
+  test("fetchAccessToken returns the cached token without forcing", async () => {
+    const refreshSession = vi.fn(async () => bundle(2));
+    const { client } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: false });
+    expect(token).toBe("access-1");
+    expect(refreshSession).not.toHaveBeenCalled();
+  });
+
+  test("forced fetch rotates the session via refreshSession", async () => {
+    const refreshSession = vi.fn(async (rt: string) => {
+      expect(rt).toBe("refresh-1");
+      return bundle(2);
+    });
+    const { client, storage } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(token).toBe("access-2");
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-2",
+    );
+  });
+
+  test("a null refresh clears the session", async () => {
+    const { client, storage } = makeClient({
+      refreshSession: async () => null,
+    });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(token).toBeNull();
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+  });
+
+  test("concurrent forced fetches collapse to a single refresh", async () => {
+    const gate = deferred<void>();
+    const refreshSession = vi.fn(async () => {
+      await gate.promise;
+      return bundle(2);
+    });
+    const { client } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    const pending = [
+      client.fetchAccessToken({ forceRefreshToken: true }),
+      client.fetchAccessToken({ forceRefreshToken: true }),
+      client.fetchAccessToken({ forceRefreshToken: true }),
+    ];
+    gate.resolve();
+    const results = await Promise.all(pending);
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(results).toEqual(["access-2", "access-2", "access-2"]);
+  });
+
+  test("signOut revokes on the server and clears locally", async () => {
+    const signOut = vi.fn(async (rt: string) => {
+      expect(rt).toBe("refresh-1");
+    });
+    const { client } = makeClient({ signOut });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    await client.signOut();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+  });
+
+  test("syncs sign-out from another tab via storage events", async () => {
+    const listeners: Array<(event: StorageEvent) => void> = [];
+    const storage = new InMemoryStorage();
+    (globalThis as { window?: unknown }).window = {
+      addEventListener: (_type: string, l: (event: StorageEvent) => void) =>
+        listeners.push(l),
+      removeEventListener: () => {},
+    };
+
+    const { client } = makeClient({}, storage);
+    await client.init();
+    await client.setSession(bundle(1));
+    expect(client.getSnapshot().isAuthenticated).toBe(true);
+
+    // Another tab cleared the JWT key.
+    listeners.forEach((l) =>
+      l({
+        storageArea: storage,
+        key: `${JWT_STORAGE_KEY}_${SUFFIX}`,
+        newValue: null,
+      } as unknown as StorageEvent),
+    );
+
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+  });
+});

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -21,15 +21,6 @@ function bundle(n: number): TokenBundle {
   };
 }
 
-/** A resolvable promise, to control refresh timing in the concurrency test. */
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
-  });
-  return { promise, resolve };
-}
-
 function makeClient(
   authApi: Partial<AuthApi> = {},
   storage = new InMemoryStorage(),
@@ -136,9 +127,9 @@ describe("AuthClient", () => {
   });
 
   test("concurrent forced fetches collapse to a single refresh", async () => {
-    const gate = deferred<void>();
+    const { promise, resolve } = Promise.withResolvers<void>();
     const refreshSession = vi.fn(async () => {
-      await gate.promise;
+      await promise;
       return bundle(2);
     });
     const { client } = makeClient({ refreshSession });
@@ -150,7 +141,7 @@ describe("AuthClient", () => {
       client.fetchAccessToken({ forceRefreshToken: true }),
       client.fetchAccessToken({ forceRefreshToken: true }),
     ];
-    gate.resolve();
+    resolve();
     const results = await Promise.all(pending);
 
     expect(refreshSession).toHaveBeenCalledTimes(1);

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -201,4 +201,41 @@ describe("AuthClient", () => {
       token: null,
     });
   });
+
+  test("re-attaches the storage listener when init runs after dispose", async () => {
+    const listeners = new Set<(event: StorageEvent) => void>();
+    const storage = new InMemoryStorage();
+    (globalThis as { window?: unknown }).window = {
+      addEventListener: (_type: string, l: (event: StorageEvent) => void) =>
+        listeners.add(l),
+      removeEventListener: (_type: string, l: (event: StorageEvent) => void) =>
+        listeners.delete(l),
+    };
+
+    const { client } = makeClient({}, storage);
+    // init/dispose is a symmetric, repeatable lifecycle: an init() after a
+    // dispose() must restore cross-tab sync. (A consumer that re-mounts the same
+    // client — e.g. React StrictMode — drives exactly this sequence; that path
+    // is covered end-to-end in the React bindings' tests.)
+    await client.init();
+    client.dispose();
+    await client.init();
+    await client.setSession(bundle(1));
+    expect(client.getSnapshot().isAuthenticated).toBe(true);
+    expect(listeners.size).toBe(1);
+
+    // Another tab cleared the JWT key.
+    listeners.forEach((l) =>
+      l({
+        storageArea: storage,
+        key: `${JWT_STORAGE_KEY}_${SUFFIX}`,
+        newValue: null,
+      } as unknown as StorageEvent),
+    );
+
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+  });
 });

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -52,7 +52,10 @@ export interface AuthState {
 
 type Listener = () => void;
 
-const INITIAL_AUTH_STATE: AuthState = Object.freeze({
+/** The state a fresh client reports until {@link AuthClient.init} has loaded
+ * the persisted session. Exported so framework bindings can use it as their
+ * pre-hydration snapshot. */
+export const INITIAL_AUTH_STATE: AuthState = Object.freeze({
   isLoading: true,
   isAuthenticated: false,
   token: null,
@@ -101,7 +104,9 @@ export class AuthClient {
     this.#lockKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
   }
 
-  // --- Reactive store API (for React's useSyncExternalStore) ---------------
+  // --- Observable store API ------------------------------------------------
+  // A minimal subscribe/snapshot store any UI framework can consume (React via
+  // useSyncExternalStore, others via their own reactivity).
 
   subscribe = (listener: Listener): (() => void) => {
     this.#listeners.add(listener);
@@ -109,9 +114,6 @@ export class AuthClient {
   };
 
   getSnapshot = (): AuthState => this.#snapshot;
-
-  // Just a static value for now. Will carry future SSR state.
-  getServerSnapshot = (): AuthState => INITIAL_AUTH_STATE;
 
   /** The current access token, or null. */
   getAccessToken(): string | null {
@@ -122,12 +124,19 @@ export class AuthClient {
 
   /**
    * Load any persisted session from storage and start listening for cross-tab
-   * changes. Idempotent. Until this resolves, the client reports `isLoading`.
+   * changes. Until this resolves, the client reports `isLoading`.
+   *
+   * Symmetric and repeatable with {@link dispose}: loading the session happens
+   * once, but the cross-tab listener is (re)attached on every call, so an
+   * `init` after a `dispose` fully restores the client.
    */
   async init(): Promise<void> {
+    // Attach before the one-time guard so a dispose()/init() cycle re-attaches
+    // the listener rather than skipping it. Idempotent, so repeat calls are
+    // harmless.
+    this.#attachStorageListener();
     if (this.#initialized) return;
     this.#initialized = true;
-    this.#attachStorageListener();
     const [accessToken, refreshToken] = await Promise.all([
       this.#storage.get(JWT_STORAGE_KEY),
       this.#storage.get(REFRESH_TOKEN_STORAGE_KEY),
@@ -139,13 +148,17 @@ export class AuthClient {
     this.#notify();
   }
 
-  /** Detach listeners. Call on teardown. */
+  /**
+   * Detach the cross-tab storage listener. Call on teardown. Store subscribers
+   * are intentionally left in place — each is removed via the unsubscribe
+   * returned by {@link subscribe} — so a later {@link init} restores the client
+   * without losing its subscribers.
+   */
   dispose(): void {
     if (this.#storageListener !== null && typeof window !== "undefined") {
       window.removeEventListener("storage", this.#storageListener);
       this.#storageListener = null;
     }
-    this.#listeners.clear();
   }
 
   // --- Public actions ------------------------------------------------------
@@ -256,6 +269,7 @@ export class AuthClient {
 
   #attachStorageListener(): void {
     if (typeof window === "undefined") return;
+    if (this.#storageListener !== null) return;
     const jwtKey = this.#storage.key(JWT_STORAGE_KEY);
     const refreshKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
     const listener = (event: StorageEvent) => {

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -1,0 +1,289 @@
+import type { TokenBundle } from "../lib/types";
+import { browserMutex } from "./mutex";
+import {
+  JWT_STORAGE_KEY,
+  NamespacedStorage,
+  REFRESH_TOKEN_STORAGE_KEY,
+  TokenStorage,
+} from "./storage";
+
+// Retry a failed refresh this long (ms) after the Nth network error. A refresh
+// commonly fails transiently on mobile when the app is backgrounded mid-call
+// and succeeds once it returns to the foreground.
+const RETRY_BACKOFF = [500, 2000];
+const RETRY_JITTER = 100;
+
+/**
+ * The two auth API calls the core client makes. Kept as an injected interface
+ * so this layer never imports Convex: the React bindings implement it (over an
+ * HTTP client, to avoid deadlocking the websocket during a refresh), and tests
+ * implement it with a fake.
+ */
+export interface AuthApi {
+  /**
+   * Rotate the refresh token and mint a fresh access token. `null` means the
+   * session is gone (unknown or expired refresh token) — treat as signed out.
+   */
+  refreshSession: (refreshToken: string) => Promise<TokenBundle | null>;
+  /** Revoke the session for a refresh token. Idempotent. */
+  signOut: (refreshToken: string) => Promise<void>;
+}
+
+export interface AuthClientOptions {
+  authApi: AuthApi;
+  /** Where tokens are persisted. */
+  storage: TokenStorage;
+  /** Namespace for storage keys; typically the deployment URL. */
+  storageNamespace: string;
+  /** Log refresh/lifecycle steps to the console. */
+  verbose?: boolean;
+}
+
+/** The reactive snapshot the React layer subscribes to. */
+export interface AuthState {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  token: string | null;
+}
+
+type Listener = () => void;
+
+const INITIAL_SNAPSHOT: AuthState = Object.freeze({
+  isLoading: true,
+  isAuthenticated: false,
+  token: null,
+});
+
+function isNetworkError(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    /network|failed to fetch|load failed/i.test(error.message)
+  );
+}
+
+/**
+ * Framework-agnostic owner of the auth session on the client.
+ *
+ * It persists the {@link TokenBundle} from a sign-in, hands out the access
+ * token via {@link AuthClient.fetchAccessToken} (refreshing under a cross-tab
+ * lock when forced), keeps in sync across tabs, and exposes a
+ * subscribe/snapshot API so any UI framework can render its state. It establishes
+ * sessions from provider authentication results. Providers authenticate users and
+ * call {@link AuthClient.setSession} with the resulting bundle.
+ */
+export class AuthClient {
+  readonly #authApi: AuthApi;
+  readonly #storage: NamespacedStorage;
+  readonly #verbose: boolean;
+  readonly #lockKey: string;
+
+  #accessToken: string | null = null;
+  #refreshToken: string | null = null;
+  #isLoading = true;
+  #initialized = false;
+
+  #snapshot: AuthState = INITIAL_SNAPSHOT;
+  readonly #listeners = new Set<Listener>();
+  #storageListener: ((event: StorageEvent) => void) | null = null;
+
+  constructor(options: AuthClientOptions) {
+    this.#authApi = options.authApi;
+    this.#storage = new NamespacedStorage(
+      options.storage,
+      options.storageNamespace,
+    );
+    this.#verbose = options.verbose ?? false;
+    this.#lockKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
+  }
+
+  // --- Reactive store API (for React's useSyncExternalStore) ---------------
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  };
+
+  getSnapshot = (): AuthState => this.#snapshot;
+
+  // Just a static value for now. Will carry future SSR state.
+  getServerSnapshot = (): AuthState => INITIAL_SNAPSHOT;
+
+  /** The current access token, or null. */
+  getAccessToken(): string | null {
+    return this.#accessToken;
+  }
+
+  // --- Lifecycle -----------------------------------------------------------
+
+  /**
+   * Load any persisted session from storage and start listening for cross-tab
+   * changes. Idempotent. Until this resolves, the client reports `isLoading`.
+   */
+  async init(): Promise<void> {
+    if (this.#initialized) return;
+    this.#initialized = true;
+    this.#attachStorageListener();
+    const [accessToken, refreshToken] = await Promise.all([
+      this.#storage.get(JWT_STORAGE_KEY),
+      this.#storage.get(REFRESH_TOKEN_STORAGE_KEY),
+    ]);
+    this.#accessToken = accessToken ?? null;
+    this.#refreshToken = refreshToken ?? null;
+    this.#log(`init: token is null: ${this.#accessToken === null}`);
+    this.#isLoading = false;
+    this.#notify();
+  }
+
+  /** Detach listeners. Call on teardown. */
+  dispose(): void {
+    if (this.#storageListener !== null && typeof window !== "undefined") {
+      window.removeEventListener("storage", this.#storageListener);
+      this.#storageListener = null;
+    }
+    this.#listeners.clear();
+  }
+
+  // --- Public actions ------------------------------------------------------
+
+  /**
+   * Adopt the session a provider just established. Providers call this after
+   * their own sign-in flow returns a {@link TokenBundle}.
+   */
+  setSession = async (bundle: TokenBundle): Promise<void> => {
+    await this.#storeTokens(bundle);
+  };
+
+  /**
+   * Revoke the current session on the server (best effort) and clear it
+   * locally.
+   */
+  signOut = async (): Promise<void> => {
+    const refreshToken = await this.#currentRefreshToken();
+    if (refreshToken !== null) {
+      try {
+        await this.#authApi.signOut(refreshToken);
+      } catch {
+        // Usually means we were already signed out, which is fine.
+      }
+    }
+    this.#log("signed out, erasing tokens");
+    await this.#storeTokens(null);
+  };
+
+  /**
+   * The function handed to Convex's `ConvexProviderWithAuth`. Returns the
+   * cached access token, or — when `forceRefreshToken` is true (the server
+   * rejected the last token or it is near expiry) — rotates the refresh token
+   * under a cross-tab lock and returns the fresh access token. Returns `null`
+   * (never `undefined`) when there is no usable session.
+   */
+  fetchAccessToken = async ({
+    forceRefreshToken,
+  }: {
+    forceRefreshToken: boolean;
+  }): Promise<string | null> => {
+    if (!forceRefreshToken) {
+      return this.#accessToken;
+    }
+    const tokenBeforeLock = this.#accessToken;
+    return await browserMutex(this.#lockKey, async () => {
+      // Another tab may have refreshed while we waited for the lock; if so,
+      // use its result rather than rotating again.
+      if (this.#accessToken !== tokenBeforeLock) {
+        this.#log(`using token refreshed by another tab`);
+        return this.#accessToken;
+      }
+      const refreshToken = await this.#currentRefreshToken();
+      if (refreshToken === null) {
+        this.#log("no refresh token, cannot refresh");
+        return null;
+      }
+      const bundle = await this.#refreshWithRetry(refreshToken);
+      await this.#storeTokens(bundle);
+      return this.#accessToken;
+    });
+  };
+
+  // --- Internals -----------------------------------------------------------
+
+  /** The authoritative refresh token: storage (shared across tabs) then memory. */
+  async #currentRefreshToken(): Promise<string | null> {
+    return (
+      (await this.#storage.get(REFRESH_TOKEN_STORAGE_KEY)) ?? this.#refreshToken
+    );
+  }
+
+  async #refreshWithRetry(refreshToken: string): Promise<TokenBundle | null> {
+    let lastError: unknown;
+    for (let retry = 0; retry < RETRY_BACKOFF.length; retry++) {
+      try {
+        return await this.#authApi.refreshSession(refreshToken);
+      } catch (error) {
+        lastError = error;
+        if (!isNetworkError(error)) break;
+        const wait = RETRY_BACKOFF[retry] + RETRY_JITTER * Math.random();
+        this.#log(`refresh network error, retry ${retry + 1} in ${wait}ms`);
+        await new Promise((resolve) => setTimeout(resolve, wait));
+      }
+    }
+    throw lastError;
+  }
+
+  /**
+   * Set the in-memory + persisted session to `bundle` (or clear it when null),
+   * then notify subscribers if the authenticated state changed.
+   */
+  async #storeTokens(bundle: TokenBundle | null): Promise<void> {
+    if (bundle === null) {
+      this.#accessToken = null;
+      this.#refreshToken = null;
+      await this.#storage.remove(JWT_STORAGE_KEY);
+      await this.#storage.remove(REFRESH_TOKEN_STORAGE_KEY);
+    } else {
+      this.#accessToken = bundle.accessToken;
+      this.#refreshToken = bundle.refreshToken;
+      await this.#storage.set(JWT_STORAGE_KEY, bundle.accessToken);
+      await this.#storage.set(REFRESH_TOKEN_STORAGE_KEY, bundle.refreshToken);
+    }
+    this.#isLoading = false;
+    this.#notify();
+  }
+
+  #attachStorageListener(): void {
+    if (typeof window === "undefined") return;
+    const jwtKey = this.#storage.key(JWT_STORAGE_KEY);
+    const refreshKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
+    const listener = (event: StorageEvent) => {
+      // Only react to our own storage area (e.g. ignore sessionStorage events
+      // when we use localStorage). Keys arrive as separate events, so we handle
+      // the JWT and refresh keys independently and never write back here (that
+      // would loop).
+      if (event.storageArea !== this.#storage.storage) return;
+      if (event.key === jwtKey) {
+        this.#accessToken = event.newValue;
+        this.#log(`synced access token, is null: ${event.newValue === null}`);
+        this.#isLoading = false;
+        this.#notify();
+      } else if (event.key === refreshKey) {
+        this.#refreshToken = event.newValue;
+      }
+    };
+    window.addEventListener("storage", listener);
+    this.#storageListener = listener;
+  }
+
+  #notify(): void {
+    this.#snapshot = {
+      isLoading: this.#isLoading,
+      isAuthenticated: this.#accessToken !== null,
+      token: this.#accessToken,
+    };
+    for (const listener of this.#listeners) listener();
+  }
+
+  #log(message: string): void {
+    if (this.#verbose) {
+      console.debug(`${new Date().toISOString()} [convex-auth] ${message}`);
+    }
+  }
+}

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -1,5 +1,5 @@
 import type { TokenBundle } from "../lib/types";
-import { browserMutex } from "./mutex";
+import { runWithMutex } from "./mutex";
 import {
   JWT_STORAGE_KEY,
   NamespacedStorage,
@@ -15,9 +15,9 @@ const RETRY_JITTER = 100;
 
 /**
  * The two auth API calls the core client makes. Kept as an injected interface
- * so this layer never imports Convex: the React bindings implement it (over an
- * HTTP client, to avoid deadlocking the websocket during a refresh), and tests
- * implement it with a fake.
+ * so this layer never imports Convex: framework bindings should implement it
+ * (over an HTTP client, to avoid deadlocking the websocket during a refresh),
+ * and tests implement it with a fake.
  */
 export interface AuthApi {
   /**
@@ -29,7 +29,11 @@ export interface AuthApi {
   signOut: (refreshToken: string) => Promise<void>;
 }
 
-export interface AuthClientOptions {
+/**
+ * Configuration for the {@link AuthClient}.
+ */
+export interface AuthClientConfig {
+  /** The API that the server exposes for auth. */
   authApi: AuthApi;
   /** Where tokens are persisted. */
   storage: TokenStorage;
@@ -48,7 +52,7 @@ export interface AuthState {
 
 type Listener = () => void;
 
-const INITIAL_SNAPSHOT: AuthState = Object.freeze({
+const INITIAL_AUTH_STATE: AuthState = Object.freeze({
   isLoading: true,
   isAuthenticated: false,
   token: null,
@@ -67,9 +71,10 @@ function isNetworkError(error: unknown): boolean {
  * It persists the {@link TokenBundle} from a sign-in, hands out the access
  * token via {@link AuthClient.fetchAccessToken} (refreshing under a cross-tab
  * lock when forced), keeps in sync across tabs, and exposes a
- * subscribe/snapshot API so any UI framework can render its state. It establishes
- * sessions from provider authentication results. Providers authenticate users and
- * call {@link AuthClient.setSession} with the resulting bundle.
+ * subscribe/snapshot API so any UI framework can render its state. It
+ * establishes sessions from provider authentication results. Providers
+ * authenticate and sign-in users and call {@link AuthClient.setSession} with
+ * a token bundle.
  */
 export class AuthClient {
   readonly #authApi: AuthApi;
@@ -82,17 +87,17 @@ export class AuthClient {
   #isLoading = true;
   #initialized = false;
 
-  #snapshot: AuthState = INITIAL_SNAPSHOT;
+  #snapshot: AuthState = INITIAL_AUTH_STATE;
   readonly #listeners = new Set<Listener>();
   #storageListener: ((event: StorageEvent) => void) | null = null;
 
-  constructor(options: AuthClientOptions) {
-    this.#authApi = options.authApi;
+  constructor(config: AuthClientConfig) {
+    this.#authApi = config.authApi;
     this.#storage = new NamespacedStorage(
-      options.storage,
-      options.storageNamespace,
+      config.storage,
+      config.storageNamespace,
     );
-    this.#verbose = options.verbose ?? false;
+    this.#verbose = config.verbose ?? false;
     this.#lockKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
   }
 
@@ -106,7 +111,7 @@ export class AuthClient {
   getSnapshot = (): AuthState => this.#snapshot;
 
   // Just a static value for now. Will carry future SSR state.
-  getServerSnapshot = (): AuthState => INITIAL_SNAPSHOT;
+  getServerSnapshot = (): AuthState => INITIAL_AUTH_STATE;
 
   /** The current access token, or null. */
   getAccessToken(): string | null {
@@ -186,7 +191,7 @@ export class AuthClient {
       return this.#accessToken;
     }
     const tokenBeforeLock = this.#accessToken;
-    return await browserMutex(this.#lockKey, async () => {
+    return await runWithMutex(this.#lockKey, async () => {
       // Another tab may have refreshed while we waited for the lock; if so,
       // use its result rather than rotating again.
       if (this.#accessToken !== tokenBeforeLock) {

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -43,7 +43,7 @@ export interface AuthClientConfig {
   verbose?: boolean;
 }
 
-/** The reactive snapshot the React layer subscribes to. */
+/** Auth state that can be subscribed to via {@link AuthClient.subscribe} */
 export interface AuthState {
   isLoading: boolean;
   isAuthenticated: boolean;
@@ -108,11 +108,19 @@ export class AuthClient {
   // A minimal subscribe/snapshot store any UI framework can consume (React via
   // useSyncExternalStore, others via their own reactivity).
 
+  /**
+   * Subscribe to be notified when the {@link AuthState} changes.
+   *
+   * Subscribers should call {@link getSnapshot} when notified of a change.
+   */
   subscribe = (listener: Listener): (() => void) => {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
   };
 
+  /**
+   * Returns the latest {@link AuthState} snapshot.
+   */
   getSnapshot = (): AuthState => this.#snapshot;
 
   /** The current access token, or null. */

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -1,0 +1,98 @@
+/**
+ * A framework-agnostic storage abstraction for auth tokens (and any other
+ * client-side secrets a client library needs to persist).
+ *
+ * In browsers, both `localStorage` and `sessionStorage` satisfy
+ * {@link TokenStorage} directly. `sessionStorage` gives each tab its own
+ * session; `localStorage` shares one across tabs. In React Native, wrap
+ * something like `expo-secure-store`.
+ *
+ * Nothing here depends on React or Convex, so other client libraries can build
+ * on it.
+ */
+
+/**
+ * Read/write/delete string values by key. Every method may be synchronous or
+ * return a promise, so async stores (e.g. React Native secure storage) work
+ * without ceremony.
+ */
+export interface TokenStorage {
+  /** Read a value. */
+  getItem: (
+    key: string,
+  ) => string | undefined | null | Promise<string | undefined | null>;
+  /** Write a value. */
+  setItem: (key: string, value: string) => void | Promise<void>;
+  /** Remove a value. */
+  removeItem: (key: string) => void | Promise<void>;
+}
+
+/** Storage key for the current access token (a JWT). */
+export const JWT_STORAGE_KEY = "__convexAuthJWT";
+/** Storage key for the current (rotating) refresh token. */
+export const REFRESH_TOKEN_STORAGE_KEY = "__convexAuthRefreshToken";
+
+/**
+ * An in-memory {@link TokenStorage}, used as a fallback when no persistent
+ * storage is available (SSR, or a non-browser runtime). Sessions stored here do
+ * not survive a reload.
+ */
+export class InMemoryStorage implements TokenStorage {
+  private store: Record<string, string> = {};
+  getItem(key: string) {
+    return this.store[key] ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store[key] = value;
+  }
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+}
+
+/**
+ * The default storage: the browser's `localStorage` when available, otherwise
+ * an {@link InMemoryStorage}. Callers that need cross-tab sessions, React
+ * Native, or per-tab sessions should pass their own storage instead.
+ */
+export function defaultStorage(): TokenStorage {
+  if (typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage;
+  }
+  return new InMemoryStorage();
+}
+
+/**
+ * A view over a {@link TokenStorage} that suffixes every key with a sanitized
+ * namespace. Keying by (e.g.) the deployment URL keeps tokens for different
+ * deployments from colliding when they share one origin's `localStorage` (the
+ * classic dev-vs-prod-on-localhost case). Two clients sharing a namespace share
+ * a session; distinct namespaces isolate them.
+ */
+export class NamespacedStorage {
+  /** The wrapped storage. Exposed so callers can compare a `StorageEvent`'s
+   * `storageArea` against it for cross-tab sync. */
+  readonly storage: TokenStorage;
+  private readonly suffix: string;
+
+  constructor(storage: TokenStorage, namespace: string) {
+    this.storage = storage;
+    // Non-alphanumeric characters are stripped for React Native compatibility.
+    this.suffix = namespace.replace(/[^a-zA-Z0-9]/g, "");
+  }
+
+  /** The fully-qualified (namespaced) key for a logical key. */
+  key(key: string): string {
+    return `${key}_${this.suffix}`;
+  }
+
+  get(key: string) {
+    return this.storage.getItem(this.key(key));
+  }
+  set(key: string, value: string) {
+    return this.storage.setItem(this.key(key), value);
+  }
+  remove(key: string) {
+    return this.storage.removeItem(this.key(key));
+  }
+}


### PR DESCRIPTION
Framework agnostic primitives for interacting with Convex Auth.

Includes token storage and concurrent refresh support (via a mutex) and an API for exposing refresh and logout and communicating auth state changes out to observers (e.g. a React lib).

A React client building on these primitives is in #397.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
