### PR TITLE
Add OAuth provider component

### DIFF
--- a/examples/react-oauth/.gitignore
+++ b/examples/react-oauth/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-oauth/README.md
+++ b/examples/react-oauth/README.md
@@ -1,0 +1,19 @@
+# react-oauth example
+
+An in-repo Convex backend that mounts the `@convex-dev/auth` core component
+together with its oauth provider. It exists as an example of wiring oauth
+into an application and for integration testing the oauth provider end to end.
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-oauth
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx generate-auth-keys   # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+```
+
+## Test usage
+
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-oauth/convex/_generated/api.d.ts
+++ b/examples/react-oauth/convex/_generated/api.d.ts
@@ -51,4 +51,5 @@ export declare const internal: FilterApi<
 export declare const components: {
   core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
   oauthGoogle: import("@convex-dev/auth/providers/oauth/_generated/component.js").ComponentApi<"oauthGoogle">;
+  oauthGithub: import("@convex-dev/auth/providers/oauth/_generated/component.js").ComponentApi<"oauthGithub">;
 };

--- a/examples/react-oauth/convex/_generated/api.d.ts
+++ b/examples/react-oauth/convex/_generated/api.d.ts
@@ -8,22 +8,19 @@
  * @module
  */
 
-import type * as public_ from "../public.js";
-import type * as setup from "../setup.js";
-import type * as validation from "../validation.js";
+import type * as auth from "../auth.js";
+import type * as users from "../users.js";
 
 import type {
   ApiFromModules,
   FilterApi,
   FunctionReference,
 } from "convex/server";
-import { anyApi, componentsGeneric } from "convex/server";
 
-const fullApi: ApiFromModules<{
-  public: typeof public_;
-  setup: typeof setup;
-  validation: typeof validation;
-}> = anyApi as any;
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  users: typeof users;
+}>;
 
 /**
  * A utility for referencing Convex functions in your app's public API.
@@ -33,10 +30,10 @@ const fullApi: ApiFromModules<{
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-export const api: FilterApi<
+export declare const api: FilterApi<
   typeof fullApi,
   FunctionReference<any, "public">
-> = anyApi as any;
+>;
 
 /**
  * A utility for referencing Convex functions in your app's internal API.
@@ -46,11 +43,12 @@ export const api: FilterApi<
  * const myFunctionReference = internal.myModule.myFunction;
  * ```
  */
-export const internal: FilterApi<
+export declare const internal: FilterApi<
   typeof fullApi,
   FunctionReference<any, "internal">
-> = anyApi as any;
+>;
 
-export const components = componentsGeneric() as unknown as {
-  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  authOauth: import("@convex-dev/auth/providers/oauth/_generated/component.js").ComponentApi<"authOauth">;
 };

--- a/examples/react-oauth/convex/_generated/api.d.ts
+++ b/examples/react-oauth/convex/_generated/api.d.ts
@@ -50,5 +50,5 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
-  authOauth: import("@convex-dev/auth/providers/oauth/_generated/component.js").ComponentApi<"authOauth">;
+  oauthGoogle: import("@convex-dev/auth/providers/oauth/_generated/component.js").ComponentApi<"oauthGoogle">;
 };

