### PR TITLE
Simplify the anonymous example

### DIFF
--- a/examples/react-minimal/convex/currentUser.ts
+++ b/examples/react-minimal/convex/currentUser.ts
@@ -19,6 +19,6 @@ export const loggedInUser = query({
       return null;
     }
 
-    return { id: user._id, name: user.name };
+    return { id: user._id };
   },
 });

--- a/examples/react-minimal/convex/schema.ts
+++ b/examples/react-minimal/convex/schema.ts
@@ -1,13 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
-import { v } from "convex/values";
 
 export default defineSchema({
-  messages: defineTable({
-    authorId: v.string(),
-    authorName: v.string(),
-    body: v.string(),
-  }).index("by_author", ["authorId"]),
-  users: defineTable({
-    name: v.string(),
-  }),
+  users: defineTable({}),
 });

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -12,8 +12,7 @@ export const upsertFromAuth = internalMutation({
   handler: async (ctx, args) => {
     switch (args.provider) {
       case "anonymous": {
-        const name = "Anonymous";
-        return ctx.db.insert("users", { name });
+        return ctx.db.insert("users", {});
       }
       default: {
         const _exhaustive: never = args.provider;

--- a/examples/react-minimal/src/App.tsx
+++ b/examples/react-minimal/src/App.tsx
@@ -44,8 +44,7 @@ function Dashboard() {
   return (
     <>
       <p>
-        Signed in as <strong>{user ? user.name : "…"}</strong>
-        {user ? ` (${user.id})` : ""}
+        Signed in as <strong>{user ? user.id : "…"}</strong>
       </p>
       <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
       <button onClick={() => signOut()}>Sign out</button>


### PR DESCRIPTION
Drop the `name` field from the anonymous example's `users` table so a fresh install starts with an empty table, and remove the unused `messages` table.

I’m doing this to simplify the code in the example, since it’s going to be embedded in the docs for anonymous auth.