### PR TITLE
Simplify demos

### DIFF
--- a/examples/react-minimal/package.json
+++ b/examples/react-minimal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@convex-dev/auth-example-react-minimal",
+  "name": "example-react-minimal",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/examples/react-minimal/src/App.tsx
+++ b/examples/react-minimal/src/App.tsx
@@ -9,26 +9,9 @@ import { useAnonymousAuth } from "@convex-dev/auth/providers/anonymous/react";
 import { useQuery } from "convex/react";
 import { api } from "../convex/_generated/api";
 
-/**
- * A minimal end-to-end exercise of the core client: anonymous sign-in →
- * `setSession` → an authenticated query → sign-out. The `Authenticated` /
- * `Unauthenticated` / `AuthLoading` components read Convex's validated auth
- * state (from the JWT handshake), so what they render confirms the whole loop.
- *
- * Sign-in goes through the anonymous provider's client (`useAnonymousAuth`),
- * which wraps that provider's `signInAnonymous` → `setSession` wiring.
- */
 export function App() {
   return (
-    <main
-      style={{
-        fontFamily: "system-ui, sans-serif",
-        maxWidth: 480,
-        margin: "4rem auto",
-        padding: "0 1rem",
-        lineHeight: 1.5,
-      }}
-    >
+    <main>
       <h1>Convex Auth — minimal client</h1>
       <AuthLoading>
         <p>Loading…</p>
@@ -63,9 +46,7 @@ function Dashboard() {
         Signed in as <strong>{user ? user.name : "…"}</strong>
         {user ? ` (${user.id})` : ""}
       </p>
-      <p style={{ wordBreak: "break-all", color: "#666", fontSize: "0.8rem" }}>
-        Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}
-      </p>
+      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
       <button onClick={() => signOut()}>Sign out</button>
     </>
   );

--- a/examples/react-minimal/src/index.css
+++ b/examples/react-minimal/src/index.css
@@ -1,0 +1,11 @@
+body {
+  background-color: oklch(96.8% 0.007 247.896);
+}
+
+main {
+  font-family: system-ui, sans-serif;
+  max-width: 480px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}

--- a/examples/react-minimal/src/main.tsx
+++ b/examples/react-minimal/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { api } from "../convex/_generated/api";
 import { App } from "./App";
+import "./index.css";
 
 const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
 

--- a/examples/react-password/package.json
+++ b/examples/react-password/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@convex-dev/auth-example-react-password",
+  "name": "example-react-password",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -7,7 +7,8 @@
     "@convex-dev/auth": "workspace:*",
     "convex": "^1.41.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.1"
   },
   "scripts": {
     "dev": "convex dev --start vite",

--- a/examples/react-password/src/App.tsx
+++ b/examples/react-password/src/App.tsx
@@ -2,282 +2,70 @@ import {
   Authenticated,
   AuthLoading,
   Unauthenticated,
-  useAuthActions,
-  useAuthToken,
 } from "@convex-dev/auth/react";
-import { FunctionReturnType } from "convex/server";
-import { useAction, useQuery } from "convex/react";
-import { useState } from "react";
-import { api } from "../convex/_generated/api";
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import { Dashboard } from "./routes/dashboard";
+import { LogIn } from "./routes/logIn";
+import { SignUp } from "./routes/signUp";
 
 export function App() {
   return (
-    <main
-      style={{
-        fontFamily: "system-ui, sans-serif",
-        maxWidth: 480,
-        margin: "4rem auto",
-        padding: "0 1rem",
-        lineHeight: 1.5,
-      }}
-    >
-      <h1>Convex Auth — password client</h1>
-      <AuthLoading>
-        <p>Loading…</p>
-      </AuthLoading>
-      <Unauthenticated>
-        <SignedOut />
-      </Unauthenticated>
-      <Authenticated>
-        <Dashboard />
-      </Authenticated>
+    <main>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <Dashboard />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            <RequireNoAuth>
+              <LogIn />
+            </RequireNoAuth>
+          }
+        />
+        <Route
+          path="/signup"
+          element={
+            <RequireNoAuth>
+              <SignUp />
+            </RequireNoAuth>
+          }
+        />
+      </Routes>
     </main>
   );
 }
 
