### PR TITLE
react-minimal example: wire up the client

### DIFF
--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -1,4 +1,5 @@
-import { internalMutation } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 
 /**
@@ -25,5 +26,21 @@ export const upsertFromAuth = internalMutation({
         return _exhaustive;
       }
     }
+  },
+});
+
+/**
+ * The currently signed-in user, or null. Demonstrates an authenticated query:
+ * Convex validates the access token the client sends and exposes its `sub`
+ * claim (the app user id) via `ctx.auth`.
+ */
+export const loggedInUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+    return await ctx.db.get("users", identity.subject as Id<"users">);
   },
 });

--- a/examples/react-minimal/index.html
+++ b/examples/react-minimal/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convex Auth — react-minimal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-minimal/package.json
+++ b/examples/react-minimal/package.json
@@ -11,11 +11,17 @@
     "react-dom": "^19.2.7"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "convex-test": "^0.0.53",
     "typescript": "^6.0.3",

--- a/examples/react-minimal/src/App.tsx
+++ b/examples/react-minimal/src/App.tsx
@@ -1,0 +1,72 @@
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useAuthActions,
+  useAuthToken,
+} from "@convex-dev/auth/react";
+import { useAnonymousAuth } from "@convex-dev/auth/providers/anonymous/react";
+import { useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+
+/**
+ * A minimal end-to-end exercise of the core client: anonymous sign-in →
+ * `setSession` → an authenticated query → sign-out. The `Authenticated` /
+ * `Unauthenticated` / `AuthLoading` components read Convex's validated auth
+ * state (from the JWT handshake), so what they render confirms the whole loop.
+ *
+ * Sign-in goes through the anonymous provider's client (`useAnonymousAuth`),
+ * which wraps that provider's `signInAnonymous` → `setSession` wiring.
+ */
+export function App() {
+  return (
+    <main
+      style={{
+        fontFamily: "system-ui, sans-serif",
+        maxWidth: 480,
+        margin: "4rem auto",
+        padding: "0 1rem",
+        lineHeight: 1.5,
+      }}
+    >
+      <h1>Convex Auth — minimal client</h1>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <SignIn />
+      </Unauthenticated>
+      <Authenticated>
+        <Dashboard />
+      </Authenticated>
+    </main>
+  );
+}
+
+function SignIn() {
+  const { signInAnonymous } = useAnonymousAuth(api.auth.signInAnonymous);
+  return (
+    <>
+      <p>You are signed out.</p>
+      <button onClick={() => signInAnonymous()}>Sign in anonymously</button>
+    </>
+  );
+}
+
+function Dashboard() {
+  const user = useQuery(api.users.loggedInUser);
+  const token = useAuthToken();
+  const { signOut } = useAuthActions();
+  return (
+    <>
+      <p>
+        Signed in as <strong>{user ? user.name : "…"}</strong>
+        {user ? ` (${user._id})` : ""}
+      </p>
+      <p style={{ wordBreak: "break-all", color: "#666", fontSize: "0.8rem" }}>
+        Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}
+      </p>
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}

--- a/examples/react-minimal/src/main.tsx
+++ b/examples/react-minimal/src/main.tsx
@@ -1,0 +1,22 @@
+import { ConvexAuthProvider } from "@convex-dev/auth/react";
+import { ConvexReactClient } from "convex/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { api } from "../convex/_generated/api";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexAuthProvider
+      client={convex}
+      api={{
+        refreshSession: api.auth.refreshSession,
+        signOut: api.auth.signOut,
+      }}
+    >
+      <App />
+    </ConvexAuthProvider>
+  </StrictMode>,
+);

--- a/examples/react-minimal/src/main.tsx
+++ b/examples/react-minimal/src/main.tsx
@@ -5,7 +5,7 @@ import { createRoot } from "react-dom/client";
 import { api } from "../convex/_generated/api";
 import { App } from "./App";
 
-const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/react-minimal/tsconfig.json
+++ b/examples/react-minimal/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["convex/**/*"],
+  "include": ["convex/**/*", "src/**/*", "vite.config.ts"],
   "exclude": ["node_modules", "convex/_generated"]
 }

--- a/examples/react-minimal/vite.config.ts
+++ b/examples/react-minimal/vite.config.ts
@@ -1,0 +1,8 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Dev/build config for the example frontend. Tests use `vitest.config.ts`
+// (Vitest prefers it over this file), so the two don't interfere.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))


### PR DESCRIPTION
Adds a runnable Vite/React app that uses the `@convex-dev/auth/react` client.

Builds on the React client code in #397 and the anonymous client in #404.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
