### PR TITLE
Anonymous provider: React client

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "./core/convex.config.js": "./src/components/core/convex.config.ts",
     "./core/*": "./src/components/core/*.ts",
     "./providers/anonymous/convex.config.js": "./src/components/anonymous/convex.config.ts",
+    "./providers/anonymous/react": "./src/components/anonymous/react.tsx",
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",
     "./providers/password/convex.config.js": "./src/components/password/convex.config.ts",
     "./providers/password/*": "./src/components/password/*.ts",

--- a/packages/core/src/components/anonymous/react.test.tsx
+++ b/packages/core/src/components/anonymous/react.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AuthClient } from "../../browser/sessionManager";
+import { InMemoryStorage } from "../../browser/storage";
+import type { TokenBundle } from "../../lib/types";
+import { AuthProvider, useAuth } from "../../react/client";
+import { useAuthToken } from "../../react";
+import { SignInAnonymousMutation, useAnonymousAuth } from "./react";
+
+// The provider client only cares that `useMutation(signInAnonymous)` yields a
+// function returning a bundle; stub convex/react's `useMutation` to be that.
+const { runSignIn } = vi.hoisted(() => ({ runSignIn: vi.fn() }));
+vi.mock("convex/react", async (importActual) => ({
+  ...(await importActual<typeof import("convex/react")>()),
+  useMutation: () => runSignIn,
+}));
+
+const NAMESPACE = "https://happy-animal-123.convex.cloud";
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 0,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 0,
+  userId: "user-1",
+};
+
+// A stand-in for the app's `api.auth.signInAnonymous` reference. The mocked
+// `useMutation` ignores it, so any value typed as the reference will do.
+const signInAnonymous = {} as SignInAnonymousMutation;
+
+function renderAnonymousAuth() {
+  const client = new AuthClient({
+    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    storage: new InMemoryStorage(),
+    storageNamespace: NAMESPACE,
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <AuthProvider authClient={client}>{children}</AuthProvider>
+  );
+  return renderHook(
+    () => ({
+      auth: useAuth(),
+      token: useAuthToken(),
+      anonymous: useAnonymousAuth(signInAnonymous),
+    }),
+    { wrapper },
+  );
+}
+
+describe("useAnonymousAuth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runSignIn.mockReset();
+  });
+
+  test("signIn adopts the bundle from signInAnonymous into the core client", async () => {
+    runSignIn.mockResolvedValue(bundle);
+    const { result } = renderAnonymousAuth();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    expect(result.current.auth.isAuthenticated).toBe(false);
+
+    await act(async () => {
+      await result.current.anonymous.signInAnonymous();
+    });
+
+    expect(runSignIn).toHaveBeenCalledTimes(1);
+    expect(result.current.auth.isAuthenticated).toBe(true);
+    expect(result.current.token).toBe("access-1");
+  });
+});

--- a/packages/core/src/components/anonymous/react.tsx
+++ b/packages/core/src/components/anonymous/react.tsx
@@ -1,0 +1,60 @@
+/**
+ * React client for the anonymous provider, exported at
+ * `@convex-dev/auth/providers/anonymous/react`.
+ *
+ * A provider's job on the client is to run its own sign-in flow and hand the
+ * resulting {@link TokenBundle} to the core client's `setSession` (see
+ * {@link useAuthActions}). This anonymous provider is the simplest case. It
+ * has a single mutation that directly returns the `TokenBundle`.
+ *
+ * It's useful as an example of the bare minimum required of a provider client.
+ *
+ * @module
+ */
+"use client";
+
+import { useMutation } from "convex/react";
+import { FunctionReference } from "convex/server";
+import { useCallback } from "react";
+import type { TokenBundle } from "../../lib/types";
+import { useAuthActions } from "../../react";
+
+/**
+ * The `signInAnonymous` mutation the anonymous provider adds to the app's API.
+ */
+export type SignInAnonymousMutation = FunctionReference<
+  "mutation",
+  "public",
+  Record<string, never>,
+  TokenBundle
+>;
+
+/**
+ * Client for the anonymous provider: wire its sign-in mutation to the core
+ * client.
+ *
+ * The passed in `signInMutation` mints a session and returns a {@link
+ * TokenBundle}; the hook feeds that bundle to `setSession` so the Convex
+ * client authenticates. Passing a `TokenBundle` to `setSession` is the general
+ * pattern that every auth provider should follow.
+ *
+ * ```tsx
+ * import { useAnonymousAuth } from "@convex-dev/auth/providers/anonymous/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * function SignIn() {
+ *   const { signInAnonymous } = useAnonymousAuth(api.auth.signInAnonymous);
+ *   return <button onClick={() => signInAnonymous()}>Sign in anonymously</button>;
+ * }
+ * ```
+ *
+ * @param signInMutation The app's `signInAnonymous` mutation reference.
+ */
+export function useAnonymousAuth(signInMutation: SignInAnonymousMutation) {
+  const { setSession } = useAuthActions();
+  const runSignIn = useMutation(signInMutation);
+  const signInAnonymous = useCallback(async () => {
+    await setSession(await runSignIn());
+  }, [runSignIn, setSession]);
+  return { signInAnonymous };
+}

--- a/packages/core/src/components/anonymous/react.tsx
+++ b/packages/core/src/components/anonymous/react.tsx
@@ -47,6 +47,12 @@ export type SignInAnonymousMutation = FunctionReference<
  *   return <button onClick={() => signInAnonymous()}>Sign in anonymously</button>;
  * }
  * ```
+ * When the `TokenBundle` is passed to `setSession`, that kicks off the
+ * internal Convex auth machinery that authenticates the client with the
+ * configured backend and re-renders components in an authenticated state.
+ * Content within `<Authenticated>` helper components will render as will other
+ * components that build on the authenticated state returned by
+ * `useConvexAuthActions`.
  *
  * @param signInMutation The app's `signInAnonymous` mutation reference.
  */


### PR DESCRIPTION
Add a small React client for the anonymous provider, exported at `@convex-dev/auth/providers/anonymous/react`: `useAnonymousAuth` takes the app's `signInAnonymous` mutation reference, calls it, and hands the resulting `TokenBundle` to the core client's `setSession`.

It will get used in the example app in #398 as well as serve as a simple example itself of what a client API needs to do.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