-type SignInResult = FunctionReturnType<typeof api.auth.signInWithPassword>;
-type SignUpResult = FunctionReturnType<typeof api.auth.signUpWithPassword>;
-type SignInError = Extract<SignInResult, { success: false }>["userError"];
-type SignUpError = Extract<SignUpResult, { success: false }>["userError"];
-
-function describeSignInError(userError: SignInError): string {
-  switch (userError.error) {
-    case "USER_NOT_FOUND":
-      return "No account exists with that username.";
-    case "INVALID_CREDENTIALS":
-      return "Incorrect username or password.";
-    case "PASSWORD_TOO_SHORT":
-      return `Password must be at least ${userError.minimumLength} characters.`;
-    case "PASSWORD_TOO_LONG":
-      return `Password must be at most ${userError.maximumLength} characters.`;
-    case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
-      return "Password can't start or end with whitespace.";
-    case "RATE_LIMITED":
-      return `Too many attempts. Try again in ${Math.ceil(
-        userError.retryAfterMs / 1000,
-      )} seconds.`;
-    default:
-      userError satisfies never;
-      return `Unknown error: ` + userError;
-  }
-}
-
-function describeSignUpError(userError: SignUpError): string {
-  switch (userError.error) {
-    case "USERNAME_TAKEN":
-      return "That username is already taken.";
-    case "PASSWORD_TOO_SHORT":
-      return `Password must be at least ${userError.minimumLength} characters.`;
-    case "PASSWORD_TOO_LONG":
-      return `Password must be at most ${userError.maximumLength} characters.`;
-    case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
-      return "Password can't start or end with whitespace.";
-    default:
-      userError satisfies never;
-      return `Unknown error: ` + userError;
-  }
-}
-
-function SignedOut() {
-  const [mode, setMode] = useState<"signIn" | "signUp">("signIn");
+function RequireAuth({ children }: { children: React.ReactNode }) {
   return (
     <>
-      {mode === "signIn" ? <SignInForm /> : <SignUpForm />}
-      <p style={{ fontSize: "0.9rem" }}>
-        {mode === "signIn"
-          ? "Don't have an account? "
-          : "Already have an account? "}
-        <button
-          type="button"
-          onClick={() => setMode(mode === "signIn" ? "signUp" : "signIn")}
-          style={{
-            background: "none",
-            border: "none",
-            padding: 0,
-            color: "#2563eb",
-            cursor: "pointer",
-            textDecoration: "underline",
-          }}
-        >
-          {mode === "signIn" ? "Sign up" : "Sign in"}
-        </button>
-      </p>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <Navigate to="/login" replace />
+      </Unauthenticated>
+      <Authenticated>{children}</Authenticated>
     </>
   );
 }
 
-function SignInForm() {
-  const { setSession } = useAuthActions();
-  const signIn = useAction(api.auth.signInWithPassword);
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
-
-  return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-        setError(null);
-        setPending(true);
-        try {
-          const result = await signIn({ username, password });
-          if (result.success) {
-            // Adopting the session flips <Unauthenticated> to <Authenticated>,
-            // which unmounts this form.
-            await setSession(result.tokens);
-            return;
-          }
-          setError(describeSignInError(result.userError));
-        } catch {
-          // The action only throws for unexpected/infrastructure failures; expected
-          // rejections come back as `userError` above.
-          setError("Something went wrong. Please try again.");
-        } finally {
-          setPending(false);
-        }
-      }}
-    >
-      <h2>Sign in</h2>
-      <label style={labelStyle}>
-        Username
-        <input
-          type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          autoComplete="username"
-          required
-          disabled={pending}
-          style={inputStyle}
-        />
-      </label>
-      <label style={labelStyle}>
-        Password
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          autoComplete="current-password"
-          required
-          disabled={pending}
-          style={inputStyle}
-        />
-      </label>
-      {error ? <ErrorMessage>{error}</ErrorMessage> : null}
-      <button type="submit" disabled={pending} style={buttonStyle}>
-        {pending ? "Signing in…" : "Sign in"}
-      </button>
-    </form>
-  );
-}
-
-function SignUpForm() {
-  const { setSession } = useAuthActions();
-  const signUp = useAction(api.auth.signUpWithPassword);
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
-
-  return (
-    <form
-      onSubmit={async (e) => {
-        e.preventDefault();
-        setError(null);
-        setPending(true);
-        try {
-          const result = await signUp({ username, password });
-          if (result.success) {
-            await setSession(result.tokens);
-            return;
-          }
-          setError(describeSignUpError(result.userError));
-        } catch {
-          setError("Something went wrong. Please try again.");
-        } finally {
-          setPending(false);
-        }
-      }}
-    >
-      <h2>Sign up</h2>
-      <label style={labelStyle}>
-        Username
-        <input
-          type="text"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          autoComplete="username"
-          required
-          disabled={pending}
-          style={inputStyle}
-        />
-      </label>
-      <label style={labelStyle}>
-        Password
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          autoComplete="new-password"
-          required
-          disabled={pending}
-          style={inputStyle}
-        />
-      </label>
-      {error ? <ErrorMessage>{error}</ErrorMessage> : null}
-      <button type="submit" disabled={pending} style={buttonStyle}>
-        {pending ? "Creating account…" : "Create account"}
-      </button>
-    </form>
-  );
-}
-
-function ErrorMessage({ children }: { children: string }) {
-  return (
-    <p role="alert" style={{ color: "#dc2626", fontSize: "0.9rem" }}>
-      {children}
-    </p>
-  );
-}
-
-function Dashboard() {
-  const user = useQuery(api.users.loggedInUser);
-  const token = useAuthToken();
-  const { signOut } = useAuthActions();
+function RequireNoAuth({ children }: { children: React.ReactNode }) {
   return (
     <>
-      {user && (
-        <p>
-          Signed in as <strong>{user.username}</strong> ({user.id})
-        </p>
-      )}
-      <p style={{ wordBreak: "break-all", color: "#666", fontSize: "0.8rem" }}>
-        Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}
-      </p>
-      <button onClick={() => signOut()} style={buttonStyle}>
-        Sign out
-      </button>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Authenticated>
+        <Navigate to="/" replace />
+      </Authenticated>
+      <Unauthenticated>{children}</Unauthenticated>
     </>
   );
 }
