### PR TITLE
Add framework-agnostic SSR server layer (@convex-dev/auth/server)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "./providers/password/*": "./src/components/password/*.ts",
     "./providers/testing/*": "./src/components/testing/*.ts",
     "./browser": "./src/browser/index.ts",
+    "./server": "./src/server/index.ts",
     "./react": "./src/react/index.tsx"
   },
   "scripts": {

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -1,0 +1,71 @@
+/**
+ * A framework-agnostic cookie abstraction for server-side (SSR) auth.
+ *
+ * SSR frameworks each expose cookies differently — Next.js has `NextRequest`/
+ * `NextResponse` cookies in middleware and `next/headers` `cookies()` in route
+ * handlers and server components; other frameworks have their own. This module
+ * defines the small interface the shared {@link ServerAuthSession} needs, so a
+ * framework binding only has to adapt its cookies to {@link CookieStore}.
+ *
+ * Nothing here depends on React, Next.js, or Convex.
+ *
+ * @module
+ */
+
+import { JWT_STORAGE_KEY, REFRESH_TOKEN_STORAGE_KEY } from "../browser/storage";
+
+/** The cookie holding the current access token (a JWT). */
+export const AUTH_JWT_COOKIE = JWT_STORAGE_KEY;
+/** The cookie holding the current (rotating) refresh token. */
+export const AUTH_REFRESH_COOKIE = REFRESH_TOKEN_STORAGE_KEY;
+
+/** Attributes applied when writing a cookie. */
+export interface CookieOptions {
+  /** Whether to hide the cookie from client JS. */
+  httpOnly?: boolean;
+  /** Whether to send only over HTTPS. */
+  secure?: boolean;
+  /** CSRF posture. Defaults to `"lax"`. */
+  sameSite?: "lax" | "strict" | "none";
+  /** Cookie path. Defaults to `"/"`. */
+  path?: string;
+  /** Max age in seconds. */
+  maxAge?: number;
+  /** Absolute expiry. */
+  expires?: Date;
+  /** Cookie domain. */
+  domain?: string;
+}
+
+/**
+ * Read/write/delete cookies. Every method may be synchronous or return a
+ * promise, so request/response cookie APIs that are async (e.g. `next/headers`
+ * `cookies()`) work without ceremony.
+ */
+export interface CookieStore {
+  /** Read a cookie value. */
+  get: (name: string) => string | undefined | Promise<string | undefined>;
+  /** Write a cookie. */
+  set: (
+    name: string,
+    value: string,
+    options?: CookieOptions,
+  ) => void | Promise<void>;
+  /** Delete a cookie. */
+  delete: (name: string) => void | Promise<void>;
+}
+
+/**
+ * The default attributes for auth cookies: httpOnly (so the tokens never reach
+ * client JS), `secure` in production, `sameSite: "lax"`, rooted at `/`.
+ * Per-cookie lifetime (`expires`) is derived from the token bundle by the
+ * caller.
+ */
+export function defaultCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+  };
+}

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -56,15 +56,16 @@ export interface CookieStore {
 }
 
 /**
- * The default attributes for auth cookies: httpOnly (so the tokens never reach
- * client JS), `secure` in production, `sameSite: "lax"`, rooted at `/`.
- * Per-cookie lifetime (`expires`) is derived from the token bundle by the
- * caller.
+ * The default attributes for auth cookies.
+ *
+ *  * `httpOnly: true` (so the refresh token never reaches client JS)
+ *  * `sameSite: "lax"` to aid in CSRF protection (see
+ *     https://auth.pilcrowonpaper.com/csrf)
+ *  * `path: "/"` so the cookies will be sent for all paths on the site
  */
 export function defaultCookieOptions(): CookieOptions {
   return {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     path: "/",
   };

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Framework-agnostic server (SSR) building blocks for Convex Auth: a cookie
+ * abstraction, access-token inspection, and the {@link ServerAuthSession} that
+ * ties them together. The Next.js bindings (`@convex-dev/auth/nextjs/server`)
+ * build on these, and other SSR frameworks can too.
+ *
+ * @module
+ */
+
+export {
+  type CookieOptions,
+  type CookieStore,
+  AUTH_JWT_COOKIE,
+  AUTH_REFRESH_COOKIE,
+  defaultCookieOptions,
+} from "./cookies";
+export {
+  type DecodedAccessToken,
+  decodeAccessToken,
+  isTokenExpiring,
+} from "./jwt";
+export { ServerAuthSession, type ServerAuthSessionConfig } from "./session";
+export type { AuthApi } from "../browser/sessionManager";
+export type { TokenBundle } from "../lib/types";

--- a/packages/core/src/server/jwt.ts
+++ b/packages/core/src/server/jwt.ts
@@ -1,0 +1,48 @@
+/**
+ * Access-token (JWT) inspection helpers for the server layer. These only
+ * *decode* the token to read its claims — they never verify the signature
+ * (Convex verifies it against the JWKS). Decoding is enough to decide whether a
+ * cached access token is still usable or should be refreshed.
+ *
+ * @module
+ */
+
+import { decodeJwt } from "jose";
+
+/** The claims the server cares about from an access token. */
+export interface DecodedAccessToken {
+  /** Expiry as a UNIX timestamp in seconds, or `null` if absent/unparseable. */
+  exp: number | null;
+  /** The subject (app user id), or `null` if absent/unparseable. */
+  sub: string | null;
+}
+
+/**
+ * Decode an access token's claims without verifying its signature. Returns
+ * nulls if the token is malformed.
+ */
+export function decodeAccessToken(token: string): DecodedAccessToken {
+  try {
+    const claims = decodeJwt(token);
+    return {
+      exp: typeof claims.exp === "number" ? claims.exp : null,
+      sub: typeof claims.sub === "string" ? claims.sub : null,
+    };
+  } catch {
+    return { exp: null, sub: null };
+  }
+}
+
+/**
+ * Whether a token is expired or within `skewSeconds` of expiry (so the caller
+ * should refresh). A token whose expiry can't be read is treated as expiring.
+ */
+export function isTokenExpiring(
+  token: string,
+  skewSeconds = 10,
+  nowMs: number = Date.now(),
+): boolean {
+  const { exp } = decodeAccessToken(token);
+  if (exp === null) return true;
+  return exp * 1000 - nowMs <= skewSeconds * 1000;
+}

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -17,19 +17,20 @@ function jwt(expSeconds: number, sub = "user-1"): string {
   return `${b64({ alg: "RS256", typ: "JWT" })}.${b64({ sub, exp: expSeconds })}.sig`;
 }
 
+// Pin "now" so token-expiry math is deterministic.
 const NOW = 1_000_000; // seconds
 const nowMs = NOW * 1000;
 
 function newTokenBundle(
   n: number,
-  accessTtl = 60,
-  refreshTtl = 2_592_000,
+  accessTtlSeconds = 60,
+  refreshTtlSeconds = 60 * 60 * 24 * 30,
 ): TokenBundle {
   return {
-    accessToken: jwt(NOW + accessTtl),
-    accessTokenExpiresAt: nowMs + accessTtl * 1000,
+    accessToken: jwt(NOW + accessTtlSeconds),
+    accessTokenExpiresAt: nowMs + accessTtlSeconds * 1000,
     refreshToken: `refresh-${n}`,
-    refreshTokenExpiresAt: nowMs + refreshTtl * 1000,
+    refreshTokenExpiresAt: nowMs + refreshTtlSeconds * 1000,
     userId: "user-1",
   };
 }
@@ -59,12 +60,10 @@ function newSession(
   const session = new ServerAuthSession({
     authApi: {
       refreshSession: async () => null,
-      signOut: async () => { },
+      signOut: async () => {},
       ...authApi,
     },
     cookies,
-    // Pin "now" so token-expiry math is deterministic.
-    refreshSkewSeconds: 10,
   });
   return { session, cookies };
 }
@@ -170,7 +169,7 @@ describe("ServerAuthSession", () => {
   });
 
   test("signOut with no session is a no-op that still clears cookies", async () => {
-    const signOut = vi.fn(async () => { });
+    const signOut = vi.fn(async () => {});
     const cookies = new FakeCookies();
     const { session } = newSession({ signOut }, cookies);
 

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test, vi } from "vitest";
+import type { TokenBundle } from "../lib/types";
+import type { AuthApi } from "../browser/sessionManager";
+import {
+  CookieOptions,
+  CookieStore,
+  AUTH_JWT_COOKIE,
+  AUTH_REFRESH_COOKIE,
+} from "./cookies";
+import { ServerAuthSession } from "./session";
+
+/** Build an unsigned JWT whose payload has the given `exp` (seconds). `jose`'s
+ * `decodeJwt` reads the payload without verifying the signature. */
+function jwt(expSeconds: number, sub = "user-1"): string {
+  const b64 = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${b64({ alg: "RS256", typ: "JWT" })}.${b64({ sub, exp: expSeconds })}.sig`;
+}
+
+const NOW = 1_000_000; // seconds
+const nowMs = NOW * 1000;
+
+function newTokenBundle(
+  n: number,
+  accessTtl = 60,
+  refreshTtl = 2_592_000,
+): TokenBundle {
+  return {
+    accessToken: jwt(NOW + accessTtl),
+    accessTokenExpiresAt: nowMs + accessTtl * 1000,
+    refreshToken: `refresh-${n}`,
+    refreshTokenExpiresAt: nowMs + refreshTtl * 1000,
+    userId: "user-1",
+  };
+}
+
+/** An in-memory {@link CookieStore} that also records the options each cookie
+ * was written with, so tests can assert httpOnly etc. */
+class FakeCookies implements CookieStore {
+  values = new Map<string, string>();
+  options = new Map<string, CookieOptions | undefined>();
+  get(name: string) {
+    return this.values.get(name);
+  }
+  set(name: string, value: string, options?: CookieOptions) {
+    this.values.set(name, value);
+    this.options.set(name, options);
+  }
+  delete(name: string) {
+    this.values.delete(name);
+    this.options.delete(name);
+  }
+}
+
+function newSession(
+  authApi: Partial<AuthApi> = {},
+  cookies = new FakeCookies(),
+) {
+  const session = new ServerAuthSession({
+    authApi: {
+      refreshSession: async () => null,
+      signOut: async () => { },
+      ...authApi,
+    },
+    cookies,
+    // Pin "now" so token-expiry math is deterministic.
+    refreshSkewSeconds: 10,
+  });
+  return { session, cookies };
+}
+
+describe("ServerAuthSession", () => {
+  test("getToken returns a comfortably-valid cookie token without refreshing", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession({ refreshSession }, cookies);
+
+    expect(await session.getToken()).toBe(jwt(NOW + 60));
+    expect(refreshSession).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test("getToken refreshes a near-expiry token and rewrites both cookies", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const next = newTokenBundle(2);
+    const refreshSession = vi.fn(async (rt: string) => {
+      expect(rt).toBe("refresh-1");
+      return next;
+    });
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // within the 10s skew
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession({ refreshSession }, cookies);
+
+    expect(await session.getToken()).toBe(next.accessToken);
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(cookies.get(AUTH_JWT_COOKIE)).toBe(next.accessToken);
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBe("refresh-2");
+    expect(cookies.options.get(AUTH_REFRESH_COOKIE)?.httpOnly).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  test("getToken refreshes when the JWT cookie is missing", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession({ refreshSession }, cookies);
+
+    expect(await session.getToken()).toBe(newTokenBundle(2).accessToken);
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
+  test("a null refresh clears both cookies and yields no token", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5));
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession(
+      { refreshSession: async () => null },
+      cookies,
+    );
+
+    expect(await session.getToken()).toBeNull();
+    expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  test("getToken returns null when there is no refresh cookie", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // expiring, and nothing to refresh with
+    const { session } = newSession({ refreshSession }, cookies);
+
+    expect(await session.getToken()).toBeNull();
+    expect(refreshSession).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test("setTokens writes both cookies httpOnly", async () => {
+    const cookies = new FakeCookies();
+    const { session } = newSession({}, cookies);
+    await session.setTokens(newTokenBundle(1));
+
+    expect(cookies.get(AUTH_JWT_COOKIE)).toBe(newTokenBundle(1).accessToken);
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBe("refresh-1");
+    expect(cookies.options.get(AUTH_JWT_COOKIE)?.httpOnly).toBe(true);
+    expect(cookies.options.get(AUTH_REFRESH_COOKIE)?.httpOnly).toBe(true);
+  });
+
+  test("signOut revokes on the server and clears cookies", async () => {
+    const signOut = vi.fn(async (rt: string) => {
+      expect(rt).toBe("refresh-1");
+    });
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession({ signOut }, cookies);
+
+    await session.signOut();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
+  });
+
+  test("signOut with no session is a no-op that still clears cookies", async () => {
+    const signOut = vi.fn(async () => { });
+    const cookies = new FakeCookies();
+    const { session } = newSession({ signOut }, cookies);
+
+    await session.signOut();
+    expect(signOut).not.toHaveBeenCalled();
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
+  });
+
+  test("isAuthenticated reflects a non-expired JWT cookie", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const cookies = new FakeCookies();
+    const { session } = newSession({}, cookies);
+    expect(await session.isAuthenticated()).toBe(false);
+
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
+    expect(await session.isAuthenticated()).toBe(true);
+
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW - 1));
+    expect(await session.isAuthenticated()).toBe(false);
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -1,0 +1,144 @@
+/**
+ * The framework-agnostic owner of an auth session on the server (SSR).
+ *
+ * Where the browser {@link AuthClient} keeps the session in `localStorage` and
+ * holds the refresh token in client JS, the server keeps it in cookies — the
+ * refresh token in an httpOnly cookie that never reaches the browser. This
+ * class orchestrates reading those cookies, refreshing the access token against
+ * the server when it is missing or near expiry, and writing the rotated tokens
+ * back as cookies.
+ *
+ * Like {@link AuthClient} it takes an injected {@link AuthApi}, so it never
+ * imports Convex: a framework binding supplies an `AuthApi` on top of an HTTP
+ * client and a {@link CookieStore} built on its request/response cookies, and
+ * tests supply fakes. The server can access the real refresh token (from the
+ * cookie), so the existing `AuthApi.refreshSession(refreshToken)` shape fits
+ * directly.
+ *
+ * @module
+ */
+
+import type { AuthApi } from "../browser/sessionManager";
+import type { TokenBundle } from "../lib/types";
+import {
+  AUTH_JWT_COOKIE,
+  AUTH_REFRESH_COOKIE,
+  CookieOptions,
+  CookieStore,
+  defaultCookieOptions,
+} from "./cookies";
+import { isTokenExpiring } from "./jwt";
+
+/** Configuration for a {@link ServerAuthSession}. */
+export interface ServerAuthSessionConfig {
+  /**
+   * The auth API (refresh/sign-out), typically based on a Convex HTTP client.
+   */
+  authApi: AuthApi;
+  /** Request/response cookies for this SSR request. */
+  cookies: CookieStore;
+  /**
+   * Seconds before access-token expiry at which {@link ServerAuthSession.getToken}
+   * proactively refreshes. Defaults to 10.
+   */
+  refreshSkewSeconds?: number;
+  /**
+   * Base cookie attributes (httpOnly/secure/sameSite/path). Per-cookie
+   * lifetime is derived from the token bundle. Defaults to
+   * {@link defaultCookieOptions}.
+   */
+  cookieOptions?: CookieOptions;
+}
+
+export class ServerAuthSession {
+  readonly #authApi: AuthApi;
+  readonly #cookies: CookieStore;
+  readonly #skew: number;
+  readonly #cookieOptions: CookieOptions;
+
+  constructor(config: ServerAuthSessionConfig) {
+    this.#authApi = config.authApi;
+    this.#cookies = config.cookies;
+    this.#skew = config.refreshSkewSeconds ?? 10;
+    this.#cookieOptions = config.cookieOptions ?? defaultCookieOptions();
+  }
+
+  /**
+   * The access token to authenticate SSR requests with. Returns the cookie's
+   * token when it is still comfortably valid; otherwise refreshes (rotating the
+   * refresh token and rewriting both cookies). `null` means no usable session.
+   */
+  async getToken(): Promise<string | null> {
+    const token = (await this.#cookies.get(AUTH_JWT_COOKIE)) ?? null;
+    if (token !== null && !isTokenExpiring(token, this.#skew)) {
+      return token;
+    }
+    const bundle = await this.refresh();
+    return bundle?.accessToken ?? null;
+  }
+
+  /**
+   * Force a refresh from the refresh-token cookie. On success rotates the
+   * tokens and rewrites both cookies; on failure (unknown/expired token) clears
+   * them. Returns the new bundle or `null`.
+   */
+  async refresh(): Promise<TokenBundle | null> {
+    const refreshToken = (await this.#cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
+    if (refreshToken === null) {
+      return null;
+    }
+    const bundle = await this.#authApi.refreshSession(refreshToken);
+    if (bundle === null) {
+      await this.#clear();
+      return null;
+    }
+    await this.setTokens(bundle);
+    return bundle;
+  }
+
+  /**
+   * Persist a token bundle as cookies. Used after a sign-in whose bundle was
+   * minted elsewhere (e.g. a client provider flow) to move the refresh token
+   * into the httpOnly cookie. Both cookies live as long as the refresh token;
+   * the access token is refreshed on expiry via {@link getToken}.
+   */
+  async setTokens(bundle: TokenBundle): Promise<void> {
+    const expires = new Date(bundle.refreshTokenExpiresAt);
+    await this.#cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, {
+      ...this.#cookieOptions,
+      expires,
+    });
+    await this.#cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {
+      ...this.#cookieOptions,
+      expires,
+    });
+  }
+
+  /**
+   * Revoke the session on the server (best effort) and clear both cookies.
+   * Idempotent.
+   */
+  async signOut(): Promise<void> {
+    const refreshToken = (await this.#cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
+    if (refreshToken !== null) {
+      try {
+        await this.#authApi.signOut(refreshToken);
+      } catch {
+        // Usually means we were already signed out, which is fine.
+      }
+    }
+    await this.#clear();
+  }
+
+  /** Whether a non-expired access token is present in cookies. */
+  async isAuthenticated(): Promise<boolean> {
+    const token = (await this.#cookies.get(AUTH_JWT_COOKIE)) ?? null;
+    return token !== null && !isTokenExpiring(token, 0);
+  }
+
+  /** Deletes the cookies. This will be reflected in the eventual response. */
+  async #clear(): Promise<void> {
+    await this.#cookies.delete(AUTH_JWT_COOKIE);
+    await this.#cookies.delete(AUTH_REFRESH_COOKIE);
+  }
+}

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -43,9 +43,8 @@ export interface ServerAuthSessionConfig {
    */
   refreshSkewSeconds?: number;
   /**
-   * Base cookie attributes (httpOnly/secure/sameSite/path). Per-cookie
-   * lifetime is derived from the token bundle. Defaults to
-   * {@link defaultCookieOptions}.
+   * Base cookie attributes (httpOnly/sameSite/path). Per-cookie lifetime is
+   * derived from the token bundle. Defaults to {@link defaultCookieOptions}.
    */
   cookieOptions?: CookieOptions;
 }
@@ -53,13 +52,13 @@ export interface ServerAuthSessionConfig {
 export class ServerAuthSession {
   readonly #authApi: AuthApi;
   readonly #cookies: CookieStore;
-  readonly #skew: number;
+  readonly #refreshSkewSeconds: number;
   readonly #cookieOptions: CookieOptions;
 
   constructor(config: ServerAuthSessionConfig) {
     this.#authApi = config.authApi;
     this.#cookies = config.cookies;
-    this.#skew = config.refreshSkewSeconds ?? 10;
+    this.#refreshSkewSeconds = config.refreshSkewSeconds ?? 10;
     this.#cookieOptions = config.cookieOptions ?? defaultCookieOptions();
   }
 
@@ -70,7 +69,7 @@ export class ServerAuthSession {
    */
   async getToken(): Promise<string | null> {
     const token = (await this.#cookies.get(AUTH_JWT_COOKIE)) ?? null;
-    if (token !== null && !isTokenExpiring(token, this.#skew)) {
+    if (token !== null && !isTokenExpiring(token, this.#refreshSkewSeconds)) {
       return token;
     }
     const bundle = await this.refresh();


### PR DESCRIPTION
This is basically the server-side counterpart to `AuthClient` added in #388. These pieces will be used to build SSR integrations, starting with Next.js support in a follow on PR.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
