### PR TITLE
Split support for SPA and SSR sign-in and token handling

### DIFF
--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -16,7 +16,8 @@ export {
 export { runWithMutex } from "./mutex";
 export {
   AuthClient,
-  type AuthApi,
+  type SpaAuthApi,
+  type SsrAuthApi,
   type AuthClientConfig,
   type AuthState,
 } from "./sessionManager";

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { SlimTokenBundle, TokenBundle } from "../lib/types";
-import { AuthClient, AuthApi } from "./sessionManager";
+import { AuthClient, SpaAuthApi, SsrAuthApi } from "./sessionManager";
 import {
   InMemoryStorage,
   JWT_STORAGE_KEY,
@@ -22,10 +22,28 @@ function bundle(n: number): TokenBundle {
 }
 
 function makeClient(
-  authApi: Partial<AuthApi> = {},
+  authApi: Partial<SpaAuthApi> = {},
   storage = new InMemoryStorage(),
 ) {
   const client = new AuthClient({
+    mode: "spa",
+    authApi: {
+      refreshSession: async () => null,
+      signOut: async () => {},
+      ...authApi,
+    },
+    storage,
+    storageNamespace: NAMESPACE,
+  });
+  return { client, storage };
+}
+
+function makeSsrClient(
+  authApi: Partial<SsrAuthApi> = {},
+  storage = new InMemoryStorage(),
+) {
+  const client = new AuthClient({
+    mode: "ssr",
     authApi: {
       refreshSession: async () => null,
       signOut: async () => {},
@@ -94,7 +112,7 @@ describe("AuthClient", () => {
   });
 
   test("forced fetch rotates the session via refreshSession", async () => {
-    const refreshSession = vi.fn(async (rt: string | null) => {
+    const refreshSession = vi.fn(async (rt: string) => {
       expect(rt).toBe("refresh-1");
       return bundle(2);
     });
@@ -149,7 +167,7 @@ describe("AuthClient", () => {
   });
 
   test("signOut revokes on the server and clears locally", async () => {
-    const signOut = vi.fn(async (rt: string | null) => {
+    const signOut = vi.fn(async (rt: string) => {
       expect(rt).toBe("refresh-1");
     });
     const { client } = makeClient({ signOut });
@@ -249,7 +267,7 @@ describe("AuthClient (SSR)", () => {
   });
 
   test("setSession adopts an access-only session, storing no refresh token", async () => {
-    const { client, storage } = makeClient();
+    const { client, storage } = makeSsrClient();
     await client.init();
     await client.setSession(ssrAuthResult(1));
 
@@ -268,7 +286,7 @@ describe("AuthClient (SSR)", () => {
   test("hydrates a session from just the access token", async () => {
     const storage = new InMemoryStorage();
     storage.setItem(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
-    const { client } = makeClient({}, storage);
+    const { client } = makeSsrClient({}, storage);
     await client.init();
     expect(client.getSnapshot()).toMatchObject({
       isAuthenticated: true,
@@ -276,17 +294,18 @@ describe("AuthClient (SSR)", () => {
     });
   });
 
-  test("forced fetch refreshes via the token-less (null) API call", async () => {
+  test("forced fetch refreshes via the token-less API call", async () => {
     const refreshSession = vi.fn(async () => ssrAuthResult(2));
-    const { client, storage } = makeClient({ refreshSession });
+    const { client, storage } = makeSsrClient({ refreshSession });
     await client.init();
     await client.setSession(ssrAuthResult(1));
 
     const token = await client.fetchAccessToken({ forceRefreshToken: true });
     expect(token).toBe("access-2");
     expect(refreshSession).toHaveBeenCalledTimes(1);
-    // No refresh token in JS, so the API is called with null (it reads the cookie).
-    expect(refreshSession).toHaveBeenCalledWith(null);
+    // No refresh token in JS, so the API is called with no arguments (it reads
+    // the cookie server-side).
+    expect(refreshSession).toHaveBeenCalledWith();
     expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-2");
     expect(
       storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`),
@@ -294,7 +313,7 @@ describe("AuthClient (SSR)", () => {
   });
 
   test("a null refresh clears the session", async () => {
-    const { client, storage } = makeClient({
+    const { client, storage } = makeSsrClient({
       refreshSession: async () => null,
     });
     await client.init();
@@ -309,15 +328,15 @@ describe("AuthClient (SSR)", () => {
     expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
   });
 
-  test("signOut calls the API with a null token and clears locally", async () => {
+  test("signOut calls the API with no arguments and clears locally", async () => {
     const signOut = vi.fn(async () => {});
-    const { client } = makeClient({ signOut });
+    const { client } = makeSsrClient({ signOut });
     await client.init();
     await client.setSession(ssrAuthResult(1));
 
     await client.signOut();
     expect(signOut).toHaveBeenCalledTimes(1);
-    expect(signOut).toHaveBeenCalledWith(null);
+    expect(signOut).toHaveBeenCalledWith();
     expect(client.getSnapshot()).toMatchObject({
       isAuthenticated: false,
       token: null,

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -28,7 +28,7 @@ function makeClient(
   const client = new AuthClient({
     authApi: {
       refreshSession: async () => null,
-      signOut: async () => { },
+      signOut: async () => {},
       ...authApi,
     },
     storage,
@@ -170,7 +170,7 @@ describe("AuthClient", () => {
     (globalThis as { window?: unknown }).window = {
       addEventListener: (_type: string, l: (event: StorageEvent) => void) =>
         listeners.push(l),
-      removeEventListener: () => { },
+      removeEventListener: () => {},
     };
 
     const { client } = makeClient({}, storage);
@@ -231,15 +231,19 @@ describe("AuthClient", () => {
   });
 });
 
-function publicSession(n: number): SlimTokenBundle {
-  return { accessToken: `access-${n}`, accessTokenExpiresAt: 0, userId: "user-1" };
+/**
+ * Returns a {@link SlimTokenBundle} which is the typical auth response from
+ * an SSR integration.
+ */
+function ssrAuthResult(n: number): SlimTokenBundle {
+  return {
+    accessToken: `access-${n}`,
+    accessTokenExpiresAt: 0,
+    userId: "user-1",
+  };
 }
 
-// A "delegated" (SSR/cookie-based) session is not a separate mode — the client
-// is configured identically, and the delegated shape emerges purely from the
-// data: sign-in and refresh yield an access-only PublicSession, so no refresh
-// token is ever stored, and the API is called with a `null` refresh token.
-describe("AuthClient (delegated / access-only sessions)", () => {
+describe("AuthClient (SSR)", () => {
   afterEach(() => {
     delete (globalThis as { window?: unknown }).window;
   });
@@ -247,7 +251,7 @@ describe("AuthClient (delegated / access-only sessions)", () => {
   test("setSession adopts an access-only session, storing no refresh token", async () => {
     const { client, storage } = makeClient();
     await client.init();
-    await client.setSession(publicSession(1));
+    await client.setSession(ssrAuthResult(1));
 
     expect(client.getSnapshot()).toEqual({
       isLoading: false,
@@ -256,10 +260,12 @@ describe("AuthClient (delegated / access-only sessions)", () => {
     });
     expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-1");
     // The refresh token lives in a server-only cookie — never in JS storage.
-    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+    expect(
+      storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`),
+    ).toBeNull();
   });
 
-  test("hydrates a delegated session from just the access token", async () => {
+  test("hydrates a session from just the access token", async () => {
     const storage = new InMemoryStorage();
     storage.setItem(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
     const { client } = makeClient({}, storage);
@@ -271,10 +277,10 @@ describe("AuthClient (delegated / access-only sessions)", () => {
   });
 
   test("forced fetch refreshes via the token-less (null) API call", async () => {
-    const refreshSession = vi.fn(async () => publicSession(2));
+    const refreshSession = vi.fn(async () => ssrAuthResult(2));
     const { client, storage } = makeClient({ refreshSession });
     await client.init();
-    await client.setSession(publicSession(1));
+    await client.setSession(ssrAuthResult(1));
 
     const token = await client.fetchAccessToken({ forceRefreshToken: true });
     expect(token).toBe("access-2");
@@ -282,15 +288,17 @@ describe("AuthClient (delegated / access-only sessions)", () => {
     // No refresh token in JS, so the API is called with null (it reads the cookie).
     expect(refreshSession).toHaveBeenCalledWith(null);
     expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-2");
-    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+    expect(
+      storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`),
+    ).toBeNull();
   });
 
-  test("a null delegated refresh clears the session", async () => {
+  test("a null refresh clears the session", async () => {
     const { client, storage } = makeClient({
       refreshSession: async () => null,
     });
     await client.init();
-    await client.setSession(publicSession(1));
+    await client.setSession(ssrAuthResult(1));
 
     const token = await client.fetchAccessToken({ forceRefreshToken: true });
     expect(token).toBeNull();
@@ -302,10 +310,10 @@ describe("AuthClient (delegated / access-only sessions)", () => {
   });
 
   test("signOut calls the API with a null token and clears locally", async () => {
-    const signOut = vi.fn(async () => { });
+    const signOut = vi.fn(async () => {});
     const { client } = makeClient({ signOut });
     await client.init();
-    await client.setSession(publicSession(1));
+    await client.setSession(ssrAuthResult(1));
 
     await client.signOut();
     expect(signOut).toHaveBeenCalledTimes(1);

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import type { TokenBundle } from "../lib/types";
+import type { SlimTokenBundle, TokenBundle } from "../lib/types";
 import { AuthClient, AuthApi } from "./sessionManager";
 import {
   InMemoryStorage,
@@ -28,7 +28,7 @@ function makeClient(
   const client = new AuthClient({
     authApi: {
       refreshSession: async () => null,
-      signOut: async () => {},
+      signOut: async () => { },
       ...authApi,
     },
     storage,
@@ -94,7 +94,7 @@ describe("AuthClient", () => {
   });
 
   test("forced fetch rotates the session via refreshSession", async () => {
-    const refreshSession = vi.fn(async (rt: string) => {
+    const refreshSession = vi.fn(async (rt: string | null) => {
       expect(rt).toBe("refresh-1");
       return bundle(2);
     });
@@ -149,7 +149,7 @@ describe("AuthClient", () => {
   });
 
   test("signOut revokes on the server and clears locally", async () => {
-    const signOut = vi.fn(async (rt: string) => {
+    const signOut = vi.fn(async (rt: string | null) => {
       expect(rt).toBe("refresh-1");
     });
     const { client } = makeClient({ signOut });
@@ -170,7 +170,7 @@ describe("AuthClient", () => {
     (globalThis as { window?: unknown }).window = {
       addEventListener: (_type: string, l: (event: StorageEvent) => void) =>
         listeners.push(l),
-      removeEventListener: () => {},
+      removeEventListener: () => { },
     };
 
     const { client } = makeClient({}, storage);
@@ -224,6 +224,92 @@ describe("AuthClient", () => {
       } as unknown as StorageEvent),
     );
 
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+  });
+});
+
+function publicSession(n: number): SlimTokenBundle {
+  return { accessToken: `access-${n}`, accessTokenExpiresAt: 0, userId: "user-1" };
+}
+
+// A "delegated" (SSR/cookie-based) session is not a separate mode — the client
+// is configured identically, and the delegated shape emerges purely from the
+// data: sign-in and refresh yield an access-only PublicSession, so no refresh
+// token is ever stored, and the API is called with a `null` refresh token.
+describe("AuthClient (delegated / access-only sessions)", () => {
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  test("setSession adopts an access-only session, storing no refresh token", async () => {
+    const { client, storage } = makeClient();
+    await client.init();
+    await client.setSession(publicSession(1));
+
+    expect(client.getSnapshot()).toEqual({
+      isLoading: false,
+      isAuthenticated: true,
+      token: "access-1",
+    });
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-1");
+    // The refresh token lives in a server-only cookie — never in JS storage.
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+  });
+
+  test("hydrates a delegated session from just the access token", async () => {
+    const storage = new InMemoryStorage();
+    storage.setItem(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
+    const { client } = makeClient({}, storage);
+    await client.init();
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: true,
+      token: "access-1",
+    });
+  });
+
+  test("forced fetch refreshes via the token-less (null) API call", async () => {
+    const refreshSession = vi.fn(async () => publicSession(2));
+    const { client, storage } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(publicSession(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(token).toBe("access-2");
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    // No refresh token in JS, so the API is called with null (it reads the cookie).
+    expect(refreshSession).toHaveBeenCalledWith(null);
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-2");
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+  });
+
+  test("a null delegated refresh clears the session", async () => {
+    const { client, storage } = makeClient({
+      refreshSession: async () => null,
+    });
+    await client.init();
+    await client.setSession(publicSession(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(token).toBeNull();
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: false,
+      token: null,
+    });
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBeNull();
+  });
+
+  test("signOut calls the API with a null token and clears locally", async () => {
+    const signOut = vi.fn(async () => { });
+    const { client } = makeClient({ signOut });
+    await client.init();
+    await client.setSession(publicSession(1));
+
+    await client.signOut();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signOut).toHaveBeenCalledWith(null);
     expect(client.getSnapshot()).toMatchObject({
       isAuthenticated: false,
       token: null,

--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -342,4 +342,16 @@ describe("AuthClient (SSR)", () => {
       token: null,
     });
   });
+
+  test("clears refresh token if present", async () => {
+    const refreshSession = vi.fn(async () => ssrAuthResult(2));
+    const storage = new InMemoryStorage();
+    storage.setItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`, "refresh-1");
+    const { client } = makeSsrClient({ refreshSession }, storage);
+    await client.init();
+    await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      null,
+    );
+  });
 });

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -106,7 +106,7 @@ export class AuthClient {
    */
   readonly #refresh: () => Promise<TokenBundle | SlimTokenBundle | null>;
   /** Revoke the session on the server. */
-  readonly #signOutApi: () => Promise<void>;
+  readonly #signOutInternal: () => Promise<void>;
   readonly #storage: NamespacedStorage;
   readonly #verbose: boolean;
   readonly #lockKey: string;
@@ -141,7 +141,7 @@ export class AuthClient {
         if (refreshToken === null) return null;
         return authApi.refreshSession(refreshToken);
       };
-      this.#signOutApi = async () => {
+      this.#signOutInternal = async () => {
         const refreshToken = await this.#currentRefreshToken();
         if (refreshToken !== null) await authApi.signOut(refreshToken);
       };
@@ -150,7 +150,7 @@ export class AuthClient {
       // The refresh token is in an httpOnly cookie that the API reads
       // server-side, so it isn't passed directly.
       this.#refresh = () => authApi.refreshSession();
-      this.#signOutApi = () => authApi.signOut();
+      this.#signOutInternal = () => authApi.signOut();
     }
   }
 
@@ -234,14 +234,11 @@ export class AuthClient {
   };
 
   /**
-   * Revoke the current session on the server (best effort) and clear it
-   * locally. The refresh token is passed to the API when the client holds one.
-   * Otherwise it is expected to be present in an httpOnly cookie which will be
-   * sent to the server for handling the sign out operation.
+   * Revoke the current session on the server and clear it locally.
    */
   signOut = async (): Promise<void> => {
     try {
-      await this.#signOutApi();
+      await this.#signOutInternal();
     } catch {
       // Usually means we were already signed out, which is fine.
     }
@@ -250,11 +247,10 @@ export class AuthClient {
   };
 
   /**
-   * The function handed to Convex's `ConvexProviderWithAuth`. Returns the
-   * cached access token, or — when `forceRefreshToken` is true (the server
-   * rejected the last token or it is near expiry) — rotates the refresh token
-   * under a cross-tab lock and returns the fresh access token. Returns `null`
-   * (never `undefined`) when there is no usable session.
+   * The function handed to Convex's `ConvexProviderWithAuth`.
+   *
+   * Returns a cached access token, or fetches a new token if
+   * `forceRefreshToken` is `true`.
    */
   fetchAccessToken = async ({
     forceRefreshToken,
@@ -348,6 +344,12 @@ export class AuthClient {
    * Stores just the access token and notifies subscribers.
    */
   async #storeAccessOnly(session: SlimTokenBundle): Promise<void> {
+    // Null out/remove any existing refresh token. It shouldn't be set unless
+    // this was somehow a client instance configured for SPA use being
+    // "upgraded" to SSR use.
+    this.#refreshToken = null;
+    await this.#storage.remove(REFRESH_TOKEN_STORAGE_KEY);
+
     this.#accessToken = session.accessToken;
     await this.#storage.set(JWT_STORAGE_KEY, session.accessToken);
     this.#isLoading = false;

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -14,21 +14,19 @@ const RETRY_BACKOFF = [500, 2000];
 const RETRY_JITTER = 100;
 
 /**
- * The two auth API calls the core client makes, as an injected interface so
- * this layer never imports Convex: framework bindings implement it (over an
- * HTTP client, to avoid deadlocking the websocket during a refresh), and tests
- * implement it with a fake.
+ * An interface representing the core refresh and sign out APIs that the
+ * framework provides.
  *
- * The one interface serves SPA and SSR session models. In the default direct
- * model the client holds the refresh token and passes it in, and a refresh
- * returns a full {@link TokenBundle} (including the rotated refresh token to
- * persist). Under SSR the refresh token lives in a server-only httpOnly cookie
- * the browser can't read, so `refreshToken` is `null`, the implementation
- * reaches the real token server-side (e.g. by POSTing to a route that reads
- * the cookie), and a refresh returns an access-only {@link SlimTokenBundle}. The
- * client persists the result according to its shape — see {@link AuthClient},
- * which reads which fields came back rather than being told which model it is
- * in.
+ * This interface serves SPA and SSR session models.
+ *
+ * In the SPA model the client holds the refresh token and passes to it
+ * directly to the Convex backend to refresh. That refresh returns a full
+ * {@link TokenBundle} (including a new refresh token to persist).
+ *
+ * Under SSR the refresh token lives in an httpOnly cookie that JS code can't
+ * read. Token refresh happens via an HTTP request to the SSR host which
+ * carries the refresh token in the cookie. The refresh request returns a
+ * {@link SlimTokenBundle} with just a new access token.
  */
 export interface AuthApi {
   /**
@@ -46,7 +44,7 @@ export interface AuthApi {
   ) => Promise<TokenBundle | SlimTokenBundle | null>;
 
   /**
-   * Revoke the current session. 
+   * Revoke the current session.
    *
    * If the client has access to the `refreshToken` (it's a SPA), it should
    * pass it in. Clients without access to the refresh token (SSR) should pass
@@ -204,17 +202,20 @@ export class AuthClient {
   /**
    * Adopt the session a provider just established. Providers call this after
    * their own sign-in flow returns a session: a full {@link TokenBundle} when
-   * the client holds the refresh token, or an access-only {@link SlimTokenBundle}
-   * when it is delegated (cookie-held).
+   * the client holds the refresh token (SPA), or an access-only {@link
+   * SlimTokenBundle} when the refresh token is in a cookie (SSR).
    */
-  setSession = async (session: TokenBundle | SlimTokenBundle): Promise<void> => {
+  setSession = async (
+    session: TokenBundle | SlimTokenBundle,
+  ): Promise<void> => {
     await this.#adopt(session);
   };
 
   /**
    * Revoke the current session on the server (best effort) and clear it
-   * locally. The refresh token is passed to the API when the client holds one
-   * (`null` when it is delegated, where the API reaches the cookie itself).
+   * locally. The refresh token is passed to the API when the client holds one.
+   * Otherwise it is expected to be present in an httpOnly cookie which will be
+   * sent to the server for handling the sign out operation.
    */
   signOut = async (): Promise<void> => {
     const refreshToken = await this.#currentRefreshToken();
@@ -290,10 +291,10 @@ export class AuthClient {
   }
 
   /**
-   * Adopt a sign-in or refresh result, persisting it by its shape: a full
-   * {@link TokenBundle} stores both tokens; an access-only {@link SlimTokenBundle}
-   * stores just the access token (a delegated, cookie-held session); `null`
-   * clears the session.
+   * Adopt a sign-in or refresh result, persisting it by its shape:
+   *  - a full {@link TokenBundle} stores both refresh and access tokens
+   *  - a {@link SlimTokenBundle} stores just the access token
+   *  - `null` clears the session
    */
   async #adopt(result: TokenBundle | SlimTokenBundle | null): Promise<void> {
     if (result === null) {
@@ -306,8 +307,8 @@ export class AuthClient {
   }
 
   /**
-   * Set the in-memory + persisted session to `bundle` (or clear it when null),
-   * then notify subscribers if the authenticated state changed.
+   * Stores (or clears in the case of a `null` bundle) the access and refresh
+   * tokens.
    */
   async #storeTokens(bundle: TokenBundle | null): Promise<void> {
     if (bundle === null) {
@@ -326,10 +327,7 @@ export class AuthClient {
   }
 
   /**
-   * Store an access-only (delegated, cookie-held) session: set just the access
-   * token, never touching the refresh-token slot (there is none in JS). Clearing
-   * always goes through {@link #storeTokens}, so this only ever adopts a
-   * session. Notifies subscribers.
+   * Stores just the access token and notifies subscribers.
    */
   async #storeAccessOnly(session: SlimTokenBundle): Promise<void> {
     this.#accessToken = session.accessToken;

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -1,4 +1,4 @@
-import type { TokenBundle } from "../lib/types";
+import type { SlimTokenBundle, TokenBundle } from "../lib/types";
 import { runWithMutex } from "./mutex";
 import {
   JWT_STORAGE_KEY,
@@ -14,19 +14,45 @@ const RETRY_BACKOFF = [500, 2000];
 const RETRY_JITTER = 100;
 
 /**
- * The two auth API calls the core client makes. Kept as an injected interface
- * so this layer never imports Convex: framework bindings should implement it
- * (over an HTTP client, to avoid deadlocking the websocket during a refresh),
- * and tests implement it with a fake.
+ * The two auth API calls the core client makes, as an injected interface so
+ * this layer never imports Convex: framework bindings implement it (over an
+ * HTTP client, to avoid deadlocking the websocket during a refresh), and tests
+ * implement it with a fake.
+ *
+ * The one interface serves SPA and SSR session models. In the default direct
+ * model the client holds the refresh token and passes it in, and a refresh
+ * returns a full {@link TokenBundle} (including the rotated refresh token to
+ * persist). Under SSR the refresh token lives in a server-only httpOnly cookie
+ * the browser can't read, so `refreshToken` is `null`, the implementation
+ * reaches the real token server-side (e.g. by POSTing to a route that reads
+ * the cookie), and a refresh returns an access-only {@link SlimTokenBundle}. The
+ * client persists the result according to its shape — see {@link AuthClient},
+ * which reads which fields came back rather than being told which model it is
+ * in.
  */
 export interface AuthApi {
   /**
-   * Rotate the refresh token and mint a fresh access token. `null` means the
-   * session is gone (unknown or expired refresh token) — treat as signed out.
+   * Rotate the refresh token and mint a fresh access token.
+   *
+   * If a `refreshToken` is supplied, that means the client has access to
+   * it and can expect a full {@link TokenBundle} as the return value.
+   *
+   * Clients without access to the `refreshToken` (SSR when the token is
+   * in an httpOnly cookie) should pass `null` and will receive a
+   * {@link SlimTokenBundle} as the return value.
    */
-  refreshSession: (refreshToken: string) => Promise<TokenBundle | null>;
-  /** Revoke the session for a refresh token. Idempotent. */
-  signOut: (refreshToken: string) => Promise<void>;
+  refreshSession: (
+    refreshToken: string | null,
+  ) => Promise<TokenBundle | SlimTokenBundle | null>;
+
+  /**
+   * Revoke the current session. 
+   *
+   * If the client has access to the `refreshToken` (it's a SPA), it should
+   * pass it in. Clients without access to the refresh token (SSR) should pass
+   * `null`.
+   */
+  signOut: (refreshToken: string | null) => Promise<void>;
 }
 
 /**
@@ -86,6 +112,10 @@ export class AuthClient {
   readonly #lockKey: string;
 
   #accessToken: string | null = null;
+  /**
+   * If the client code is running in SSR mode, this value will always be
+   * `null`.
+   */
   #refreshToken: string | null = null;
   #isLoading = true;
   #initialized = false;
@@ -173,24 +203,25 @@ export class AuthClient {
 
   /**
    * Adopt the session a provider just established. Providers call this after
-   * their own sign-in flow returns a {@link TokenBundle}.
+   * their own sign-in flow returns a session: a full {@link TokenBundle} when
+   * the client holds the refresh token, or an access-only {@link SlimTokenBundle}
+   * when it is delegated (cookie-held).
    */
-  setSession = async (bundle: TokenBundle): Promise<void> => {
-    await this.#storeTokens(bundle);
+  setSession = async (session: TokenBundle | SlimTokenBundle): Promise<void> => {
+    await this.#adopt(session);
   };
 
   /**
    * Revoke the current session on the server (best effort) and clear it
-   * locally.
+   * locally. The refresh token is passed to the API when the client holds one
+   * (`null` when it is delegated, where the API reaches the cookie itself).
    */
   signOut = async (): Promise<void> => {
     const refreshToken = await this.#currentRefreshToken();
-    if (refreshToken !== null) {
-      try {
-        await this.#authApi.signOut(refreshToken);
-      } catch {
-        // Usually means we were already signed out, which is fine.
-      }
+    try {
+      await this.#authApi.signOut(refreshToken);
+    } catch {
+      // Usually means we were already signed out, which is fine.
     }
     this.#log("signed out, erasing tokens");
     await this.#storeTokens(null);
@@ -220,12 +251,10 @@ export class AuthClient {
         return this.#accessToken;
       }
       const refreshToken = await this.#currentRefreshToken();
-      if (refreshToken === null) {
-        this.#log("no refresh token, cannot refresh");
-        return null;
-      }
-      const bundle = await this.#refreshWithRetry(refreshToken);
-      await this.#storeTokens(bundle);
+      const result = await this.#withRetry(() =>
+        this.#authApi.refreshSession(refreshToken),
+      );
+      await this.#adopt(result);
       return this.#accessToken;
     });
   };
@@ -239,11 +268,16 @@ export class AuthClient {
     );
   }
 
-  async #refreshWithRetry(refreshToken: string): Promise<TokenBundle | null> {
+  /**
+   * Run a refresh `op`, retrying only on transient network errors (backoff +
+   * jitter). Shared by both refresh modes — the caller supplies the actual
+   * refresh call so this stays agnostic to whether a token is passed.
+   */
+  async #withRetry<T>(op: () => Promise<T>): Promise<T> {
     let lastError: unknown;
     for (let retry = 0; retry < RETRY_BACKOFF.length; retry++) {
       try {
-        return await this.#authApi.refreshSession(refreshToken);
+        return await op();
       } catch (error) {
         lastError = error;
         if (!isNetworkError(error)) break;
@@ -253,6 +287,22 @@ export class AuthClient {
       }
     }
     throw lastError;
+  }
+
+  /**
+   * Adopt a sign-in or refresh result, persisting it by its shape: a full
+   * {@link TokenBundle} stores both tokens; an access-only {@link SlimTokenBundle}
+   * stores just the access token (a delegated, cookie-held session); `null`
+   * clears the session.
+   */
+  async #adopt(result: TokenBundle | SlimTokenBundle | null): Promise<void> {
+    if (result === null) {
+      await this.#storeTokens(null);
+    } else if ("refreshToken" in result) {
+      await this.#storeTokens(result);
+    } else {
+      await this.#storeAccessOnly(result);
+    }
   }
 
   /**
@@ -271,6 +321,19 @@ export class AuthClient {
       await this.#storage.set(JWT_STORAGE_KEY, bundle.accessToken);
       await this.#storage.set(REFRESH_TOKEN_STORAGE_KEY, bundle.refreshToken);
     }
+    this.#isLoading = false;
+    this.#notify();
+  }
+
+  /**
+   * Store an access-only (delegated, cookie-held) session: set just the access
+   * token, never touching the refresh-token slot (there is none in JS). Clearing
+   * always goes through {@link #storeTokens}, so this only ever adopts a
+   * session. Notifies subscribers.
+   */
+  async #storeAccessOnly(session: SlimTokenBundle): Promise<void> {
+    this.#accessToken = session.accessToken;
+    await this.#storage.set(JWT_STORAGE_KEY, session.accessToken);
     this.#isLoading = false;
     this.#notify();
   }

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -14,51 +14,33 @@ const RETRY_BACKOFF = [500, 2000];
 const RETRY_JITTER = 100;
 
 /**
- * An interface representing the core refresh and sign out APIs that the
- * framework provides.
+ * The refresh and sign-out API for a **SPA** client, where JS holds the
+ * refresh token directly.
  *
- * This interface serves SPA and SSR session models.
- *
- * In the SPA model the client holds the refresh token and passes to it
- * directly to the Convex backend to refresh. That refresh returns a full
- * {@link TokenBundle} (including a new refresh token to persist).
- *
- * Under SSR the refresh token lives in an httpOnly cookie that JS code can't
- * read. Token refresh happens via an HTTP request to the SSR host which
- * carries the refresh token in the cookie. The refresh request returns a
- * {@link SlimTokenBundle} with just a new access token.
+ * Refreshing rotates the token and returns a full {@link TokenBundle}
+ * (including the next refresh token to persist), or `null` when the session is
+ * gone.
  */
-export interface AuthApi {
-  /**
-   * Rotate the refresh token and mint a fresh access token.
-   *
-   * If a `refreshToken` is supplied, that means the client has access to
-   * it and can expect a full {@link TokenBundle} as the return value.
-   *
-   * Clients without access to the `refreshToken` (SSR when the token is
-   * in an httpOnly cookie) should pass `null` and will receive a
-   * {@link SlimTokenBundle} as the return value.
-   */
-  refreshSession: (
-    refreshToken: string | null,
-  ) => Promise<TokenBundle | SlimTokenBundle | null>;
-
-  /**
-   * Revoke the current session.
-   *
-   * If the client has access to the `refreshToken` (it's a SPA), it should
-   * pass it in. Clients without access to the refresh token (SSR) should pass
-   * `null`.
-   */
-  signOut: (refreshToken: string | null) => Promise<void>;
+export interface SpaAuthApi {
+  refreshSession: (refreshToken: string) => Promise<TokenBundle | null>;
+  signOut: (refreshToken: string) => Promise<void>;
 }
 
 /**
- * Configuration for the {@link AuthClient}.
+ * The refresh and sign-out API for an **SSR** client, where the refresh token
+ * lives in an httpOnly cookie that JS can't read.
+ *
+ * Refreshing goes through an HTTP request to the SSR host, which carries the
+ * refresh token in the cookie and replies with a {@link SlimTokenBundle}
+ * containing a new access token, or `null` when the session is gone.
  */
-export interface AuthClientConfig {
-  /** The API that the server exposes for auth. */
-  authApi: AuthApi;
+export interface SsrAuthApi {
+  refreshSession: () => Promise<SlimTokenBundle | null>;
+  signOut: () => Promise<void>;
+}
+
+/** Config common to both session models. */
+interface AuthClientConfigBase {
   /** Where tokens are persisted. */
   storage: TokenStorage;
   /** Namespace for storage keys; typically the deployment URL. */
@@ -66,6 +48,20 @@ export interface AuthClientConfig {
   /** Log refresh/lifecycle steps to the console. */
   verbose?: boolean;
 }
+
+/**
+ * Configuration for the {@link AuthClient}, discriminated by session `mode`.
+ *
+ * The mode determines who holds the refresh token, and therefore the shape of
+ * the auth API the client drives:
+ *  - `"spa"`: JS holds the refresh token; the client passes it to a
+ *    {@link SpaAuthApi}.
+ *  - `"ssr"`: the refresh token is in an httpOnly cookie; a {@link SsrAuthApi}
+ *    is called without one and reads the cookie server-side.
+ */
+export type AuthClientConfig =
+  | (AuthClientConfigBase & { mode: "spa"; authApi: SpaAuthApi })
+  | (AuthClientConfigBase & { mode: "ssr"; authApi: SsrAuthApi });
 
 /** Auth state that can be subscribed to via {@link AuthClient.subscribe} */
 export interface AuthState {
@@ -104,7 +100,13 @@ function isNetworkError(error: unknown): boolean {
  * a token bundle.
  */
 export class AuthClient {
-  readonly #authApi: AuthApi;
+  /**
+   * Rotate the session, resolving to the new bundle or `null` when the session
+   * is gone.
+   */
+  readonly #refresh: () => Promise<TokenBundle | SlimTokenBundle | null>;
+  /** Revoke the session on the server. */
+  readonly #signOutApi: () => Promise<void>;
   readonly #storage: NamespacedStorage;
   readonly #verbose: boolean;
   readonly #lockKey: string;
@@ -123,13 +125,33 @@ export class AuthClient {
   #storageListener: ((event: StorageEvent) => void) | null = null;
 
   constructor(config: AuthClientConfig) {
-    this.#authApi = config.authApi;
     this.#storage = new NamespacedStorage(
       config.storage,
       config.storageNamespace,
     );
     this.#verbose = config.verbose ?? false;
     this.#lockKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
+
+    // Bind the mode-specific refresh/sign-out behavior.
+    if (config.mode === "spa") {
+      const { authApi } = config;
+      this.#refresh = async () => {
+        const refreshToken = await this.#currentRefreshToken();
+        // No token means there's no session to refresh — don't call the API.
+        if (refreshToken === null) return null;
+        return authApi.refreshSession(refreshToken);
+      };
+      this.#signOutApi = async () => {
+        const refreshToken = await this.#currentRefreshToken();
+        if (refreshToken !== null) await authApi.signOut(refreshToken);
+      };
+    } else {
+      const { authApi } = config;
+      // The refresh token is in an httpOnly cookie that the API reads
+      // server-side, so it isn't passed directly.
+      this.#refresh = () => authApi.refreshSession();
+      this.#signOutApi = () => authApi.signOut();
+    }
   }
 
   // --- Observable store API ------------------------------------------------
@@ -218,9 +240,8 @@ export class AuthClient {
    * sent to the server for handling the sign out operation.
    */
   signOut = async (): Promise<void> => {
-    const refreshToken = await this.#currentRefreshToken();
     try {
-      await this.#authApi.signOut(refreshToken);
+      await this.#signOutApi();
     } catch {
       // Usually means we were already signed out, which is fine.
     }
@@ -251,10 +272,7 @@ export class AuthClient {
         this.#log(`using token refreshed by another tab`);
         return this.#accessToken;
       }
-      const refreshToken = await this.#currentRefreshToken();
-      const result = await this.#withRetry(() =>
-        this.#authApi.refreshSession(refreshToken),
-      );
+      const result = await this.#withRetry(() => this.#refresh());
       await this.#adopt(result);
       return this.#accessToken;
     });

--- a/packages/core/src/components/anonymous/react.test.tsx
+++ b/packages/core/src/components/anonymous/react.test.tsx
@@ -33,6 +33,7 @@ const signInAnonymous = {} as SignInAnonymousMutation;
 
 function renderAnonymousAuth() {
   const client = new AuthClient({
+    mode: "spa",
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -60,6 +60,7 @@ const flows = [
 
 function renderFlow(useFlow: () => Flow) {
   const client = new AuthClient({
+    mode: "spa",
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -29,6 +29,58 @@ export const vTokenBundle = v.object({
 export type TokenBundle = Infer<typeof vTokenBundle>;
 
 /**
+ * The access-only view of a session that an SSR route hands back to the
+ * browser. It is a {@link TokenBundle} with the refresh token (and its expiry)
+ * removed: under SSR the refresh token lives only in an httpOnly cookie and
+ * must never reach client JS.
+ */
+export type SlimTokenBundle = {
+  accessToken: string;
+  accessTokenExpiresAt: number;
+  userId: string;
+};
+
+/** Project a {@link TokenBundle} down to its access-only {@link SlimTokenBundle},
+ * dropping the refresh token so it is never sent to the browser. */
+export function makeSlimBundle(bundle: TokenBundle): SlimTokenBundle {
+  return {
+    accessToken: bundle.accessToken,
+    accessTokenExpiresAt: bundle.accessTokenExpiresAt,
+    userId: bundle.userId,
+  };
+}
+
+/** The app's `refreshSession` mutation reference: exchange a refresh token for a
+ * fresh {@link TokenBundle}, or `null` when the session is gone. */
+export type RefreshSessionFn = FunctionReference<
+  "mutation",
+  "public",
+  { refreshToken: string },
+  TokenBundle | null
+>;
+
+/** The app's `signOut` mutation reference: revoke the session for a refresh
+ * token. */
+export type SignOutFn = FunctionReference<
+  "mutation",
+  "public",
+  { refreshToken: string },
+  null
+>;
+
+/**
+ * The auth mutations the app exports from `setupCore(...).attachUserCallback`.
+ * Passed as references (not names) because an app may re-export them under any
+ * names. Shared by every binding that refreshes or revokes a session — the React
+ * client ({@link ConvexAuthProvider}), the SSR refresh/sign-out handlers, and the
+ * Next.js middleware — so the contract can never drift between them.
+ */
+export type ConvexAuthApi = {
+  refreshSession: RefreshSessionFn;
+  signOut: SignOutFn;
+};
+
+/**
  * Shared identity-claims contract between the *provider* components that
  * authenticate users and the *core* component.
  *

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -29,10 +29,10 @@ export const vTokenBundle = v.object({
 export type TokenBundle = Infer<typeof vTokenBundle>;
 
 /**
- * The access-only view of a session that an SSR route hands back to the
- * browser. It is a {@link TokenBundle} with the refresh token (and its expiry)
- * removed: under SSR the refresh token lives only in an httpOnly cookie and
- * must never reach client JS.
+ * The token bundle that an SSR route hands back to the client. It is a slimmed
+ * down version of a {@link TokenBundle} with the refresh token (and its
+ * expiry) removed: under SSR the refresh token lives only in an httpOnly
+ * cookie and never reaches client JS.
  */
 export type SlimTokenBundle = {
   accessToken: string;
@@ -40,8 +40,10 @@ export type SlimTokenBundle = {
   userId: string;
 };
 
-/** Project a {@link TokenBundle} down to its access-only {@link SlimTokenBundle},
- * dropping the refresh token so it is never sent to the browser. */
+/**
+ * Strip down a {@link TokenBundle} down to a {@link SlimTokenBundle},
+ * dropping the refresh token so it is never sent to the browser.
+ */
 export function makeSlimBundle(bundle: TokenBundle): SlimTokenBundle {
   return {
     accessToken: bundle.accessToken,
@@ -71,9 +73,7 @@ export type SignOutFn = FunctionReference<
 /**
  * The auth mutations the app exports from `setupCore(...).attachUserCallback`.
  * Passed as references (not names) because an app may re-export them under any
- * names. Shared by every binding that refreshes or revokes a session — the React
- * client ({@link ConvexAuthProvider}), the SSR refresh/sign-out handlers, and the
- * Next.js middleware — so the contract can never drift between them.
+ * names. Consumed by both SPA and SSR implementations.
  */
 export type ConvexAuthApi = {
   refreshSession: RefreshSessionFn;

--- a/packages/core/src/react/client.test.tsx
+++ b/packages/core/src/react/client.test.tsx
@@ -147,7 +147,7 @@ describe("React bindings", () => {
   });
 
   test("signOut revokes on the server and clears consumers", async () => {
-    const signOut = vi.fn(async (rt: string) => {
+    const signOut = vi.fn(async (rt: string | null) => {
       expect(rt).toBe("refresh-1");
     });
     const { client } = makeClient({ signOut });

--- a/packages/core/src/react/client.test.tsx
+++ b/packages/core/src/react/client.test.tsx
@@ -2,7 +2,7 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { ReactNode } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { AuthApi, AuthClient } from "../browser/sessionManager";
+import { SpaAuthApi, AuthClient } from "../browser/sessionManager";
 import {
   InMemoryStorage,
   JWT_STORAGE_KEY,
@@ -27,10 +27,11 @@ function bundle(n: number): TokenBundle {
 }
 
 function makeClient(
-  authApi: Partial<AuthApi> = {},
+  authApi: Partial<SpaAuthApi> = {},
   storage = new InMemoryStorage(),
 ) {
   const client = new AuthClient({
+    mode: "spa",
     authApi: {
       refreshSession: async () => null,
       signOut: async () => {},
@@ -147,7 +148,7 @@ describe("React bindings", () => {
   });
 
   test("signOut revokes on the server and clears consumers", async () => {
-    const signOut = vi.fn(async (rt: string | null) => {
+    const signOut = vi.fn(async (rt: string) => {
       expect(rt).toBe("refresh-1");
     });
     const { client } = makeClient({ signOut });

--- a/packages/core/src/react/client.tsx
+++ b/packages/core/src/react/client.tsx
@@ -10,7 +10,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { INITIAL_AUTH_STATE, type AuthClient } from "../browser/sessionManager";
-import type { TokenBundle } from "../lib/types";
+import type { SlimTokenBundle, TokenBundle } from "../lib/types";
 
 // React calls this during SSR and initial hydration — before `init()` has read
 // storage — so it always reports the loading state. It lives here rather than
@@ -20,10 +20,12 @@ const getServerSnapshot = () => INITIAL_AUTH_STATE;
 /** The value exposed by {@link useAuthActions}. */
 export type ConvexAuthActionsContextType = {
   /**
-   * Adopt a session established by a provider. A provider's sign-in flow
-   * returns a {@link TokenBundle}; pass it here to authenticate the client.
+   * Adopt a session established by a provider. A provider's client-direct
+   * sign-in returns a full {@link TokenBundle}; its SSR sibling returns an
+   * access-only {@link SlimTokenBundle}. Pass either here to authenticate the
+   * client.
    */
-  setSession: (bundle: TokenBundle) => Promise<void>;
+  setSession: (session: TokenBundle | SlimTokenBundle) => Promise<void>;
   /** Sign out: revoke the session on the server and clear it locally. */
   signOut: () => Promise<void>;
 };
@@ -41,12 +43,12 @@ export const ConvexAuthTokenContext = createContext<string | null>(null);
  */
 const ConvexAuthInternalContext = createContext<
   | {
-      isLoading: boolean;
-      isAuthenticated: boolean;
-      fetchAccessToken: (args: {
-        forceRefreshToken: boolean;
-      }) => Promise<string | null>;
-    }
+    isLoading: boolean;
+    isAuthenticated: boolean;
+    fetchAccessToken: (args: {
+      forceRefreshToken: boolean;
+    }) => Promise<string | null>;
+  }
   | undefined
 >(undefined);
 

--- a/packages/core/src/react/client.tsx
+++ b/packages/core/src/react/client.tsx
@@ -20,10 +20,12 @@ const getServerSnapshot = () => INITIAL_AUTH_STATE;
 /** The value exposed by {@link useAuthActions}. */
 export type ConvexAuthActionsContextType = {
   /**
-   * Adopt a session established by a provider. A provider's client-direct
-   * sign-in returns a full {@link TokenBundle}; its SSR sibling returns an
-   * access-only {@link SlimTokenBundle}. Pass either here to authenticate the
-   * client.
+   * Initialize or refresh a session.
+   *
+   * A SPA client will receive a full {@link TokenBundle} so it can access the
+   * refresh token for direct session refreshing. An SSR client will receive a
+   * {@link SlimTokenBundle} which doesn't include the refresh token (that
+   * value is in an httpOnly cookie, not reachable by client JS code).
    */
   setSession: (session: TokenBundle | SlimTokenBundle) => Promise<void>;
   /** Sign out: revoke the session on the server and clear it locally. */
@@ -43,12 +45,12 @@ export const ConvexAuthTokenContext = createContext<string | null>(null);
  */
 const ConvexAuthInternalContext = createContext<
   | {
-    isLoading: boolean;
-    isAuthenticated: boolean;
-    fetchAccessToken: (args: {
-      forceRefreshToken: boolean;
-    }) => Promise<string | null>;
-  }
+      isLoading: boolean;
+      isAuthenticated: boolean;
+      fetchAccessToken: (args: {
+        forceRefreshToken: boolean;
+      }) => Promise<string | null>;
+    }
   | undefined
 >(undefined);
 

--- a/packages/core/src/react/index.tsx
+++ b/packages/core/src/react/index.tsx
@@ -89,17 +89,12 @@ export function ConvexAuthProvider({
       logger: client.logger,
     });
     return new AuthClient({
+      mode: "spa",
       authApi: {
-        // The browser holds the refresh token, so it is always present here; a
-        // `null` means there is no session to refresh, so short-circuit.
         refreshSession: (refreshToken) =>
-          refreshToken === null
-            ? Promise.resolve(null)
-            : httpClient.mutation(api.refreshSession, { refreshToken }),
+          httpClient.mutation(api.refreshSession, { refreshToken }),
         signOut: async (refreshToken) => {
-          if (refreshToken !== null) {
-            await httpClient.mutation(api.signOut, { refreshToken });
-          }
+          await httpClient.mutation(api.signOut, { refreshToken });
         },
       },
       storage: storage ?? defaultStorage(),

--- a/packages/core/src/react/index.tsx
+++ b/packages/core/src/react/index.tsx
@@ -17,11 +17,10 @@
 
 import { ConvexHttpClient } from "convex/browser";
 import { ConvexProviderWithAuth, ConvexReactClient } from "convex/react";
-import { FunctionReference } from "convex/server";
 import { ReactNode, useContext, useMemo } from "react";
 import { AuthClient } from "../browser/sessionManager";
 import { TokenStorage, defaultStorage } from "../browser/storage";
-import type { TokenBundle } from "../lib/types";
+import type { ConvexAuthApi } from "../lib/types";
 import {
   AuthProvider,
   ConvexAuthActionsContext,
@@ -32,28 +31,8 @@ import {
 export { useConvexAuth } from "convex/react";
 export { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 export type { TokenStorage } from "../browser/storage";
-export type { TokenBundle } from "../lib/types";
+export type { ConvexAuthApi, TokenBundle } from "../lib/types";
 export type { ConvexAuthActionsContextType } from "./client";
-
-/**
- * The auth mutations the app exports from `setupCore(...).attachUserCallback`.
- * Passed as references (not names) because an app may re-export them under any
- * names.
- */
-export type ConvexAuthApi = {
-  refreshSession: FunctionReference<
-    "mutation",
-    "public",
-    { refreshToken: string },
-    TokenBundle | null
-  >;
-  signOut: FunctionReference<
-    "mutation",
-    "public",
-    { refreshToken: string },
-    null
-  >;
-};
 
 /**
  * Replace your `ConvexProvider` with this to enable authentication.
@@ -111,10 +90,16 @@ export function ConvexAuthProvider({
     });
     return new AuthClient({
       authApi: {
+        // The browser holds the refresh token, so it is always present here; a
+        // `null` means there is no session to refresh, so short-circuit.
         refreshSession: (refreshToken) =>
-          httpClient.mutation(api.refreshSession, { refreshToken }),
+          refreshToken === null
+            ? Promise.resolve(null)
+            : httpClient.mutation(api.refreshSession, { refreshToken }),
         signOut: async (refreshToken) => {
-          await httpClient.mutation(api.signOut, { refreshToken });
+          if (refreshToken !== null) {
+            await httpClient.mutation(api.signOut, { refreshToken });
+          }
         },
       },
       storage: storage ?? defaultStorage(),

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -73,11 +73,13 @@ export function defaultCookieOptions(): CookieOptions {
 }
 
 /**
- * Write a session's tokens as cookies: the access token in
- * {@link AUTH_JWT_COOKIE} and the refresh token in {@link AUTH_REFRESH_COOKIE}.
- * Both live as long as the refresh token (the access token is refreshed on
- * expiry). With {@link defaultCookieOptions} the refresh cookie is httpOnly, so
- * it never reaches client JS.
+ * Write the tokens in a `bundle` as cookies.
+ *
+ * The access token is stored in in {@link AUTH_JWT_COOKIE} and the refresh
+ * token in {@link AUTH_REFRESH_COOKIE}. Both live as long as the refresh
+ * token, although the access token will likely expire sooner and need to be
+ * refreshed). With {@link defaultCookieOptions} the refresh cookie is
+ * httpOnly, so it never reaches client JS.
  *
  * This is the one place that knows which cookies hold a session and how their
  * lifetimes derive from the bundle, so refresh, middleware, and every provider's

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -20,7 +20,7 @@ export const AUTH_JWT_COOKIE = JWT_STORAGE_KEY;
 /** The cookie holding the current (rotating) refresh token. */
 export const AUTH_REFRESH_COOKIE = REFRESH_TOKEN_STORAGE_KEY;
 
-/** Attributes applied when writing a cookie. */
+/** Attributes applied when writing a cookie. The low-level shape, all optional. */
 export interface CookieOptions {
   /** Whether to hide the cookie from client JS. */
   httpOnly?: boolean;
@@ -37,6 +37,18 @@ export interface CookieOptions {
   /** Cookie domain. */
   domain?: string;
 }
+
+/**
+ * The cookie options a framework integration must supply for auth cookies.
+ *
+ * `secure` is required. Whether auth cookies are HTTPS-only depends on the
+ * deployment (HTTPS in production, plain http on localhost), so every
+ * integration has to decide it explicitly rather than inherit a default that
+ * would be wrong in one environment or the other.
+ */
+export type AuthCookieOptions = Omit<CookieOptions, "secure"> & {
+  secure: boolean;
+};
 
 /**
  * Read/write/delete cookies. Every method may be synchronous or return a
@@ -57,14 +69,18 @@ export interface CookieStore {
 }
 
 /**
- * The default attributes for auth cookies.
+ * The environment-independent attributes for auth cookies, merged under any
+ * caller-supplied options by {@link writeAuthCookies}.
  *
  *  * `httpOnly: true` (so the refresh token never reaches client JS)
  *  * `sameSite: "lax"` to aid in CSRF protection (see
  *     https://auth.pilcrowonpaper.com/csrf)
  *  * `path: "/"` so the cookies will be sent for all paths on the site
+ *
+ * `secure` is deliberately absent: it varies by environment and is supplied by
+ * the caller via {@link AuthCookieOptions}.
  */
-export function defaultCookieOptions(): CookieOptions {
+function invariantCookieOptions(): Omit<CookieOptions, "secure"> {
   return {
     httpOnly: true,
     sameSite: "lax",
@@ -78,8 +94,8 @@ export function defaultCookieOptions(): CookieOptions {
  * The access token is stored in in {@link AUTH_JWT_COOKIE} and the refresh
  * token in {@link AUTH_REFRESH_COOKIE}. Both live as long as the refresh
  * token, although the access token will likely expire sooner and need to be
- * refreshed). With {@link defaultCookieOptions} the refresh cookie is
- * httpOnly, so it never reaches client JS.
+ * refreshed). The invariant attributes (httpOnly etc.) are merged in, so the
+ * refresh cookie is httpOnly and never reaches client JS.
  *
  * This is the one place that knows which cookies hold a session and how their
  * lifetimes derive from the bundle, so refresh, middleware, and every provider's
@@ -88,15 +104,13 @@ export function defaultCookieOptions(): CookieOptions {
 export async function writeAuthCookies(
   cookies: CookieStore,
   bundle: TokenBundle,
-  options: CookieOptions = defaultCookieOptions(),
+  options: AuthCookieOptions,
 ): Promise<void> {
+  const base = { ...invariantCookieOptions(), ...options };
   const expires = new Date(bundle.refreshTokenExpiresAt);
-  await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, {
-    ...options,
-    expires,
-  });
+  await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, { ...base, expires });
   await cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {
-    ...options,
+    ...base,
     expires,
   });
 }

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -13,6 +13,7 @@
  */
 
 import { JWT_STORAGE_KEY, REFRESH_TOKEN_STORAGE_KEY } from "../browser/storage";
+import type { TokenBundle } from "../lib/types";
 
 /** The cookie holding the current access token (a JWT). */
 export const AUTH_JWT_COOKIE = JWT_STORAGE_KEY;
@@ -69,4 +70,37 @@ export function defaultCookieOptions(): CookieOptions {
     sameSite: "lax",
     path: "/",
   };
+}
+
+/**
+ * Write a session's tokens as cookies: the access token in
+ * {@link AUTH_JWT_COOKIE} and the refresh token in {@link AUTH_REFRESH_COOKIE}.
+ * Both live as long as the refresh token (the access token is refreshed on
+ * expiry). With {@link defaultCookieOptions} the refresh cookie is httpOnly, so
+ * it never reaches client JS.
+ *
+ * This is the one place that knows which cookies hold a session and how their
+ * lifetimes derive from the bundle, so refresh, middleware, and every provider's
+ * sign-in handler shape cookies identically.
+ */
+export async function writeAuthCookies(
+  cookies: CookieStore,
+  bundle: TokenBundle,
+  options: CookieOptions = defaultCookieOptions(),
+): Promise<void> {
+  const expires = new Date(bundle.refreshTokenExpiresAt);
+  await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, {
+    ...options,
+    expires,
+  });
+  await cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {
+    ...options,
+    expires,
+  });
+}
+
+/** Delete both auth cookies. The counterpart of {@link writeAuthCookies}. */
+export async function clearAuthCookies(cookies: CookieStore): Promise<void> {
+  await cookies.delete(AUTH_JWT_COOKIE);
+  await cookies.delete(AUTH_REFRESH_COOKIE);
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -7,12 +7,12 @@
  */
 
 export {
+  type AuthCookieOptions,
   type CookieOptions,
   type CookieStore,
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
   clearAuthCookies,
-  defaultCookieOptions,
   writeAuthCookies,
 } from "./cookies";
 export {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,8 +1,7 @@
 /**
  * Framework-agnostic server (SSR) building blocks for Convex Auth: a cookie
  * abstraction, access-token inspection, and the {@link ServerAuthSession} that
- * ties them together. The Next.js bindings (`@convex-dev/auth/nextjs/server`)
- * build on these, and other SSR frameworks can too.
+ * ties them together.
  *
  * @module
  */
@@ -12,13 +11,25 @@ export {
   type CookieStore,
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
+  clearAuthCookies,
   defaultCookieOptions,
+  writeAuthCookies,
 } from "./cookies";
 export {
   type DecodedAccessToken,
   decodeAccessToken,
   isTokenExpiring,
 } from "./jwt";
-export { ServerAuthSession, type ServerAuthSessionConfig } from "./session";
-export type { AuthApi } from "../browser/sessionManager";
-export type { TokenBundle } from "../lib/types";
+export {
+  ServerAuthSession,
+  type RefreshSession,
+  type ServerAuthSessionConfig,
+} from "./session";
+export type {
+  ConvexAuthApi,
+  RefreshSessionFn,
+  SignOutFn,
+  SlimTokenBundle,
+  TokenBundle,
+} from "../lib/types";
+export { makeSlimBundle } from "../lib/types";

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -56,7 +56,11 @@ function newSession(
   refreshSession: RefreshSession = async () => null,
   cookies = new FakeCookies(),
 ) {
-  const session = new ServerAuthSession({ refreshSession, cookies });
+  const session = new ServerAuthSession({
+    refreshSession,
+    cookies,
+    cookieOptions: { secure: false },
+  });
   return { session, cookies };
 }
 

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 import type { TokenBundle } from "../lib/types";
-import type { AuthApi } from "../browser/sessionManager";
 import {
   CookieOptions,
   CookieStore,
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
 } from "./cookies";
-import { ServerAuthSession } from "./session";
+import { RefreshSession, ServerAuthSession } from "./session";
 
 /** Build an unsigned JWT whose payload has the given `exp` (seconds). `jose`'s
  * `decodeJwt` reads the payload without verifying the signature. */
@@ -54,17 +53,10 @@ class FakeCookies implements CookieStore {
 }
 
 function newSession(
-  authApi: Partial<AuthApi> = {},
+  refreshSession: RefreshSession = async () => null,
   cookies = new FakeCookies(),
 ) {
-  const session = new ServerAuthSession({
-    authApi: {
-      refreshSession: async () => null,
-      signOut: async () => {},
-      ...authApi,
-    },
-    cookies,
-  });
+  const session = new ServerAuthSession({ refreshSession, cookies });
   return { session, cookies };
 }
 
@@ -75,7 +67,7 @@ describe("ServerAuthSession", () => {
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession({ refreshSession }, cookies);
+    const { session } = newSession(refreshSession, cookies);
 
     expect(await session.getToken()).toBe(jwt(NOW + 60));
     expect(refreshSession).not.toHaveBeenCalled();
@@ -92,7 +84,7 @@ describe("ServerAuthSession", () => {
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // within the 10s skew
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession({ refreshSession }, cookies);
+    const { session } = newSession(refreshSession, cookies);
 
     expect(await session.getToken()).toBe(next.accessToken);
     expect(refreshSession).toHaveBeenCalledTimes(1);
@@ -107,7 +99,7 @@ describe("ServerAuthSession", () => {
     const refreshSession = vi.fn(async () => newTokenBundle(2));
     const cookies = new FakeCookies();
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession({ refreshSession }, cookies);
+    const { session } = newSession(refreshSession, cookies);
 
     expect(await session.getToken()).toBe(newTokenBundle(2).accessToken);
     expect(refreshSession).toHaveBeenCalledTimes(1);
@@ -119,10 +111,7 @@ describe("ServerAuthSession", () => {
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5));
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession(
-      { refreshSession: async () => null },
-      cookies,
-    );
+    const { session } = newSession(async () => null, cookies);
 
     expect(await session.getToken()).toBeNull();
     expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
@@ -135,7 +124,7 @@ describe("ServerAuthSession", () => {
     const refreshSession = vi.fn(async () => newTokenBundle(2));
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // expiring, and nothing to refresh with
-    const { session } = newSession({ refreshSession }, cookies);
+    const { session } = newSession(refreshSession, cookies);
 
     expect(await session.getToken()).toBeNull();
     expect(refreshSession).not.toHaveBeenCalled();
@@ -144,7 +133,7 @@ describe("ServerAuthSession", () => {
 
   test("setTokens writes both cookies httpOnly", async () => {
     const cookies = new FakeCookies();
-    const { session } = newSession({}, cookies);
+    const { session } = newSession(undefined, cookies);
     await session.setTokens(newTokenBundle(1));
 
     expect(cookies.get(AUTH_JWT_COOKIE)).toBe(newTokenBundle(1).accessToken);
@@ -153,35 +142,10 @@ describe("ServerAuthSession", () => {
     expect(cookies.options.get(AUTH_REFRESH_COOKIE)?.httpOnly).toBe(true);
   });
 
-  test("signOut revokes on the server and clears cookies", async () => {
-    const signOut = vi.fn(async (rt: string) => {
-      expect(rt).toBe("refresh-1");
-    });
-    const cookies = new FakeCookies();
-    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
-    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession({ signOut }, cookies);
-
-    await session.signOut();
-    expect(signOut).toHaveBeenCalledTimes(1);
-    expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
-    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
-  });
-
-  test("signOut with no session is a no-op that still clears cookies", async () => {
-    const signOut = vi.fn(async () => {});
-    const cookies = new FakeCookies();
-    const { session } = newSession({ signOut }, cookies);
-
-    await session.signOut();
-    expect(signOut).not.toHaveBeenCalled();
-    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
-  });
-
   test("isAuthenticated reflects a non-expired JWT cookie", async () => {
     vi.spyOn(Date, "now").mockReturnValue(nowMs);
     const cookies = new FakeCookies();
-    const { session } = newSession({}, cookies);
+    const { session } = newSession(undefined, cookies);
     expect(await session.isAuthenticated()).toBe(false);
 
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -8,33 +8,43 @@
  * the server when it is missing or near expiry, and writing the rotated tokens
  * back as cookies.
  *
- * Like {@link AuthClient} it takes an injected {@link AuthApi}, so it never
- * imports Convex: a framework binding supplies an `AuthApi` on top of an HTTP
- * client and a {@link CookieStore} built on its request/response cookies, and
- * tests supply fakes. The server can access the real refresh token (from the
- * cookie), so the existing `AuthApi.refreshSession(refreshToken)` shape fits
- * directly.
+ * It takes an injected `refreshSession` callback, so it never imports Convex: a
+ * framework binding supplies one on top of an HTTP client and a
+ * {@link CookieStore} built on its request/response cookies, and tests supply a
+ * fake. The server can access the real refresh token (from the cookie), so it
+ * always passes a `refreshToken` and gets back a full {@link TokenBundle} to
+ * re-cookie. Signing out is a separate concern (see the `signOutHandler`), so it
+ * is not part of this class.
  *
  * @module
  */
 
-import type { AuthApi } from "../browser/sessionManager";
 import type { TokenBundle } from "../lib/types";
 import {
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
   CookieOptions,
   CookieStore,
+  clearAuthCookies,
   defaultCookieOptions,
+  writeAuthCookies,
 } from "./cookies";
 import { isTokenExpiring } from "./jwt";
 
+/**
+ * Rotate a refresh token into a fresh {@link TokenBundle}, or `null` when the
+ * session is gone (unknown or expired refresh token). A framework binding
+ * usually implements this over a Convex HTTP client; tests pass a fake.
+ */
+export type RefreshSession = (
+  refreshToken: string,
+) => Promise<TokenBundle | null>;
+
 /** Configuration for a {@link ServerAuthSession}. */
 export interface ServerAuthSessionConfig {
-  /**
-   * The auth API (refresh/sign-out), typically based on a Convex HTTP client.
-   */
-  authApi: AuthApi;
+  /** Exchange the cookie's refresh token for a fresh session (typically over a
+   * Convex HTTP client). */
+  refreshSession: RefreshSession;
   /** Request/response cookies for this SSR request. */
   cookies: CookieStore;
   /**
@@ -50,13 +60,13 @@ export interface ServerAuthSessionConfig {
 }
 
 export class ServerAuthSession {
-  readonly #authApi: AuthApi;
+  readonly #refreshSession: RefreshSession;
   readonly #cookies: CookieStore;
   readonly #refreshSkewSeconds: number;
   readonly #cookieOptions: CookieOptions;
 
   constructor(config: ServerAuthSessionConfig) {
-    this.#authApi = config.authApi;
+    this.#refreshSession = config.refreshSession;
     this.#cookies = config.cookies;
     this.#refreshSkewSeconds = config.refreshSkewSeconds ?? 10;
     this.#cookieOptions = config.cookieOptions ?? defaultCookieOptions();
@@ -86,7 +96,7 @@ export class ServerAuthSession {
     if (refreshToken === null) {
       return null;
     }
-    const bundle = await this.#authApi.refreshSession(refreshToken);
+    const bundle = await this.#refreshSession(refreshToken);
     if (bundle === null) {
       await this.#clear();
       return null;
@@ -102,31 +112,7 @@ export class ServerAuthSession {
    * the access token is refreshed on expiry via {@link getToken}.
    */
   async setTokens(bundle: TokenBundle): Promise<void> {
-    const expires = new Date(bundle.refreshTokenExpiresAt);
-    await this.#cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, {
-      ...this.#cookieOptions,
-      expires,
-    });
-    await this.#cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {
-      ...this.#cookieOptions,
-      expires,
-    });
-  }
-
-  /**
-   * Revoke the session on the server (best effort) and clear both cookies.
-   * Idempotent.
-   */
-  async signOut(): Promise<void> {
-    const refreshToken = (await this.#cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
-    if (refreshToken !== null) {
-      try {
-        await this.#authApi.signOut(refreshToken);
-      } catch {
-        // Usually means we were already signed out, which is fine.
-      }
-    }
-    await this.#clear();
+    await writeAuthCookies(this.#cookies, bundle, this.#cookieOptions);
   }
 
   /** Whether a non-expired access token is present in cookies. */
@@ -137,7 +123,6 @@ export class ServerAuthSession {
 
   /** Deletes the cookies. This will be reflected in the eventual response. */
   async #clear(): Promise<void> {
-    await this.#cookies.delete(AUTH_JWT_COOKIE);
-    await this.#cookies.delete(AUTH_REFRESH_COOKIE);
+    await clearAuthCookies(this.#cookies);
   }
 }

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -1,20 +1,20 @@
 /**
  * The framework-agnostic owner of an auth session on the server (SSR).
  *
- * Where the browser {@link AuthClient} keeps the session in `localStorage` and
- * holds the refresh token in client JS, the server keeps it in cookies — the
- * refresh token in an httpOnly cookie that never reaches the browser. This
- * class orchestrates reading those cookies, refreshing the access token against
- * the server when it is missing or near expiry, and writing the rotated tokens
- * back as cookies.
+ * Whereas SPA clients keep the session tokens in `localStorage` and accesses
+ * the refresh token in client JS, an SSR client and host exchange the tokens
+ * via cookies. This code orchestrates reading those cookies, refreshing the
+ * access token against the server when it is missing or near expiry, and
+ * writing the rotated tokens back as cookies.
  *
- * It takes an injected `refreshSession` callback, so it never imports Convex: a
- * framework binding supplies one on top of an HTTP client and a
- * {@link CookieStore} built on its request/response cookies, and tests supply a
- * fake. The server can access the real refresh token (from the cookie), so it
- * always passes a `refreshToken` and gets back a full {@link TokenBundle} to
- * re-cookie. Signing out is a separate concern (see the `signOutHandler`), so it
- * is not part of this class.
+ * The {@link ServerAuthSessionConfig} class takes an injected `refreshSession`
+ * callback, so it never imports Convex: a framework binding supplies one on
+ * top of an HTTP client and a {@link CookieStore} built on its
+ * request/response cookies, and tests supply a fake. The SSR host accesses the
+ * refresh token (from the cookie), passes it in a refresh request to the
+ * Convex backend and gets back a full {@link TokenBundle}. It uses that bundle
+ * to update the cookie values and communicate the refreshed access token to
+ * the client.
  *
  * @module
  */

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -23,10 +23,9 @@ import type { TokenBundle } from "../lib/types";
 import {
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
-  CookieOptions,
+  AuthCookieOptions,
   CookieStore,
   clearAuthCookies,
-  defaultCookieOptions,
   writeAuthCookies,
 } from "./cookies";
 import { isTokenExpiring } from "./jwt";
@@ -53,23 +52,23 @@ export interface ServerAuthSessionConfig {
    */
   refreshSkewSeconds?: number;
   /**
-   * Base cookie attributes (httpOnly/sameSite/path). Per-cookie lifetime is
-   * derived from the token bundle. Defaults to {@link defaultCookieOptions}.
+   * Base cookie attributes. Per-cookie lifetime is derived from the token
+   * bundle. `secure` is required (see {@link AuthCookieOptions}).
    */
-  cookieOptions?: CookieOptions;
+  cookieOptions: AuthCookieOptions;
 }
 
 export class ServerAuthSession {
   readonly #refreshSession: RefreshSession;
   readonly #cookies: CookieStore;
   readonly #refreshSkewSeconds: number;
-  readonly #cookieOptions: CookieOptions;
+  readonly #cookieOptions: AuthCookieOptions;
 
   constructor(config: ServerAuthSessionConfig) {
     this.#refreshSession = config.refreshSession;
     this.#cookies = config.cookies;
     this.#refreshSkewSeconds = config.refreshSkewSeconds ?? 10;
-    this.#cookieOptions = config.cookieOptions ?? defaultCookieOptions();
+    this.#cookieOptions = config.cookieOptions;
   }
 
   /**


### PR DESCRIPTION
When using SSR, client code will call through the SSR frontend server for all actions related to auth. The response will have the refresh token as an httpOnly cookie, not present in the token bundle returned to the client.

This change puts some of that groundwork in place.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