-
-const labelStyle = {
-  display: "block",
-  marginBottom: "0.75rem",
-  fontSize: "0.9rem",
-} as const;
-
-const inputStyle = {
-  display: "block",
-  width: "100%",
-  padding: "0.5rem",
-  marginTop: "0.25rem",
-  boxSizing: "border-box",
-  fontSize: "1rem",
-} as const;
-
-const buttonStyle = {
-  padding: "0.5rem 1rem",
-  fontSize: "1rem",
-  cursor: "pointer",
-} as const;

--- a/examples/react-password/src/index.css
+++ b/examples/react-password/src/index.css
@@ -1,0 +1,35 @@
+body {
+  background-color: oklch(96.8% 0.007 247.896);
+}
+
+main {
+  font-family: system-ui, sans-serif;
+  max-width: 480px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}
+
+/*
+In this demo, we apply a few basic styles on elements themselves
+so that the layout looks okay.
+
+In a real app, you should replace these elements by elements of
+your app’s design system, so that the auth UIs look consistent
+with the rest of your app.
+*/
+
+label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  box-sizing: border-box;
+  font-size: 1rem;
+}

--- a/examples/react-password/src/main.tsx
+++ b/examples/react-password/src/main.tsx
@@ -2,8 +2,10 @@ import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ConvexReactClient } from "convex/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import { api } from "../convex/_generated/api";
 import { App } from "./App";
+import "./index.css";
 
 const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
 
@@ -16,7 +18,9 @@ createRoot(document.getElementById("root")!).render(
         signOut: api.auth.signOut,
       }}
     >
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ConvexAuthProvider>
   </StrictMode>,
 );

