### PR TITLE
Password provider: react-password example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,10 @@ This is a pnpm monorepo:
 - `packages/core` — the core auth component, published as `@convex-dev/auth`. Owns sessions, accounts, and JWT minting; it is provider-agnostic.
 - `packages/password` — the password provider component, published as `@convex-dev/auth-password`. Stores and verifies passwords keyed by an opaque user id.
 - `packages/argon2id` — a private package (`@convex-dev/argon2id`) wrapping the argon2id WASM hasher used by the password provider. Its `prepare` script builds the Rust/WASM output when it's missing.
-- `examples/react-minimal` — a minimal example app wiring up the core component.
+- `examples/` — example apps, each an in-repo Convex backend run from its own
+  directory:
+  - `react-minimal` wires up the core with the anonymous provider.
+  - `react-password` wires up the core with the password provider.
 
 Use `pnpm install` at the root. Common tasks:
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Common tasks:
 - `pnpm typecheck` — typecheck across packages.
 - `pnpm lint` — ESLint.
 - `pnpm format` — Prettier.
+
+## Examples
+
+The `examples/` directory holds in-repo example apps. Each is a self-contained
+Convex backend that mounts the auth components, and is run from its own
+directory (see the example's own README):
+
+- `examples/react-minimal` — the core component with the anonymous provider.
+- `examples/react-password` — the core component with the password provider.
+
+Their tests run as part of `pnpm test` at the repo root.

--- a/convex.json
+++ b/convex.json
@@ -1,4 +1,0 @@
-{
-  "functions": "examples/react-minimal/convex",
-  "$schema": "./node_modules/convex/schemas/convex.schema.json"
-}

--- a/examples/react-minimal/README.md
+++ b/examples/react-minimal/README.md
@@ -10,14 +10,14 @@ The auth system owns sessions, providers, accounts, and JWT minting;
 
 ## Generate code / run
 
-Run the example from the root directory.
+Run the example from its own directory.
 
 ```bash
+cd examples/react-minimal
 npx convex dev --once    # provisions a deployment, generates convex/_generated
 npx generate-auth-keys   # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
 ```
 
 ## Test usage
 
-The tests defined in the example are run along with `npm run test:auth` in the
-repo root.
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-minimal/convex/auth.test.ts
+++ b/examples/react-minimal/convex/auth.test.ts
@@ -1,8 +1,8 @@
 import { convexTest } from "convex-test";
 import { describe, expect, test, vi, afterEach } from "vitest";
 import { api } from "./_generated/api.js";
-import { registerAnonymousProvider } from "@convex-dev/auth/providers/testing/anonymous.js";
-import { registerCore } from "@convex-dev/auth/providers/testing/core.js";
+import { registerAnonymousProvider } from "@convex-dev/auth/providers/testing/anonymous";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
 import schema from "./schema.js";
 import { generateKeyPair, exportPKCS8, exportJWK, decodeJwt } from "jose";
 import { randomUUID } from "crypto";

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -1,6 +1,6 @@
 import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
-import { Anonymous } from "@convex-dev/auth/providers/anonymous/setup.js";
+import { provider, setupCore } from "@convex-dev/auth/core/setup";
+import { Anonymous } from "@convex-dev/auth/providers/anonymous/setup";
 
 // The core owns sessions, accounts, and JWT minting. It calls back into our
 // `upsertFromAuth` on every sign-in from a provider.

--- a/examples/react-minimal/convex/convex.config.ts
+++ b/examples/react-minimal/convex/convex.config.ts
@@ -1,7 +1,7 @@
 import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
-import anonymous from "@convex-dev/auth/providers/anonymous/convex.config.js";
+import core from "@convex-dev/auth/core/convex.config";
+import anonymous from "@convex-dev/auth/providers/anonymous/convex.config";
 
 const app = defineApp({
   env: {

--- a/examples/react-password/.gitignore
+++ b/examples/react-password/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-password/README.md
+++ b/examples/react-password/README.md
@@ -1,0 +1,25 @@
+# react-password example
+
+An in-repo Convex backend that mounts the `@convex-dev/auth` core component
+together with the `@convex-dev/auth-password` provider. It exists as an example
+of wiring username/password auth into an application and for integration testing
+the password provider end to end.
+
+The core owns sessions, accounts, and JWT minting; the password provider stores
+and verifies passwords keyed to an opaque user id. `convex/users.ts` owns the
+app side (the `createOrUpdateUser` callback), and `convex/auth.ts` exposes the
+`signUpWithPassword` / `signInWithPassword` actions.
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-password
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx generate-auth-keys   # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+```
+
+## Test usage
+
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-password/convex/_generated/api.d.ts
+++ b/examples/react-password/convex/_generated/api.d.ts
@@ -1,0 +1,54 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  authPasswordProvider: import("@convex-dev/auth-password/component/_generated/component.js").ComponentApi<"authPasswordProvider">;
+};

--- a/examples/react-password/convex/_generated/api.js
+++ b/examples/react-password/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-password/convex/_generated/dataModel.d.ts
+++ b/examples/react-password/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-password/convex/_generated/server.d.ts
+++ b/examples/react-password/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-password/convex/_generated/server.js
+++ b/examples/react-password/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-password/convex/auth.config.ts
+++ b/examples/react-password/convex/auth.config.ts
@@ -1,0 +1,11 @@
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+};

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -1,5 +1,5 @@
 import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
+import { provider, setupCore } from "@convex-dev/auth/core/setup";
 import { UsernamePassword } from "@convex-dev/auth-password/setup";
 
 // The core owns sessions, accounts, and JWT minting. It calls back into our

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -1,0 +1,21 @@
+import { components, internal } from "./_generated/api";
+import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
+import { UsernamePassword } from "@convex-dev/auth-password/setup";
+
+// The core owns sessions, accounts, and JWT minting. It calls back into our
+// `createOrUpdateUser` on every sign-in from a provider. The password provider
+// exposes the sign up / sign in actions, keyed to an opaque app user id.
+export const {
+  signOut,
+  refreshSession,
+  providers: {
+    password: { signUpWithPassword, signInWithPassword },
+  },
+} = setupCore({
+  component: components.core,
+  providers: [
+    provider(UsernamePassword, {
+      component: components.authPasswordProvider,
+    }),
+  ],
+}).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-password/convex/convex.config.ts
+++ b/examples/react-password/convex/convex.config.ts
@@ -1,7 +1,7 @@
 import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
-import passwordProvider from "@convex-dev/auth-password/component/convex.config.js";
+import core from "@convex-dev/auth/core/convex.config";
+import passwordProvider from "@convex-dev/auth-password/component/convex.config";
 
 const app = defineApp({
   env: {

--- a/examples/react-password/convex/convex.config.ts
+++ b/examples/react-password/convex/convex.config.ts
@@ -1,0 +1,22 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+import passwordProvider from "@convex-dev/auth-password/component/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(passwordProvider);
+
+export default app;

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -51,8 +51,7 @@ const signIn = (
 ) => t.action(api.auth.signInWithPassword, { username, password });
 
 type PasswordResult =
-  | Awaited<ReturnType<typeof signUp>>
-  | Awaited<ReturnType<typeof signIn>>;
+  Awaited<ReturnType<typeof signUp>> | Awaited<ReturnType<typeof signIn>>;
 type PasswordSuccess = Extract<PasswordResult, { success: true }>;
 
 describe("setupUsernamePassword", () => {

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -1,0 +1,127 @@
+import { convexTest } from "convex-test";
+import { beforeAll, describe, expect, test } from "vitest";
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+import { api } from "./_generated/api.js";
+import { registerCore } from "@convex-dev/auth/providers/testing/core.js";
+import { registerPasswordProvider } from "@convex-dev/auth-password/testing";
+import schema from "./schema.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const PASSWORD = "correct horse battery staple"; // 28 chars, valid
+
+// The core signs JWTs from these env vars (see core/public.ts). Mint a real
+// RS256 key pair once and expose the issuer, mirroring the core's own suite.
+beforeAll(async () => {
+  const { publicKey, privateKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const pkcs8 = await exportPKCS8(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+  process.env.CONVEX_SITE_URL = "https://example.convex.site";
+  process.env.AUTH_PRIVATE_KEY = btoa(pkcs8);
+  process.env.AUTH_JWKS = JSON.stringify({
+    keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
+  });
+});
+
+function setup() {
+  const t = convexTest(schema, modules);
+  registerCore(t);
+  registerPasswordProvider(t);
+  return t;
+}
+
+const signUp = (
+  t: ReturnType<typeof setup>,
+  username: string,
+  password: string,
+) => t.action(api.auth.signUpWithPassword, { username, password });
+
+const signIn = (
+  t: ReturnType<typeof setup>,
+  username: string,
+  password: string,
+) => t.action(api.auth.signInWithPassword, { username, password });
+
+describe("setupUsernamePassword", () => {
+  test("signs up a new user and returns a session", async () => {
+    const t = setup();
+    const result = await signUp(t, "alice", PASSWORD);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("expected success");
+    expect(result.tokens.userId).toBeTruthy();
+    expect(result.tokens.accessToken).toBeTruthy();
+    expect(result.tokens.refreshToken).toBeTruthy();
+  });
+
+  test("signs in with the correct password", async () => {
+    const t = setup();
+    const up = await signUp(t, "alice", PASSWORD);
+    const inResult = await signIn(t, "alice", PASSWORD);
+    expect(inResult.success).toBe(true);
+    if (!inResult.success || !up.success) throw new Error("expected success");
+    // Same identity → same app user id.
+    expect(inResult.tokens.userId).toBe(up.tokens.userId);
+  });
+
+  test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
+    const t = setup();
+    await signUp(t, "alice", PASSWORD);
+    const result = await signIn(t, "alice", "wrong horse battery staple");
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "INVALID_CREDENTIALS" },
+    });
+  });
+
+  test("rejects an unknown username with USER_NOT_FOUND", async () => {
+    const t = setup();
+    const result = await signIn(t, "nobody", PASSWORD);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USER_NOT_FOUND" },
+    });
+  });
+
+  test("rejects signing up a taken username", async () => {
+    const t = setup();
+    await signUp(t, "alice", PASSWORD);
+    const result = await signUp(t, "alice", PASSWORD);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("usernames are case-insensitive", async () => {
+    const t = setup();
+    const up = await signUp(t, "Alice", PASSWORD);
+    if (!up.success) throw new Error("expected success");
+
+    // A different casing is treated as the same account for both sign-in...
+    const inResult = await signIn(t, "ALICE", PASSWORD);
+    expect(inResult.success).toBe(true);
+    if (!inResult.success) throw new Error("expected success");
+    expect(inResult.tokens.userId).toBe(up.tokens.userId);
+
+    // ...and the taken-username check.
+    const dup = await signUp(t, "alice", PASSWORD);
+    expect(dup).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("rejects a too-short password at sign-up without creating an account", async () => {
+    const t = setup();
+    const up = await signUp(t, "alice", "short");
+    expect(up.success).toBe(false);
+    if (up.success) throw new Error("expected failure");
+    expect(up.userError.error).toBe("PASSWORD_TOO_SHORT");
+
+    // No account was created, so a later sign-up with a valid password works.
+    const retry = await signUp(t, "alice", PASSWORD);
+    expect(retry.success).toBe(true);
+  });
+});

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -50,25 +50,55 @@ const signIn = (
   password: string,
 ) => t.action(api.auth.signInWithPassword, { username, password });
 
+type PasswordResult =
+  | Awaited<ReturnType<typeof signUp>>
+  | Awaited<ReturnType<typeof signIn>>;
+type PasswordSuccess = Extract<PasswordResult, { success: true }>;
+
 describe("setupUsernamePassword", () => {
   test("signs up a new user and returns a session", async () => {
     const t = await setup();
     const result = await signUp(t, "alice", PASSWORD);
-    expect(result.success).toBe(true);
-    if (!result.success) throw new Error("expected success");
-    expect(result.tokens.userId).toBeTruthy();
-    expect(result.tokens.accessToken).toBeTruthy();
-    expect(result.tokens.refreshToken).toBeTruthy();
+    expect(result).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
   });
 
   test("signs in with the correct password", async () => {
     const t = await setup();
     const up = await signUp(t, "alice", PASSWORD);
     const inResult = await signIn(t, "alice", PASSWORD);
-    expect(inResult.success).toBe(true);
-    if (!inResult.success || !up.success) throw new Error("expected success");
+    expect(up).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+    expect(inResult).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
     // Same identity → same app user id.
-    expect(inResult.tokens.userId).toBe(up.tokens.userId);
+    expect((inResult as PasswordSuccess).tokens.userId).toBe(
+      (up as PasswordSuccess).tokens.userId,
+    );
   });
 
   test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
@@ -103,13 +133,32 @@ describe("setupUsernamePassword", () => {
   test("usernames are case-insensitive", async () => {
     const t = await setup();
     const up = await signUp(t, "Alice", PASSWORD);
-    if (!up.success) throw new Error("expected success");
+    expect(up).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
 
     // A different casing is treated as the same account for both sign-in...
     const inResult = await signIn(t, "ALICE", PASSWORD);
-    expect(inResult.success).toBe(true);
-    if (!inResult.success) throw new Error("expected success");
-    expect(inResult.tokens.userId).toBe(up.tokens.userId);
+    expect(inResult).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+    expect((inResult as PasswordSuccess).tokens.userId).toBe(
+      (up as PasswordSuccess).tokens.userId,
+    );
 
     // ...and the taken-username check.
     const dup = await signUp(t, "alice", PASSWORD);
@@ -122,12 +171,22 @@ describe("setupUsernamePassword", () => {
   test("rejects a too-short password at sign-up without creating an account", async () => {
     const t = await setup();
     const up = await signUp(t, "alice", "short");
-    expect(up.success).toBe(false);
-    if (up.success) throw new Error("expected failure");
-    expect(up.userError.error).toBe("PASSWORD_TOO_SHORT");
+    expect(up).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
+    });
 
     // No account was created, so a later sign-up with a valid password works.
     const retry = await signUp(t, "alice", PASSWORD);
-    expect(retry.success).toBe(true);
+    expect(retry).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
   });
 });

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -2,7 +2,7 @@ import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { api } from "./_generated/api.js";
-import { registerCore } from "@convex-dev/auth/providers/testing/core.js";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
 import { registerPasswordProvider } from "@convex-dev/auth-password/testing";
 import schema from "./schema.js";
 

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -1,5 +1,5 @@
 import { convexTest } from "convex-test";
-import { beforeAll, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { api } from "./_generated/api.js";
 import { registerCore } from "@convex-dev/auth/providers/testing/core.js";
@@ -10,43 +10,49 @@ const modules = import.meta.glob("./**/*.ts");
 
 const PASSWORD = "correct horse battery staple"; // 28 chars, valid
 
-// The core signs JWTs from these env vars (see core/public.ts). Mint a real
-// RS256 key pair once and expose the issuer, mirroring the core's own suite.
-beforeAll(async () => {
+async function setup() {
+  // The core signs JWTs from these env vars (see core/public.ts). Mint a real
+  // RS256 key pair for each test and stub the env so Vitest can reset it.
   const { publicKey, privateKey } = await generateKeyPair("RS256", {
     extractable: true,
   });
   const pkcs8 = await exportPKCS8(privateKey);
   const publicJwk = await exportJWK(publicKey);
-  process.env.CONVEX_SITE_URL = "https://example.convex.site";
-  process.env.AUTH_PRIVATE_KEY = btoa(pkcs8);
-  process.env.AUTH_JWKS = JSON.stringify({
-    keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
-  });
-});
 
-function setup() {
+  vi.stubEnv("CONVEX_SITE_URL", "https://example.convex.site");
+  vi.stubEnv("AUTH_PRIVATE_KEY", btoa(pkcs8));
+  vi.stubEnv(
+    "AUTH_JWKS",
+    JSON.stringify({
+      keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
+    }),
+  );
+
   const t = convexTest(schema, modules);
   registerCore(t);
   registerPasswordProvider(t);
   return t;
 }
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 const signUp = (
-  t: ReturnType<typeof setup>,
+  t: Awaited<ReturnType<typeof setup>>,
   username: string,
   password: string,
 ) => t.action(api.auth.signUpWithPassword, { username, password });
 
 const signIn = (
-  t: ReturnType<typeof setup>,
+  t: Awaited<ReturnType<typeof setup>>,
   username: string,
   password: string,
 ) => t.action(api.auth.signInWithPassword, { username, password });
 
 describe("setupUsernamePassword", () => {
   test("signs up a new user and returns a session", async () => {
-    const t = setup();
+    const t = await setup();
     const result = await signUp(t, "alice", PASSWORD);
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("expected success");
@@ -56,7 +62,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("signs in with the correct password", async () => {
-    const t = setup();
+    const t = await setup();
     const up = await signUp(t, "alice", PASSWORD);
     const inResult = await signIn(t, "alice", PASSWORD);
     expect(inResult.success).toBe(true);
@@ -66,7 +72,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
-    const t = setup();
+    const t = await setup();
     await signUp(t, "alice", PASSWORD);
     const result = await signIn(t, "alice", "wrong horse battery staple");
     expect(result).toEqual({
@@ -76,7 +82,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("rejects an unknown username with USER_NOT_FOUND", async () => {
-    const t = setup();
+    const t = await setup();
     const result = await signIn(t, "nobody", PASSWORD);
     expect(result).toEqual({
       success: false,
@@ -85,7 +91,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("rejects signing up a taken username", async () => {
-    const t = setup();
+    const t = await setup();
     await signUp(t, "alice", PASSWORD);
     const result = await signUp(t, "alice", PASSWORD);
     expect(result).toEqual({
@@ -95,7 +101,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("usernames are case-insensitive", async () => {
-    const t = setup();
+    const t = await setup();
     const up = await signUp(t, "Alice", PASSWORD);
     if (!up.success) throw new Error("expected success");
 
@@ -114,7 +120,7 @@ describe("setupUsernamePassword", () => {
   });
 
   test("rejects a too-short password at sign-up without creating an account", async () => {
-    const t = setup();
+    const t = await setup();
     const up = await signUp(t, "alice", "short");
     expect(up.success).toBe(false);
     if (up.success) throw new Error("expected failure");

--- a/examples/react-password/convex/schema.ts
+++ b/examples/react-password/convex/schema.ts
@@ -1,0 +1,10 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+// A minimal app schema. The app owns its users table; the auth components only
+// keep the opaque user-id string it returns.
+export default defineSchema({
+  users: defineTable({
+    username: v.optional(v.string()),
+  }),
+});

--- a/examples/react-password/convex/tsconfig.json
+++ b/examples/react-password/convex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -1,0 +1,32 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * The app's create-or-update-user callback (see `attachUserCallback`). The core
+ * invokes it on every sign-in — without a `userId` the first time an identity is
+ * seen, and with the resolved `userId` thereafter. On the first sign-in we mint
+ * a users row from the profile's username; on later sign-ins we echo the id.
+ */
+export const createOrUpdateUser = internalMutation({
+  args: {
+    provider: v.literal("password"),
+    providerAccountId: v.string(),
+    profile: v.any(),
+    userId: v.union(v.string(), v.null()),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    if (args.userId !== null) {
+      const existing = ctx.db.normalizeId("users", args.userId);
+      if (existing === null) {
+        throw new Error(`Unknown user id: ${args.userId}`);
+      }
+      return existing;
+    }
+    const username =
+      typeof args.profile?.username === "string"
+        ? args.profile.username
+        : undefined;
+    return await ctx.db.insert("users", { username });
+  },
+});

--- a/examples/react-password/package.json
+++ b/examples/react-password/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@convex-dev/auth-example-react-password",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "@convex-dev/auth-password": "workspace:*",
+    "convex": "^1.41.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@convex-dev/rate-limiter": "^0.3.2",
+    "@edge-runtime/vm": "^5.0.0",
+    "@types/node": "^24.12.4",
+    "@types/react": "^19.2.17",
+    "@vitejs/plugin-react": "^4.3.4",
+    "convex-test": "^0.0.53",
+    "jose": "^5.10.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/react-password/tsconfig.json
+++ b/examples/react-password/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["convex/**/*"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/examples/react-password/vitest.config.ts
+++ b/examples/react-password/vitest.config.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import type { Plugin } from "vite";
+import { defineConfig } from "vitest/config";
+
+// Convex's bundler turns `import mod from "*.wasm"` into a `WebAssembly.Module`.
+// Vitest doesn't handle `.wasm` out of the box, so mirror that behavior: read
+// the file at load time and emit a module whose default export is a
+// `WebAssembly.Module`, with the bytes inlined as base64 so it works in the
+// edge-runtime test environment (no fs at eval time).
+//
+// The `.wasm` import lives in the `@convex-dev/argon2id` dependency (pulled in
+// by the password provider), so that package is inlined below to route it
+// through this plugin rather than being externalized.
+function wasmModulePlugin(): Plugin {
+  return {
+    name: "wasm-as-webassembly-module",
+    // Run before Vite's built-in `.wasm` handling, which would otherwise try to
+    // ESM-resolve the module's wasm-bindgen imports (e.g. "wbg") and fail.
+    enforce: "pre",
+    load(id) {
+      if (!id.endsWith(".wasm")) return null;
+      const base64 = readFileSync(id).toString("base64");
+      return `const bytes = Uint8Array.from(atob(${JSON.stringify(
+        base64,
+      )}), (c) => c.charCodeAt(0));
+export default new WebAssembly.Module(bytes);`;
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [wasmModulePlugin()],
+  test: {
+    // Convex functions run in an edge-like runtime; convex-test relies on it.
+    environment: "edge-runtime",
+    include: ["convex/**/*.test.ts"],
+    server: {
+      deps: {
+        // convex-test loads function modules dynamically; inlining keeps that
+        // resolution working under Vitest's transform pipeline. `@convex-dev/argon2id`
+        // is inlined so its `.wasm` import is handled by `wasmModulePlugin`.
+        inline: ["convex-test", "@convex-dev/argon2id"],
+      },
+    },
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,10 +27,10 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    "./lib/*": "./src/lib/*",
-    "./core/*": "./src/components/core/*",
-    "./providers/anonymous/*": "./src/components/anonymous/*",
-    "./providers/testing/*": "./src/components/testing/*"
+    "./lib/*": "./src/lib/*.ts",
+    "./core/*": "./src/components/core/*.ts",
+    "./providers/anonymous/*": "./src/components/anonymous/*.ts",
+    "./providers/testing/*": "./src/components/testing/*.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -23,7 +23,7 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    "./component/*": "./src/component/*",
+    "./component/*": "./src/component/*.ts",
     "./setup": "./src/setup.ts",
     "./testing": "./src/testing.ts"
   },

--- a/packages/password/src/setup.ts
+++ b/packages/password/src/setup.ts
@@ -1,6 +1,6 @@
 import { actionGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
-import { defineProvider, vTokenBundle } from "@convex-dev/auth/lib/types.js";
+import { defineProvider, vTokenBundle } from "@convex-dev/auth/lib/types";
 import type { ComponentApi } from "./component/_generated/component.js";
 import {
   validatePasswordInputFormat,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,52 @@ importers:
         specifier: ^8.0.16
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
+  examples/react-password:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@convex-dev/auth-password':
+        specifier: workspace:*
+        version: link:../../packages/password
+      convex:
+        specifier: ^1.41.0
+        version: 1.42.1(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.42.1(react@19.2.7))
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   packages/argon2id:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Password provider: react-password example

Adds an in-repo example app wiring up the core with the password provider
via setupUsernamePassword, run from its own directory.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

stub env in test

Fix tests

format

Fix imports to remove `.js` suffix