--- a/examples/react-oauth/convex/_generated/api.js
+++ b/examples/react-oauth/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-oauth/convex/_generated/dataModel.d.ts
+++ b/examples/react-oauth/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-oauth/convex/_generated/server.d.ts
+++ b/examples/react-oauth/convex/_generated/server.d.ts
@@ -25,6 +25,7 @@ import type { DataModel } from "./dataModel.js";
  * Typesafe environment variables declared in `convex.config.ts`.
  */
 type Env = {
+  readonly AUTH_GOOGLE_CLIENT_ID: string;
   readonly AUTH_GOOGLE_CLIENT_SECRET: string;
   readonly AUTH_JWKS: string;
   readonly AUTH_PRIVATE_KEY: string;

--- a/examples/react-oauth/convex/_generated/server.d.ts
+++ b/examples/react-oauth/convex/_generated/server.d.ts
@@ -25,6 +25,7 @@ import type { DataModel } from "./dataModel.js";
  * Typesafe environment variables declared in `convex.config.ts`.
  */
 type Env = {
+  readonly AUTH_GOOGLE_CLIENT_SECRET: string;
   readonly AUTH_JWKS: string;
   readonly AUTH_PRIVATE_KEY: string;
 };

--- a/examples/react-oauth/convex/_generated/server.d.ts
+++ b/examples/react-oauth/convex/_generated/server.d.ts
@@ -25,6 +25,8 @@ import type { DataModel } from "./dataModel.js";
  * Typesafe environment variables declared in `convex.config.ts`.
  */
 type Env = {
+  readonly AUTH_GITHUB_CLIENT_ID: string;
+  readonly AUTH_GITHUB_CLIENT_SECRET: string;
   readonly AUTH_GOOGLE_CLIENT_ID: string;
   readonly AUTH_GOOGLE_CLIENT_SECRET: string;
   readonly AUTH_JWKS: string;

--- a/examples/react-oauth/convex/_generated/server.d.ts
+++ b/examples/react-oauth/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-oauth/convex/_generated/server.js
+++ b/examples/react-oauth/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-oauth/convex/auth.config.ts
+++ b/examples/react-oauth/convex/auth.config.ts
@@ -1,0 +1,13 @@
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -16,9 +16,9 @@ export const {
   component: components.core,
   providers: [
     provider(Oauth, {
-      component: components.authOauth,
       providers: {
         google: {
+          component: components.oauthGoogle,
           clientId: process.env.AUTH_GOOGLE_CLIENT_ID ?? "",
           authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
           scopes: ["openid", "email", "profile"],

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -3,28 +3,25 @@ import { provider, setupCore } from "@convex-dev/auth/core/setup";
 import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
 
 // The core owns sessions, accounts, and JWT minting. It calls back into our
-// `createOrUpdateUser` on every sign-in from a provider. The oauth provider
-// exposes `signInOauth`, which records an authorization request and returns
-// the provider authorization URL for the client to navigate to.
+// `createOrUpdateUser` on every sign-in from a provider. Each Oauth instance
+// covers one IdP and exposes `signIn`, which records an authorization
+// request and returns the provider authorization URL for the client to
+// navigate to.
 export const {
   signOut,
   refreshSession,
   providers: {
-    oauth: { signInOauth },
+    google: { signIn: signInGoogle },
   },
 } = setupCore({
   component: components.core,
   providers: [
-    provider(Oauth, {
-      providers: {
-        google: {
-          component: components.oauthGoogle,
-          authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
-          tokenEndpoint: "https://oauth2.googleapis.com/token",
-          scopes: ["openid", "email", "profile"],
-          pkce: true,
-        },
-      },
+    provider(Oauth("google"), {
+      component: components.oauthGoogle,
+      authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenEndpoint: "https://oauth2.googleapis.com/token",
+      scopes: ["openid", "email", "profile"],
+      pkce: true,
       allowedRedirectOrigins: ["http://localhost:5173"],
     }),
   ],

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -3,19 +3,29 @@ import { provider, setupCore } from "@convex-dev/auth/core/setup";
 import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
 
 // The core owns sessions, accounts, and JWT minting. It calls back into our
-// `createOrUpdateUser` on every sign-in from a provider. The password provider
-// exposes the sign up / sign in actions, keyed to an opaque app user id.
+// `createOrUpdateUser` on every sign-in from a provider. The oauth provider
+// exposes `signInOauth`, which records an authorization request and returns
+// the provider authorization URL for the client to navigate to.
 export const {
   signOut,
   refreshSession,
   providers: {
-    oauth: { signIn },
+    oauth: { signInOauth },
   },
 } = setupCore({
   component: components.core,
   providers: [
     provider(Oauth, {
       component: components.authOauth,
+      providers: {
+        google: {
+          clientId: process.env.AUTH_GOOGLE_CLIENT_ID ?? "",
+          authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+          scopes: ["openid", "email", "profile"],
+          pkce: true,
+        },
+      },
+      allowedRedirectOrigins: ["http://localhost:5173"],
     }),
   ],
 }).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -20,6 +20,7 @@ export const {
       component: components.oauthGoogle,
       authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenEndpoint: "https://oauth2.googleapis.com/token",
+      issuer: "https://accounts.google.com",
       scopes: ["openid", "email", "profile"],
       pkce: true,
       allowedRedirectOrigins: ["http://localhost:5173"],

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -1,0 +1,21 @@
+import { components, internal } from "./_generated/api";
+import { provider, setupCore } from "@convex-dev/auth/core/setup";
+import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
+
+// The core owns sessions, accounts, and JWT minting. It calls back into our
+// `createOrUpdateUser` on every sign-in from a provider. The password provider
+// exposes the sign up / sign in actions, keyed to an opaque app user id.
+export const {
+  signOut,
+  refreshSession,
+  providers: {
+    oauth: { signIn },
+  },
+} = setupCore({
+  component: components.core,
+  providers: [
+    provider(Oauth, {
+      component: components.authOauth,
+    }),
+  ],
+}).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -7,11 +7,15 @@ import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
 // covers one IdP and exposes `signIn`, which records an authorization
 // request and returns the provider authorization URL for the client to
 // navigate to.
+/** A GitHub `/user/emails` entry, the fields the profile mapping reads. */
+type GithubEmail = { email: string; primary: boolean; verified: boolean };
+
 export const {
   signOut,
   refreshSession,
   providers: {
     google: { signIn: signInGoogle, redeem: redeemGoogle },
+    github: { signIn: signInGithub, redeem: redeemGithub },
   },
 } = setupCore({
   component: components.core,
@@ -25,6 +29,34 @@ export const {
       issuer: "https://accounts.google.com",
       scopes: ["openid", "email", "profile"],
       pkce: true,
+      allowedRedirectOrigins: ["http://localhost:5173"],
+    }),
+    // GitHub is plain OAuth (no id_token), so identity comes from userinfo
+    // endpoints and a profile mapping. No `pkce`: GitHub OAuth apps silently
+    // ignore it.
+    provider(Oauth("github"), {
+      component: components.oauthGithub,
+      // Must match the mount in convex.config.ts.
+      httpPrefix: "/oauth/github",
+      authorizationEndpoint: "https://github.com/login/oauth/authorize",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+      scopes: ["read:user", "user:email"],
+      userInfoEndpoints: {
+        user: "https://api.github.com/user",
+        emails: "https://api.github.com/user/emails",
+      },
+      profile: (_claims, userInfoResponses) => {
+        const user = userInfoResponses?.user;
+        const emails: GithubEmail[] = userInfoResponses?.emails ?? [];
+        const best =
+          emails.find((entry) => entry.primary && entry.verified) ??
+          emails.find((entry) => entry.verified);
+        return {
+          id: String(user.id),
+          email: best?.email ?? user.email,
+          name: user.name ?? user.login,
+        };
+      },
       allowedRedirectOrigins: ["http://localhost:5173"],
     }),
   ],

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -11,7 +11,7 @@ export const {
   signOut,
   refreshSession,
   providers: {
-    google: { signIn: signInGoogle },
+    google: { signIn: signInGoogle, redeem: redeemGoogle },
   },
 } = setupCore({
   component: components.core,

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -1,4 +1,5 @@
 import { components, internal } from "./_generated/api";
+import { env } from "./_generated/server";
 import { provider, setupCore } from "@convex-dev/auth/core/setup";
 import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
 
@@ -19,7 +20,7 @@ export const {
       providers: {
         google: {
           component: components.oauthGoogle,
-          clientId: process.env.AUTH_GOOGLE_CLIENT_ID ?? "",
+          clientId: env.AUTH_GOOGLE_CLIENT_ID,
           authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
           scopes: ["openid", "email", "profile"],
           pkce: true,

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -1,5 +1,4 @@
 import { components, internal } from "./_generated/api";
-import { env } from "./_generated/server";
 import { provider, setupCore } from "@convex-dev/auth/core/setup";
 import { Oauth } from "@convex-dev/auth/providers/oauth/setup";
 
@@ -20,8 +19,8 @@ export const {
       providers: {
         google: {
           component: components.oauthGoogle,
-          clientId: env.AUTH_GOOGLE_CLIENT_ID,
           authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenEndpoint: "https://oauth2.googleapis.com/token",
           scopes: ["openid", "email", "profile"],
           pkce: true,
         },

--- a/examples/react-oauth/convex/auth.ts
+++ b/examples/react-oauth/convex/auth.ts
@@ -18,6 +18,8 @@ export const {
   providers: [
     provider(Oauth("google"), {
       component: components.oauthGoogle,
+      // Must match the mount in convex.config.ts.
+      httpPrefix: "/oauth/google",
       authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenEndpoint: "https://oauth2.googleapis.com/token",
       issuer: "https://accounts.google.com",

--- a/examples/react-oauth/convex/convex.config.ts
+++ b/examples/react-oauth/convex/convex.config.ts
@@ -1,0 +1,22 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+import oauthProvider from "@convex-dev/auth/providers/oauth/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(oauthProvider);
+
+export default app;

--- a/examples/react-oauth/convex/convex.config.ts
+++ b/examples/react-oauth/convex/convex.config.ts
@@ -7,6 +7,7 @@ const app = defineApp({
   env: {
     AUTH_PRIVATE_KEY: v.string(),
     AUTH_JWKS: v.string(),
+    AUTH_GOOGLE_CLIENT_SECRET: v.string(),
   },
 });
 
@@ -17,6 +18,15 @@ app.use(core, {
     AUTH_JWKS: app.env.AUTH_JWKS,
   },
 });
-app.use(oauthProvider);
+
+// The oauth component mounts once per IdP: each mount gets its own callback
+// route and client secret binding.
+app.use(oauthProvider, {
+  name: "oauthGoogle",
+  httpPrefix: "/oauth/google",
+  env: {
+    CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET,
+  },
+});
 
 export default app;

--- a/examples/react-oauth/convex/convex.config.ts
+++ b/examples/react-oauth/convex/convex.config.ts
@@ -21,11 +21,12 @@ app.use(core, {
 });
 
 // The oauth component mounts once per IdP: each mount gets its own callback
-// route and client secret binding.
+// route and client credential bindings.
 app.use(oauthProvider, {
   name: "oauthGoogle",
   httpPrefix: "/oauth/google",
   env: {
+    CLIENT_ID: app.env.AUTH_GOOGLE_CLIENT_ID,
     CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET,
   },
 });

--- a/examples/react-oauth/convex/convex.config.ts
+++ b/examples/react-oauth/convex/convex.config.ts
@@ -7,6 +7,7 @@ const app = defineApp({
   env: {
     AUTH_PRIVATE_KEY: v.string(),
     AUTH_JWKS: v.string(),
+    AUTH_GOOGLE_CLIENT_ID: v.string(),
     AUTH_GOOGLE_CLIENT_SECRET: v.string(),
   },
 });

--- a/examples/react-oauth/convex/convex.config.ts
+++ b/examples/react-oauth/convex/convex.config.ts
@@ -9,6 +9,8 @@ const app = defineApp({
     AUTH_JWKS: v.string(),
     AUTH_GOOGLE_CLIENT_ID: v.string(),
     AUTH_GOOGLE_CLIENT_SECRET: v.string(),
+    AUTH_GITHUB_CLIENT_ID: v.string(),
+    AUTH_GITHUB_CLIENT_SECRET: v.string(),
   },
 });
 
@@ -28,6 +30,15 @@ app.use(oauthProvider, {
   env: {
     CLIENT_ID: app.env.AUTH_GOOGLE_CLIENT_ID,
     CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET,
+  },
+});
+
+app.use(oauthProvider, {
+  name: "oauthGithub",
+  httpPrefix: "/oauth/github",
+  env: {
+    CLIENT_ID: app.env.AUTH_GITHUB_CLIENT_ID,
+    CLIENT_SECRET: app.env.AUTH_GITHUB_CLIENT_SECRET,
   },
 });
 

--- a/examples/react-oauth/convex/oauth.test.ts
+++ b/examples/react-oauth/convex/oauth.test.ts
@@ -27,13 +27,14 @@ async function setup() {
   );
   // convex-test doesn't emulate per-mount env binding renames (convex.config
   // maps AUTH_GOOGLE_CLIENT_ID onto the component's CLIENT_ID), so stub the
-  // component-side names directly.
+  // component-side names directly; both mounts see the same credentials.
   vi.stubEnv("CLIENT_ID", "test-client-id");
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
 
   const t = convexTest(schema, modules);
   registerCore(t);
   registerOauthProvider(t, "oauthGoogle");
+  registerOauthProvider(t, "oauthGithub");
   return t;
 }
 
@@ -79,6 +80,34 @@ describe("oauth", () => {
   test("redeem returns null for an unknown code", async () => {
     const t = await setup();
     const result = await t.mutation(api.auth.redeemGoogle, {
+      code: "not-a-real-code",
+      state: "not-a-real-state",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("github signIn returns its own authorization URL without PKCE", async () => {
+    const t = await setup();
+    const { redirect, state } = await t.mutation(api.auth.signInGithub, {
+      redirectTo: "http://localhost:5173/",
+    });
+    const url = new URL(redirect);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://github.com/login/oauth/authorize",
+    );
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://example.convex.site/oauth/github/callback",
+    );
+    expect(url.searchParams.get("scope")).toBe("read:user user:email");
+    expect(url.searchParams.get("state")).toBe(state);
+    // The github provider is configured without `pkce`.
+    expect(url.searchParams.get("code_challenge")).toBeNull();
+    expect(url.searchParams.get("code_challenge_method")).toBeNull();
+  });
+
+  test("github redeem returns null for an unknown code", async () => {
+    const t = await setup();
+    const result = await t.mutation(api.auth.redeemGithub, {
       code: "not-a-real-code",
       state: "not-a-real-state",
     });

--- a/examples/react-oauth/convex/oauth.test.ts
+++ b/examples/react-oauth/convex/oauth.test.ts
@@ -3,12 +3,10 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { api } from "./_generated/api.js";
 import { registerCore } from "@convex-dev/auth/providers/testing/core";
-import { registerPasswordProvider } from "@convex-dev/auth/providers/testing/password";
+import { registerOauthProvider } from "@convex-dev/auth/providers/testing/oauth";
 import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
-
-const PASSWORD = "correct horse battery staple"; // 28 chars, valid
 
 async function setup() {
   // The core signs JWTs from these env vars (see core/public.ts). Mint a real
@@ -27,10 +25,15 @@ async function setup() {
       keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
     }),
   );
+  // convex-test doesn't emulate per-mount env binding renames (convex.config
+  // maps AUTH_GOOGLE_CLIENT_ID onto the component's CLIENT_ID), so stub the
+  // component-side names directly.
+  vi.stubEnv("CLIENT_ID", "test-client-id");
+  vi.stubEnv("CLIENT_SECRET", "test-client-secret");
 
   const t = convexTest(schema, modules);
   registerCore(t);
-  registerPasswordProvider(t);
+  registerOauthProvider(t, "oauthGoogle");
   return t;
 }
 
@@ -38,154 +41,47 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-const signUp = (
-  t: Awaited<ReturnType<typeof setup>>,
-  username: string,
-  password: string,
-) => t.action(api.auth.signUpWithPassword, { username, password });
-
-const signIn = (
-  t: Awaited<ReturnType<typeof setup>>,
-  username: string,
-  password: string,
-) => t.action(api.auth.signInWithPassword, { username, password });
-
-type PasswordResult =
-  Awaited<ReturnType<typeof signUp>> | Awaited<ReturnType<typeof signIn>>;
-type PasswordSuccess = Extract<PasswordResult, { success: true }>;
-
-describe("setupUsernamePassword", () => {
-  test("signs up a new user and returns a session", async () => {
+// The full callback flow (code exchange, ticket mint) runs over the
+// component's HTTP route, which app-level convex-test doesn't serve; it's
+// covered by the component's own tests. These tests cover the app-facing
+// mutations.
+describe("oauth", () => {
+  test("signIn returns the authorization URL and the minted state", async () => {
     const t = await setup();
-    const result = await signUp(t, "alice", PASSWORD);
-    expect(result).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
+    const { redirect, state } = await t.mutation(api.auth.signInGoogle, {
+      redirectTo: "http://localhost:5173/",
     });
-  });
-
-  test("signs in with the correct password", async () => {
-    const t = await setup();
-    const up = await signUp(t, "alice", PASSWORD);
-    const inResult = await signIn(t, "alice", PASSWORD);
-    expect(up).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
-    });
-    expect(inResult).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
-    });
-    // Same identity → same app user id.
-    expect((inResult as PasswordSuccess).tokens.userId).toBe(
-      (up as PasswordSuccess).tokens.userId,
+    expect(state).toEqual(expect.any(String));
+    const url = new URL(redirect);
+    expect(`${url.origin}${url.pathname}`).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth",
     );
-  });
-
-  test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
-    const t = await setup();
-    await signUp(t, "alice", PASSWORD);
-    const result = await signIn(t, "alice", "wrong horse battery staple");
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "INVALID_CREDENTIALS" },
-    });
-  });
-
-  test("rejects an unknown username with USER_NOT_FOUND", async () => {
-    const t = await setup();
-    const result = await signIn(t, "nobody", PASSWORD);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "USER_NOT_FOUND" },
-    });
-  });
-
-  test("rejects signing up a taken username", async () => {
-    const t = await setup();
-    await signUp(t, "alice", PASSWORD);
-    const result = await signUp(t, "alice", PASSWORD);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "USERNAME_TAKEN" },
-    });
-  });
-
-  test("usernames are case-insensitive", async () => {
-    const t = await setup();
-    const up = await signUp(t, "Alice", PASSWORD);
-    expect(up).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
-    });
-
-    // A different casing is treated as the same account for both sign-in...
-    const inResult = await signIn(t, "ALICE", PASSWORD);
-    expect(inResult).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
-    });
-    expect((inResult as PasswordSuccess).tokens.userId).toBe(
-      (up as PasswordSuccess).tokens.userId,
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("test-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://example.convex.site/oauth/google/callback",
     );
-
-    // ...and the taken-username check.
-    const dup = await signUp(t, "alice", PASSWORD);
-    expect(dup).toEqual({
-      success: false,
-      userError: { error: "USERNAME_TAKEN" },
-    });
+    expect(url.searchParams.get("scope")).toBe("openid email profile");
+    expect(url.searchParams.get("state")).toBe(state);
+    expect(url.searchParams.get("code_challenge")).toEqual(expect.any(String));
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
   });
 
-  test("rejects a too-short password at sign-up without creating an account", async () => {
+  test("signIn rejects a redirectTo outside allowedRedirectOrigins", async () => {
     const t = await setup();
-    const up = await signUp(t, "alice", "short");
-    expect(up).toEqual({
-      success: false,
-      userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
-    });
+    await expect(
+      t.mutation(api.auth.signInGoogle, {
+        redirectTo: "https://evil.example.com/after",
+      }),
+    ).rejects.toThrow("not in allowedRedirectOrigins");
+  });
 
-    // No account was created, so a later sign-up with a valid password works.
-    const retry = await signUp(t, "alice", PASSWORD);
-    expect(retry).toEqual({
-      success: true,
-      tokens: {
-        accessToken: expect.any(String),
-        accessTokenExpiresAt: expect.any(Number),
-        refreshToken: expect.any(String),
-        refreshTokenExpiresAt: expect.any(Number),
-        userId: expect.any(String),
-      },
+  test("redeem returns null for an unknown code", async () => {
+    const t = await setup();
+    const result = await t.mutation(api.auth.redeemGoogle, {
+      code: "not-a-real-code",
+      state: "not-a-real-state",
     });
+    expect(result).toBeNull();
   });
 });

--- a/examples/react-oauth/convex/oauth.test.ts
+++ b/examples/react-oauth/convex/oauth.test.ts
@@ -1,0 +1,191 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+import { api } from "./_generated/api.js";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
+import { registerPasswordProvider } from "@convex-dev/auth/providers/testing/password";
+import schema from "./schema.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const PASSWORD = "correct horse battery staple"; // 28 chars, valid
+
+async function setup() {
+  // The core signs JWTs from these env vars (see core/public.ts). Mint a real
+  // RS256 key pair for each test and stub the env so Vitest can reset it.
+  const { publicKey, privateKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const pkcs8 = await exportPKCS8(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+
+  vi.stubEnv("CONVEX_SITE_URL", "https://example.convex.site");
+  vi.stubEnv("AUTH_PRIVATE_KEY", btoa(pkcs8));
+  vi.stubEnv(
+    "AUTH_JWKS",
+    JSON.stringify({
+      keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
+    }),
+  );
+
+  const t = convexTest(schema, modules);
+  registerCore(t);
+  registerPasswordProvider(t);
+  return t;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const signUp = (
+  t: Awaited<ReturnType<typeof setup>>,
+  username: string,
+  password: string,
+) => t.action(api.auth.signUpWithPassword, { username, password });
+
+const signIn = (
+  t: Awaited<ReturnType<typeof setup>>,
+  username: string,
+  password: string,
+) => t.action(api.auth.signInWithPassword, { username, password });
+
+type PasswordResult =
+  Awaited<ReturnType<typeof signUp>> | Awaited<ReturnType<typeof signIn>>;
+type PasswordSuccess = Extract<PasswordResult, { success: true }>;
+
+describe("setupUsernamePassword", () => {
+  test("signs up a new user and returns a session", async () => {
+    const t = await setup();
+    const result = await signUp(t, "alice", PASSWORD);
+    expect(result).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+  });
+
+  test("signs in with the correct password", async () => {
+    const t = await setup();
+    const up = await signUp(t, "alice", PASSWORD);
+    const inResult = await signIn(t, "alice", PASSWORD);
+    expect(up).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+    expect(inResult).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+    // Same identity → same app user id.
+    expect((inResult as PasswordSuccess).tokens.userId).toBe(
+      (up as PasswordSuccess).tokens.userId,
+    );
+  });
+
+  test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
+    const t = await setup();
+    await signUp(t, "alice", PASSWORD);
+    const result = await signIn(t, "alice", "wrong horse battery staple");
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "INVALID_CREDENTIALS" },
+    });
+  });
+
+  test("rejects an unknown username with USER_NOT_FOUND", async () => {
+    const t = await setup();
+    const result = await signIn(t, "nobody", PASSWORD);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USER_NOT_FOUND" },
+    });
+  });
+
+  test("rejects signing up a taken username", async () => {
+    const t = await setup();
+    await signUp(t, "alice", PASSWORD);
+    const result = await signUp(t, "alice", PASSWORD);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("usernames are case-insensitive", async () => {
+    const t = await setup();
+    const up = await signUp(t, "Alice", PASSWORD);
+    expect(up).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+
+    // A different casing is treated as the same account for both sign-in...
+    const inResult = await signIn(t, "ALICE", PASSWORD);
+    expect(inResult).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+    expect((inResult as PasswordSuccess).tokens.userId).toBe(
+      (up as PasswordSuccess).tokens.userId,
+    );
+
+    // ...and the taken-username check.
+    const dup = await signUp(t, "alice", PASSWORD);
+    expect(dup).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("rejects a too-short password at sign-up without creating an account", async () => {
+    const t = await setup();
+    const up = await signUp(t, "alice", "short");
+    expect(up).toEqual({
+      success: false,
+      userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
+    });
+
+    // No account was created, so a later sign-up with a valid password works.
+    const retry = await signUp(t, "alice", PASSWORD);
+    expect(retry).toEqual({
+      success: true,
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        userId: expect.any(String),
+      },
+    });
+  });
+});

--- a/examples/react-oauth/convex/schema.ts
+++ b/examples/react-oauth/convex/schema.ts
@@ -1,0 +1,10 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+// A minimal app schema. The app owns its users table; the auth components only
+// keep the opaque user-id string it returns.
+export default defineSchema({
+  users: defineTable({
+    email: v.string(),
+  }),
+});

--- a/examples/react-oauth/convex/tsconfig.json
+++ b/examples/react-oauth/convex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-oauth/convex/users.ts
+++ b/examples/react-oauth/convex/users.ts
@@ -1,0 +1,32 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * The app's create-or-update-user callback (see `attachUserCallback`). The core
+ * invokes it on every sign-in — without a `userId` the first time an identity is
+ * seen, and with the resolved `userId` thereafter. On the first sign-in we mint
+ * a users row from the profile's username; on later sign-ins we echo the id.
+ */
+export const createOrUpdateUser = internalMutation({
+  args: {
+    provider: v.literal("oauth"),
+    providerAccountId: v.string(),
+    profile: v.any(),
+    userId: v.union(v.string(), v.null()),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    if (args.userId !== null) {
+      const existing = ctx.db.normalizeId("users", args.userId);
+      if (existing === null) {
+        throw new Error(`Unknown user id: ${args.userId}`);
+      }
+      return existing;
+    }
+    const email = args.profile?.email;
+    if (email === undefined) {
+      throw new Error("Profile email is required");
+    }
+    return await ctx.db.insert("users", { email });
+  },
+});

--- a/examples/react-oauth/convex/users.ts
+++ b/examples/react-oauth/convex/users.ts
@@ -9,7 +9,7 @@ import { v } from "convex/values";
  */
 export const createOrUpdateUser = internalMutation({
   args: {
-    provider: v.literal("oauth"),
+    provider: v.literal("google"),
     providerAccountId: v.string(),
     profile: v.any(),
     userId: v.union(v.string(), v.null()),

--- a/examples/react-oauth/convex/users.ts
+++ b/examples/react-oauth/convex/users.ts
@@ -36,7 +36,7 @@ export const me = query({
  */
 export const createOrUpdateUser = internalMutation({
   args: {
-    provider: v.literal("google"),
+    provider: v.union(v.literal("google"), v.literal("github")),
     providerAccountId: v.string(),
     profile: v.any(),
     userId: v.union(v.string(), v.null()),

--- a/examples/react-oauth/convex/users.ts
+++ b/examples/react-oauth/convex/users.ts
@@ -1,5 +1,32 @@
-import { internalMutation } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 import { v } from "convex/values";
+
+/**
+ * The signed-in user's document, or `null` when unauthenticated. The JWT's
+ * subject is the app user id minted by `createOrUpdateUser`.
+ */
+export const me = query({
+  args: {},
+  returns: v.union(
+    v.null(),
+    v.object({
+      _id: v.id("users"),
+      _creationTime: v.number(),
+      email: v.string(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+    const userId = ctx.db.normalizeId("users", identity.subject);
+    if (userId === null) {
+      return null;
+    }
+    return await ctx.db.get("users", userId);
+  },
+});
 
 /**
  * The app's create-or-update-user callback (see `attachUserCallback`). The core

--- a/examples/react-oauth/index.html
+++ b/examples/react-oauth/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convex Auth · OAuth Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-oauth/package.json
+++ b/examples/react-oauth/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently -n vite,convex -c green,blue \"vite\" \"convex dev\"",
+    "dev": "concurrently -n vite,convex -c green,blue \"vite\" \"convex dev --tail-logs\"",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"

--- a/examples/react-oauth/package.json
+++ b/examples/react-oauth/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@convex-dev/auth-example-react-oauth",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -n vite,convex -c green,blue \"vite\" \"convex dev\"",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "convex": "^1.41.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@convex-dev/rate-limiter": "^0.3.2",
+    "@edge-runtime/vm": "^5.0.0",
+    "@tailwindcss/vite": "^4.3.2",
+    "@types/node": "^24.12.4",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.0",
+    "concurrently": "^10.0.3",
+    "convex-test": "^0.0.53",
+    "jose": "^5.10.0",
+    "tailwindcss": "^4.3.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/react-oauth/src/App.tsx
+++ b/examples/react-oauth/src/App.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { api } from "../convex/_generated/api";
-import { useAuthActions } from "./auth";
+import { useAuthActions, type OAuthProviderName } from "./auth";
 
 /** Google's multi-color "G" mark. */
 const GoogleIcon = (): ReactNode => (
@@ -25,7 +25,48 @@ const GoogleIcon = (): ReactNode => (
   </svg>
 );
 
-/** The sign-in card: the Google button plus any sign-in flow error. */
+/** GitHub's Octocat mark, tinted via `currentColor`. */
+const GitHubIcon = (): ReactNode => (
+  <svg
+    className="h-5 w-5 shrink-0"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
+  </svg>
+);
+
+/** A brand-styled OAuth sign-in option rendered as a button. */
+type ProviderButton = {
+  /** The provider to pass to `signIn`. */
+  id: OAuthProviderName;
+  /** Human-readable provider name, shown in the button label. */
+  name: string;
+  /** Brand icon rendered to the left of the label. */
+  icon: ReactNode;
+  /** Tailwind color/border classes controlling the button's appearance. */
+  className: string;
+};
+
+/** Available sign-in providers. */
+const PROVIDERS: ProviderButton[] = [
+  {
+    id: "google",
+    name: "Google",
+    icon: <GoogleIcon />,
+    className:
+      "bg-white text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
+  },
+  {
+    id: "github",
+    name: "GitHub",
+    icon: <GitHubIcon />,
+    className: "bg-gray-900 text-white hover:bg-gray-800",
+  },
+];
+
+/** The sign-in card: one button per provider plus any sign-in flow error. */
 function SignedOut(): ReactNode {
   const { signIn, flowError } = useAuthActions();
   return (
@@ -41,14 +82,19 @@ function SignedOut(): ReactNode {
           {flowError}
         </p>
       )}
-      <button
-        type="button"
-        onClick={() => void signIn()}
-        className="flex w-full items-center justify-center gap-3 rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2"
-      >
-        <GoogleIcon />
-        Continue with Google
-      </button>
+      <div className="flex flex-col gap-3">
+        {PROVIDERS.map((provider) => (
+          <button
+            key={provider.id}
+            type="button"
+            onClick={() => void signIn(provider.id)}
+            className={`flex w-full items-center justify-center gap-3 rounded-lg px-4 py-2.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 ${provider.className}`}
+          >
+            {provider.icon}
+            Continue with {provider.name}
+          </button>
+        ))}
+      </div>
     </>
   );
 }

--- a/examples/react-oauth/src/App.tsx
+++ b/examples/react-oauth/src/App.tsx
@@ -1,22 +1,7 @@
 import { type ReactNode } from "react";
-
-/**
- * A brand-styled OAuth sign-in option rendered as a button.
- */
-type OAuthProvider = {
-  /** Human-readable provider name, shown in the button label. */
-  name: string;
-  /**
-   * Authorization URL the button navigates to.
-   *
-   * Placeholder for now - replace `"#"` with the real OAuth URL.
-   */
-  href: string;
-  /** Brand icon rendered to the left of the label. */
-  icon: ReactNode;
-  /** Tailwind color/border classes controlling the button's appearance. */
-  className: string;
-};
+import { useConvexAuth, useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+import { useAuthActions } from "./auth";
 
 /** Google's multi-color "G" mark. */
 const GoogleIcon = (): ReactNode => (
@@ -40,63 +25,69 @@ const GoogleIcon = (): ReactNode => (
   </svg>
 );
 
-/** GitHub's Octocat mark, tinted via `currentColor`. */
-const GitHubIcon = (): ReactNode => (
-  <svg
-    className="h-5 w-5 shrink-0"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    aria-hidden="true"
-  >
-    <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
-  </svg>
-);
+/** The sign-in card: the Google button plus any sign-in flow error. */
+function SignedOut(): ReactNode {
+  const { signIn, flowError } = useAuthActions();
+  return (
+    <>
+      <div className="mb-8 text-center">
+        <h1 className="text-xl font-semibold text-gray-900">Sign in</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Continue with your preferred account
+        </p>
+      </div>
+      {flowError !== null && (
+        <p className="mb-4 rounded-lg bg-red-50 px-4 py-2.5 text-sm text-red-700">
+          {flowError}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={() => void signIn()}
+        className="flex w-full items-center justify-center gap-3 rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-gray-700 ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2"
+      >
+        <GoogleIcon />
+        Continue with Google
+      </button>
+    </>
+  );
+}
+
+/** The signed-in card: who the server says you are, and sign-out. */
+function SignedIn(): ReactNode {
+  const { signOut } = useAuthActions();
+  const user = useQuery(api.users.me);
+  return (
+    <>
+      <div className="mb-8 text-center">
+        <h1 className="text-xl font-semibold text-gray-900">Signed in</h1>
+        <p className="mt-1 text-sm text-gray-500">{user?.email ?? "…"}</p>
+      </div>
+      <button
+        type="button"
+        onClick={() => void signOut()}
+        className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2"
+      >
+        Sign out
+      </button>
+    </>
+  );
+}
 
 /**
- * Available sign-in providers. The `href` values are placeholders and
- * should be pointed at the real OAuth authorization endpoints.
- */
-const PROVIDERS: OAuthProvider[] = [
-  {
-    name: "Google",
-    href: "#",
-    icon: <GoogleIcon />,
-    className:
-      "bg-white text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
-  },
-  {
-    name: "GitHub",
-    href: "#",
-    icon: <GitHubIcon />,
-    className: "bg-gray-900 text-white hover:bg-gray-800",
-  },
-];
-
-/**
- * Landing page presenting OAuth sign-in options as button-styled links.
+ * Landing page: sign-in options while signed out, the session's user while
+ * signed in, and a brief loading state while a callback code is redeemed.
  */
 export default function App(): ReactNode {
+  const { isLoading, isAuthenticated } = useConvexAuth();
   return (
     <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-xl ring-1 ring-gray-200">
-        <div className="mb-8 text-center">
-          <h1 className="text-xl font-semibold text-gray-900">Sign in</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Continue with your preferred account
-          </p>
-        </div>
-        <div className="flex flex-col gap-3">
-          {PROVIDERS.map((provider) => (
-            <a
-              key={provider.name}
-              href={provider.href}
-              className={`flex w-full items-center justify-center gap-3 rounded-lg px-4 py-2.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 ${provider.className}`}
-            >
-              {provider.icon}
-              Continue with {provider.name}
-            </a>
-          ))}
-        </div>
+        {isLoading && (
+          <p className="text-center text-sm text-gray-500">Signing you in…</p>
+        )}
+        {!isLoading && isAuthenticated && <SignedIn />}
+        {!isLoading && !isAuthenticated && <SignedOut />}
       </div>
     </main>
   );

--- a/examples/react-oauth/src/App.tsx
+++ b/examples/react-oauth/src/App.tsx
@@ -1,0 +1,103 @@
+import { type ReactNode } from "react";
+
+/**
+ * A brand-styled OAuth sign-in option rendered as a button.
+ */
+type OAuthProvider = {
+  /** Human-readable provider name, shown in the button label. */
+  name: string;
+  /**
+   * Authorization URL the button navigates to.
+   *
+   * Placeholder for now - replace `"#"` with the real OAuth URL.
+   */
+  href: string;
+  /** Brand icon rendered to the left of the label. */
+  icon: ReactNode;
+  /** Tailwind color/border classes controlling the button's appearance. */
+  className: string;
+};
+
+/** Google's multi-color "G" mark. */
+const GoogleIcon = (): ReactNode => (
+  <svg className="h-5 w-5 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="#4285F4"
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+    />
+    <path
+      fill="#34A853"
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+    />
+  </svg>
+);
+
+/** GitHub's Octocat mark, tinted via `currentColor`. */
+const GitHubIcon = (): ReactNode => (
+  <svg
+    className="h-5 w-5 shrink-0"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.39 1.24-3.23-.13-.3-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.25 2.88.12 3.18.77.84 1.24 1.92 1.24 3.23 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
+  </svg>
+);
+
+/**
+ * Available sign-in providers. The `href` values are placeholders and
+ * should be pointed at the real OAuth authorization endpoints.
+ */
+const PROVIDERS: OAuthProvider[] = [
+  {
+    name: "Google",
+    href: "#",
+    icon: <GoogleIcon />,
+    className:
+      "bg-white text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
+  },
+  {
+    name: "GitHub",
+    href: "#",
+    icon: <GitHubIcon />,
+    className: "bg-gray-900 text-white hover:bg-gray-800",
+  },
+];
+
+/**
+ * Landing page presenting OAuth sign-in options as button-styled links.
+ */
+export default function App(): ReactNode {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-8 shadow-xl ring-1 ring-gray-200">
+        <div className="mb-8 text-center">
+          <h1 className="text-xl font-semibold text-gray-900">Sign in</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Continue with your preferred account
+          </p>
+        </div>
+        <div className="flex flex-col gap-3">
+          {PROVIDERS.map((provider) => (
+            <a
+              key={provider.name}
+              href={provider.href}
+              className={`flex w-full items-center justify-center gap-3 rounded-lg px-4 py-2.5 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 ${provider.className}`}
+            >
+              {provider.icon}
+              Continue with {provider.name}
+            </a>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/examples/react-oauth/src/auth.tsx
+++ b/examples/react-oauth/src/auth.tsx
@@ -1,0 +1,277 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ConvexProviderWithAuth, type ConvexReactClient } from "convex/react";
+import type { TokenBundle } from "@convex-dev/auth/lib/types";
+import { api } from "../convex/_generated/api";
+
+/**
+ * Storage keys are namespaced by deployment host so tokens from different
+ * deployments served on the same origin (e.g. dev and prod apps on
+ * localhost) don't collide.
+ */
+const deploymentHost = new URL(import.meta.env.VITE_CONVEX_URL).host;
+const TOKENS_KEY = `convexAuth.tokens.${deploymentHost}`;
+const STATE_KEY = `convexAuth.oauthState.${deploymentHost}`;
+
+/**
+ * Refresh this long before the access token actually expires, so a token
+ * handed to the Convex client isn't already stale on arrival.
+ */
+const ACCESS_TOKEN_SKEW_MS = 30 * 1000;
+
+/** The stored token bundle, or `null` if absent, expired, or unreadable. */
+function loadTokens(): TokenBundle | null {
+  const raw = localStorage.getItem(TOKENS_KEY);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const bundle = JSON.parse(raw) as TokenBundle;
+    if (bundle.refreshTokenExpiresAt <= Date.now()) {
+      localStorage.removeItem(TOKENS_KEY);
+      return null;
+    }
+    return bundle;
+  } catch {
+    localStorage.removeItem(TOKENS_KEY);
+    return null;
+  }
+}
+
+/** Sign-in and sign-out actions plus the latest sign-in flow error. */
+type AuthActions = {
+  /** Start the Google OAuth flow; navigates away to the provider. */
+  signIn: () => Promise<void>;
+  /** End the session on the server (best-effort) and locally. */
+  signOut: () => Promise<void>;
+  /** User-facing message when the last sign-in attempt failed, else null. */
+  flowError: string | null;
+};
+
+/** Auth state in the shape `ConvexProviderWithAuth`'s `useAuth` prop expects. */
+type AuthState = {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  fetchAccessToken: (args: {
+    forceRefreshToken: boolean;
+  }) => Promise<string | null>;
+};
+
+const AuthStateContext = createContext<AuthState | null>(null);
+const AuthActionsContext = createContext<AuthActions | null>(null);
+
+/**
+ * Module-level hook handed to `ConvexProviderWithAuth`, which requires a
+ * stable `useAuth` reference across renders (a new function identity resets
+ * its auth state to loading).
+ */
+function useAuthState(): AuthState {
+  const state = useContext(AuthStateContext);
+  if (state === null) {
+    throw new Error("useAuthState must be used inside AuthProvider");
+  }
+  return state;
+}
+
+/** The sign-in/sign-out actions provided by {@link AuthProvider}. */
+export function useAuthActions(): AuthActions {
+  const actions = useContext(AuthActionsContext);
+  if (actions === null) {
+    throw new Error("useAuthActions must be used inside AuthProvider");
+  }
+  return actions;
+}
+
+/** User-facing messages for the callback's normalized `error` param. */
+const FLOW_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: "Sign-in was cancelled.",
+  expired: "Sign-in took too long. Please try again.",
+  oauth_error: "Something went wrong during sign-in. Please try again.",
+};
+
+/**
+ * Owns the OAuth client flow and the session token lifecycle, and provides
+ * an authenticated Convex client to the tree via `ConvexProviderWithAuth`.
+ *
+ * Flow: `signIn` asks the server for an authorization URL, keeps the minted
+ * `state` in localStorage, and navigates away. The provider callback
+ * redirects back with a one-time `code` (or `error`); on mount this
+ * component redeems `code` + `state` for a token bundle and persists it.
+ *
+ * Cross-tab coordination (refresh mutex, storage-event sync) is deliberately
+ * omitted: the core's refresh grace window absorbs racing tabs, and a
+ * sibling tab self-corrects on its next refresh.
+ */
+export function AuthProvider({
+  client,
+  children,
+}: {
+  client: ConvexReactClient;
+  children: ReactNode;
+}): ReactNode {
+  const [tokens, setTokensState] = useState<TokenBundle | null>(loadTokens);
+  const [flowError, setFlowError] = useState<string | null>(null);
+  // Loading while a callback code is being redeemed; everything else about
+  // the initial auth state is known synchronously from localStorage.
+  const [redeeming, setRedeeming] = useState<boolean>(() =>
+    new URLSearchParams(window.location.search).has("code"),
+  );
+
+  // Mirror of `tokens` so fetchAccessToken can stay referentially stable.
+  const tokensRef = useRef<TokenBundle | null>(tokens);
+  const setTokens = useCallback((bundle: TokenBundle | null) => {
+    if (bundle === null) {
+      localStorage.removeItem(TOKENS_KEY);
+    } else {
+      localStorage.setItem(TOKENS_KEY, JSON.stringify(bundle));
+    }
+    tokensRef.current = bundle;
+    setTokensState(bundle);
+  }, []);
+
+  useEffect(() => {
+    // Read and strip the callback params synchronously, before any await:
+    // the StrictMode re-run of this effect then finds a clean URL and
+    // no-ops, so the one-time code is only redeemed once.
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get("code");
+    const errorParam = url.searchParams.get("error");
+    if (code === null && errorParam === null) {
+      return;
+    }
+    url.searchParams.delete("code");
+    url.searchParams.delete("error");
+    window.history.replaceState(null, "", url.toString());
+    if (errorParam !== null) {
+      setFlowError(
+        FLOW_ERROR_MESSAGES[errorParam] ?? FLOW_ERROR_MESSAGES.oauth_error,
+      );
+      setRedeeming(false);
+      return;
+    }
+    if (code === null) {
+      return;
+    }
+    // The state minted at sign-in is this client's proof that it initiated
+    // the flow; it's read from storage only, never from the URL (login-CSRF
+    // guard), and consumed here whether or not redemption succeeds.
+    const state = localStorage.getItem(STATE_KEY);
+    localStorage.removeItem(STATE_KEY);
+    if (state === null) {
+      setFlowError("This sign-in can't be completed here. Please try again.");
+      setRedeeming(false);
+      return;
+    }
+    void (async () => {
+      const bundle = await client.mutation(api.auth.redeemGoogle, {
+        code,
+        state,
+      });
+      if (bundle === null) {
+        setFlowError("Sign-in expired. Please try again.");
+      } else {
+        setTokens(bundle);
+      }
+      setRedeeming(false);
+    })();
+    // Runs once on mount; client and setTokens are stable.
+  }, []);
+
+  const signIn = useCallback(async () => {
+    setFlowError(null);
+    const { redirect, state } = await client.mutation(api.auth.signInGoogle, {
+      redirectTo: window.location.href,
+    });
+    localStorage.setItem(STATE_KEY, state);
+    window.location.href = redirect;
+  }, [client]);
+
+  const signOut = useCallback(async () => {
+    const bundle = tokensRef.current;
+    // Clear locally first so the UI signs out even if the server call fails
+    // (the session may already be gone).
+    setTokens(null);
+    if (bundle !== null) {
+      try {
+        await client.mutation(api.auth.signOut, {
+          refreshToken: bundle.refreshToken,
+        });
+      } catch {
+        // Best-effort; local state is already cleared.
+      }
+    }
+  }, [client, setTokens]);
+
+  // Single-flight guard so concurrent token requests share one refresh.
+  const refreshInFlight = useRef<Promise<string | null> | null>(null);
+
+  const fetchAccessToken = useCallback(
+    async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
+      const current = tokensRef.current;
+      if (current === null) {
+        return null;
+      }
+      const isFresh =
+        current.accessTokenExpiresAt > Date.now() + ACCESS_TOKEN_SKEW_MS;
+      if (!forceRefreshToken && isFresh) {
+        return current.accessToken;
+      }
+      if (refreshInFlight.current === null) {
+        refreshInFlight.current = (async () => {
+          try {
+            // Re-read storage at call time: another tab may have rotated
+            // the refresh token since ours was captured.
+            const stored = loadTokens();
+            if (stored === null) {
+              setTokens(null);
+              return null;
+            }
+            const bundle = await client.mutation(api.auth.refreshSession, {
+              refreshToken: stored.refreshToken,
+            });
+            setTokens(bundle);
+            if (bundle === null) {
+              return null;
+            }
+            return bundle.accessToken;
+          } finally {
+            refreshInFlight.current = null;
+          }
+        })();
+      }
+      return await refreshInFlight.current;
+    },
+    [client, setTokens],
+  );
+
+  const authState = useMemo(
+    () => ({
+      isLoading: redeeming,
+      isAuthenticated: tokens !== null,
+      fetchAccessToken,
+    }),
+    [redeeming, tokens, fetchAccessToken],
+  );
+  const actions = useMemo(
+    () => ({ signIn, signOut, flowError }),
+    [signIn, signOut, flowError],
+  );
+
+  return (
+    <AuthStateContext.Provider value={authState}>
+      <AuthActionsContext.Provider value={actions}>
+        <ConvexProviderWithAuth client={client} useAuth={useAuthState}>
+          {children}
+        </ConvexProviderWithAuth>
+      </AuthActionsContext.Provider>
+    </AuthStateContext.Provider>
+  );
+}

--- a/examples/react-oauth/src/auth.tsx
+++ b/examples/react-oauth/src/auth.tsx
@@ -19,7 +19,16 @@ import { api } from "../convex/_generated/api";
  */
 const deploymentHost = new URL(import.meta.env.VITE_CONVEX_URL).host;
 const TOKENS_KEY = `convexAuth.tokens.${deploymentHost}`;
-const STATE_KEY = `convexAuth.oauthState.${deploymentHost}`;
+const FLOW_KEY = `convexAuth.oauthFlow.${deploymentHost}`;
+
+/** Client-callable mutation refs for each provider wired in convex/auth.ts. */
+const PROVIDER_API = {
+  google: { signIn: api.auth.signInGoogle, redeem: api.auth.redeemGoogle },
+  github: { signIn: api.auth.signInGithub, redeem: api.auth.redeemGithub },
+};
+
+/** Providers the example can sign in with. */
+export type OAuthProviderName = keyof typeof PROVIDER_API;
 
 /**
  * Refresh this long before the access token actually expires, so a token
@@ -48,8 +57,8 @@ function loadTokens(): TokenBundle | null {
 
 /** Sign-in and sign-out actions plus the latest sign-in flow error. */
 type AuthActions = {
-  /** Start the Google OAuth flow; navigates away to the provider. */
-  signIn: () => Promise<void>;
+  /** Start the named provider's OAuth flow; navigates away to the provider. */
+  signIn: (provider: OAuthProviderName) => Promise<void>;
   /** End the session on the server (best-effort) and locally. */
   signOut: () => Promise<void>;
   /** User-facing message when the last sign-in attempt failed, else null. */
@@ -88,6 +97,38 @@ export function useAuthActions(): AuthActions {
     throw new Error("useAuthActions must be used inside AuthProvider");
   }
   return actions;
+}
+
+/**
+ * Take (read and remove) the pending sign-in flow stored at sign-in time:
+ * the state that proves this client initiated the flow, and which provider
+ * it belongs to (the callback returns only `code`).
+ */
+function takePendingFlow(): {
+  provider: OAuthProviderName;
+  state: string;
+} | null {
+  const raw = localStorage.getItem(FLOW_KEY);
+  localStorage.removeItem(FLOW_KEY);
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { provider?: unknown; state?: unknown };
+    if (
+      typeof parsed.provider !== "string" ||
+      !(parsed.provider in PROVIDER_API) ||
+      typeof parsed.state !== "string"
+    ) {
+      return null;
+    }
+    return {
+      provider: parsed.provider as OAuthProviderName,
+      state: parsed.state,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /** User-facing messages for the callback's normalized `error` param. */
@@ -163,18 +204,20 @@ export function AuthProvider({
     // The state minted at sign-in is this client's proof that it initiated
     // the flow; it's read from storage only, never from the URL (login-CSRF
     // guard), and consumed here whether or not redemption succeeds.
-    const state = localStorage.getItem(STATE_KEY);
-    localStorage.removeItem(STATE_KEY);
-    if (state === null) {
+    const pending = takePendingFlow();
+    if (pending === null) {
       setFlowError("This sign-in can't be completed here. Please try again.");
       setRedeeming(false);
       return;
     }
     void (async () => {
-      const bundle = await client.mutation(api.auth.redeemGoogle, {
-        code,
-        state,
-      });
+      const bundle = await client.mutation(
+        PROVIDER_API[pending.provider].redeem,
+        {
+          code,
+          state: pending.state,
+        },
+      );
       if (bundle === null) {
         setFlowError("Sign-in expired. Please try again.");
       } else {
@@ -185,14 +228,18 @@ export function AuthProvider({
     // Runs once on mount; client and setTokens are stable.
   }, []);
 
-  const signIn = useCallback(async () => {
-    setFlowError(null);
-    const { redirect, state } = await client.mutation(api.auth.signInGoogle, {
-      redirectTo: window.location.href,
-    });
-    localStorage.setItem(STATE_KEY, state);
-    window.location.href = redirect;
-  }, [client]);
+  const signIn = useCallback(
+    async (provider: OAuthProviderName) => {
+      setFlowError(null);
+      const { redirect, state } = await client.mutation(
+        PROVIDER_API[provider].signIn,
+        { redirectTo: window.location.href },
+      );
+      localStorage.setItem(FLOW_KEY, JSON.stringify({ provider, state }));
+      window.location.href = redirect;
+    },
+    [client],
+  );
 
   const signOut = useCallback(async () => {
     const bundle = tokensRef.current;

--- a/examples/react-oauth/src/index.css
+++ b/examples/react-oauth/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/examples/react-oauth/src/main.tsx
+++ b/examples/react-oauth/src/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+/**
+ * Locates the mount node and renders the app into it.
+ */
+const rootElement = document.getElementById("root");
+if (rootElement === null) {
+  throw new Error("Root element #root not found");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-oauth/src/main.tsx
+++ b/examples/react-oauth/src/main.tsx
@@ -1,7 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { ConvexReactClient } from "convex/react";
 import App from "./App";
+import { AuthProvider } from "./auth";
 import "./index.css";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
 
 /**
  * Locates the mount node and renders the app into it.
@@ -13,6 +17,8 @@ if (rootElement === null) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <AuthProvider client={convex}>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 );

--- a/examples/react-oauth/src/vite-env.d.ts
+++ b/examples/react-oauth/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/react-oauth/tsconfig.json
+++ b/examples/react-oauth/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "vite.config.ts", "convex/**/*"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/examples/react-oauth/vite.config.ts
+++ b/examples/react-oauth/vite.config.ts
@@ -1,0 +1,13 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * Vite configuration for the OAuth example app.
+ *
+ * Uses the React plugin for JSX/Fast Refresh and the Tailwind v4 plugin,
+ * which handles CSS processing without a separate PostCSS or Tailwind config.
+ */
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,8 @@
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",
     "./providers/password/convex.config.js": "./src/components/password/convex.config.ts",
     "./providers/password/*": "./src/components/password/*.ts",
+    "./providers/oauth/convex.config.js": "./src/components/oauth/convex.config.ts",
+    "./providers/oauth/*": "./src/components/oauth/*.ts",
     "./providers/testing/*": "./src/components/testing/*.ts"
   },
   "scripts": {

--- a/packages/core/src/components/oauth/_generated/api.ts
+++ b/packages/core/src/components/oauth/_generated/api.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as crypto from "../crypto.js";
 import type * as provider from "../provider.js";
 import type * as setup from "../setup.js";
 
@@ -19,6 +20,7 @@ import type {
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
+  crypto: typeof crypto;
   provider: typeof provider;
   setup: typeof setup;
 }> = anyApi as any;

--- a/packages/core/src/components/oauth/_generated/api.ts
+++ b/packages/core/src/components/oauth/_generated/api.ts
@@ -8,9 +8,8 @@
  * @module
  */
 
-import type * as public_ from "../public.js";
+import type * as provider from "../provider.js";
 import type * as setup from "../setup.js";
-import type * as validation from "../validation.js";
 
 import type {
   ApiFromModules,
@@ -20,9 +19,8 @@ import type {
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
-  public: typeof public_;
+  provider: typeof provider;
   setup: typeof setup;
-  validation: typeof validation;
 }> = anyApi as any;
 
 /**
@@ -51,6 +49,4 @@ export const internal: FilterApi<
   FunctionReference<any, "internal">
 > = anyApi as any;
 
-export const components = componentsGeneric() as unknown as {
-  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
-};
+export const components = componentsGeneric() as unknown as {};

--- a/packages/core/src/components/oauth/_generated/api.ts
+++ b/packages/core/src/components/oauth/_generated/api.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as crypto from "../crypto.js";
+import type * as http from "../http.js";
 import type * as provider from "../provider.js";
 import type * as setup from "../setup.js";
 
@@ -21,6 +22,7 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   crypto: typeof crypto;
+  http: typeof http;
   provider: typeof provider;
   setup: typeof setup;
 }> = anyApi as any;

--- a/packages/core/src/components/oauth/_generated/api.ts
+++ b/packages/core/src/components/oauth/_generated/api.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as constants from "../constants.js";
 import type * as crypto from "../crypto.js";
 import type * as http from "../http.js";
 import type * as provider from "../provider.js";
@@ -21,6 +22,7 @@ import type {
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
+  constants: typeof constants;
   crypto: typeof crypto;
   http: typeof http;
   provider: typeof provider;

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -35,6 +35,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          callbackUrl: string;
           codeVerifier?: string;
           issuer?: string;
           provider: string;
@@ -43,7 +44,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           tokenEndpoint: string;
           userInfoEndpoints?: Record<string, string>;
         },
-        { callbackBaseUrl: string; clientId: string },
+        { clientId: string },
         Name
       >;
     };

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -32,8 +32,10 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           provider: string;
           redirectTo: string;
           stateHash: string;
+          tokenEndpoint: string;
+          userinfoEndpoints?: Record<string, string>;
         },
-        string,
+        { callbackBaseUrl: string; clientId: string },
         Name
       >;
     };

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -1,0 +1,35 @@
+/* eslint-disable */
+/**
+ * Generated `ComponentApi` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type { FunctionReference } from "convex/server";
+
+/**
+ * A utility for referencing a Convex component's exposed API.
+ *
+ * Useful when expecting a parameter like `components.myComponent`.
+ * Usage:
+ * ```ts
+ * async function myFunction(ctx: QueryCtx, component: ComponentApi) {
+ *   return ctx.runQuery(component.someFile.someQuery, { ...args });
+ * }
+ * ```
+ */
+export type ComponentApi<Name extends string | undefined = string | undefined> =
+  {
+    provider: {
+      createOauthAccount: FunctionReference<
+        "mutation",
+        "internal",
+        {},
+        any,
+        Name
+      >;
+    };
+  };

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -27,12 +27,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       claimTicket: FunctionReference<
         "mutation",
         "internal",
-        { ottHash: string; stateHash: string },
-        null | {
-          claims?: any;
-          provider: string;
-          userInfoResponses?: Record<string, any>;
-        },
+        { ottHash: string; provider: string; stateHash: string },
+        null | { claims?: any; userInfoResponses?: Record<string, any> },
         Name
       >;
       createAuthorizationRequest: FunctionReference<
@@ -40,6 +36,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           codeVerifier?: string;
+          issuer?: string;
           provider: string;
           redirectTo: string;
           stateHash: string;

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -24,6 +24,17 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     provider: {
+      claimTicket: FunctionReference<
+        "mutation",
+        "internal",
+        { ottHash: string; stateHash: string },
+        null | {
+          claims?: any;
+          provider: string;
+          userInfoResponses?: Record<string, any>;
+        },
+        Name
+      >;
       createAuthorizationRequest: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -24,11 +24,16 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     provider: {
-      createOauthAccount: FunctionReference<
+      createAuthorizationRequest: FunctionReference<
         "mutation",
         "internal",
-        {},
-        any,
+        {
+          codeVerifier?: string;
+          provider: string;
+          redirectTo: string;
+          stateHash: string;
+        },
+        string,
         Name
       >;
     };

--- a/packages/core/src/components/oauth/_generated/component.ts
+++ b/packages/core/src/components/oauth/_generated/component.ts
@@ -28,7 +28,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         { ottHash: string; provider: string; stateHash: string },
-        null | { claims?: any; userInfoResponses?: Record<string, any> },
+        null | { payload: string },
         Name
       >;
       createAuthorizationRequest: FunctionReference<
@@ -41,7 +41,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           redirectTo: string;
           stateHash: string;
           tokenEndpoint: string;
-          userinfoEndpoints?: Record<string, string>;
+          userInfoEndpoints?: Record<string, string>;
         },
         { callbackBaseUrl: string; clientId: string },
         Name

--- a/packages/core/src/components/oauth/_generated/dataModel.ts
+++ b/packages/core/src/components/oauth/_generated/dataModel.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/packages/core/src/components/oauth/_generated/server.ts
+++ b/packages/core/src/components/oauth/_generated/server.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query: QueryBuilder<DataModel, "public"> = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery: QueryBuilder<DataModel, "internal"> =
+  internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation: MutationBuilder<DataModel, "public"> = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation: MutationBuilder<DataModel, "internal"> =
+  internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action: ActionBuilder<DataModel, "public"> = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction: ActionBuilder<DataModel, "internal"> =
+  internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction: HttpActionBuilder = httpActionGeneric;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * If you're using code generation, use the `QueryCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ *
+ * If you're using code generation, use the `MutationCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/packages/core/src/components/oauth/_generated/server.ts
+++ b/packages/core/src/components/oauth/_generated/server.ts
@@ -34,6 +34,7 @@ import type { DataModel } from "./dataModel.js";
  * Typesafe environment variables declared in `convex.config.ts`.
  */
 type Env = {
+  readonly CLIENT_ID: string;
   readonly CLIENT_SECRET: string;
 };
 

--- a/packages/core/src/components/oauth/_generated/server.ts
+++ b/packages/core/src/components/oauth/_generated/server.ts
@@ -31,6 +31,13 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly CLIENT_SECRET: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -106,6 +113,7 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
+export const env: Env = process.env as unknown as Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/packages/core/src/components/oauth/constants.ts
+++ b/packages/core/src/components/oauth/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Path the component's HTTP router serves the provider callback under,
+ * relative to the mount's `httpPrefix`. Also the suffix of the redirect URI
+ * built app-side and registered with the provider, so every use must
+ * byte-match.
+ */
+export const CALLBACK_PATH = "/callback";

--- a/packages/core/src/components/oauth/convex.config.ts
+++ b/packages/core/src/components/oauth/convex.config.ts
@@ -1,0 +1,5 @@
+import { defineComponent } from "convex/server";
+
+const component = defineComponent("authOauth");
+
+export default component;

--- a/packages/core/src/components/oauth/convex.config.ts
+++ b/packages/core/src/components/oauth/convex.config.ts
@@ -4,21 +4,26 @@ import { v } from "convex/values";
 /**
  * The oauth provider component. Mounted once per upstream IdP, each mount
  * with its own name, `httpPrefix` (the provider callback route), and
- * `CLIENT_SECRET` binding:
+ * client credential bindings:
  *
  * ```ts
  * app.use(oauthProvider, {
  *   name: "oauthGoogle",
  *   httpPrefix: "/oauth/google",
- *   env: { CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET },
+ *   env: {
+ *     CLIENT_ID: app.env.AUTH_GOOGLE_CLIENT_ID,
+ *     CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET,
+ *   },
  * });
  * ```
  *
- * Per-mount env bindings are what let the secret reach the component's
- * callback (for the token exchange) without ever being stored in a table.
+ * Per-mount env bindings are what let the credential pair reach the
+ * component's callback (for the token exchange) without ever being stored
+ * in a table.
  */
 const component = defineComponent("authOauth", {
   env: {
+    CLIENT_ID: v.string(),
     CLIENT_SECRET: v.string(),
   },
 });

--- a/packages/core/src/components/oauth/convex.config.ts
+++ b/packages/core/src/components/oauth/convex.config.ts
@@ -1,5 +1,26 @@
 import { defineComponent } from "convex/server";
+import { v } from "convex/values";
 
-const component = defineComponent("authOauth");
+/**
+ * The oauth provider component. Mounted once per upstream IdP, each mount
+ * with its own name, `httpPrefix` (the provider callback route), and
+ * `CLIENT_SECRET` binding:
+ *
+ * ```ts
+ * app.use(oauthProvider, {
+ *   name: "oauthGoogle",
+ *   httpPrefix: "/oauth/google",
+ *   env: { CLIENT_SECRET: app.env.AUTH_GOOGLE_CLIENT_SECRET },
+ * });
+ * ```
+ *
+ * Per-mount env bindings are what let the secret reach the component's
+ * callback (for the token exchange) without ever being stored in a table.
+ */
+const component = defineComponent("authOauth", {
+  env: {
+    CLIENT_SECRET: v.string(),
+  },
+});
 
 export default component;

--- a/packages/core/src/components/oauth/crypto.ts
+++ b/packages/core/src/components/oauth/crypto.ts
@@ -6,7 +6,10 @@
 
 function base64UrlEncode(bytes: Uint8Array): string {
   const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
 /** SHA-256 hex digest, used so raw state and one-time tokens are never persisted. */

--- a/packages/core/src/components/oauth/crypto.ts
+++ b/packages/core/src/components/oauth/crypto.ts
@@ -5,8 +5,7 @@
  */
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
+  const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 

--- a/packages/core/src/components/oauth/crypto.ts
+++ b/packages/core/src/components/oauth/crypto.ts
@@ -33,3 +33,25 @@ export async function sha256Base64Url(value: string): Promise<string> {
 export function generateRandomToken(): string {
   return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
 }
+
+function base64UrlDecode(value: string): Uint8Array {
+  const base64 = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+/**
+ * Decode a JWT's payload without verifying its signature. Only safe for
+ * tokens received directly from the issuer over TLS (e.g. an id_token from
+ * the token exchange), where transport authenticates the issuer.
+ */
+export function decodeJwtPayload(jwt: string): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed JWT");
+  }
+  return JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[1])));
+}

--- a/packages/core/src/components/oauth/crypto.ts
+++ b/packages/core/src/components/oauth/crypto.ts
@@ -58,3 +58,62 @@ export function decodeJwtPayload(jwt: string): Record<string, unknown> {
   }
   return JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[1])));
 }
+
+/**
+ * Derive an AES-256-GCM key from a raw one-time token. A domain-separated
+ * SHA-256 suffices as the KDF: the token is itself 256 bits of CSPRNG
+ * output, so no stretching is needed.
+ */
+async function deriveTokenKey(token: string): Promise<CryptoKey> {
+  const keyBytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`convex-auth-ticket-payload:${token}`),
+  );
+  return await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+/**
+ * Encrypt a ticket payload with a key derived from the raw one-time token.
+ * The token is never persisted (only its hash is), so database access alone
+ * cannot decrypt the result; the key preimage travels only in the callback
+ * redirect URL. Returns base64url(iv || ciphertext).
+ */
+export async function encryptWithToken(
+  token: string,
+  plaintext: string,
+): Promise<string> {
+  const key = await deriveTokenKey(token);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      new TextEncoder().encode(plaintext),
+    ),
+  );
+  const combined = new Uint8Array(iv.length + ciphertext.length);
+  combined.set(iv);
+  combined.set(ciphertext, iv.length);
+  return base64UrlEncode(combined);
+}
+
+/**
+ * Decrypt {@link encryptWithToken} output. Throws when the token is wrong
+ * or the payload was tampered with (AES-GCM authenticates).
+ */
+export async function decryptWithToken(
+  token: string,
+  encrypted: string,
+): Promise<string> {
+  const key = await deriveTokenKey(token);
+  const combined = base64UrlDecode(encrypted);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: combined.slice(0, 12) },
+    key,
+    combined.slice(12),
+  );
+  return new TextDecoder().decode(plaintext);
+}

--- a/packages/core/src/components/oauth/crypto.ts
+++ b/packages/core/src/components/oauth/crypto.ts
@@ -1,0 +1,36 @@
+/**
+ * Crypto helpers for the OAuth provider. Used by both the app-side recipe
+ * (hashing state before it crosses the component boundary) and the component
+ * itself (hashing one-time tokens at rest).
+ */
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** SHA-256 hex digest, used so raw state and one-time tokens are never persisted. */
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** base64url(SHA-256(value)) — the PKCE `S256` code challenge encoding. */
+export async function sha256Base64Url(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/** Cryptographically random 256-bit opaque token, base64url encoded. */
+export function generateRandomToken(): string {
+  return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
+}

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -1,5 +1,7 @@
 import { httpRouter } from "convex/server";
-import { httpAction } from "./_generated/server";
+import { env, httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { decodeJwtPayload, generateRandomToken, sha256Hex } from "./crypto";
 
 // Each per-IdP mount serves its own provider callback under the prefix the
 // app declares in convex.config.ts (`app.use(oauthProvider, { name:
@@ -7,13 +9,220 @@ import { httpAction } from "./_generated/server";
 // is <prefix>/callback — the redirect URI registered with the provider.
 const http = httpRouter();
 
+/** Append query params to an absolute URL, preserving existing ones. */
+function withParams(target: string, params: Record<string, string>): string {
+  const url = new URL(target);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+/** A 302 redirect response. */
+function redirect(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+}
+
+/**
+ * Fetch that treats any HTTP redirect as an error. Token and userinfo
+ * endpoints never legitimately redirect; following one could forward
+ * credentials to an unintended host.
+ */
+async function fetchRefusingRedirects(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const response = await fetch(url, { ...init, redirect: "manual" });
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error(`Request to ${url} responded with a redirect`);
+  }
+  return response;
+}
+
+/**
+ * Exchange an authorization code for tokens at the provider's token
+ * endpoint. Client credentials are sent in the POST body — empirically the
+ * most compatible style (HTTP Basic has a form-urlencoding ambiguity many
+ * providers get wrong).
+ */
+async function exchangeCode(args: {
+  tokenEndpoint: string;
+  code: string;
+  codeVerifier: string | undefined;
+}): Promise<{ idToken: string | undefined; accessToken: string | undefined }> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    client_id: env.CLIENT_ID,
+    client_secret: env.CLIENT_SECRET,
+    redirect_uri: `${process.env.CONVEX_SITE_URL}/callback`,
+  });
+  if (args.codeVerifier !== undefined) {
+    body.set("code_verifier", args.codeVerifier);
+  }
+  const response = await fetchRefusingRedirects(args.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      // GitHub's token endpoint returns form-encoded output without this.
+      Accept: "application/json",
+    },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Token exchange failed with ${response.status}: ${await response.text()}`,
+    );
+  }
+  const tokens = await response.json();
+  return {
+    idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
+    accessToken:
+      typeof tokens.access_token === "string" ? tokens.access_token : undefined,
+  };
+}
+
+/**
+ * Decode an id_token and check the claims that guard against config mixups:
+ * the token was minted for this OAuth app (`aud`) and isn't expired (`exp`).
+ * Signature verification is deliberately skipped — the token came directly
+ * from the provider's token endpoint over TLS, which OIDC Core sanctions in
+ * place of checking the signature.
+ */
+function validateIdToken(idToken: string): Record<string, unknown> {
+  const claims = decodeJwtPayload(idToken);
+  const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+  if (!audiences.includes(env.CLIENT_ID)) {
+    throw new Error("id_token audience does not match CLIENT_ID");
+  }
+  if (typeof claims.exp !== "number" || claims.exp * 1000 < Date.now()) {
+    throw new Error("id_token is expired");
+  }
+  return claims;
+}
+
+/**
+ * Fetch each configured userinfo endpoint with the access token. All
+ * popular providers accept the same shape — GET with a bearer token — with
+ * provider variation living in the endpoint URL's query params.
+ */
+async function fetchUserInfo(
+  endpoints: Record<string, string>,
+  accessToken: string,
+): Promise<Record<string, unknown>> {
+  const responses = await Promise.all(
+    Object.entries(endpoints).map(async ([key, endpoint]) => {
+      const response = await fetchRefusingRedirects(endpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json",
+          // GitHub's API rejects requests without a User-Agent.
+          "User-Agent": "convex-auth",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Userinfo request "${key}" failed with ${response.status}: ${await response.text()}`,
+        );
+      }
+      return [key, await response.json()] as const;
+    }),
+  );
+  return Object.fromEntries(responses);
+}
+
 http.route({
   path: "/callback",
   method: "GET",
-  handler: httpAction(async () => {
-    // TODO: claim the authorization request by state, exchange the code,
-    // mint a one-time ticket, and redirect to the stored redirectTo.
-    return new Response("Not implemented", { status: 501 });
+  handler: httpAction(async (ctx, request) => {
+    const url = new URL(request.url);
+    const state = url.searchParams.get("state");
+    const code = url.searchParams.get("code");
+    const error = url.searchParams.get("error");
+
+    // Without state we can't identify the flow, so there's no stored
+    // redirectTo to send the user back to — a bare 400 is all we have.
+    if (state === null) {
+      return new Response("Missing state", { status: 400 });
+    }
+
+    // Claiming is atomic (find + delete in one mutation), so a replayed or
+    // raced callback finds nothing. Possession of the provider-echoed state
+    // is the only check here; binding to the initiating client happens at
+    // redemption.
+    const authRequest = await ctx.runMutation(
+      internal.provider.claimAuthorizationRequest,
+      { stateHash: await sha256Hex(state) },
+    );
+    if (authRequest === null) {
+      return new Response("Unknown or expired authorization request", {
+        status: 400,
+      });
+    }
+
+    // From here on the flow is legitimate, so failures go back to the app
+    // as a normalized error param; raw detail goes to logs only.
+    if (error !== null || code === null) {
+      console.error(
+        `OAuth callback error from provider "${authRequest.provider}":`,
+        error ?? "missing code",
+        url.searchParams.get("error_description") ?? "",
+      );
+      const normalized = error === "access_denied" ? "access_denied" : "oauth_error";
+      return redirect(withParams(authRequest.redirectTo, { error: normalized }));
+    }
+
+    try {
+      const { idToken, accessToken } = await exchangeCode({
+        tokenEndpoint: authRequest.tokenEndpoint,
+        code,
+        codeVerifier: authRequest.codeVerifier,
+      });
+
+      const claims = idToken === undefined ? undefined : validateIdToken(idToken);
+
+      let userInfoResponses: Record<string, unknown> | undefined;
+      if (authRequest.userinfoEndpoints !== undefined) {
+        if (accessToken === undefined) {
+          throw new Error("Token exchange returned no access_token");
+        }
+        userInfoResponses = await fetchUserInfo(
+          authRequest.userinfoEndpoints,
+          accessToken,
+        );
+      }
+
+      // A provider that returns no id_token and has no configured userinfo
+      // endpoints gives us nothing to identify the user with.
+      if (claims === undefined && userInfoResponses === undefined) {
+        throw new Error(
+          "Token exchange returned no id_token and no userinfoEndpoints are configured",
+        );
+      }
+
+      // Nothing user-visible exists yet; the ticket is a short-lived,
+      // one-time proof that provider authentication succeeded. Only the
+      // hash of the one-time token is stored.
+      const ott = generateRandomToken();
+      await ctx.runMutation(internal.provider.createTicket, {
+        provider: authRequest.provider,
+        stateHash: authRequest.stateHash,
+        ottHash: await sha256Hex(ott),
+        claims,
+        userInfoResponses,
+      });
+
+      return redirect(withParams(authRequest.redirectTo, { code: ott }));
+    } catch (exchangeError) {
+      console.error(
+        `OAuth exchange failed for provider "${authRequest.provider}":`,
+        exchangeError,
+      );
+      return redirect(withParams(authRequest.redirectTo, { error: "oauth_error" }));
+    }
   }),
 });
 

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -87,6 +87,7 @@ async function fetchRefusingRedirects(
 async function exchangeCode(args: {
   tokenEndpoint: string;
   code: string;
+  callbackUrl: string;
   codeVerifier: string | undefined;
 }): Promise<{ idToken: string | undefined; accessToken: string | undefined }> {
   const body = new URLSearchParams({
@@ -94,7 +95,9 @@ async function exchangeCode(args: {
     code: args.code,
     client_id: env.CLIENT_ID,
     client_secret: env.CLIENT_SECRET,
-    redirect_uri: `${process.env.CONVEX_SITE_URL}${CALLBACK_PATH}`,
+    // Must byte-match the redirect_uri from the authorization request, so
+    // it comes off the request row rather than being rebuilt here.
+    redirect_uri: args.callbackUrl,
   });
   if (args.codeVerifier !== undefined) {
     body.set("code_verifier", args.codeVerifier);
@@ -246,6 +249,7 @@ http.route({
       const { idToken, accessToken } = await exchangeCode({
         tokenEndpoint: authRequest.tokenEndpoint,
         code,
+        callbackUrl: authRequest.callbackUrl,
         codeVerifier: authRequest.codeVerifier,
       });
 

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -48,14 +48,15 @@ function redirectToApp(
 /**
  * Fetch that enforces a timeout and treats any HTTP redirect as an error.
  * Token and userinfo endpoints never legitimately redirect; following one
- * could forward credentials to an unintended host. The timeout turns a
- * stalled endpoint into a normal failure, which redirects the user back to
- * the app instead of stranding them on a platform error.
+ * could forward credentials to an unintended host. The body is consumed
+ * while the timeout is still armed, so an endpoint that stalls before or
+ * after sending headers becomes a normal failure that redirects the user
+ * back to the app instead of pinning the callback until the platform limit.
  */
 async function fetchRefusingRedirects(
   url: string,
   init: RequestInit,
-): Promise<Response> {
+): Promise<{ ok: boolean; status: number; bodyText: string }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -67,7 +68,11 @@ async function fetchRefusingRedirects(
     if (response.status >= 300 && response.status < 400) {
       throw new Error(`Request to ${url} responded with a redirect`);
     }
-    return response;
+    return {
+      ok: response.ok,
+      status: response.status,
+      bodyText: await response.text(),
+    };
   } finally {
     clearTimeout(timeout);
   }
@@ -105,10 +110,10 @@ async function exchangeCode(args: {
   });
   if (!response.ok) {
     throw new Error(
-      `Token exchange failed with ${response.status}: ${await response.text()}`,
+      `Token exchange failed with ${response.status}: ${response.bodyText}`,
     );
   }
-  const tokens = await response.json();
+  const tokens = JSON.parse(response.bodyText) as Record<string, unknown>;
   return {
     idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
     accessToken:
@@ -118,24 +123,32 @@ async function exchangeCode(args: {
 
 /**
  * Decode an id_token and check the claims that guard against config mixups
- * and issuer collisions: the token was minted for this OAuth app (`aud`,
- * and `azp` when present), by the configured issuer (`iss`, when the app
- * config names one — `sub` is only unique within an issuer), and isn't
- * expired (`exp`). Signature verification is deliberately skipped — the
- * token came directly from the provider's token endpoint over TLS, which
- * OIDC Core sanctions in place of checking the signature.
+ * and issuer collisions: the token was minted by the configured issuer
+ * (`iss`; required whenever an id_token comes back, because `sub` is only
+ * unique within an issuer and a shared or multi-tenant token endpoint can
+ * serve several), for this OAuth app alone (`aud` must be exactly
+ * CLIENT_ID; multi-audience tokens are rejected because no other audience
+ * is trusted, and `azp` must match when present), and isn't expired
+ * (`exp`). Signature verification is deliberately skipped: the token came
+ * directly from the provider's token endpoint over TLS, which OIDC Core
+ * sanctions in place of checking the signature.
  */
 function validateIdToken(
   idToken: string,
   expectedIssuer: string | undefined,
 ): Record<string, unknown> {
+  if (expectedIssuer === undefined) {
+    throw new Error(
+      "The provider returned an id_token but no issuer is configured; set `issuer` in the provider options so the token can be validated",
+    );
+  }
   const claims = decodeJwtPayload(idToken);
-  if (expectedIssuer !== undefined && claims.iss !== expectedIssuer) {
+  if (claims.iss !== expectedIssuer) {
     throw new Error("id_token issuer does not match the configured issuer");
   }
   const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
-  if (!audiences.includes(env.CLIENT_ID)) {
-    throw new Error("id_token audience does not match CLIENT_ID");
+  if (audiences.length !== 1 || audiences[0] !== env.CLIENT_ID) {
+    throw new Error("id_token audience must be exactly CLIENT_ID");
   }
   if (claims.azp !== undefined && claims.azp !== env.CLIENT_ID) {
     throw new Error("id_token authorized party does not match CLIENT_ID");
@@ -167,10 +180,10 @@ async function fetchUserInfo(
       });
       if (!response.ok) {
         throw new Error(
-          `Userinfo request "${key}" failed with ${response.status}: ${await response.text()}`,
+          `Userinfo request "${key}" failed with ${response.status}: ${response.bodyText}`,
         );
       }
-      return [key, await response.json()] as const;
+      return [key, JSON.parse(response.bodyText) as unknown] as const;
     }),
   );
   return Object.fromEntries(responses);

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -86,17 +86,28 @@ async function exchangeCode(args: {
 }
 
 /**
- * Decode an id_token and check the claims that guard against config mixups:
- * the token was minted for this OAuth app (`aud`) and isn't expired (`exp`).
- * Signature verification is deliberately skipped — the token came directly
- * from the provider's token endpoint over TLS, which OIDC Core sanctions in
- * place of checking the signature.
+ * Decode an id_token and check the claims that guard against config mixups
+ * and issuer collisions: the token was minted for this OAuth app (`aud`,
+ * and `azp` when present), by the configured issuer (`iss`, when the app
+ * config names one — `sub` is only unique within an issuer), and isn't
+ * expired (`exp`). Signature verification is deliberately skipped — the
+ * token came directly from the provider's token endpoint over TLS, which
+ * OIDC Core sanctions in place of checking the signature.
  */
-function validateIdToken(idToken: string): Record<string, unknown> {
+function validateIdToken(
+  idToken: string,
+  expectedIssuer: string | undefined,
+): Record<string, unknown> {
   const claims = decodeJwtPayload(idToken);
+  if (expectedIssuer !== undefined && claims.iss !== expectedIssuer) {
+    throw new Error("id_token issuer does not match the configured issuer");
+  }
   const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
   if (!audiences.includes(env.CLIENT_ID)) {
     throw new Error("id_token audience does not match CLIENT_ID");
+  }
+  if (claims.azp !== undefined && claims.azp !== env.CLIENT_ID) {
+    throw new Error("id_token authorized party does not match CLIENT_ID");
   }
   if (typeof claims.exp !== "number" || claims.exp * 1000 < Date.now()) {
     throw new Error("id_token is expired");
@@ -171,8 +182,11 @@ http.route({
         error ?? "missing code",
         url.searchParams.get("error_description") ?? "",
       );
-      const normalized = error === "access_denied" ? "access_denied" : "oauth_error";
-      return redirect(withParams(authRequest.redirectTo, { error: normalized }));
+      const normalized =
+        error === "access_denied" ? "access_denied" : "oauth_error";
+      return redirect(
+        withParams(authRequest.redirectTo, { error: normalized }),
+      );
     }
 
     try {
@@ -182,7 +196,10 @@ http.route({
         codeVerifier: authRequest.codeVerifier,
       });
 
-      const claims = idToken === undefined ? undefined : validateIdToken(idToken);
+      const claims =
+        idToken === undefined
+          ? undefined
+          : validateIdToken(idToken, authRequest.issuer);
 
       let userInfoResponses: Record<string, unknown> | undefined;
       if (authRequest.userinfoEndpoints !== undefined) {
@@ -221,7 +238,9 @@ http.route({
         `OAuth exchange failed for provider "${authRequest.provider}":`,
         exchangeError,
       );
-      return redirect(withParams(authRequest.redirectTo, { error: "oauth_error" }));
+      return redirect(
+        withParams(authRequest.redirectTo, { error: "oauth_error" }),
+      );
     }
   }),
 });

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -1,0 +1,20 @@
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+
+// Each per-IdP mount serves its own provider callback under the prefix the
+// app declares in convex.config.ts (`app.use(oauthProvider, { name:
+// "oauthGoogle", httpPrefix: "/oauth/google", ... })`), so the served path
+// is <prefix>/callback — the redirect URI registered with the provider.
+const http = httpRouter();
+
+http.route({
+  path: "/callback",
+  method: "GET",
+  handler: httpAction(async () => {
+    // TODO: claim the authorization request by state, exchange the code,
+    // mint a one-time ticket, and redirect to the stored redirectTo.
+    return new Response("Not implemented", { status: 501 });
+  }),
+});
+
+export default http;

--- a/packages/core/src/components/oauth/http.ts
+++ b/packages/core/src/components/oauth/http.ts
@@ -1,7 +1,13 @@
 import { httpRouter } from "convex/server";
 import { env, httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { decodeJwtPayload, generateRandomToken, sha256Hex } from "./crypto";
+import { CALLBACK_PATH } from "./constants";
+import {
+  decodeJwtPayload,
+  encryptWithToken,
+  generateRandomToken,
+  sha256Hex,
+} from "./crypto";
 
 // Each per-IdP mount serves its own provider callback under the prefix the
 // app declares in convex.config.ts (`app.use(oauthProvider, { name:
@@ -9,14 +15,8 @@ import { decodeJwtPayload, generateRandomToken, sha256Hex } from "./crypto";
 // is <prefix>/callback — the redirect URI registered with the provider.
 const http = httpRouter();
 
-/** Append query params to an absolute URL, preserving existing ones. */
-function withParams(target: string, params: Record<string, string>): string {
-  const url = new URL(target);
-  for (const [key, value] of Object.entries(params)) {
-    url.searchParams.set(key, value);
-  }
-  return url.toString();
-}
+/** Outbound requests fail after this instead of pinning the callback to the platform limit. */
+const FETCH_TIMEOUT_MS = 30 * 1000;
 
 /** A 302 redirect response. */
 function redirect(location: string): Response {
@@ -27,19 +27,50 @@ function redirect(location: string): Response {
 }
 
 /**
- * Fetch that treats any HTTP redirect as an error. Token and userinfo
- * endpoints never legitimately redirect; following one could forward
- * credentials to an unintended host.
+ * 302 back to the app's `redirectTo` with outcome params. Stale
+ * `code`/`error` params from a previous attempt are removed first, so a
+ * `redirectTo` derived from the app's current URL can't carry a
+ * contradictory outcome.
+ */
+function redirectToApp(
+  redirectTo: string,
+  params: Record<string, string>,
+): Response {
+  const url = new URL(redirectTo);
+  url.searchParams.delete("code");
+  url.searchParams.delete("error");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return redirect(url.toString());
+}
+
+/**
+ * Fetch that enforces a timeout and treats any HTTP redirect as an error.
+ * Token and userinfo endpoints never legitimately redirect; following one
+ * could forward credentials to an unintended host. The timeout turns a
+ * stalled endpoint into a normal failure, which redirects the user back to
+ * the app instead of stranding them on a platform error.
  */
 async function fetchRefusingRedirects(
   url: string,
   init: RequestInit,
 ): Promise<Response> {
-  const response = await fetch(url, { ...init, redirect: "manual" });
-  if (response.status >= 300 && response.status < 400) {
-    throw new Error(`Request to ${url} responded with a redirect`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      throw new Error(`Request to ${url} responded with a redirect`);
+    }
+    return response;
+  } finally {
+    clearTimeout(timeout);
   }
-  return response;
 }
 
 /**
@@ -58,7 +89,7 @@ async function exchangeCode(args: {
     code: args.code,
     client_id: env.CLIENT_ID,
     client_secret: env.CLIENT_SECRET,
-    redirect_uri: `${process.env.CONVEX_SITE_URL}/callback`,
+    redirect_uri: `${process.env.CONVEX_SITE_URL}${CALLBACK_PATH}`,
   });
   if (args.codeVerifier !== undefined) {
     body.set("code_verifier", args.codeVerifier);
@@ -146,7 +177,7 @@ async function fetchUserInfo(
 }
 
 http.route({
-  path: "/callback",
+  path: CALLBACK_PATH,
   method: "GET",
   handler: httpAction(async (ctx, request) => {
     const url = new URL(request.url);
@@ -155,9 +186,12 @@ http.route({
     const error = url.searchParams.get("error");
 
     // Without state we can't identify the flow, so there's no stored
-    // redirectTo to send the user back to — a bare 400 is all we have.
+    // redirectTo to send the user back to; a bare 400 is all we have.
     if (state === null) {
-      return new Response("Missing state", { status: 400 });
+      return new Response(
+        "This sign-in link is invalid. Return to the app and try signing in again.",
+        { status: 400 },
+      );
     }
 
     // Claiming is atomic (find + delete in one mutation), so a replayed or
@@ -168,10 +202,18 @@ http.route({
       internal.provider.claimAuthorizationRequest,
       { stateHash: await sha256Hex(state) },
     );
+    // No row means the flow is gone entirely (already claimed, or forged);
+    // there is nowhere left to redirect to.
     if (authRequest === null) {
-      return new Response("Unknown or expired authorization request", {
-        status: 400,
-      });
+      return new Response(
+        "This sign-in link has expired or was already used. Return to the app and try signing in again.",
+        { status: 400 },
+      );
+    }
+    // An expired request still knows where the user came from; send them
+    // back to the app instead of stranding them here.
+    if (authRequest.expired) {
+      return redirectToApp(authRequest.redirectTo, { error: "expired" });
     }
 
     // From here on the flow is legitimate, so failures go back to the app
@@ -184,9 +226,7 @@ http.route({
       );
       const normalized =
         error === "access_denied" ? "access_denied" : "oauth_error";
-      return redirect(
-        withParams(authRequest.redirectTo, { error: normalized }),
-      );
+      return redirectToApp(authRequest.redirectTo, { error: normalized });
     }
 
     try {
@@ -201,46 +241,48 @@ http.route({
           ? undefined
           : validateIdToken(idToken, authRequest.issuer);
 
-      let userInfoResponses: Record<string, unknown> | undefined;
-      if (authRequest.userinfoEndpoints !== undefined) {
-        if (accessToken === undefined) {
-          throw new Error("Token exchange returned no access_token");
-        }
-        userInfoResponses = await fetchUserInfo(
-          authRequest.userinfoEndpoints,
-          accessToken,
-        );
+      if (
+        authRequest.userInfoEndpoints !== undefined &&
+        accessToken === undefined
+      ) {
+        throw new Error("Token exchange returned no access_token");
       }
+      const userInfoResponses =
+        authRequest.userInfoEndpoints === undefined || accessToken === undefined
+          ? undefined
+          : await fetchUserInfo(authRequest.userInfoEndpoints, accessToken);
 
       // A provider that returns no id_token and has no configured userinfo
       // endpoints gives us nothing to identify the user with.
       if (claims === undefined && userInfoResponses === undefined) {
         throw new Error(
-          "Token exchange returned no id_token and no userinfoEndpoints are configured",
+          "Token exchange returned no id_token and no userInfoEndpoints are configured",
         );
       }
 
       // Nothing user-visible exists yet; the ticket is a short-lived,
       // one-time proof that provider authentication succeeded. Only the
-      // hash of the one-time token is stored.
+      // hash of the one-time token is stored, and the identity payload is
+      // encrypted with a key derived from the raw token, so database access
+      // alone can read neither.
       const ott = generateRandomToken();
       await ctx.runMutation(internal.provider.createTicket, {
         provider: authRequest.provider,
         stateHash: authRequest.stateHash,
         ottHash: await sha256Hex(ott),
-        claims,
-        userInfoResponses,
+        payload: await encryptWithToken(
+          ott,
+          JSON.stringify({ claims, userInfoResponses }),
+        ),
       });
 
-      return redirect(withParams(authRequest.redirectTo, { code: ott }));
+      return redirectToApp(authRequest.redirectTo, { code: ott });
     } catch (exchangeError) {
       console.error(
         `OAuth exchange failed for provider "${authRequest.provider}":`,
         exchangeError,
       );
-      return redirect(
-        withParams(authRequest.redirectTo, { error: "oauth_error" }),
-      );
+      return redirectToApp(authRequest.redirectTo, { error: "oauth_error" });
     }
   }),
 });

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -6,14 +6,28 @@ import schema from "./schema.js";
 const modules = import.meta.glob("./**/*.ts");
 
 function setup() {
+  // Components see a CONVEX_SITE_URL prefixed with their http mount.
+  process.env.CONVEX_SITE_URL = "https://test.convex.site/oauth";
   const t = convexTest(schema, modules);
   return t;
 }
 
 describe("oauth", () => {
-  test("createOauthAccount, returns ID", async () => {
+  test("createAuthorizationRequest stores the request and returns the callback base URL", async () => {
     const t = setup();
-    const result = await t.mutation(api.provider.createOauthAccount, {});
-    expect(result).not.toBe(null);
+    const result = await t.mutation(api.provider.createAuthorizationRequest, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      redirectTo: "https://app.example.com/after",
+    });
+    expect(result).toBe("https://test.convex.site/oauth");
+    await t.run(async (ctx) => {
+      const requests = await ctx.db.query("authorizationRequests").collect();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].provider).toBe("google");
+      expect(requests[0].stateHash).toBe("0".repeat(64));
+      expect(requests[0].codeVerifier).toBeUndefined();
+      expect(requests[0].expiresAt).toBeGreaterThan(Date.now());
+    });
   });
 });

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -126,14 +126,15 @@ describe("oauth", () => {
       claims: { sub: "user-123" },
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
+      provider: "google",
       ottHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(claimed).toEqual({
-      provider: "google",
       claims: { sub: "user-123" },
     });
     const second = await t.mutation(api.provider.claimTicket, {
+      provider: "google",
       ottHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
@@ -149,8 +150,29 @@ describe("oauth", () => {
       claims: { sub: "user-123" },
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
+      provider: "google",
       ottHash: "a".repeat(64),
       stateHash: "f".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+    });
+  });
+
+  test("claimTicket returns null on provider mismatch and preserves the ticket", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      claims: { sub: "user-123" },
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      provider: "github",
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
     });
     expect(claimed).toBeNull();
     await t.run(async (ctx) => {
@@ -170,6 +192,7 @@ describe("oauth", () => {
     });
     vi.advanceTimersByTime(3 * 60 * 1000);
     const claimed = await t.mutation(api.provider.claimTicket, {
+      provider: "google",
       ottHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -1,6 +1,11 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api.js";
+import {
+  decryptWithToken,
+  encryptWithToken,
+  generateRandomToken,
+} from "./crypto.js";
 import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -8,9 +13,9 @@ const modules = import.meta.glob("./**/*.ts");
 function setup() {
   // Each per-IdP mount sees a CONVEX_SITE_URL prefixed with its http mount,
   // and its own client credential bindings.
-  process.env.CONVEX_SITE_URL = "https://test.convex.site/oauth/google";
-  process.env.CLIENT_ID = "test-client-id";
-  process.env.CLIENT_SECRET = "test-client-secret";
+  vi.stubEnv("CONVEX_SITE_URL", "https://test.convex.site/oauth/google");
+  vi.stubEnv("CLIENT_ID", "test-client-id");
+  vi.stubEnv("CLIENT_SECRET", "test-client-secret");
   const t = convexTest(schema, modules);
   return t;
 }
@@ -25,6 +30,7 @@ const requestArgs = {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 describe("oauth", () => {
@@ -59,6 +65,7 @@ describe("oauth", () => {
       { stateHash: requestArgs.stateHash },
     );
     expect(claimed).toEqual({
+      expired: false,
       provider: "google",
       stateHash: requestArgs.stateHash,
       redirectTo: "https://app.example.com/after",
@@ -80,7 +87,7 @@ describe("oauth", () => {
     expect(claimed).toBeNull();
   });
 
-  test("claimAuthorizationRequest deletes but does not return an expired request", async () => {
+  test("claimAuthorizationRequest deletes an expired request and returns only redirectTo", async () => {
     vi.useFakeTimers();
     const t = setup();
     await t.mutation(api.provider.createAuthorizationRequest, requestArgs);
@@ -89,7 +96,10 @@ describe("oauth", () => {
       internal.provider.claimAuthorizationRequest,
       { stateHash: requestArgs.stateHash },
     );
-    expect(claimed).toBeNull();
+    expect(claimed).toEqual({
+      expired: true,
+      redirectTo: "https://app.example.com/after",
+    });
     await t.run(async (ctx) => {
       const requests = await ctx.db.query("authorizationRequests").collect();
       expect(requests).toHaveLength(0);
@@ -102,17 +112,13 @@ describe("oauth", () => {
       provider: "google",
       stateHash: "0".repeat(64),
       ottHash: "a".repeat(64),
-      claims: { sub: "user-123", email: "user@example.com" },
+      payload: "encrypted-payload",
     });
     await t.run(async (ctx) => {
       const tickets = await ctx.db.query("tickets").collect();
       expect(tickets).toHaveLength(1);
       expect(tickets[0].ottHash).toBe("a".repeat(64));
-      expect(tickets[0].claims).toEqual({
-        sub: "user-123",
-        email: "user@example.com",
-      });
-      expect(tickets[0].userInfoResponses).toBeUndefined();
+      expect(tickets[0].payload).toBe("encrypted-payload");
       expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
     });
   });
@@ -123,16 +129,14 @@ describe("oauth", () => {
       provider: "google",
       stateHash: "0".repeat(64),
       ottHash: "a".repeat(64),
-      claims: { sub: "user-123" },
+      payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       provider: "google",
       ottHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
-    expect(claimed).toEqual({
-      claims: { sub: "user-123" },
-    });
+    expect(claimed).toEqual({ payload: "encrypted-payload" });
     const second = await t.mutation(api.provider.claimTicket, {
       provider: "google",
       ottHash: "a".repeat(64),
@@ -147,7 +151,7 @@ describe("oauth", () => {
       provider: "google",
       stateHash: "0".repeat(64),
       ottHash: "a".repeat(64),
-      claims: { sub: "user-123" },
+      payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       provider: "google",
@@ -167,7 +171,7 @@ describe("oauth", () => {
       provider: "google",
       stateHash: "0".repeat(64),
       ottHash: "a".repeat(64),
-      claims: { sub: "user-123" },
+      payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       provider: "github",
@@ -188,7 +192,7 @@ describe("oauth", () => {
       provider: "google",
       stateHash: "0".repeat(64),
       ottHash: "a".repeat(64),
-      claims: { sub: "user-123" },
+      payload: "encrypted-payload",
     });
     vi.advanceTimersByTime(3 * 60 * 1000);
     const claimed = await t.mutation(api.provider.claimTicket, {
@@ -201,5 +205,16 @@ describe("oauth", () => {
       const tickets = await ctx.db.query("tickets").collect();
       expect(tickets).toHaveLength(0);
     });
+  });
+
+  test("ticket payload encryption round-trips only with the right token", async () => {
+    const token = generateRandomToken();
+    const payload = JSON.stringify({ claims: { sub: "user-123" } });
+    const encrypted = await encryptWithToken(token, payload);
+    expect(encrypted).not.toContain("user-123");
+    expect(await decryptWithToken(token, encrypted)).toBe(payload);
+    await expect(
+      decryptWithToken(generateRandomToken(), encrypted),
+    ).rejects.toThrow();
   });
 });

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -6,8 +6,8 @@ import schema from "./schema.js";
 const modules = import.meta.glob("./**/*.ts");
 
 function setup() {
-  // Components see a CONVEX_SITE_URL prefixed with their http mount.
-  process.env.CONVEX_SITE_URL = "https://test.convex.site/oauth";
+  // Each per-IdP mount sees a CONVEX_SITE_URL prefixed with its http mount.
+  process.env.CONVEX_SITE_URL = "https://test.convex.site/oauth/google";
   const t = convexTest(schema, modules);
   return t;
 }
@@ -20,7 +20,7 @@ describe("oauth", () => {
       stateHash: "0".repeat(64),
       redirectTo: "https://app.example.com/after",
     });
-    expect(result).toBe("https://test.convex.site/oauth");
+    expect(result).toBe("https://test.convex.site/oauth/google");
     await t.run(async (ctx) => {
       const requests = await ctx.db.query("authorizationRequests").collect();
       expect(requests).toHaveLength(1);

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -11,9 +11,7 @@ import schema from "./schema.js";
 const modules = import.meta.glob("./**/*.ts");
 
 function setup() {
-  // Each per-IdP mount sees a CONVEX_SITE_URL prefixed with its http mount,
-  // and its own client credential bindings.
-  vi.stubEnv("CONVEX_SITE_URL", "https://test.convex.site/oauth/google");
+  // Each per-IdP mount binds its own client credentials.
   vi.stubEnv("CLIENT_ID", "test-client-id");
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
   const t = convexTest(schema, modules);
@@ -25,6 +23,7 @@ const requestArgs = {
   provider: "google",
   stateHash: "0".repeat(64),
   redirectTo: "https://app.example.com/after",
+  callbackUrl: "https://test.convex.site/oauth/google/callback",
   tokenEndpoint: "https://oauth2.googleapis.com/token",
 };
 
@@ -41,7 +40,6 @@ describe("oauth", () => {
       requestArgs,
     );
     expect(result).toEqual({
-      callbackBaseUrl: "https://test.convex.site/oauth/google",
       clientId: "test-client-id",
     });
     await t.run(async (ctx) => {
@@ -69,6 +67,7 @@ describe("oauth", () => {
       provider: "google",
       stateHash: requestArgs.stateHash,
       redirectTo: "https://app.example.com/after",
+      callbackUrl: "https://test.convex.site/oauth/google/callback",
       tokenEndpoint: "https://oauth2.googleapis.com/token",
     });
     const second = await t.mutation(

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -1,0 +1,19 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api.js";
+import schema from "./schema.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+function setup() {
+  const t = convexTest(schema, modules);
+  return t;
+}
+
+describe("oauth", () => {
+  test("createOauthAccount, returns ID", async () => {
+    const t = setup();
+    const result = await t.mutation(api.provider.createOauthAccount, {});
+    expect(result).not.toBe(null);
+  });
+});

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -116,4 +116,67 @@ describe("oauth", () => {
       expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
     });
   });
+
+  test("claimTicket returns the ticket exactly once", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      claims: { sub: "user-123" },
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(claimed).toEqual({
+      provider: "google",
+      claims: { sub: "user-123" },
+    });
+    const second = await t.mutation(api.provider.claimTicket, {
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(second).toBeNull();
+  });
+
+  test("claimTicket returns null on state mismatch and preserves the ticket", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      claims: { sub: "user-123" },
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      ottHash: "a".repeat(64),
+      stateHash: "f".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+    });
+  });
+
+  test("claimTicket deletes but does not return an expired ticket", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      claims: { sub: "user-123" },
+    });
+    vi.advanceTimersByTime(3 * 60 * 1000);
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(0);
+    });
+  });
 });

--- a/packages/core/src/components/oauth/oauth.test.ts
+++ b/packages/core/src/components/oauth/oauth.test.ts
@@ -1,33 +1,119 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
-import { api } from "./_generated/api.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "./_generated/api.js";
 import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
 
 function setup() {
-  // Each per-IdP mount sees a CONVEX_SITE_URL prefixed with its http mount.
+  // Each per-IdP mount sees a CONVEX_SITE_URL prefixed with its http mount,
+  // and its own client credential bindings.
   process.env.CONVEX_SITE_URL = "https://test.convex.site/oauth/google";
+  process.env.CLIENT_ID = "test-client-id";
+  process.env.CLIENT_SECRET = "test-client-secret";
   const t = convexTest(schema, modules);
   return t;
 }
 
+/** Args for a valid authorization request, overridable per test. */
+const requestArgs = {
+  provider: "google",
+  stateHash: "0".repeat(64),
+  redirectTo: "https://app.example.com/after",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("oauth", () => {
-  test("createAuthorizationRequest stores the request and returns the callback base URL", async () => {
+  test("createAuthorizationRequest stores the request and returns per-mount values", async () => {
     const t = setup();
-    const result = await t.mutation(api.provider.createAuthorizationRequest, {
-      provider: "google",
-      stateHash: "0".repeat(64),
-      redirectTo: "https://app.example.com/after",
+    const result = await t.mutation(
+      api.provider.createAuthorizationRequest,
+      requestArgs,
+    );
+    expect(result).toEqual({
+      callbackBaseUrl: "https://test.convex.site/oauth/google",
+      clientId: "test-client-id",
     });
-    expect(result).toBe("https://test.convex.site/oauth/google");
     await t.run(async (ctx) => {
       const requests = await ctx.db.query("authorizationRequests").collect();
       expect(requests).toHaveLength(1);
       expect(requests[0].provider).toBe("google");
       expect(requests[0].stateHash).toBe("0".repeat(64));
+      expect(requests[0].tokenEndpoint).toBe(
+        "https://oauth2.googleapis.com/token",
+      );
       expect(requests[0].codeVerifier).toBeUndefined();
       expect(requests[0].expiresAt).toBeGreaterThan(Date.now());
+    });
+  });
+
+  test("claimAuthorizationRequest returns the request exactly once", async () => {
+    const t = setup();
+    await t.mutation(api.provider.createAuthorizationRequest, requestArgs);
+    const claimed = await t.mutation(
+      internal.provider.claimAuthorizationRequest,
+      { stateHash: requestArgs.stateHash },
+    );
+    expect(claimed).toEqual({
+      provider: "google",
+      stateHash: requestArgs.stateHash,
+      redirectTo: "https://app.example.com/after",
+      tokenEndpoint: "https://oauth2.googleapis.com/token",
+    });
+    const second = await t.mutation(
+      internal.provider.claimAuthorizationRequest,
+      { stateHash: requestArgs.stateHash },
+    );
+    expect(second).toBeNull();
+  });
+
+  test("claimAuthorizationRequest returns null for an unknown state hash", async () => {
+    const t = setup();
+    const claimed = await t.mutation(
+      internal.provider.claimAuthorizationRequest,
+      { stateHash: "f".repeat(64) },
+    );
+    expect(claimed).toBeNull();
+  });
+
+  test("claimAuthorizationRequest deletes but does not return an expired request", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    await t.mutation(api.provider.createAuthorizationRequest, requestArgs);
+    vi.advanceTimersByTime(11 * 60 * 1000);
+    const claimed = await t.mutation(
+      internal.provider.claimAuthorizationRequest,
+      { stateHash: requestArgs.stateHash },
+    );
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const requests = await ctx.db.query("authorizationRequests").collect();
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  test("createTicket stores hashed one-time token with expiry", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      provider: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      claims: { sub: "user-123", email: "user@example.com" },
+    });
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+      expect(tickets[0].ottHash).toBe("a".repeat(64));
+      expect(tickets[0].claims).toEqual({
+        sub: "user-123",
+        email: "user@example.com",
+      });
+      expect(tickets[0].userInfoResponses).toBeUndefined();
+      expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
     });
   });
 });

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -11,7 +11,7 @@ const TICKET_TTL_MS = 2 * 60 * 1000;
 
 /**
  * Record an in-flight authorization request. Called by the app-side
- * `signInOauth` before it redirects the user to the provider; the provider
+ * `signIn` before it redirects the user to the provider; the provider
  * callback later claims the request by state hash.
  *
  * Exchange config the callback needs (`tokenEndpoint`, `userinfoEndpoints`)

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -14,35 +14,30 @@ const TICKET_TTL_MS = 2 * 60 * 1000;
  * `signIn` before it redirects the user to the provider; the provider
  * callback later claims the request by state hash.
  *
- * Exchange config the callback needs (`tokenEndpoint`, `userinfoEndpoints`)
- * is snapshotted onto the row here because the component can't see app-side
- * config.
+ * Exchange config the callback needs (`callbackUrl`, `tokenEndpoint`,
+ * `userInfoEndpoints`) is snapshotted onto the row here because the
+ * component can't see app-side config or system env vars — a typed-env
+ * component's `process.env` only contains its bound vars, so the caller
+ * builds `callbackUrl` from `CONVEX_SITE_URL` app-side.
  *
- * Returns the two per-mount values the caller needs to build the
- * authorization URL: the component's mounted base URL
- * (`process.env.CONVEX_SITE_URL` is overridden inside components to include
- * the `httpPrefix` the app mounted the component under) and the mount's
- * `CLIENT_ID` env binding.
+ * Returns the mount's `CLIENT_ID` env binding, which the caller needs for
+ * the authorization URL.
  */
 export const createAuthorizationRequest = mutation({
   args: {
     provider: v.string(),
     stateHash: v.string(),
     redirectTo: v.string(),
+    callbackUrl: v.string(),
     codeVerifier: v.optional(v.string()),
     tokenEndpoint: v.string(),
     userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
     issuer: v.optional(v.string()),
   },
   returns: v.object({
-    callbackBaseUrl: v.string(),
     clientId: v.string(),
   }),
   handler: async (ctx, args) => {
-    const siteUrl = process.env.CONVEX_SITE_URL;
-    if (siteUrl === undefined) {
-      throw new Error("CONVEX_SITE_URL is not set");
-    }
     // The env declaration guarantees the bindings exist at deploy time but
     // can't express non-emptiness; catch that here, at the first sign-in,
     // rather than on the provider's error page.
@@ -55,7 +50,7 @@ export const createAuthorizationRequest = mutation({
       ...args,
       expiresAt: Date.now() + AUTHORIZATION_REQUEST_TTL_MS,
     });
-    return { callbackBaseUrl: siteUrl, clientId: env.CLIENT_ID };
+    return { clientId: env.CLIENT_ID };
   },
 });
 
@@ -81,6 +76,7 @@ export const claimAuthorizationRequest = internalMutation({
       provider: v.string(),
       stateHash: v.string(),
       redirectTo: v.string(),
+      callbackUrl: v.string(),
       codeVerifier: v.optional(v.string()),
       tokenEndpoint: v.string(),
       userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
@@ -104,6 +100,7 @@ export const claimAuthorizationRequest = internalMutation({
       provider: request.provider,
       stateHash: request.stateHash,
       redirectTo: request.redirectTo,
+      callbackUrl: request.callbackUrl,
       codeVerifier: request.codeVerifier,
       tokenEndpoint: request.tokenEndpoint,
       userInfoEndpoints: request.userInfoEndpoints,

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -1,0 +1,15 @@
+import { mutation } from "./_generated/server";
+
+/**
+ * Creates an anonymous account in the `accounts` table.
+ *
+ * Returns the `anonymousId` stored in the table.
+ */
+export const createOauthAccount = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const anonymousId = crypto.randomUUID();
+    await ctx.db.insert("accounts", { providerAccountId: anonymousId });
+    return anonymousId;
+  },
+});

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -31,7 +31,7 @@ export const createAuthorizationRequest = mutation({
     redirectTo: v.string(),
     codeVerifier: v.optional(v.string()),
     tokenEndpoint: v.string(),
-    userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+    userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
     issuer: v.optional(v.string()),
   },
   returns: v.object({
@@ -42,6 +42,14 @@ export const createAuthorizationRequest = mutation({
     const siteUrl = process.env.CONVEX_SITE_URL;
     if (siteUrl === undefined) {
       throw new Error("CONVEX_SITE_URL is not set");
+    }
+    // The env declaration guarantees the bindings exist at deploy time but
+    // can't express non-emptiness; catch that here, at the first sign-in,
+    // rather than on the provider's error page.
+    if (env.CLIENT_ID === "" || env.CLIENT_SECRET === "") {
+      throw new Error(
+        "The CLIENT_ID and CLIENT_SECRET env bindings must not be empty",
+      );
     }
     await ctx.db.insert("authorizationRequests", {
       ...args,
@@ -54,7 +62,9 @@ export const createAuthorizationRequest = mutation({
 /**
  * Claim an authorization request by state hash: find, delete, and return it
  * in one transaction, so a replayed or raced callback finds nothing. An
- * expired row is also deleted but not returned.
+ * expired row is also deleted, but only its `redirectTo` is returned so the
+ * callback can send the user back to the app instead of stranding them on
+ * an error page.
  */
 export const claimAuthorizationRequest = internalMutation({
   args: {
@@ -63,12 +73,17 @@ export const claimAuthorizationRequest = internalMutation({
   returns: v.union(
     v.null(),
     v.object({
+      expired: v.literal(true),
+      redirectTo: v.string(),
+    }),
+    v.object({
+      expired: v.literal(false),
       provider: v.string(),
       stateHash: v.string(),
       redirectTo: v.string(),
       codeVerifier: v.optional(v.string()),
       tokenEndpoint: v.string(),
-      userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+      userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
       issuer: v.optional(v.string()),
     }),
   ),
@@ -82,15 +97,16 @@ export const claimAuthorizationRequest = internalMutation({
     }
     await ctx.db.delete("authorizationRequests", request._id);
     if (request.expiresAt < Date.now()) {
-      return null;
+      return { expired: true as const, redirectTo: request.redirectTo };
     }
     return {
+      expired: false as const,
       provider: request.provider,
       stateHash: request.stateHash,
       redirectTo: request.redirectTo,
       codeVerifier: request.codeVerifier,
       tokenEndpoint: request.tokenEndpoint,
-      userinfoEndpoints: request.userinfoEndpoints,
+      userInfoEndpoints: request.userInfoEndpoints,
       issuer: request.issuer,
     };
   },
@@ -99,15 +115,15 @@ export const claimAuthorizationRequest = internalMutation({
 /**
  * Mint a one-time redeemable ticket after a successful code exchange. The
  * caller (the callback) holds the raw one-time token; only its hash is
- * stored.
+ * stored, and the identity payload arrives already encrypted with a key
+ * derived from that token.
  */
 export const createTicket = internalMutation({
   args: {
     provider: v.string(),
     stateHash: v.string(),
     ottHash: v.string(),
-    claims: v.optional(v.any()),
-    userInfoResponses: v.optional(v.record(v.string(), v.any())),
+    payload: v.string(),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -141,8 +157,7 @@ export const claimTicket = mutation({
   returns: v.union(
     v.null(),
     v.object({
-      claims: v.optional(v.any()),
-      userInfoResponses: v.optional(v.record(v.string(), v.any())),
+      payload: v.string(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -164,9 +179,6 @@ export const claimTicket = mutation({
       return null;
     }
     await ctx.db.delete("tickets", ticket._id);
-    return {
-      claims: ticket.claims,
-      userInfoResponses: ticket.userInfoResponses,
-    };
+    return { payload: ticket.payload };
   },
 });

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -32,6 +32,7 @@ export const createAuthorizationRequest = mutation({
     codeVerifier: v.optional(v.string()),
     tokenEndpoint: v.string(),
     userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+    issuer: v.optional(v.string()),
   },
   returns: v.object({
     callbackBaseUrl: v.string(),
@@ -68,6 +69,7 @@ export const claimAuthorizationRequest = internalMutation({
       codeVerifier: v.optional(v.string()),
       tokenEndpoint: v.string(),
       userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+      issuer: v.optional(v.string()),
     }),
   ),
   handler: async (ctx, args) => {
@@ -78,7 +80,7 @@ export const claimAuthorizationRequest = internalMutation({
     if (request === null) {
       return null;
     }
-    await ctx.db.delete(request._id);
+    await ctx.db.delete("authorizationRequests", request._id);
     if (request.expiresAt < Date.now()) {
       return null;
     }
@@ -89,6 +91,7 @@ export const claimAuthorizationRequest = internalMutation({
       codeVerifier: request.codeVerifier,
       tokenEndpoint: request.tokenEndpoint,
       userinfoEndpoints: request.userinfoEndpoints,
+      issuer: request.issuer,
     };
   },
 });
@@ -121,21 +124,23 @@ export const createTicket = internalMutation({
  * in one transaction, so a replayed or raced redemption finds nothing.
  *
  * The caller must also present the hash of the state minted at sign-in,
- * binding redemption to the client that initiated the flow. A state mismatch
- * returns null *without* deleting: someone holding a stolen one-time token
- * but not the state must not be able to burn the real client's ticket. An
- * expired row is deleted but not returned. All failures are indistinguishable
- * to the caller.
+ * binding redemption to the client that initiated the flow, and the provider
+ * name it expects, so a misconfigured or renamed provider instance can't
+ * redeem a ticket into the wrong account namespace. A state or provider
+ * mismatch returns null *without* deleting: someone holding a stolen
+ * one-time token but not the state must not be able to burn the real
+ * client's ticket. An expired row is deleted but not returned. All failures
+ * are indistinguishable to the caller.
  */
 export const claimTicket = mutation({
   args: {
+    provider: v.string(),
     ottHash: v.string(),
     stateHash: v.string(),
   },
   returns: v.union(
     v.null(),
     v.object({
-      provider: v.string(),
       claims: v.optional(v.any()),
       userInfoResponses: v.optional(v.record(v.string(), v.any())),
     }),
@@ -149,15 +154,17 @@ export const claimTicket = mutation({
       return null;
     }
     if (ticket.expiresAt < Date.now()) {
-      await ctx.db.delete(ticket._id);
+      await ctx.db.delete("tickets", ticket._id);
       return null;
     }
-    if (ticket.stateHash !== args.stateHash) {
+    if (
+      ticket.stateHash !== args.stateHash ||
+      ticket.provider !== args.provider
+    ) {
       return null;
     }
-    await ctx.db.delete(ticket._id);
+    await ctx.db.delete("tickets", ticket._id);
     return {
-      provider: ticket.provider,
       claims: ticket.claims,
       userInfoResponses: ticket.userInfoResponses,
     };

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -1,15 +1,36 @@
+import { v } from "convex/values";
 import { mutation } from "./_generated/server";
 
+/** How long an authorization request stays claimable by the callback. */
+const AUTHORIZATION_REQUEST_TTL_MS = 10 * 60 * 1000;
+
 /**
- * Creates an anonymous account in the `accounts` table.
+ * Record an in-flight authorization request. Called by the app-side `signIn`
+ * before it redirects the user to the provider; the provider callback later
+ * claims the request by state hash.
  *
- * Returns the `anonymousId` stored in the table.
+ * Returns the component's mounted base URL (`process.env.CONVEX_SITE_URL` is
+ * overridden inside components to include the `httpPrefix` the app mounted
+ * the component under), which the caller needs to construct the OAuth
+ * `redirect_uri`.
  */
-export const createOauthAccount = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const anonymousId = crypto.randomUUID();
-    await ctx.db.insert("accounts", { providerAccountId: anonymousId });
-    return anonymousId;
+export const createAuthorizationRequest = mutation({
+  args: {
+    provider: v.string(),
+    stateHash: v.string(),
+    redirectTo: v.string(),
+    codeVerifier: v.optional(v.string()),
+  },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    const siteUrl = process.env.CONVEX_SITE_URL;
+    if (siteUrl === undefined) {
+      throw new Error("CONVEX_SITE_URL is not set");
+    }
+    await ctx.db.insert("authorizationRequests", {
+      ...args,
+      expiresAt: Date.now() + AUTHORIZATION_REQUEST_TTL_MS,
+    });
+    return siteUrl;
   },
 });

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -1,18 +1,28 @@
 import { v } from "convex/values";
-import { mutation } from "./_generated/server";
+import { env, internalMutation, mutation } from "./_generated/server";
 
 /** How long an authorization request stays claimable by the callback. */
 const AUTHORIZATION_REQUEST_TTL_MS = 10 * 60 * 1000;
 
+/** How long a minted ticket stays redeemable. Redemption is normally the
+ * page load right after the callback redirect, so this only needs slack
+ * for slow devices and networks. */
+const TICKET_TTL_MS = 2 * 60 * 1000;
+
 /**
- * Record an in-flight authorization request. Called by the app-side `signIn`
- * before it redirects the user to the provider; the provider callback later
- * claims the request by state hash.
+ * Record an in-flight authorization request. Called by the app-side
+ * `signInOauth` before it redirects the user to the provider; the provider
+ * callback later claims the request by state hash.
  *
- * Returns the component's mounted base URL (`process.env.CONVEX_SITE_URL` is
- * overridden inside components to include the `httpPrefix` the app mounted
- * the component under), which the caller needs to construct the OAuth
- * `redirect_uri`.
+ * Exchange config the callback needs (`tokenEndpoint`, `userinfoEndpoints`)
+ * is snapshotted onto the row here because the component can't see app-side
+ * config.
+ *
+ * Returns the two per-mount values the caller needs to build the
+ * authorization URL: the component's mounted base URL
+ * (`process.env.CONVEX_SITE_URL` is overridden inside components to include
+ * the `httpPrefix` the app mounted the component under) and the mount's
+ * `CLIENT_ID` env binding.
  */
 export const createAuthorizationRequest = mutation({
   args: {
@@ -20,8 +30,13 @@ export const createAuthorizationRequest = mutation({
     stateHash: v.string(),
     redirectTo: v.string(),
     codeVerifier: v.optional(v.string()),
+    tokenEndpoint: v.string(),
+    userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
   },
-  returns: v.string(),
+  returns: v.object({
+    callbackBaseUrl: v.string(),
+    clientId: v.string(),
+  }),
   handler: async (ctx, args) => {
     const siteUrl = process.env.CONVEX_SITE_URL;
     if (siteUrl === undefined) {
@@ -31,6 +46,72 @@ export const createAuthorizationRequest = mutation({
       ...args,
       expiresAt: Date.now() + AUTHORIZATION_REQUEST_TTL_MS,
     });
-    return siteUrl;
+    return { callbackBaseUrl: siteUrl, clientId: env.CLIENT_ID };
+  },
+});
+
+/**
+ * Claim an authorization request by state hash: find, delete, and return it
+ * in one transaction, so a replayed or raced callback finds nothing. An
+ * expired row is also deleted but not returned.
+ */
+export const claimAuthorizationRequest = internalMutation({
+  args: {
+    stateHash: v.string(),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      provider: v.string(),
+      stateHash: v.string(),
+      redirectTo: v.string(),
+      codeVerifier: v.optional(v.string()),
+      tokenEndpoint: v.string(),
+      userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const request = await ctx.db
+      .query("authorizationRequests")
+      .withIndex("stateHash", (q) => q.eq("stateHash", args.stateHash))
+      .unique();
+    if (request === null) {
+      return null;
+    }
+    await ctx.db.delete(request._id);
+    if (request.expiresAt < Date.now()) {
+      return null;
+    }
+    return {
+      provider: request.provider,
+      stateHash: request.stateHash,
+      redirectTo: request.redirectTo,
+      codeVerifier: request.codeVerifier,
+      tokenEndpoint: request.tokenEndpoint,
+      userinfoEndpoints: request.userinfoEndpoints,
+    };
+  },
+});
+
+/**
+ * Mint a one-time redeemable ticket after a successful code exchange. The
+ * caller (the callback) holds the raw one-time token; only its hash is
+ * stored.
+ */
+export const createTicket = internalMutation({
+  args: {
+    provider: v.string(),
+    stateHash: v.string(),
+    ottHash: v.string(),
+    claims: v.optional(v.any()),
+    userInfoResponses: v.optional(v.record(v.string(), v.any())),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.insert("tickets", {
+      ...args,
+      expiresAt: Date.now() + TICKET_TTL_MS,
+    });
+    return null;
   },
 });

--- a/packages/core/src/components/oauth/provider.ts
+++ b/packages/core/src/components/oauth/provider.ts
@@ -115,3 +115,51 @@ export const createTicket = internalMutation({
     return null;
   },
 });
+
+/**
+ * Claim a ticket by one-time token hash: find, check, delete, and return it
+ * in one transaction, so a replayed or raced redemption finds nothing.
+ *
+ * The caller must also present the hash of the state minted at sign-in,
+ * binding redemption to the client that initiated the flow. A state mismatch
+ * returns null *without* deleting: someone holding a stolen one-time token
+ * but not the state must not be able to burn the real client's ticket. An
+ * expired row is deleted but not returned. All failures are indistinguishable
+ * to the caller.
+ */
+export const claimTicket = mutation({
+  args: {
+    ottHash: v.string(),
+    stateHash: v.string(),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      provider: v.string(),
+      claims: v.optional(v.any()),
+      userInfoResponses: v.optional(v.record(v.string(), v.any())),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const ticket = await ctx.db
+      .query("tickets")
+      .withIndex("ottHash", (q) => q.eq("ottHash", args.ottHash))
+      .unique();
+    if (ticket === null) {
+      return null;
+    }
+    if (ticket.expiresAt < Date.now()) {
+      await ctx.db.delete(ticket._id);
+      return null;
+    }
+    if (ticket.stateHash !== args.stateHash) {
+      return null;
+    }
+    await ctx.db.delete(ticket._id);
+    return {
+      provider: ticket.provider,
+      claims: ticket.claims,
+      userInfoResponses: ticket.userInfoResponses,
+    };
+  },
+});

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -32,6 +32,12 @@ export default defineSchema({
      * under. Copied from app-side config like `tokenEndpoint`.
      */
     userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+    /**
+     * Expected `iss` of the provider's id_tokens, copied from app-side
+     * config. When present the callback rejects id_tokens from any other
+     * issuer.
+     */
+    issuer: v.optional(v.string()),
     /** The callback rejects requests older than this. */
     expiresAt: v.number(),
   }).index("stateHash", ["stateHash"]),

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -34,8 +34,8 @@ export default defineSchema({
     userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
     /**
      * Expected `iss` of the provider's id_tokens, copied from app-side
-     * config. When present the callback rejects id_tokens from any other
-     * issuer.
+     * config. Absent only for plain-OAuth providers; the callback rejects
+     * any returned id_token unless this is present and matches.
      */
     issuer: v.optional(v.string()),
     /** The callback rejects requests older than this. */

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -11,7 +11,7 @@ export default defineSchema({
   authorizationRequests: defineTable({
     /** Provider the request was issued for, e.g. "google". */
     provider: v.string(),
-    /** Hash of the client-generated state. The raw value is never stored. */
+    /** Hash of the server-minted state. The raw value is never stored. */
     stateHash: v.string(),
     /** Post-login destination, validated against allowed redirects at sign-in. */
     redirectTo: v.string(),
@@ -20,6 +20,18 @@ export default defineSchema({
      * Stored raw because it must be sent to the provider at code exchange.
      */
     codeVerifier: v.optional(v.string()),
+    /**
+     * The provider's token endpoint, copied from app-side config at
+     * sign-in: the callback runs inside the component, which can't see app
+     * config, so non-secret exchange config is stored on the row.
+     */
+    tokenEndpoint: v.string(),
+    /**
+     * Profile endpoints to fetch with the access token after the exchange,
+     * keyed by the name the app's `profile` mapping receives each response
+     * under. Copied from app-side config like `tokenEndpoint`.
+     */
+    userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
     /** The callback rejects requests older than this. */
     expiresAt: v.number(),
   }).index("stateHash", ["stateHash"]),
@@ -41,15 +53,22 @@ export default defineSchema({
      */
     stateHash: v.string(),
     /**
-     * sha256 of the server-minted one-time token. The raw value travels only
-     * in the callback redirect.
+     * sha256 of the server-minted one-time token. The raw value appears only
+     * in the callback redirect URL and is never stored.
      */
     ottHash: v.string(),
     /** Tickets expire quickly (~2 minutes). */
     expiresAt: v.number(),
-    /** Provider account id, e.g. the id_token `sub` claim. */
-    providerAccountId: v.string(),
-    /** Provider claims passed through to `completeSignIn` at redemption. */
-    profile: v.any(),
+    /**
+     * id_token claims, present when the provider returned one (OIDC). At
+     * least one of `claims` and `userInfoResponses` is always present; the
+     * app's `profile` mapping receives both at redemption.
+     */
+    claims: v.optional(v.any()),
+    /**
+     * Userinfo responses keyed by the configured endpoint names, present
+     * when the provider config sets `userinfoEndpoints`.
+     */
+    userInfoResponses: v.optional(v.record(v.string(), v.any())),
   }).index("ottHash", ["ottHash"]),
 });

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -31,7 +31,7 @@ export default defineSchema({
      * keyed by the name the app's `profile` mapping receives each response
      * under. Copied from app-side config like `tokenEndpoint`.
      */
-    userinfoEndpoints: v.optional(v.record(v.string(), v.string())),
+    userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
     /**
      * Expected `iss` of the provider's id_tokens, copied from app-side
      * config. When present the callback rejects id_tokens from any other
@@ -66,15 +66,14 @@ export default defineSchema({
     /** Tickets expire quickly (~2 minutes). */
     expiresAt: v.number(),
     /**
-     * id_token claims, present when the provider returned one (OIDC). At
-     * least one of `claims` and `userInfoResponses` is always present; the
-     * app's `profile` mapping receives both at redemption.
+     * The identity the provider attested: JSON of
+     * `{ claims, userInfoResponses }` (id_token claims when the provider
+     * returned one, userinfo responses keyed by the configured endpoint
+     * names; at least one is present), AES-GCM encrypted with a key derived
+     * from the raw one-time token. The raw token is never stored, so
+     * database access alone cannot read the payload, and provider-chosen
+     * JSON keys never become Convex field names.
      */
-    claims: v.optional(v.any()),
-    /**
-     * Userinfo responses keyed by the configured endpoint names, present
-     * when the provider config sets `userinfoEndpoints`.
-     */
-    userInfoResponses: v.optional(v.record(v.string(), v.any())),
+    payload: v.string(),
   }).index("ottHash", ["ottHash"]),
 });

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -1,0 +1,8 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  accounts: defineTable({
+    providerAccountId: v.string(),
+  }),
+});

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -2,10 +2,6 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
-  accounts: defineTable({
-    providerAccountId: v.string(),
-  }),
-
   /**
    * In-flight authorization requests, created at sign-in and consumed by the
    * provider callback. The callback claims a request by atomically deleting

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -16,6 +16,13 @@ export default defineSchema({
     /** Post-login destination, validated against allowed redirects at sign-in. */
     redirectTo: v.string(),
     /**
+     * The OAuth `redirect_uri`, built app-side at sign-in from
+     * `CONVEX_SITE_URL` plus the mount's `httpPrefix` (the component can't
+     * see system env vars). Stored so the code exchange presents the
+     * byte-identical value, as OAuth requires.
+     */
+    callbackUrl: v.string(),
+    /**
      * PKCE code verifier, present only when the provider config enables PKCE.
      * Stored raw because it must be sent to the provider at code exchange.
      */

--- a/packages/core/src/components/oauth/schema.ts
+++ b/packages/core/src/components/oauth/schema.ts
@@ -5,4 +5,55 @@ export default defineSchema({
   accounts: defineTable({
     providerAccountId: v.string(),
   }),
+
+  /**
+   * In-flight authorization requests, created at sign-in and consumed by the
+   * provider callback. The callback claims a request by atomically deleting
+   * it (enforcing single use) and carries its fields through the code
+   * exchange in memory.
+   */
+  authorizationRequests: defineTable({
+    /** Provider the request was issued for, e.g. "google". */
+    provider: v.string(),
+    /** Hash of the client-generated state. The raw value is never stored. */
+    stateHash: v.string(),
+    /** Post-login destination, validated against allowed redirects at sign-in. */
+    redirectTo: v.string(),
+    /**
+     * PKCE code verifier, present only when the provider config enables PKCE.
+     * Stored raw because it must be sent to the provider at code exchange.
+     */
+    codeVerifier: v.optional(v.string()),
+    /** The callback rejects requests older than this. */
+    expiresAt: v.number(),
+  }).index("stateHash", ["stateHash"]),
+
+  /**
+   * One-time redeemable proof that provider authentication succeeded. Minted
+   * by the callback after the code exchange, redeemed exactly once by a
+   * caller presenting the raw one-time token plus the original client state.
+   * Nothing user-visible (accounts, users, sessions) is created until
+   * redemption.
+   */
+  tickets: defineTable({
+    /** Provider that authenticated the user, e.g. "google". */
+    provider: v.string(),
+    /**
+     * Carried over from the authorization request. Redemption re-checks the
+     * caller-presented state against it, binding completion to the browser
+     * or server that initiated the flow.
+     */
+    stateHash: v.string(),
+    /**
+     * sha256 of the server-minted one-time token. The raw value travels only
+     * in the callback redirect.
+     */
+    ottHash: v.string(),
+    /** Tickets expire quickly (~2 minutes). */
+    expiresAt: v.number(),
+    /** Provider account id, e.g. the id_token `sub` claim. */
+    providerAccountId: v.string(),
+    /** Provider claims passed through to `completeSignIn` at redemption. */
+    profile: v.any(),
+  }).index("ottHash", ["ottHash"]),
 });

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -37,6 +37,16 @@ export type OauthOptions = {
    * `CLIENT_ID`/`CLIENT_SECRET` and serve its own callback route.
    */
   component: ComponentApi;
+  /**
+   * The `httpPrefix` this IdP's component is mounted under in
+   * convex.config.ts, e.g. `"/oauth/google"`. Must match that mount: the
+   * OAuth `redirect_uri` is built app-side as
+   * `${CONVEX_SITE_URL}${httpPrefix}/callback` because the component itself
+   * can't see the system env var (a typed-env component's `process.env`
+   * only contains its bound vars). A mismatch surfaces on the first sign-in
+   * attempt as the provider rejecting an unregistered redirect URI.
+   */
+  httpPrefix: string;
   /** The provider's authorization endpoint, e.g. Google's `https://accounts.google.com/o/oauth2/v2/auth`. */
   authorizationEndpoint: string;
   /** The provider's token endpoint, e.g. Google's `https://oauth2.googleapis.com/token`. */
@@ -191,6 +201,11 @@ export function Oauth<const N extends string>(name: N) {
         }
         return url.origin;
       });
+      if (!/^\/\S+[^/\s]$/.test(options.httpPrefix)) {
+        throw new Error(
+          `httpPrefix for provider "${name}" must start with "/" and not end with "/", e.g. "/oauth/google"`,
+        );
+      }
       requireHttpsUrl(options.authorizationEndpoint, "authorizationEndpoint");
       requireHttpsUrl(options.tokenEndpoint, "tokenEndpoint");
       if (options.userInfoEndpoints !== undefined) {
@@ -264,17 +279,28 @@ export function Oauth<const N extends string>(name: N) {
               ? generateRandomToken()
               : undefined;
 
+            // The redirect_uri is built here, app-side, because the
+            // component can't see the system env var. It's stored on the
+            // request row so the code exchange presents the byte-identical
+            // value, as OAuth requires.
+            const siteUrl = process.env.CONVEX_SITE_URL;
+            if (siteUrl === undefined) {
+              throw new Error("CONVEX_SITE_URL is not set");
+            }
+            const callbackUrl = `${siteUrl}${options.httpPrefix}${CALLBACK_PATH}`;
+
             // Only the hash crosses the component boundary, so the raw state is
             // neither stored nor visible in function logs. Exchange config the
             // callback needs is stored on the request row; the mount's
             // CLIENT_ID comes back for the authorization URL.
             const stateHash = await sha256Hex(state);
-            const { callbackBaseUrl, clientId } = await ctx.runMutation(
+            const { clientId } = await ctx.runMutation(
               options.component.provider.createAuthorizationRequest,
               {
                 provider: name,
                 stateHash,
                 redirectTo: args.redirectTo,
+                callbackUrl,
                 tokenEndpoint: options.tokenEndpoint,
                 codeVerifier,
                 userInfoEndpoints: options.userInfoEndpoints,
@@ -290,7 +316,7 @@ export function Oauth<const N extends string>(name: N) {
               ...options.extraAuthorizationParams,
               response_type: "code",
               client_id: clientId,
-              redirect_uri: `${callbackBaseUrl}${CALLBACK_PATH}`,
+              redirect_uri: callbackUrl,
               state,
             };
 

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -1,24 +1,181 @@
 import { mutationGeneric } from "convex/server";
+import { v } from "convex/values";
 import { defineProvider } from "../../lib/types";
-import { ComponentApi } from "./_generated/component";
+import type { ComponentApi } from "./_generated/component.js";
+import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
 
+/**
+ * Configuration for a single upstream OAuth provider (IdP).
+ */
+export type OauthProviderConfig = {
+  /** The OAuth client id issued by the provider. */
+  clientId: string;
+  /** The provider's authorization endpoint, e.g. Google's `https://accounts.google.com/o/oauth2/v2/auth`. */
+  authorizationEndpoint: string;
+  /** Scopes to request, e.g. `["openid", "email", "profile"]`. Omitted from the URL when absent. */
+  scopes?: string[];
+  /**
+   * Send a PKCE `S256` challenge with the authorization request. Enable only
+   * for providers that honor PKCE alongside the client secret (Google does);
+   * some providers silently ignore it (GitHub OAuth apps), which this flag
+   * should then reflect.
+   */
+  pkce?: boolean;
+  /**
+   * Extra query params for the authorization URL, e.g. Google's
+   * `{ access_type: "offline" }`. Protocol params (`state`, `redirect_uri`,
+   * ...) always win over entries here.
+   */
+  extraAuthorizationParams?: Record<string, string>;
+};
+
+/**
+ * Options for {@link Oauth}.
+ */
+export type OauthOptions = {
+  /** The mounted oauth component (`components.authOauth`). */
+  component: ComponentApi;
+  /** Upstream providers keyed by name; the key is used in routes, claims, and account identity. */
+  providers: Record<string, OauthProviderConfig>;
+  /**
+   * Origins `redirectTo` may point at, e.g. `["https://app.example.com"]`.
+   * Exact origin match; open-redirect prevention.
+   */
+  allowedRedirectOrigins: string[];
+};
+
+/**
+ * Client-generated state is opaque, but a guessable value would let an
+ * attacker inject their authorization code into a victim's flow, so a
+ * minimum length is enforced (32 base64url chars ≈ 192 bits). The cap just
+ * bounds work done on hostile input.
+ */
+const MIN_STATE_LENGTH = 32;
+const MAX_STATE_LENGTH = 256;
+
+/** `new URL` without the exception: returns null on unparseable input. */
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * OAuth sign-in against configured upstream providers. The flow:
+ *
+ * 1. `signIn` (here): validate, record an authorization request in the
+ *    component, return the provider authorization URL for the client to
+ *    navigate to.
+ * 2. The provider redirects back to the component's HTTP callback, which
+ *    claims the request, exchanges the code, and mints a one-time ticket.
+ * 3. The caller redeems the ticket (plus its original state) to complete
+ *    sign-in.
+ *
+ * The component must be mounted with an `httpPrefix` in `convex.config.ts`
+ * (e.g. `app.use(oauthProvider, { httpPrefix: "/oauth" })`) so the callback
+ * is routable; register `<site-url><httpPrefix>/callback/<provider>` as the
+ * redirect URI with each provider.
+ */
 export const Oauth = defineProvider({
   name: "oauth",
-  setup: ({ completeSignIn }, options: { component: ComponentApi }) => {
+  setup: (_helpers, options: OauthOptions) => {
     const { component } = options;
+
+    // Normalize the allowlist up front so misconfiguration fails at deploy
+    // time, not on the first sign-in.
+    const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
+      const url = parseUrl(allowed);
+      if (url === null || url.origin === "null") {
+        throw new Error(
+          `allowedRedirectOrigins entry is not a valid origin: "${allowed}"`,
+        );
+      }
+      return url.origin;
+    });
+
     return {
-      signIn: mutationGeneric({
-        args: {},
-        handler: async (ctx) => {
-          const anonymousId = await ctx.runMutation(
-            component.provider.createOauthAccount,
-            {},
+      /**
+       * Start an OAuth sign-in. The client generates and keeps `state` (it
+       * must present the same value again to complete sign-in), then
+       * navigates to the returned `redirect` URL.
+       */
+      signInOauth: mutationGeneric({
+        args: {
+          provider: v.string(),
+          state: v.string(),
+          redirectTo: v.string(),
+        },
+        returns: v.object({ redirect: v.string() }),
+        handler: async (ctx, args) => {
+          const providerConfig = options.providers[args.provider];
+          if (providerConfig === undefined) {
+            throw new Error(`Unknown OAuth provider "${args.provider}"`);
+          }
+
+          if (
+            args.state.length < MIN_STATE_LENGTH ||
+            args.state.length > MAX_STATE_LENGTH
+          ) {
+            throw new Error(
+              `state must be between ${MIN_STATE_LENGTH} and ${MAX_STATE_LENGTH} characters`,
+            );
+          }
+
+          const redirectTo = parseUrl(args.redirectTo);
+          if (redirectTo === null) {
+            throw new Error("redirectTo must be an absolute URL");
+          }
+          if (!allowedOrigins.includes(redirectTo.origin)) {
+            throw new Error(
+              `redirectTo origin "${redirectTo.origin}" is not in allowedRedirectOrigins`,
+            );
+          }
+
+          const codeVerifier = providerConfig.pkce
+            ? generateRandomToken()
+            : undefined;
+
+          // Only the hash crosses the component boundary, so the raw state is
+          // neither stored nor visible in function logs.
+          const stateHash = await sha256Hex(args.state);
+          const callbackBaseUrl = await ctx.runMutation(
+            component.provider.createAuthorizationRequest,
+            {
+              provider: args.provider,
+              stateHash,
+              redirectTo: args.redirectTo,
+              ...(codeVerifier === undefined ? {} : { codeVerifier }),
+            },
           );
-          return await completeSignIn(ctx, {
-            provider: "anonymous",
-            providerAccountId: anonymousId,
-            profile: {},
-          });
+
+          // Protocol params come last so they win over extras. Set on
+          // `searchParams` (rather than replacing `url.search`) to preserve
+          // any params baked into the configured endpoint URL.
+          const params: Record<string, string> = {
+            ...providerConfig.extraAuthorizationParams,
+            response_type: "code",
+            client_id: providerConfig.clientId,
+            redirect_uri: `${callbackBaseUrl}/callback/${args.provider}`,
+            state: args.state,
+          };
+
+          if (providerConfig.scopes !== undefined) {
+            params.scope = providerConfig.scopes.join(" ");
+          }
+
+          if (codeVerifier !== undefined) {
+            params.code_challenge = await sha256Base64Url(codeVerifier);
+            params.code_challenge_method = "S256";
+          }
+
+          const url = new URL(providerConfig.authorizationEndpoint);
+          for (const [key, value] of Object.entries(params)) {
+            url.searchParams.set(key, value);
+          }
+
+          return { redirect: url.toString() };
         },
       }),
     };

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -18,9 +18,9 @@ export type OidcClaims = {
 };
 
 /**
- * Configuration for a single upstream OAuth provider (IdP).
+ * Options for one {@link Oauth} provider instance (a single IdP).
  */
-export type OauthProviderConfig = {
+export type OauthOptions = {
   /**
    * This IdP's component mount (e.g. `components.oauthGoogle`). The
    * component is mounted once per IdP so each mount can bind its own
@@ -73,14 +73,6 @@ export type OauthProviderConfig = {
    * ...) always win over entries here.
    */
   extraAuthorizationParams?: Record<string, string>;
-};
-
-/**
- * Options for {@link Oauth}.
- */
-export type OauthOptions = {
-  /** Upstream providers keyed by name; the key is used in claims and account identity. */
-  providers: Record<string, OauthProviderConfig>;
   /**
    * Origins `redirectTo` may point at, e.g. `["https://app.example.com"]`.
    * Exact origin match; open-redirect prevention.
@@ -98,7 +90,18 @@ function parseUrl(value: string): URL | null {
 }
 
 /**
- * OAuth sign-in against configured upstream providers. The flow:
+ * OAuth sign-in against a single upstream provider (IdP). Register one
+ * instance per IdP; the instance's name is persisted to the accounts table
+ * as the account's provider:
+ *
+ * ```ts
+ * providers: [
+ *   provider(Oauth("google"), { component: components.oauthGoogle, ... }),
+ *   provider(Oauth("github"), { component: components.oauthGithub, ... }),
+ * ]
+ * ```
+ *
+ * The flow:
  *
  * 1. `signIn` (here): validate, mint `state`, record an authorization
  *    request in the component, and return the provider authorization URL
@@ -113,103 +116,97 @@ function parseUrl(value: string): URL | null {
  * (see the component's convex.config.ts); register
  * `<site-url><httpPrefix>/callback` as the redirect URI with each provider.
  */
-export const Oauth = defineProvider({
-  name: "oauth",
-  setup: (_helpers, options: OauthOptions) => {
-    // Validate configuration up front so it fails at deploy time, not on
-    // the first sign-in.
-    const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
-      const url = parseUrl(allowed);
-      if (url === null || url.origin === "null") {
-        throw new Error(
-          `allowedRedirectOrigins entry is not a valid origin: "${allowed}"`,
-        );
-      }
-      return url.origin;
-    });
-
-    return {
-      /**
-       * Start an OAuth sign-in. The server mints `state` and returns it;
-       * the client keeps it (it must present the same value again to
-       * complete sign-in) and navigates to the returned `redirect` URL.
-       */
-      signInOauth: mutationGeneric({
-        args: {
-          provider: v.string(),
-          redirectTo: v.string(),
-        },
-        returns: v.object({ redirect: v.string(), state: v.string() }),
-        handler: async (ctx, args) => {
-          // `hasOwn` rather than an undefined check: a lookup like
-          // "constructor" hits the prototype chain and returns a function.
-          if (!Object.hasOwn(options.providers, args.provider)) {
-            throw new Error(`Unknown OAuth provider "${args.provider}"`);
-          }
-          const providerConfig = options.providers[args.provider];
-
-          const redirectTo = parseUrl(args.redirectTo);
-          if (redirectTo === null) {
-            throw new Error("redirectTo must be an absolute URL");
-          }
-          if (!allowedOrigins.includes(redirectTo.origin)) {
-            throw new Error(
-              `redirectTo origin "${redirectTo.origin}" is not in allowedRedirectOrigins`,
-            );
-          }
-
-          const state = generateRandomToken();
-          const codeVerifier = providerConfig.pkce
-            ? generateRandomToken()
-            : undefined;
-
-          // Only the hash crosses the component boundary, so the raw state is
-          // neither stored nor visible in function logs. Exchange config the
-          // callback needs is stored on the request row; the mount's
-          // CLIENT_ID comes back for the authorization URL.
-          const stateHash = await sha256Hex(state);
-          const { callbackBaseUrl, clientId } = await ctx.runMutation(
-            providerConfig.component.provider.createAuthorizationRequest,
-            {
-              provider: args.provider,
-              stateHash,
-              redirectTo: args.redirectTo,
-              tokenEndpoint: providerConfig.tokenEndpoint,
-              ...(codeVerifier === undefined ? {} : { codeVerifier }),
-              ...(providerConfig.userinfoEndpoints === undefined
-                ? {}
-                : { userinfoEndpoints: providerConfig.userinfoEndpoints }),
-            },
+export function Oauth<const N extends string>(name: N) {
+  return defineProvider({
+    name,
+    setup: (_helpers, options: OauthOptions) => {
+      // Validate configuration up front so it fails at deploy time, not on
+      // the first sign-in.
+      const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
+        const url = parseUrl(allowed);
+        if (url === null || url.origin === "null") {
+          throw new Error(
+            `allowedRedirectOrigins entry is not a valid origin: "${allowed}"`,
           );
+        }
+        return url.origin;
+      });
 
-          // Protocol params come last so they win over extras. Set on
-          // `searchParams` (rather than replacing `url.search`) to preserve
-          // any params baked into the configured endpoint URL.
-          const params: Record<string, string> = {
-            ...providerConfig.extraAuthorizationParams,
-            response_type: "code",
-            client_id: clientId,
-            redirect_uri: `${callbackBaseUrl}/callback`,
-            state,
-          };
+      return {
+        /**
+         * Start an OAuth sign-in. The server mints `state` and returns it;
+         * the client keeps it (it must present the same value again to
+         * complete sign-in) and navigates to the returned `redirect` URL.
+         */
+        signIn: mutationGeneric({
+          args: {
+            redirectTo: v.string(),
+          },
+          returns: v.object({ redirect: v.string(), state: v.string() }),
+          handler: async (ctx, args) => {
+            const redirectTo = parseUrl(args.redirectTo);
+            if (redirectTo === null) {
+              throw new Error("redirectTo must be an absolute URL");
+            }
+            if (!allowedOrigins.includes(redirectTo.origin)) {
+              throw new Error(
+                `redirectTo origin "${redirectTo.origin}" is not in allowedRedirectOrigins`,
+              );
+            }
 
-          if (providerConfig.scopes !== undefined) {
-            params.scope = providerConfig.scopes.join(" ");
-          }
+            const state = generateRandomToken();
+            const codeVerifier = options.pkce
+              ? generateRandomToken()
+              : undefined;
 
-          if (codeVerifier !== undefined) {
-            params.code_challenge = await sha256Base64Url(codeVerifier);
-            params.code_challenge_method = "S256";
-          }
+            // Only the hash crosses the component boundary, so the raw state is
+            // neither stored nor visible in function logs. Exchange config the
+            // callback needs is stored on the request row; the mount's
+            // CLIENT_ID comes back for the authorization URL.
+            const stateHash = await sha256Hex(state);
+            const { callbackBaseUrl, clientId } = await ctx.runMutation(
+              options.component.provider.createAuthorizationRequest,
+              {
+                provider: name,
+                stateHash,
+                redirectTo: args.redirectTo,
+                tokenEndpoint: options.tokenEndpoint,
+                ...(codeVerifier === undefined ? {} : { codeVerifier }),
+                ...(options.userinfoEndpoints === undefined
+                  ? {}
+                  : { userinfoEndpoints: options.userinfoEndpoints }),
+              },
+            );
 
-          const url = new URL(providerConfig.authorizationEndpoint);
-          for (const [key, value] of Object.entries(params)) {
-            url.searchParams.set(key, value);
-          }
+            // Protocol params come last so they win over extras. Set on
+            // `searchParams` (rather than replacing `url.search`) to preserve
+            // any params baked into the configured endpoint URL.
+            const params: Record<string, string> = {
+              ...options.extraAuthorizationParams,
+              response_type: "code",
+              client_id: clientId,
+              redirect_uri: `${callbackBaseUrl}/callback`,
+              state,
+            };
 
-          return { redirect: url.toString(), state };
-        },
-      }),
-    };
-  },
-});
+            if (options.scopes !== undefined) {
+              params.scope = options.scopes.join(" ");
+            }
+
+            if (codeVerifier !== undefined) {
+              params.code_challenge = await sha256Base64Url(codeVerifier);
+              params.code_challenge_method = "S256";
+            }
+
+            const url = new URL(options.authorizationEndpoint);
+            for (const [key, value] of Object.entries(params)) {
+              url.searchParams.set(key, value);
+            }
+
+            return { redirect: url.toString(), state };
+          },
+        }),
+      };
+    },
+  });
+}

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -85,8 +85,14 @@ function parseUrl(value: string): URL | null {
 export const Oauth = defineProvider({
   name: "oauth",
   setup: (_helpers, options: OauthOptions) => {
-    // Normalize the allowlist up front so misconfiguration fails at deploy
-    // time, not on the first sign-in.
+    // Validate configuration up front so it fails at deploy time, not on
+    // the first sign-in.
+    for (const [name, config] of Object.entries(options.providers)) {
+      if (config.clientId === "") {
+        throw new Error(`OAuth provider "${name}" has an empty clientId`);
+      }
+    }
+
     const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
       const url = parseUrl(allowed);
       if (url === null || url.origin === "null") {
@@ -111,10 +117,12 @@ export const Oauth = defineProvider({
         },
         returns: v.object({ redirect: v.string() }),
         handler: async (ctx, args) => {
-          const providerConfig = options.providers[args.provider];
-          if (providerConfig === undefined) {
+          // `hasOwn` rather than an undefined check: a lookup like
+          // "constructor" hits the prototype chain and returns a function.
+          if (!Object.hasOwn(options.providers, args.provider)) {
             throw new Error(`Unknown OAuth provider "${args.provider}"`);
           }
+          const providerConfig = options.providers[args.provider];
 
           if (
             args.state.length < MIN_STATE_LENGTH ||

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -1,6 +1,6 @@
 import { mutationGeneric } from "convex/server";
 import { v } from "convex/values";
-import { defineProvider } from "../../lib/types";
+import { defineProvider, vTokenBundle, type TokenBundle } from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
 import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
 
@@ -51,7 +51,7 @@ export type OauthOptions = {
    * (`undefined` for non-OIDC providers) and userinfo responses keyed as
    * configured (`undefined` unless `userinfoEndpoints` is set) — to the
    * account identity used at redemption. `id` becomes the provider account
-   * id. Defaults to OIDC claims: `(claims) => ({ id: claims.sub, ...claims })`,
+   * id. Defaults to OIDC claims: `(claims) => ({ ...claims, id: claims.sub })`,
    * so providers without an id_token must supply this.
    */
   profile?: (
@@ -108,8 +108,9 @@ function parseUrl(value: string): URL | null {
  *    for the client to navigate to plus the state it must hold onto.
  * 2. The provider redirects back to the component's HTTP callback, which
  *    claims the request, exchanges the code, and mints a one-time ticket.
- * 3. The caller redeems the ticket (plus its original state) to complete
- *    sign-in.
+ * 3. `redeem` (here): the client presents the one-time code from the
+ *    callback redirect plus its original state, and gets back the session
+ *    token bundle.
  *
  * The component is mounted once per IdP in `convex.config.ts`, each mount
  * with its own name, `httpPrefix`, and `CLIENT_ID`/`CLIENT_SECRET` bindings
@@ -119,7 +120,7 @@ function parseUrl(value: string): URL | null {
 export function Oauth<const N extends string>(name: N) {
   return defineProvider({
     name,
-    setup: (_helpers, options: OauthOptions) => {
+    setup: (helpers, options: OauthOptions) => {
       // Validate configuration up front so it fails at deploy time, not on
       // the first sign-in.
       const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
@@ -204,6 +205,67 @@ export function Oauth<const N extends string>(name: N) {
             }
 
             return { redirect: url.toString(), state };
+          },
+        }),
+
+        /**
+         * Complete an OAuth sign-in by redeeming the one-time `code` from
+         * the callback redirect together with the state held since `signIn`.
+         * Returns the session token bundle, or null when the code is
+         * unknown, already redeemed, expired, or the state doesn't match —
+         * all indistinguishable to the caller, like a failed
+         * `refreshSession`.
+         *
+         * The component calls are subtransactions of this mutation, so a
+         * failure anywhere (including the app rejecting the sign-in from
+         * `createOrUpdateUser`) rolls back the ticket claim; only a
+         * successful redemption consumes the ticket.
+         */
+        redeem: mutationGeneric({
+          args: {
+            code: v.string(),
+            state: v.string(),
+          },
+          returns: v.union(vTokenBundle, v.null()),
+          handler: async (ctx, args): Promise<TokenBundle | null> => {
+            const ticket = await ctx.runMutation(
+              options.component.provider.claimTicket,
+              {
+                ottHash: await sha256Hex(args.code),
+                stateHash: await sha256Hex(args.state),
+              },
+            );
+            if (ticket === null) {
+              return null;
+            }
+
+            // The default mapping covers OIDC providers; anything without
+            // an id_token must configure `profile`.
+            const profileFn =
+              options.profile ??
+              ((oidcClaims: OidcClaims | undefined) => {
+                if (oidcClaims === undefined) {
+                  throw new Error(
+                    `Provider "${name}" returned no id_token, so a profile mapping is required`,
+                  );
+                }
+                return { ...oidcClaims, id: oidcClaims.sub };
+              });
+            const profile = profileFn(
+              ticket.claims as OidcClaims | undefined,
+              ticket.userInfoResponses,
+            );
+            if (typeof profile.id !== "string" || profile.id === "") {
+              throw new Error(
+                `Profile mapping for provider "${name}" returned no id`,
+              );
+            }
+
+            return await helpers.completeSignIn(ctx, {
+              provider: name,
+              providerAccountId: profile.id,
+              profile,
+            });
           },
         }),
       };

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -5,19 +5,59 @@ import type { ComponentApi } from "./_generated/component.js";
 import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
 
 /**
+ * Standard OIDC id_token claims, loosely typed: the well-known ones are
+ * named, everything else comes through the index signature.
+ */
+export type OidcClaims = {
+  sub: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  picture?: string;
+  [claim: string]: unknown;
+};
+
+/**
  * Configuration for a single upstream OAuth provider (IdP).
  */
 export type OauthProviderConfig = {
   /**
    * This IdP's component mount (e.g. `components.oauthGoogle`). The
    * component is mounted once per IdP so each mount can bind its own
-   * `CLIENT_SECRET` and serve its own callback route.
+   * `CLIENT_ID`/`CLIENT_SECRET` and serve its own callback route.
    */
   component: ComponentApi;
-  /** The OAuth client id issued by the provider. */
-  clientId: string;
   /** The provider's authorization endpoint, e.g. Google's `https://accounts.google.com/o/oauth2/v2/auth`. */
   authorizationEndpoint: string;
+  /** The provider's token endpoint, e.g. Google's `https://oauth2.googleapis.com/token`. */
+  tokenEndpoint: string;
+  /**
+   * Profile endpoints the callback fetches with the access token after the
+   * code exchange (GET with a bearer token; provider variation lives in the
+   * URL's query params). Keys name each response in the `profile` mapping's
+   * second argument. Required for providers that don't return an OIDC
+   * id_token, e.g. GitHub:
+   *
+   * ```ts
+   * userinfoEndpoints: {
+   *   user: "https://api.github.com/user",
+   *   emails: "https://api.github.com/user/emails",
+   * }
+   * ```
+   */
+  userinfoEndpoints?: Record<string, string>;
+  /**
+   * Map what the provider told us about the user — id_token claims
+   * (`undefined` for non-OIDC providers) and userinfo responses keyed as
+   * configured (`undefined` unless `userinfoEndpoints` is set) — to the
+   * account identity used at redemption. `id` becomes the provider account
+   * id. Defaults to OIDC claims: `(claims) => ({ id: claims.sub, ...claims })`,
+   * so providers without an id_token must supply this.
+   */
+  profile?: (
+    claims: OidcClaims | undefined,
+    userInfoResponses: Record<string, any> | undefined,
+  ) => { id: string; [key: string]: unknown };
   /** Scopes to request, e.g. `["openid", "email", "profile"]`. Omitted from the URL when absent. */
   scopes?: string[];
   /**
@@ -69,21 +109,15 @@ function parseUrl(value: string): URL | null {
  *    sign-in.
  *
  * The component is mounted once per IdP in `convex.config.ts`, each mount
- * with its own name, `httpPrefix`, and `CLIENT_SECRET` binding (see the
- * component's convex.config.ts); register `<site-url><httpPrefix>/callback`
- * as the redirect URI with each provider.
+ * with its own name, `httpPrefix`, and `CLIENT_ID`/`CLIENT_SECRET` bindings
+ * (see the component's convex.config.ts); register
+ * `<site-url><httpPrefix>/callback` as the redirect URI with each provider.
  */
 export const Oauth = defineProvider({
   name: "oauth",
   setup: (_helpers, options: OauthOptions) => {
     // Validate configuration up front so it fails at deploy time, not on
     // the first sign-in.
-    for (const [name, config] of Object.entries(options.providers)) {
-      if (config.clientId === "") {
-        throw new Error(`OAuth provider "${name}" has an empty clientId`);
-      }
-    }
-
     const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
       const url = parseUrl(allowed);
       if (url === null || url.origin === "null") {
@@ -130,15 +164,21 @@ export const Oauth = defineProvider({
             : undefined;
 
           // Only the hash crosses the component boundary, so the raw state is
-          // neither stored nor visible in function logs.
+          // neither stored nor visible in function logs. Exchange config the
+          // callback needs is stored on the request row; the mount's
+          // CLIENT_ID comes back for the authorization URL.
           const stateHash = await sha256Hex(state);
-          const callbackBaseUrl = await ctx.runMutation(
+          const { callbackBaseUrl, clientId } = await ctx.runMutation(
             providerConfig.component.provider.createAuthorizationRequest,
             {
               provider: args.provider,
               stateHash,
               redirectTo: args.redirectTo,
+              tokenEndpoint: providerConfig.tokenEndpoint,
               ...(codeVerifier === undefined ? {} : { codeVerifier }),
+              ...(providerConfig.userinfoEndpoints === undefined
+                ? {}
+                : { userinfoEndpoints: providerConfig.userinfoEndpoints }),
             },
           );
 
@@ -148,7 +188,7 @@ export const Oauth = defineProvider({
           const params: Record<string, string> = {
             ...providerConfig.extraAuthorizationParams,
             response_type: "code",
-            client_id: providerConfig.clientId,
+            client_id: clientId,
             redirect_uri: `${callbackBaseUrl}/callback`,
             state,
           };

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -48,15 +48,6 @@ export type OauthOptions = {
   allowedRedirectOrigins: string[];
 };
 
-/**
- * Client-generated state is opaque, but a guessable value would let an
- * attacker inject their authorization code into a victim's flow, so a
- * minimum length is enforced (32 base64url chars ≈ 192 bits). The cap just
- * bounds work done on hostile input.
- */
-const MIN_STATE_LENGTH = 32;
-const MAX_STATE_LENGTH = 256;
-
 /** `new URL` without the exception: returns null on unparseable input. */
 function parseUrl(value: string): URL | null {
   try {
@@ -69,9 +60,9 @@ function parseUrl(value: string): URL | null {
 /**
  * OAuth sign-in against configured upstream providers. The flow:
  *
- * 1. `signIn` (here): validate, record an authorization request in the
- *    component, return the provider authorization URL for the client to
- *    navigate to.
+ * 1. `signIn` (here): validate, mint `state`, record an authorization
+ *    request in the component, and return the provider authorization URL
+ *    for the client to navigate to plus the state it must hold onto.
  * 2. The provider redirects back to the component's HTTP callback, which
  *    claims the request, exchanges the code, and mints a one-time ticket.
  * 3. The caller redeems the ticket (plus its original state) to complete
@@ -105,17 +96,16 @@ export const Oauth = defineProvider({
 
     return {
       /**
-       * Start an OAuth sign-in. The client generates and keeps `state` (it
-       * must present the same value again to complete sign-in), then
-       * navigates to the returned `redirect` URL.
+       * Start an OAuth sign-in. The server mints `state` and returns it;
+       * the client keeps it (it must present the same value again to
+       * complete sign-in) and navigates to the returned `redirect` URL.
        */
       signInOauth: mutationGeneric({
         args: {
           provider: v.string(),
-          state: v.string(),
           redirectTo: v.string(),
         },
-        returns: v.object({ redirect: v.string() }),
+        returns: v.object({ redirect: v.string(), state: v.string() }),
         handler: async (ctx, args) => {
           // `hasOwn` rather than an undefined check: a lookup like
           // "constructor" hits the prototype chain and returns a function.
@@ -123,15 +113,6 @@ export const Oauth = defineProvider({
             throw new Error(`Unknown OAuth provider "${args.provider}"`);
           }
           const providerConfig = options.providers[args.provider];
-
-          if (
-            args.state.length < MIN_STATE_LENGTH ||
-            args.state.length > MAX_STATE_LENGTH
-          ) {
-            throw new Error(
-              `state must be between ${MIN_STATE_LENGTH} and ${MAX_STATE_LENGTH} characters`,
-            );
-          }
 
           const redirectTo = parseUrl(args.redirectTo);
           if (redirectTo === null) {
@@ -143,13 +124,14 @@ export const Oauth = defineProvider({
             );
           }
 
+          const state = generateRandomToken();
           const codeVerifier = providerConfig.pkce
             ? generateRandomToken()
             : undefined;
 
           // Only the hash crosses the component boundary, so the raw state is
           // neither stored nor visible in function logs.
-          const stateHash = await sha256Hex(args.state);
+          const stateHash = await sha256Hex(state);
           const callbackBaseUrl = await ctx.runMutation(
             providerConfig.component.provider.createAuthorizationRequest,
             {
@@ -168,7 +150,7 @@ export const Oauth = defineProvider({
             response_type: "code",
             client_id: providerConfig.clientId,
             redirect_uri: `${callbackBaseUrl}/callback`,
-            state: args.state,
+            state,
           };
 
           if (providerConfig.scopes !== undefined) {
@@ -185,7 +167,7 @@ export const Oauth = defineProvider({
             url.searchParams.set(key, value);
           }
 
-          return { redirect: url.toString() };
+          return { redirect: url.toString(), state };
         },
       }),
     };

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -1,0 +1,26 @@
+import { mutationGeneric } from "convex/server";
+import { defineProvider } from "../../lib/types";
+import { ComponentApi } from "./_generated/component";
+
+export const Oauth = defineProvider({
+  name: "oauth",
+  setup: ({ completeSignIn }, options: { component: ComponentApi }) => {
+    const { component } = options;
+    return {
+      signIn: mutationGeneric({
+        args: {},
+        handler: async (ctx) => {
+          const anonymousId = await ctx.runMutation(
+            component.provider.createOauthAccount,
+            {},
+          );
+          return await completeSignIn(ctx, {
+            provider: "anonymous",
+            providerAccountId: anonymousId,
+            profile: {},
+          });
+        },
+      }),
+    };
+  },
+});

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -1,6 +1,10 @@
 import { mutationGeneric } from "convex/server";
 import { v } from "convex/values";
-import { defineProvider, vTokenBundle, type TokenBundle } from "../../lib/types";
+import {
+  defineProvider,
+  vTokenBundle,
+  type TokenBundle,
+} from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
 import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
 
@@ -32,6 +36,15 @@ export type OauthOptions = {
   /** The provider's token endpoint, e.g. Google's `https://oauth2.googleapis.com/token`. */
   tokenEndpoint: string;
   /**
+   * Expected `iss` of the provider's id_tokens, e.g. Google's
+   * `https://accounts.google.com`. Recommended for every OIDC provider:
+   * `sub` is only unique within an issuer, so a token endpoint that serves
+   * multiple issuers (multi-tenant IdPs) could otherwise collide account
+   * identities. When set, the callback rejects id_tokens from any other
+   * issuer.
+   */
+  issuer?: string;
+  /**
    * Profile endpoints the callback fetches with the access token after the
    * code exchange (GET with a bearer token; provider variation lives in the
    * URL's query params). Keys name each response in the `profile` mapping's
@@ -56,6 +69,8 @@ export type OauthOptions = {
    */
   profile?: (
     claims: OidcClaims | undefined,
+    // `any` so app mappings can dig into responses without casting.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     userInfoResponses: Record<string, any> | undefined,
   ) => { id: string; [key: string]: unknown };
   /** Scopes to request, e.g. `["openid", "email", "profile"]`. Omitted from the URL when absent. */
@@ -176,6 +191,9 @@ export function Oauth<const N extends string>(name: N) {
                 ...(options.userinfoEndpoints === undefined
                   ? {}
                   : { userinfoEndpoints: options.userinfoEndpoints }),
+                ...(options.issuer === undefined
+                  ? {}
+                  : { issuer: options.issuer }),
               },
             );
 
@@ -231,6 +249,7 @@ export function Oauth<const N extends string>(name: N) {
             const ticket = await ctx.runMutation(
               options.component.provider.claimTicket,
               {
+                provider: name,
                 ottHash: await sha256Hex(args.code),
                 stateHash: await sha256Hex(args.state),
               },

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -55,7 +55,8 @@ export type OauthOptions = {
    * Profile endpoints the callback fetches with the access token after the
    * code exchange (GET with a bearer token; provider variation lives in the
    * URL's query params). Keys name each response in the `profile` mapping's
-   * second argument. Required for providers that don't return an OIDC
+   * second argument; only the `profile` mapping sees the responses, so this
+   * option requires one. Required for providers that don't return an OIDC
    * id_token, e.g. GitHub:
    *
    * ```ts
@@ -123,7 +124,10 @@ function requireHttpsUrl(value: string, label: string): void {
     throw new Error(`${label} is not a valid URL: "${value}"`);
   }
   const isLocalhost =
-    url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    url.hostname === "localhost" ||
+    url.hostname.endsWith(".localhost") ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]";
   if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalhost)) {
     throw new Error(`${label} must use https: "${value}"`);
   }
@@ -190,6 +194,13 @@ export function Oauth<const N extends string>(name: N) {
       requireHttpsUrl(options.authorizationEndpoint, "authorizationEndpoint");
       requireHttpsUrl(options.tokenEndpoint, "tokenEndpoint");
       if (options.userInfoEndpoints !== undefined) {
+        // The default profile mapping only reads id_token claims, so
+        // userinfo responses would be fetched and never used.
+        if (options.profile === undefined) {
+          throw new Error(
+            `userInfoEndpoints for provider "${name}" requires a \`profile\` mapping`,
+          );
+        }
         const entries = Object.entries(options.userInfoEndpoints);
         if (entries.length === 0) {
           throw new Error(
@@ -198,11 +209,15 @@ export function Oauth<const N extends string>(name: N) {
         }
         for (const [key, endpoint] of entries) {
           // Keys become Convex record field names on the authorization
-          // request row, which allow only printable ASCII not starting
-          // with "$".
-          if (!/^[ -~]+$/.test(key) || key.startsWith("$")) {
+          // request row, which allow only printable ASCII up to 1024
+          // characters, not starting with "$".
+          if (
+            !/^[ -~]+$/.test(key) ||
+            key.length > 1024 ||
+            key.startsWith("$")
+          ) {
             throw new Error(
-              `userInfoEndpoints key "${key}" for provider "${name}" must be printable ASCII and not start with "$"`,
+              `userInfoEndpoints key "${key}" for provider "${name}" must be printable ASCII, at most 1024 characters, and not start with "$"`,
             );
           }
           requireHttpsUrl(endpoint, `userInfoEndpoints["${key}"]`);

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -8,6 +8,12 @@ import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
  * Configuration for a single upstream OAuth provider (IdP).
  */
 export type OauthProviderConfig = {
+  /**
+   * This IdP's component mount (e.g. `components.oauthGoogle`). The
+   * component is mounted once per IdP so each mount can bind its own
+   * `CLIENT_SECRET` and serve its own callback route.
+   */
+  component: ComponentApi;
   /** The OAuth client id issued by the provider. */
   clientId: string;
   /** The provider's authorization endpoint, e.g. Google's `https://accounts.google.com/o/oauth2/v2/auth`. */
@@ -33,9 +39,7 @@ export type OauthProviderConfig = {
  * Options for {@link Oauth}.
  */
 export type OauthOptions = {
-  /** The mounted oauth component (`components.authOauth`). */
-  component: ComponentApi;
-  /** Upstream providers keyed by name; the key is used in routes, claims, and account identity. */
+  /** Upstream providers keyed by name; the key is used in claims and account identity. */
   providers: Record<string, OauthProviderConfig>;
   /**
    * Origins `redirectTo` may point at, e.g. `["https://app.example.com"]`.
@@ -73,16 +77,14 @@ function parseUrl(value: string): URL | null {
  * 3. The caller redeems the ticket (plus its original state) to complete
  *    sign-in.
  *
- * The component must be mounted with an `httpPrefix` in `convex.config.ts`
- * (e.g. `app.use(oauthProvider, { httpPrefix: "/oauth" })`) so the callback
- * is routable; register `<site-url><httpPrefix>/callback/<provider>` as the
- * redirect URI with each provider.
+ * The component is mounted once per IdP in `convex.config.ts`, each mount
+ * with its own name, `httpPrefix`, and `CLIENT_SECRET` binding (see the
+ * component's convex.config.ts); register `<site-url><httpPrefix>/callback`
+ * as the redirect URI with each provider.
  */
 export const Oauth = defineProvider({
   name: "oauth",
   setup: (_helpers, options: OauthOptions) => {
-    const { component } = options;
-
     // Normalize the allowlist up front so misconfiguration fails at deploy
     // time, not on the first sign-in.
     const allowedOrigins = options.allowedRedirectOrigins.map((allowed) => {
@@ -141,7 +143,7 @@ export const Oauth = defineProvider({
           // neither stored nor visible in function logs.
           const stateHash = await sha256Hex(args.state);
           const callbackBaseUrl = await ctx.runMutation(
-            component.provider.createAuthorizationRequest,
+            providerConfig.component.provider.createAuthorizationRequest,
             {
               provider: args.provider,
               stateHash,
@@ -157,7 +159,7 @@ export const Oauth = defineProvider({
             ...providerConfig.extraAuthorizationParams,
             response_type: "code",
             client_id: providerConfig.clientId,
-            redirect_uri: `${callbackBaseUrl}/callback/${args.provider}`,
+            redirect_uri: `${callbackBaseUrl}/callback`,
             state: args.state,
           };
 

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -6,7 +6,13 @@ import {
   type TokenBundle,
 } from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
-import { generateRandomToken, sha256Base64Url, sha256Hex } from "./crypto";
+import { CALLBACK_PATH } from "./constants";
+import {
+  decryptWithToken,
+  generateRandomToken,
+  sha256Base64Url,
+  sha256Hex,
+} from "./crypto";
 
 /**
  * Standard OIDC id_token claims, loosely typed: the well-known ones are
@@ -52,17 +58,17 @@ export type OauthOptions = {
    * id_token, e.g. GitHub:
    *
    * ```ts
-   * userinfoEndpoints: {
+   * userInfoEndpoints: {
    *   user: "https://api.github.com/user",
    *   emails: "https://api.github.com/user/emails",
    * }
    * ```
    */
-  userinfoEndpoints?: Record<string, string>;
+  userInfoEndpoints?: Record<string, string>;
   /**
    * Map what the provider told us about the user — id_token claims
    * (`undefined` for non-OIDC providers) and userinfo responses keyed as
-   * configured (`undefined` unless `userinfoEndpoints` is set) — to the
+   * configured (`undefined` unless `userInfoEndpoints` is set) — to the
    * account identity used at redemption. `id` becomes the provider account
    * id. Defaults to OIDC claims: `(claims) => ({ ...claims, id: claims.sub })`,
    * so providers without an id_token must supply this.
@@ -84,8 +90,9 @@ export type OauthOptions = {
   pkce?: boolean;
   /**
    * Extra query params for the authorization URL, e.g. Google's
-   * `{ access_type: "offline" }`. Protocol params (`state`, `redirect_uri`,
-   * ...) always win over entries here.
+   * `{ access_type: "offline" }`. Must not include protocol params
+   * (`state`, `redirect_uri`, `code_challenge`, ...); setup rejects them so
+   * they can never silently conflict with what `signIn` sends.
    */
   extraAuthorizationParams?: Record<string, string>;
   /**
@@ -103,6 +110,34 @@ function parseUrl(value: string): URL | null {
     return null;
   }
 }
+
+/**
+ * Require an absolute https URL (plain http is allowed only for localhost,
+ * for development against a local IdP). Credentials and tokens travel to
+ * these endpoints, so a typo'd scheme must not downgrade them to cleartext.
+ */
+function requireHttpsUrl(value: string, label: string): void {
+  const url = parseUrl(value);
+  if (url === null) {
+    throw new Error(`${label} is not a valid URL: "${value}"`);
+  }
+  const isLocalhost =
+    url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalhost)) {
+    throw new Error(`${label} must use https: "${value}"`);
+  }
+}
+
+/** Params `signIn` sets itself; `extraAuthorizationParams` may not. */
+const PROTOCOL_PARAMS = [
+  "response_type",
+  "client_id",
+  "redirect_uri",
+  "state",
+  "scope",
+  "code_challenge",
+  "code_challenge_method",
+];
 
 /**
  * OAuth sign-in against a single upstream provider (IdP). Register one
@@ -131,6 +166,10 @@ function parseUrl(value: string): URL | null {
  * with its own name, `httpPrefix`, and `CLIENT_ID`/`CLIENT_SECRET` bindings
  * (see the component's convex.config.ts); register
  * `<site-url><httpPrefix>/callback` as the redirect URI with each provider.
+ *
+ * The callback only accepts GET redirects. Providers that POST it
+ * (`response_mode=form_post`, notably Apple when name/email scopes are
+ * requested) are not supported yet.
  */
 export function Oauth<const N extends string>(name: N) {
   return defineProvider({
@@ -147,12 +186,46 @@ export function Oauth<const N extends string>(name: N) {
         }
         return url.origin;
       });
+      requireHttpsUrl(options.authorizationEndpoint, "authorizationEndpoint");
+      requireHttpsUrl(options.tokenEndpoint, "tokenEndpoint");
+      if (options.userInfoEndpoints !== undefined) {
+        const entries = Object.entries(options.userInfoEndpoints);
+        if (entries.length === 0) {
+          throw new Error(
+            `userInfoEndpoints for provider "${name}" must have at least one entry`,
+          );
+        }
+        for (const [key, endpoint] of entries) {
+          // Keys become Convex record field names on the authorization
+          // request row, which allow only printable ASCII not starting
+          // with "$".
+          if (!/^[ -~]+$/.test(key) || key.startsWith("$")) {
+            throw new Error(
+              `userInfoEndpoints key "${key}" for provider "${name}" must be printable ASCII and not start with "$"`,
+            );
+          }
+          requireHttpsUrl(endpoint, `userInfoEndpoints["${key}"]`);
+        }
+      }
+      for (const key of Object.keys(options.extraAuthorizationParams ?? {})) {
+        if (PROTOCOL_PARAMS.includes(key)) {
+          throw new Error(
+            `extraAuthorizationParams for provider "${name}" must not set protocol param "${key}"`,
+          );
+        }
+      }
 
       return {
         /**
          * Start an OAuth sign-in. The server mints `state` and returns it;
          * the client keeps it (it must present the same value again to
          * complete sign-in) and navigates to the returned `redirect` URL.
+         *
+         * The state is the client's proof at redemption that it initiated
+         * this flow. Keep it in private storage (e.g. sessionStorage) and
+         * never read it from a URL: a client that accepts state from URL
+         * params can be handed an attacker's flow and complete sign-in into
+         * the attacker's account (login CSRF).
          */
         signIn: mutationGeneric({
           args: {
@@ -187,24 +260,21 @@ export function Oauth<const N extends string>(name: N) {
                 stateHash,
                 redirectTo: args.redirectTo,
                 tokenEndpoint: options.tokenEndpoint,
-                ...(codeVerifier === undefined ? {} : { codeVerifier }),
-                ...(options.userinfoEndpoints === undefined
-                  ? {}
-                  : { userinfoEndpoints: options.userinfoEndpoints }),
-                ...(options.issuer === undefined
-                  ? {}
-                  : { issuer: options.issuer }),
+                codeVerifier,
+                userInfoEndpoints: options.userInfoEndpoints,
+                issuer: options.issuer,
               },
             );
 
-            // Protocol params come last so they win over extras. Set on
-            // `searchParams` (rather than replacing `url.search`) to preserve
-            // any params baked into the configured endpoint URL.
+            // Protocol params come last, and setup rejects extras that name
+            // them, so they can never be overridden. Set on `searchParams`
+            // (rather than replacing `url.search`) to preserve any params
+            // baked into the configured endpoint URL.
             const params: Record<string, string> = {
               ...options.extraAuthorizationParams,
               response_type: "code",
               client_id: clientId,
-              redirect_uri: `${callbackBaseUrl}/callback`,
+              redirect_uri: `${callbackBaseUrl}${CALLBACK_PATH}`,
               state,
             };
 
@@ -229,10 +299,11 @@ export function Oauth<const N extends string>(name: N) {
         /**
          * Complete an OAuth sign-in by redeeming the one-time `code` from
          * the callback redirect together with the state held since `signIn`.
-         * Returns the session token bundle, or null when the code is
-         * unknown, already redeemed, expired, or the state doesn't match —
-         * all indistinguishable to the caller, like a failed
-         * `refreshSession`.
+         * The state must be the value stored at sign-in time, never one
+         * read from a URL. Returns the session token bundle, or null when
+         * the code is unknown, already redeemed, expired, or the state
+         * doesn't match — all indistinguishable to the caller, like a
+         * failed `refreshSession`.
          *
          * The component calls are subtransactions of this mutation, so a
          * failure anywhere (including the app rejecting the sign-in from
@@ -258,6 +329,16 @@ export function Oauth<const N extends string>(name: N) {
               return null;
             }
 
+            // The ticket found by hash proves `code` is the token the
+            // payload was encrypted under, so decryption only fails on
+            // corruption.
+            const { claims, userInfoResponses } = JSON.parse(
+              await decryptWithToken(args.code, ticket.payload),
+            ) as {
+              claims: OidcClaims | undefined;
+              userInfoResponses: Record<string, unknown> | undefined;
+            };
+
             // The default mapping covers OIDC providers; anything without
             // an id_token must configure `profile`.
             const profileFn =
@@ -270,10 +351,7 @@ export function Oauth<const N extends string>(name: N) {
                 }
                 return { ...oidcClaims, id: oidcClaims.sub };
               });
-            const profile = profileFn(
-              ticket.claims as OidcClaims | undefined,
-              ticket.userInfoResponses,
-            );
+            const profile = profileFn(claims, userInfoResponses);
             if (typeof profile.id !== "string" || profile.id === "") {
               throw new Error(
                 `Profile mapping for provider "${name}" returned no id`,

--- a/packages/core/src/components/oauth/setup.ts
+++ b/packages/core/src/components/oauth/setup.ts
@@ -43,11 +43,12 @@ export type OauthOptions = {
   tokenEndpoint: string;
   /**
    * Expected `iss` of the provider's id_tokens, e.g. Google's
-   * `https://accounts.google.com`. Recommended for every OIDC provider:
+   * `https://accounts.google.com`. Required for every OIDC provider:
    * `sub` is only unique within an issuer, so a token endpoint that serves
    * multiple issuers (multi-tenant IdPs) could otherwise collide account
-   * identities. When set, the callback rejects id_tokens from any other
-   * issuer.
+   * identities. The callback rejects any returned id_token unless this is
+   * set and matches. Omit only for plain-OAuth providers that never return
+   * an id_token (e.g. GitHub).
    */
   issuer?: string;
   /**

--- a/packages/core/src/components/testing/oauth.ts
+++ b/packages/core/src/components/testing/oauth.ts
@@ -1,0 +1,19 @@
+import type { TestConvex } from "convex-test";
+import type { GenericSchema, SchemaDefinition } from "convex/server";
+import schema from "../oauth/schema";
+const modules = import.meta.glob("../oauth/**/*.ts");
+
+/**
+ * Register an OAuth provider component with a `convex-test` instance.
+ *
+ * @param t - The test convex instance, e.g. from calling `convexTest`.
+ * @param name - The name of the component, as registered in convex.config.ts.
+ *   OAuth mounts are per-IdP (e.g. `"oauthGoogle"`), so there is no default.
+ */
+export function registerOauthProvider(
+  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
+  name: string,
+) {
+  t.registerComponent(name, schema, modules);
+}
+export default { registerOauthProvider, schema, modules };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,61 @@ importers:
         specifier: ^8.0.16
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
+  examples/react-oauth:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      convex:
+        specifier: ^1.41.0
+        version: 1.42.1(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+      concurrently:
+        specifier: ^10.0.3
+        version: 10.0.3
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.42.1(react@19.2.7))
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   examples/react-password:
     dependencies:
       '@convex-dev/auth':
@@ -1259,6 +1314,11 @@ packages:
   '@tailwindcss/postcss@4.3.2':
     resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
 
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1432,6 +1492,19 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -1473,6 +1546,14 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argon2id-wasm@0.0.0-alpha.1:
     resolution: {integrity: sha512-rBKe0DTm6+lhKn0MJ4D73k4OeOyoDSMZJ3zOaD4W485dzRR6hgc8GAglGJes18E1EsNQ2drCrbBF4Vs6bV4jqg==}
@@ -1519,6 +1600,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1541,6 +1626,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1557,6 +1646,11 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  concurrently@10.0.3:
+    resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1623,6 +1717,9 @@ packages:
 
   electron-to-chromium@1.5.383:
     resolution: {integrity: sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -1887,6 +1984,14 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -2507,6 +2612,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2534,6 +2642,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
+
   shiki@4.3.1:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
@@ -2558,8 +2670,16 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2579,6 +2699,10 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
@@ -2601,6 +2725,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2807,6 +2935,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -2819,8 +2951,20 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3624,6 +3768,13 @@ snapshots:
       postcss: 8.5.16
       tailwindcss: 4.3.2
 
+  '@tailwindcss/vite@4.3.2(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -3859,6 +4010,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3921,6 +4077,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   argon2id-wasm@0.0.0-alpha.1: {}
 
   argparse@2.0.1: {}
@@ -3953,6 +4113,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3971,6 +4133,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clsx@2.1.1: {}
 
   cnfast@0.0.8: {}
@@ -3980,6 +4148,15 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   compute-scroll-into-view@3.1.1: {}
+
+  concurrently@10.0.3:
+    dependencies:
+      chalk: 5.6.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 10.2.2
+      tree-kill: 1.2.2
+      yargs: 18.0.0
 
   convert-source-map@2.0.0: {}
 
@@ -4027,6 +4204,8 @@ snapshots:
       dequal: 2.0.3
 
   electron-to-chromium@1.5.383: {}
+
+  emoji-regex@10.6.0: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -4325,6 +4504,10 @@ snapshots:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-nonce@1.0.1: {}
 
@@ -5294,6 +5477,10 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   scheduler@0.27.0: {}
 
   scroll-into-view-if-needed@3.1.0:
@@ -5342,6 +5529,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.4: {}
+
   shiki@4.3.1:
     dependencies:
       '@shikijs/core': 4.3.1
@@ -5365,10 +5554,20 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   style-to-js@1.1.21:
     dependencies:
@@ -5382,6 +5581,8 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
+
+  supports-color@10.2.2: {}
 
   tailwindcss@4.3.2: {}
 
@@ -5397,6 +5598,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
+
+  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -5610,9 +5813,28 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   ws@8.21.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add an OAuth provider component, mounted once per IdP with its own callback route and client credential env bindings.

- Full authorization-code flow: `signIn` mints state and returns the provider URL, the component's HTTP callback exchanges the code and mints a one-time ticket, `redeem` completes sign-in through the core (accounts, sessions, tokens)
- Supports OIDC (Google) and plain OAuth (GitHub) via `userInfoEndpoints` + a `profile` mapping
- Hardened: encrypted ticket payloads, state binding at redemption (login CSRF), strict id_token validation, PKCE, deploy-time config validation, fetch timeouts, callback failures always redirect back to the app
- Example app with a full React client: token lifecycle (localStorage, refresh, sign-out), Google + GitHub buttons, tests

Not yet:

- Cleanup of expired rows (authorization requests, tickets)
- Rate limiting on the public sign-in surface
- `form_post` callbacks (Apple)
- Callback HTTP test coverage
- Hardening

Note that the inline client in the example app works but didn't get a lot of scrutiny, added for completeness and testability.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