--- a/examples/react-password/src/routes/dashboard.tsx
+++ b/examples/react-password/src/routes/dashboard.tsx
@@ -1,0 +1,20 @@
+import { useAuthActions, useAuthToken } from "@convex-dev/auth/react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export function Dashboard() {
+  const user = useQuery(api.users.loggedInUser);
+  const token = useAuthToken();
+  const { signOut } = useAuthActions();
+  return (
+    <>
+      {user && (
+        <p>
+          Signed in as <strong>{user.username}</strong> ({user.id})
+        </p>
+      )}
+      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -1,0 +1,90 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useAction } from "convex/react";
+import { useState } from "react";
+import { api } from "../../convex/_generated/api";
+
+export function LogIn() {
+  const { setSession } = useAuthActions();
+  const signIn = useAction(api.auth.signInWithPassword);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  return (
+    <>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setError(null);
+          setPending(true);
+          try {
+            const result = await signIn({ username, password });
+            if (result.success) {
+              await setSession(result.tokens);
+              return;
+            }
+            setError(() => {
+              switch (result.userError.error) {
+                case "USER_NOT_FOUND":
+                  return "No account exists with that username.";
+                case "INVALID_CREDENTIALS":
+                  return "Incorrect username or password.";
+                case "PASSWORD_TOO_SHORT":
+                  return `Password must be at least ${result.userError.minimumLength} characters.`;
+                case "PASSWORD_TOO_LONG":
+                  return `Password must be at most ${result.userError.maximumLength} characters.`;
+                case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                  return "Password can't start or end with whitespace.";
+                case "RATE_LIMITED":
+                  return `Too many attempts. Try again in ${Math.ceil(result.userError.retryAfterMs / 1000)} seconds.`;
+                default:
+                  result.userError satisfies never;
+                  return `Unknown error: ` + result.userError;
+              }
+            });
+          } catch {
+            setError("Something went wrong. Please try again.");
+          } finally {
+            setPending(false);
+          }
+        }}
+      >
+        <h1>Log in</h1>
+        <label>
+          Username
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+            disabled={pending}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            required
+            disabled={pending}
+          />
+        </label>
+        {error ? (
+          <p role="alert">
+            <strong>{error}</strong>
+          </p>
+        ) : null}
+        <button type="submit" disabled={pending}>
+          {pending ? "Logging in…" : "Log in"}
+        </button>
+      </form>
+      <p>
+        Don't have an account? <a href="/signup">Sign up</a>
+      </p>
+    </>
+  );
+}

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -1,0 +1,86 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useAction } from "convex/react";
+import { useState } from "react";
+import { api } from "../../convex/_generated/api";
+
+export function SignUp() {
+  const { setSession } = useAuthActions();
+  const signUp = useAction(api.auth.signUpWithPassword);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  return (
+    <>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setError(null);
+          setPending(true);
+          try {
+            const result = await signUp({ username, password });
+            if (result.success) {
+              await setSession(result.tokens);
+              return;
+            }
+            setError(() => {
+              switch (result.userError.error) {
+                case "USERNAME_TAKEN":
+                  return "That username is already taken.";
+                case "PASSWORD_TOO_SHORT":
+                  return `Password must be at least ${result.userError.minimumLength} characters.`;
+                case "PASSWORD_TOO_LONG":
+                  return `Password must be at most ${result.userError.maximumLength} characters.`;
+                case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                  return "Password can't start or end with whitespace.";
+                default:
+                  result.userError satisfies never;
+                  return `Unknown error: ` + result.userError;
+              }
+            });
+          } catch {
+            setError("Something went wrong. Please try again.");
+          } finally {
+            setPending(false);
+          }
+        }}
+      >
+        <h1>Sign up</h1>
+        <label>
+          Username
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+            disabled={pending}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            required
+            disabled={pending}
+          />
+        </label>
+        {error ? (
+          <p role="alert">
+            <strong>{error}</strong>
+          </p>
+        ) : null}
+        <button type="submit" disabled={pending}>
+          {pending ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+      <p>
+        Already have an account? <a href="/login">Log in</a>
+      </p>
+    </>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.18.1
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
@@ -196,13 +199,13 @@ importers:
         version: 0.0.8
       fumadocs-core:
         specifier: 16.11.1
-        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.1.0
-        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0))
+        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0))
       fumadocs-ui:
         specifier: npm:@fumadocs/base-ui@16.11.1
-        version: '@fumadocs/base-ui@16.11.1(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)'
+        version: '@fumadocs/base-ui@16.11.1(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)'
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@19.2.7)
@@ -1628,6 +1631,10 @@ packages:
       react:
         optional: true
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2500,6 +2507,23 @@ packages:
       '@types/react':
         optional: true
 
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2591,6 +2615,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -3277,14 +3304,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@fumadocs/base-ui@16.11.1(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)':
+  '@fumadocs/base-ui@16.11.1(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)':
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.1.0(tailwindcss@4.3.2)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.23.0(react@19.2.7)
       motion: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4049,6 +4076,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4325,7 +4354,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -4354,18 +4383,19 @@ snapshots:
       next: 16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)):
+  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       github-slugger: 2.0.0
       js-yaml: 5.2.1
       mdast-util-mdx: 3.0.0
@@ -5259,6 +5289,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
@@ -5410,6 +5454,8 @@ snapshots:
       compute-scroll-into-view: 3.1.1
 
   semver@7.8.5: {}
+
+  set-cookie-parser@2.7.2: {}
 
   sharp@0.34.5:
     dependencies:


### PR DESCRIPTION
I adjusted the demos (in particular react-password) to make them easier to use:

- I moved the styling to a `.css` file, so that the `.tsx` code doesn’t need to contain any styling.
- I’m suggesting the following structure for the examples/demos:
  - Using Vite + React Router. We want to use a router because it reflects the most accurately the structure of real apps. This allows us to have a short `.tsx` file for each page: this will mirror what users will need to do in their apps. React Router allows us to do this without too needing too much boilerplate/framework-specific code.
  - It’s fine to keep the anonymous/minimal demo in a single file


![image.png](https://app.graphite.com/user-attachments/assets/3686373c-9426-481a-9851-c5e7b002d5cb.png)

