### PR TITLE
Add draft of CLI script for auth project scaffolding

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,10 +19,11 @@
     "directory": "packages/core"
   },
   "bin": {
-    "generate-auth-keys": "./scripts/generate-auth-keys.mjs"
+    "@convex-dev/auth": "./scripts/init.mjs"
   },
   "files": [
-    "src"
+    "src",
+    "scripts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -45,6 +46,7 @@
   "dependencies": {
     "@convex-dev/rate-limiter": "^0.3.2",
     "argon2id-wasm": "0.0.0-alpha.1",
+    "commander": "^14.0.2",
     "jose": "^5.2.2"
   },
   "devDependencies": {

--- a/packages/core/scripts/init.mjs
+++ b/packages/core/scripts/init.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * `npx @convex-dev/auth` — initialize a basic Convex Auth (v2) project.
+ *
+ * What it does, in order:
+ *   1. Confirms `@convex-dev/auth` is a dependency of the project in the current
+ *      directory. If it isn't, it crashes with the exact install command for the
+ *      detected package manager (it does NOT install anything itself).
+ *   2. Generates an RS256 key pair and sets the AUTH_PRIVATE_KEY / AUTH_JWKS env
+ *      vars on the Convex deployment (idempotent; `--force` rotates them).
+ *   3. Scaffolds `convex/auth.config.ts`, `convex/convex.config.ts` and
+ *      `convex/auth.ts`. Existing files are left untouched — the CLI instead
+ *      prints the content the file should contain.
+ *
+ * The command's behavior is expressed as a set of injectable dependencies (see
+ * `defaultDeps`) so it can be driven end-to-end in unit tests with the file
+ * system, key generation, and Convex env access all stubbed out.
+ */
+import { Command } from "commander";
+import { generateKeyPair, exportPKCS8, exportJWK } from "jose";
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ALG = "RS256";
+
+/** The package the generated `convex.config.ts` / `auth.ts` import from. */
+const AUTH_PACKAGE = "@convex-dev/auth";
+
+/** Where to grab the v2 (reboot) build from until it's on npm proper. */
+const INSTALL_SPEC = `${AUTH_PACKAGE}@https://pkg.pr.new/${AUTH_PACKAGE}@reboot`;
+
+/** Files scaffolded into the project's `convex/` directory, in write order. */
+export const FILE_TEMPLATES = {
+  "auth.config.ts": `import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: \`\${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json\`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;
+`,
+  "convex.config.ts": `import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+// TODO Add auth providers
+
+export default app;
+`,
+  "auth.ts": `import { components, internal } from "./_generated/api";
+import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
+
+export const {
+  signOut,
+  refreshSession,
+  providers: {
+    // TODO
+  },
+} = setupCore({
+  component: components.core,
+  providers: [
+    // TODO
+  ],
+}).attachUserCallback(internal.users.createOrUpdateUser);
+`,
+};
+
+/** The install command for a given package manager. */
+export function installCommand(packageManager) {
+  switch (packageManager) {
+    case "pnpm":
+      return `pnpm add ${INSTALL_SPEC}`;
+    case "bun":
+      return `bun add ${INSTALL_SPEC}`;
+    case "yarn":
+      return `yarn add ${INSTALL_SPEC}`;
+    case "npm":
+    default:
+      return `npm install ${INSTALL_SPEC}`;
+  }
+}
+
+/**
+ * Detect the package manager in use, preferring the agent that actually invoked
+ * the CLI (`npm_config_user_agent`) and falling back to whichever lockfile is
+ * present in `dir`. Defaults to npm.
+ */
+export function detectPackageManager(dir, env = process.env) {
+  const userAgent = env.npm_config_user_agent ?? "";
+  if (userAgent.startsWith("pnpm")) return "pnpm";
+  if (userAgent.startsWith("bun")) return "bun";
+  if (userAgent.startsWith("yarn")) return "yarn";
+  if (userAgent.startsWith("npm")) return "npm";
+
+  if (existsSync(join(dir, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(dir, "bun.lockb")) || existsSync(join(dir, "bun.lock")))
+    return "bun";
+  if (existsSync(join(dir, "yarn.lock"))) return "yarn";
+  return "npm";
+}
+
+/** Generate a fresh RS256 key pair as base64 PKCS8 + a JWKS JSON string. */
+async function generateAuthKeys() {
+  const { publicKey, privateKey } = await generateKeyPair(ALG, {
+    extractable: true,
+  });
+  const privatePem = await exportPKCS8(privateKey);
+  const pubJwk = await exportJWK(publicKey);
+  const kid = randomUUID();
+
+  return {
+    authPrivateKey: Buffer.from(privatePem).toString("base64"),
+    authJwks: JSON.stringify({
+      keys: [{ ...pubJwk, kid, alg: ALG, use: "sig" }],
+    }),
+  };
+}
+
+/** Read an env var off the current directory's Convex deployment. */
+function getConvexEnv(key) {
+  const result = spawnSync("npx", ["convex", "env", "get", key], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  const value = (result.stdout ?? "").trim();
+  return value.length > 0 ? value : null;
+}
+
+/** Set an env var on the current directory's Convex deployment. */
+function setConvexEnv(key, value) {
+  const result = spawnSync("npx", ["convex", "env", "set", key, value], {
+    stdio: "inherit",
+    cwd: process.cwd(),
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to set ${key} on the Convex deployment.`);
+  }
+}
+
+/** The real implementations, injected into `runInit` (overridden in tests). */
+export function defaultDeps() {
+  return {
+    cwd: () => process.cwd(),
+    fs: { existsSync, readFileSync, writeFileSync, mkdirSync },
+    log: (message) => console.log(message),
+    warn: (message) => console.warn(message),
+    generateKeys: generateAuthKeys,
+    getEnv: getConvexEnv,
+    setEnv: setConvexEnv,
+    detectPackageManager,
+  };
+}
+
+/** Whether `@convex-dev/auth` appears in the package's (dev)dependencies. */
+function hasAuthDependency(pkg) {
+  return (
+    AUTH_PACKAGE in (pkg.dependencies ?? {}) ||
+    AUTH_PACKAGE in (pkg.devDependencies ?? {})
+  );
+}
+
+/** Indent a block of text for display inside a warning. */
+function indent(text) {
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? `    ${line}` : line))
+    .join("\n");
+}
+
+/** Ensure the signing keys exist on the deployment (idempotent). */
+async function ensureAuthKeys(deps, force) {
+  if (!force && deps.getEnv("AUTH_PRIVATE_KEY") && deps.getEnv("AUTH_JWKS")) {
+    deps.log(
+      "AUTH_PRIVATE_KEY and AUTH_JWKS are already set; leaving them unchanged " +
+        "(pass --force to rotate the signing key).",
+    );
+    return;
+  }
+  const { authPrivateKey, authJwks } = await deps.generateKeys();
+  deps.setEnv("AUTH_PRIVATE_KEY", authPrivateKey);
+  deps.setEnv("AUTH_JWKS", authJwks);
+  deps.log("Set AUTH_PRIVATE_KEY and AUTH_JWKS on the Convex deployment.");
+}
+
+/**
+ * Write each scaffolded file into `convex/`, creating the directory if needed.
+ * A file that already exists is never overwritten: instead we warn and print
+ * the content it should contain.
+ */
+function writeAuthFiles(deps, dir) {
+  const convexDir = join(dir, "convex");
+  if (!deps.fs.existsSync(convexDir)) {
+    deps.fs.mkdirSync(convexDir, { recursive: true });
+  }
+
+  for (const [name, content] of Object.entries(FILE_TEMPLATES)) {
+    const filePath = join(convexDir, name);
+    if (deps.fs.existsSync(filePath)) {
+      deps.warn(
+        `\n⚠ convex/${name} already exists — leaving it untouched.\n` +
+          `  Make sure it contains the following:\n\n${indent(content)}`,
+      );
+      continue;
+    }
+    deps.fs.writeFileSync(filePath, content);
+    deps.log(`  created convex/${name}`);
+  }
+}
+
+/**
+ * Run the full initialization against the injected `deps`. Fatal problems are
+ * reported via `command.error`, which prints to stderr and exits (or throws a
+ * `CommanderError` when the command has `exitOverride` set, as in tests).
+ */
+async function runInit(deps, options, command) {
+  const dir = deps.cwd();
+  const pkgPath = join(dir, "package.json");
+
+  if (!deps.fs.existsSync(pkgPath)) {
+    command.error(
+      `No package.json found in ${dir}.\n` +
+        "Run this command from the root of your project.",
+    );
+    return;
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(deps.fs.readFileSync(pkgPath, "utf8"));
+  } catch {
+    command.error(`Could not parse ${pkgPath} as JSON.`);
+    return;
+  }
+
+  if (!hasAuthDependency(pkg)) {
+    const packageManager = deps.detectPackageManager(dir);
+    command.error(
+      `${AUTH_PACKAGE} is not a dependency of this project.\n\n` +
+        "Install it first, then re-run this command:\n\n" +
+        `  ${installCommand(packageManager)}\n`,
+    );
+    return;
+  }
+
+  deps.log("Setting up the auth signing keys…");
+  await ensureAuthKeys(deps, options.force);
+
+  deps.log("Scaffolding Convex Auth files…");
+  writeAuthFiles(deps, dir);
+
+  deps.log(
+    "\nConvex Auth is set up. Next: add a provider to convex/auth.ts and " +
+      "convex/convex.config.ts (see the TODOs), then run your dev server.",
+  );
+}
+
+/** Build the commander program, wired to the given dependencies. */
+export function createProgram(deps = defaultDeps()) {
+  const program = new Command();
+  program
+    .name("@convex-dev/auth")
+    .description("Initialize a basic Convex Auth project")
+    .option("--force", "Regenerate the auth signing keys even if already set")
+    .action((options, command) => runInit(deps, options, command));
+  return program;
+}
+
+export { runInit };
+
+// Run when invoked directly (`npx @convex-dev/auth`), not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  createProgram().parseAsync(process.argv);
+}

--- a/packages/core/src/cli/init.test.ts
+++ b/packages/core/src/cli/init.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment node
+import { describe, expect, test, vi } from "vitest";
+import {
+  createProgram,
+  detectPackageManager,
+  FILE_TEMPLATES,
+  installCommand,
+} from "../../scripts/init.mjs";
+
+const PROJECT = "/project";
+
+/** Minimal in-memory stand-in for the subset of `node:fs` the CLI uses. */
+function makeFs(initialFiles: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(initialFiles));
+  const dirs = new Set<string>();
+  return {
+    files,
+    dirs,
+    existsSync: (p: string) => files.has(p) || dirs.has(p),
+    readFileSync: (p: string) => {
+      const contents = files.get(p);
+      if (contents === undefined) throw new Error(`ENOENT: ${p}`);
+      return contents;
+    },
+    writeFileSync: (p: string, contents: string) => {
+      files.set(p, contents);
+    },
+    mkdirSync: (p: string) => {
+      dirs.add(p);
+    },
+  };
+}
+
+type Overrides = {
+  files?: Record<string, string>;
+  getEnv?: (key: string) => string | null;
+  generateKeys?: () => Promise<{ authPrivateKey: string; authJwks: string }>;
+  detectPackageManager?: (dir: string) => string;
+};
+
+function makeDeps(overrides: Overrides = {}) {
+  const fs = makeFs(overrides.files);
+  const logs: string[] = [];
+  const warns: string[] = [];
+  const setEnvCalls: Array<[string, string]> = [];
+  const generateKeys = vi.fn(
+    overrides.generateKeys ??
+      (async () => ({ authPrivateKey: "PRIV", authJwks: "JWKS" })),
+  );
+  const deps = {
+    cwd: () => PROJECT,
+    fs,
+    log: (m: string) => logs.push(m),
+    warn: (m: string) => warns.push(m),
+    getEnv: overrides.getEnv ?? (() => null),
+    setEnv: (k: string, v: string) => setEnvCalls.push([k, v]),
+    generateKeys,
+    detectPackageManager: overrides.detectPackageManager ?? (() => "npm"),
+  };
+  return { deps, fs, logs, warns, setEnvCalls, generateKeys };
+}
+
+/** Drive the CLI exactly as a user would, but capture output/exit. */
+async function runCli(deps: unknown, args: string[] = []) {
+  const stderr: string[] = [];
+  // The stub deps intentionally implement only the narrow surface the CLI uses,
+  // so widen to the parameter type the loosely-typed .mjs expects.
+  const program = createProgram(deps as Parameters<typeof createProgram>[0]);
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: (s) => stderr.push(s),
+    writeOut: () => {},
+  });
+  let error: Error | undefined;
+  try {
+    await program.parseAsync(["node", "convex-auth", ...args]);
+  } catch (e) {
+    error = e as Error;
+  }
+  return { error, stderr: stderr.join("") };
+}
+
+const pkgWithAuth = JSON.stringify({
+  dependencies: { "@convex-dev/auth": "^2.0.0" },
+});
+
+describe("convex-auth init CLI", () => {
+  test("crashes with the install command when @convex-dev/auth is missing", async () => {
+    const { deps, fs, setEnvCalls } = makeDeps({
+      files: { "/project/package.json": JSON.stringify({ dependencies: {} }) },
+      detectPackageManager: () => "pnpm",
+    });
+
+    const { error } = await runCli(deps);
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("is not a dependency");
+    expect(error!.message).toContain(
+      "pnpm add @convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
+    );
+    // It must not touch env vars or write any files on this path.
+    expect(setEnvCalls).toEqual([]);
+    expect(fs.files.has("/project/convex/auth.ts")).toBe(false);
+  });
+
+  test("crashes when there is no package.json", async () => {
+    const { deps } = makeDeps({ files: {} });
+    const { error } = await runCli(deps);
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("No package.json found");
+  });
+
+  test("crashes when package.json is not valid JSON", async () => {
+    const { deps } = makeDeps({
+      files: { "/project/package.json": "{ not json" },
+    });
+    const { error } = await runCli(deps);
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("Could not parse");
+  });
+
+  test("sets env vars and scaffolds all files on the happy path", async () => {
+    const { deps, fs, logs, setEnvCalls, generateKeys } = makeDeps({
+      files: { "/project/package.json": pkgWithAuth },
+    });
+
+    const { error } = await runCli(deps);
+
+    expect(error).toBeUndefined();
+    expect(generateKeys).toHaveBeenCalledTimes(1);
+    expect(setEnvCalls).toEqual([
+      ["AUTH_PRIVATE_KEY", "PRIV"],
+      ["AUTH_JWKS", "JWKS"],
+    ]);
+
+    // The convex/ directory is created and every template is written verbatim.
+    expect(fs.dirs.has("/project/convex")).toBe(true);
+    for (const [name, content] of Object.entries(FILE_TEMPLATES)) {
+      expect(fs.files.get(`/project/convex/${name}`)).toBe(content);
+      expect(logs.join("\n")).toContain(`created convex/${name}`);
+    }
+  });
+
+  test("recognizes @convex-dev/auth listed under devDependencies", async () => {
+    const { deps, fs } = makeDeps({
+      files: {
+        "/project/package.json": JSON.stringify({
+          devDependencies: { "@convex-dev/auth": "^2.0.0" },
+        }),
+      },
+    });
+    const { error } = await runCli(deps);
+    expect(error).toBeUndefined();
+    expect(fs.files.has("/project/convex/auth.ts")).toBe(true);
+  });
+
+  test("leaves the keys untouched when both are already set", async () => {
+    const { deps, logs, setEnvCalls, generateKeys } = makeDeps({
+      files: { "/project/package.json": pkgWithAuth },
+      getEnv: () => "already-set",
+    });
+
+    const { error } = await runCli(deps);
+
+    expect(error).toBeUndefined();
+    expect(generateKeys).not.toHaveBeenCalled();
+    expect(setEnvCalls).toEqual([]);
+    expect(logs.join("\n")).toContain("already set");
+  });
+
+  test("--force rotates the keys even when both are already set", async () => {
+    const { deps, setEnvCalls, generateKeys } = makeDeps({
+      files: { "/project/package.json": pkgWithAuth },
+      getEnv: () => "already-set",
+    });
+
+    const { error } = await runCli(deps, ["--force"]);
+
+    expect(error).toBeUndefined();
+    expect(generateKeys).toHaveBeenCalledTimes(1);
+    expect(setEnvCalls).toEqual([
+      ["AUTH_PRIVATE_KEY", "PRIV"],
+      ["AUTH_JWKS", "JWKS"],
+    ]);
+  });
+
+  test("does not overwrite an existing file, but warns with its content", async () => {
+    const { deps, fs, warns } = makeDeps({
+      files: {
+        "/project/package.json": pkgWithAuth,
+        "/project/convex/auth.ts": "// my hand-written auth.ts",
+      },
+    });
+
+    const { error } = await runCli(deps);
+
+    expect(error).toBeUndefined();
+    // Untouched…
+    expect(fs.files.get("/project/convex/auth.ts")).toBe(
+      "// my hand-written auth.ts",
+    );
+    // …but the warning tells the user what it should contain.
+    const warning = warns.join("\n");
+    expect(warning).toContain("convex/auth.ts already exists");
+    expect(warning).toContain("setupCore");
+    // The other files were still created.
+    expect(fs.files.get("/project/convex/convex.config.ts")).toBe(
+      FILE_TEMPLATES["convex.config.ts"],
+    );
+  });
+});
+
+describe("installCommand", () => {
+  test.each([
+    ["npm", "npm install"],
+    ["pnpm", "pnpm add"],
+    ["bun", "bun add"],
+    ["yarn", "yarn add"],
+  ])("%s uses the right add command", (pm, prefix) => {
+    expect(installCommand(pm)).toContain(prefix);
+    expect(installCommand(pm)).toContain(
+      "@convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
+    );
+  });
+
+  test("unknown package managers fall back to npm", () => {
+    expect(installCommand("who-knows")).toContain("npm install");
+  });
+});
+
+describe("detectPackageManager", () => {
+  test("prefers the invoking agent from npm_config_user_agent", () => {
+    expect(
+      detectPackageManager("/nowhere", {
+        npm_config_user_agent: "pnpm/9.0.0 npm/? node/v20",
+      }),
+    ).toBe("pnpm");
+    expect(
+      detectPackageManager("/nowhere", {
+        npm_config_user_agent: "bun/1.1.0",
+      }),
+    ).toBe("bun");
+  });
+
+  test("falls back to npm with no signal", () => {
+    expect(detectPackageManager("/nowhere", {})).toBe("npm");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       argon2id-wasm:
         specifier: 0.0.0-alpha.1
         version: 0.0.0-alpha.1
+      commander:
+        specifier: ^14.0.2
+        version: 14.0.3
       jose:
         specifier: ^5.2.2
         version: 5.10.0
@@ -1675,6 +1678,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
@@ -4292,6 +4299,8 @@ snapshots:
   collapse-white-space@2.1.0: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@14.0.3: {}
 
   compute-scroll-into-view@3.1.1: {}
 


### PR DESCRIPTION
I’m adding a rough v0 version of a scaffolding script for auth projects.

I don't think I need a review right now. I'm thinking of this script as temporary. Ideally, we remove the need for key pair and we make the list of files to change simple enough. 