### PR TITLE
Add usePasswordSignIn and usePasswordSignUp hooks

### DIFF
--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -16,33 +16,34 @@ export function LogIn() {
         onSubmit={async (e) => {
           e.preventDefault();
           setError(null);
-          try {
-            const result = await signIn({ username, password });
-            if (result.success) {
-              return;
-            }
-            setError(() => {
-              switch (result.userError.error) {
-                case "USER_NOT_FOUND":
-                  return "No account exists with that username.";
-                case "INVALID_CREDENTIALS":
-                  return "Incorrect username or password.";
-                case "PASSWORD_TOO_SHORT":
-                  return `Password must be at least ${result.userError.minimumLength} characters.`;
-                case "PASSWORD_TOO_LONG":
-                  return `Password must be at most ${result.userError.maximumLength} characters.`;
-                case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
-                  return "Password can't start or end with whitespace.";
-                case "RATE_LIMITED":
-                  return `Too many attempts. Try again in ${Math.ceil(result.userError.retryAfterMs / 1000)} seconds.`;
-                default:
-                  result.userError satisfies never;
-                  return `Unknown error: ` + result.userError;
-              }
-            });
-          } catch {
-            setError("Something went wrong. Please try again.");
+          const result = await signIn({ username, password });
+          if (result.success) {
+            return;
           }
+          setError(() => {
+            switch (result.userError.error) {
+              case "USER_NOT_FOUND":
+                return "No account exists with that username.";
+              case "INVALID_CREDENTIALS":
+                return "Incorrect username or password.";
+              case "PASSWORD_TOO_SHORT":
+                return `Password must be at least ${result.userError.minimumLength} characters.`;
+              case "PASSWORD_TOO_LONG":
+                return `Password must be at most ${result.userError.maximumLength} characters.`;
+              case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                return "Password can't start or end with whitespace.";
+              case "RATE_LIMITED":
+                return `Too many attempts. Try again in ${Math.ceil(result.userError.retryAfterMs / 1000)} seconds.`;
+              case "OTHER_ERROR":
+                // The action threw unexpectedly; the original error is
+                // available on `cause` if you want to log or inspect it.
+                console.error("Sign-in failed:", result.userError.cause);
+                return "Something went wrong. Please try again.";
+              default:
+                result.userError satisfies never;
+                return `Unknown error: ` + result.userError;
+            }
+          });
         }}
       >
         <h1>Log in</h1>

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -1,15 +1,12 @@
-import { useAuthActions } from "@convex-dev/auth/react";
-import { useAction } from "convex/react";
+import { useSignInWithPassword } from "@convex-dev/auth/providers/password/react";
 import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
 export function LogIn() {
-  const { setSession } = useAuthActions();
-  const signIn = useAction(api.auth.signInWithPassword);
+  const { signIn, pending } = useSignInWithPassword(api.auth.signInWithPassword);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
 
   return (
     <>
@@ -17,11 +14,9 @@ export function LogIn() {
         onSubmit={async (e) => {
           e.preventDefault();
           setError(null);
-          setPending(true);
           try {
             const result = await signIn({ username, password });
             if (result.success) {
-              await setSession(result.tokens);
               return;
             }
             setError(() => {
@@ -45,8 +40,6 @@ export function LogIn() {
             });
           } catch {
             setError("Something went wrong. Please try again.");
-          } finally {
-            setPending(false);
           }
         }}
       >

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -3,7 +3,9 @@ import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
 export function LogIn() {
-  const { signIn, pending } = useSignInWithPassword(api.auth.signInWithPassword);
+  const { signIn, pending } = useSignInWithPassword(
+    api.auth.signInWithPassword,
+  );
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -1,15 +1,12 @@
-import { useAuthActions } from "@convex-dev/auth/react";
-import { useAction } from "convex/react";
+import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
 import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
 export function SignUp() {
-  const { setSession } = useAuthActions();
-  const signUp = useAction(api.auth.signUpWithPassword);
+  const { signUp, pending } = useSignUpWithPassword(api.auth.signUpWithPassword);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
 
   return (
     <>
@@ -17,11 +14,9 @@ export function SignUp() {
         onSubmit={async (e) => {
           e.preventDefault();
           setError(null);
-          setPending(true);
           try {
             const result = await signUp({ username, password });
             if (result.success) {
-              await setSession(result.tokens);
               return;
             }
             setError(() => {
@@ -41,8 +36,6 @@ export function SignUp() {
             });
           } catch {
             setError("Something went wrong. Please try again.");
-          } finally {
-            setPending(false);
           }
         }}
       >

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -3,7 +3,9 @@ import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
 export function SignUp() {
-  const { signUp, pending } = useSignUpWithPassword(api.auth.signUpWithPassword);
+  const { signUp, pending } = useSignUpWithPassword(
+    api.auth.signUpWithPassword,
+  );
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -16,29 +16,30 @@ export function SignUp() {
         onSubmit={async (e) => {
           e.preventDefault();
           setError(null);
-          try {
-            const result = await signUp({ username, password });
-            if (result.success) {
-              return;
-            }
-            setError(() => {
-              switch (result.userError.error) {
-                case "USERNAME_TAKEN":
-                  return "That username is already taken.";
-                case "PASSWORD_TOO_SHORT":
-                  return `Password must be at least ${result.userError.minimumLength} characters.`;
-                case "PASSWORD_TOO_LONG":
-                  return `Password must be at most ${result.userError.maximumLength} characters.`;
-                case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
-                  return "Password can't start or end with whitespace.";
-                default:
-                  result.userError satisfies never;
-                  return `Unknown error: ` + result.userError;
-              }
-            });
-          } catch {
-            setError("Something went wrong. Please try again.");
+          const result = await signUp({ username, password });
+          if (result.success) {
+            return;
           }
+          setError(() => {
+            switch (result.userError.error) {
+              case "USERNAME_TAKEN":
+                return "That username is already taken.";
+              case "PASSWORD_TOO_SHORT":
+                return `Password must be at least ${result.userError.minimumLength} characters.`;
+              case "PASSWORD_TOO_LONG":
+                return `Password must be at most ${result.userError.maximumLength} characters.`;
+              case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                return "Password can't start or end with whitespace.";
+              case "OTHER_ERROR":
+                // The action threw unexpectedly; the original error is
+                // available on `cause` if you want to log or inspect it.
+                console.error("Sign-up failed:", result.userError.cause);
+                return "Something went wrong. Please try again.";
+              default:
+                result.userError satisfies never;
+                return `Unknown error: ` + result.userError;
+            }
+          });
         }}
       >
         <h1>Sign up</h1>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "./providers/anonymous/react": "./src/components/anonymous/react.tsx",
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",
     "./providers/password/convex.config.js": "./src/components/password/convex.config.ts",
+    "./providers/password/react": "./src/components/password/react.tsx",
     "./providers/password/*": "./src/components/password/*.ts",
     "./providers/testing/*": "./src/components/testing/*.ts",
     "./browser": "./src/browser/index.ts",

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -85,7 +85,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
     expect(result.current.auth.isAuthenticated).toBe(false);
 
-    let returned: Result;
+    let returned!: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });
@@ -102,7 +102,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned: Result;
+    let returned!: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });
@@ -117,7 +117,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned: Result;
+    let returned!: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -7,7 +7,15 @@ import { InMemoryStorage } from "../../browser/storage";
 import type { TokenBundle } from "../../lib/types";
 import { AuthProvider, useAuth } from "../../react/client";
 import { useAuthToken } from "../../react";
-import { useSignInWithPassword, useSignUpWithPassword } from "./react";
+import {
+  SignInWithPasswordResult,
+  SignUpWithPasswordResult,
+  useSignInWithPassword,
+  useSignUpWithPassword,
+} from "./react";
+
+type Result = SignInWithPasswordResult | SignUpWithPasswordResult;
+type Flow = { run: (c: typeof credentials) => Promise<Result>; pending: boolean };
 
 const { runAction } = vi.hoisted(() => ({ runAction: vi.fn() }));
 vi.mock("convex/react", async (importActual) => ({
@@ -47,7 +55,7 @@ const flows = [
   },
 ];
 
-function renderFlow(useFlow: () => { run: any; pending: boolean }) {
+function renderFlow(useFlow: () => Flow) {
   const client = new AuthClient({
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage: new InMemoryStorage(),
@@ -74,7 +82,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
     expect(result.current.auth.isAuthenticated).toBe(false);
 
-    let returned: any;
+    let returned: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });
@@ -91,7 +99,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned: any;
+    let returned: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });
@@ -106,7 +114,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned: any;
+    let returned: Result;
     await act(async () => {
       returned = await result.current.flow.run(credentials);
     });

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -15,7 +15,10 @@ import {
 } from "./react";
 
 type Result = SignInWithPasswordResult | SignUpWithPasswordResult;
-type Flow = { run: (c: typeof credentials) => Promise<Result>; pending: boolean };
+type Flow = {
+  run: (c: typeof credentials) => Promise<Result>;
+  pending: boolean;
+};
 
 const { runAction } = vi.hoisted(() => ({ runAction: vi.fn() }));
 vi.mock("convex/react", async (importActual) => ({

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AuthClient } from "../../browser/sessionManager";
+import { InMemoryStorage } from "../../browser/storage";
+import type { TokenBundle } from "../../lib/types";
+import { AuthProvider, useAuth } from "../../react/client";
+import { useAuthToken } from "../../react";
+import { useSignInWithPassword, useSignUpWithPassword } from "./react";
+
+const { runAction } = vi.hoisted(() => ({ runAction: vi.fn() }));
+vi.mock("convex/react", async (importActual) => ({
+  ...(await importActual<typeof import("convex/react")>()),
+  useAction: () => runAction,
+}));
+
+const NAMESPACE = "https://happy-animal-123.convex.cloud";
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 0,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 0,
+  userId: "user-1",
+};
+
+const credentials = { username: "alice", password: "hunter2" };
+
+// The mocked `useAction` ignores the reference, so any value will do.
+const action = {} as never;
+
+const flows = [
+  {
+    name: "useSignInWithPassword",
+    useFlow: () => {
+      const { signIn, pending } = useSignInWithPassword(action);
+      return { run: signIn, pending };
+    },
+  },
+  {
+    name: "useSignUpWithPassword",
+    useFlow: () => {
+      const { signUp, pending } = useSignUpWithPassword(action);
+      return { run: signUp, pending };
+    },
+  },
+];
+
+function renderFlow(useFlow: () => { run: any; pending: boolean }) {
+  const client = new AuthClient({
+    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    storage: new InMemoryStorage(),
+    storageNamespace: NAMESPACE,
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <AuthProvider authClient={client}>{children}</AuthProvider>
+  );
+  return renderHook(
+    () => ({ auth: useAuth(), token: useAuthToken(), flow: useFlow() }),
+    { wrapper },
+  );
+}
+
+describe.each(flows)("$name", ({ useFlow }) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runAction.mockReset();
+  });
+
+  test("success adopts the session and returns the result", async () => {
+    runAction.mockResolvedValue({ success: true, tokens: bundle });
+    const { result } = renderFlow(useFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    expect(result.current.auth.isAuthenticated).toBe(false);
+
+    let returned: any;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+
+    expect(runAction).toHaveBeenCalledWith(credentials);
+    expect(returned).toEqual({ success: true, tokens: bundle });
+    expect(result.current.auth.isAuthenticated).toBe(true);
+    expect(result.current.token).toBe("access-1");
+  });
+
+  test("user error is returned without adopting a session", async () => {
+    const failure = { success: false, userError: { error: "USER_NOT_FOUND" } };
+    runAction.mockResolvedValue(failure);
+    const { result } = renderFlow(useFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned: any;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+
+    expect(returned).toEqual(failure);
+    expect(result.current.auth.isAuthenticated).toBe(false);
+  });
+
+  test("thrown action folds into OTHER_ERROR preserving cause", async () => {
+    const cause = new Error("network blip");
+    runAction.mockRejectedValue(cause);
+    const { result } = renderFlow(useFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned: any;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "OTHER_ERROR", cause },
+    });
+    expect(result.current.auth.isAuthenticated).toBe(false);
+  });
+
+  test("pending is true while in flight and false after", async () => {
+    let resolveAction: (value: unknown) => void;
+    runAction.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAction = resolve;
+      }),
+    );
+    const { result } = renderFlow(useFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    expect(result.current.flow.pending).toBe(false);
+
+    let pending: Promise<unknown>;
+    act(() => {
+      pending = result.current.flow.run(credentials);
+    });
+    await waitFor(() => expect(result.current.flow.pending).toBe(true));
+
+    await act(async () => {
+      resolveAction!({ success: true, tokens: bundle });
+      await pending;
+    });
+    expect(result.current.flow.pending).toBe(false);
+  });
+
+  test("pending resets to false when the action throws", async () => {
+    runAction.mockRejectedValue(new Error("boom"));
+    const { result } = renderFlow(useFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.flow.run(credentials);
+    });
+    expect(result.current.flow.pending).toBe(false);
+  });
+});

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -47,7 +47,26 @@ type SignUpWithPasswordAction = FunctionReference<
 >;
 
 /**
- * Client for the password provider's sign-in flow: wire the app's
+ * A failure the client produces that the server never returns: the action
+ * threw (a network blip, a bug, an unexpected server error) rather than
+ * resolving to a `userError`. The flow hooks fold that into the result as
+ * `OTHER_ERROR` so callers handle *every* failure through the one `userError`
+ * switch and never need their own `try`/`catch`. The thrown value is preserved
+ * on `cause` for callers that want to inspect or log it.
+ */
+type UnexpectedFailure = {
+  success: false;
+  userError: { error: "OTHER_ERROR"; cause: unknown };
+};
+
+/** The result of the `signIn` callback from {@link useSignInWithPassword}. */
+export type SignInWithPasswordResult = SignInResult | UnexpectedFailure;
+
+/** The result of the `signUp` callback from {@link useSignUpWithPassword}. */
+export type SignUpWithPasswordResult = SignUpResult | UnexpectedFailure;
+
+/**
+ * Client for the password provider's sign-in flow: wire the backend's
  * `signInWithPassword` action to the core client.
  *
  * The returned `signIn` runs the action with the given credentials and, on
@@ -89,7 +108,7 @@ export function useSignInWithPassword(signInAction: SignInWithPasswordAction) {
 }
 
 /**
- * Client for the password provider's sign-up flow: wire the app's
+ * Client for the password provider's sign-up flow: wire the backend's
  * `signUpWithPassword` action to the core client.
  *
  * The returned `signUp` runs the action with the given credentials and, on
@@ -111,7 +130,7 @@ export function useSignInWithPassword(signInAction: SignInWithPasswordAction) {
  * }
  * ```
  *
- * @param signUpAction The app's `signUpWithPassword` action reference.
+ * @param signUpAction The backend's `signUpWithPassword` action reference.
  */
 export function useSignUpWithPassword(signUpAction: SignUpWithPasswordAction) {
   const { run, pending } = usePasswordFlow(signUpAction);
@@ -132,7 +151,7 @@ function usePasswordFlow<Result extends SignInResult | SignUpResult>(
   const [pending, setPending] = useState(false);
 
   const run = useCallback(
-    async (credentials: Credentials) => {
+    async (credentials: Credentials): Promise<Result | UnexpectedFailure> => {
       setPending(true);
       try {
         const result = await runAction(credentials);
@@ -140,9 +159,14 @@ function usePasswordFlow<Result extends SignInResult | SignUpResult>(
           await setSession(result.tokens);
         }
         return result;
+      } catch (cause) {
+        // The action threw instead of resolving to a `userError`. Fold it into
+        // the same discriminated result as `OTHER_ERROR`, preserving the thrown
+        // value on `cause`, so the caller handles it alongside every other
+        // failure and can still inspect or log the original error if it wants.
+        return { success: false, userError: { error: "OTHER_ERROR", cause } };
       } finally {
-        // Reset even if the action throws, so the caller's own catch can
-        // surface an unexpected failure without leaving the form stuck.
+        // Reset even when the action throws.
         setPending(false);
       }
     },

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -1,0 +1,153 @@
+/**
+ * React client for the password provider, exported at
+ * `@convex-dev/auth/providers/password/react`.
+ *
+ * A provider's job on the client is to run its own sign-in flow and hand the
+ * resulting {@link TokenBundle} to the core client's `setSession` (see {@link
+ * useAuthActions}).
+ *
+ * The password provider has two flows and provides a hook for each:
+ *  1. signing in to an existing account ({@link useSignInWithPassword})
+ *  2. signing up a new one ({@link useSignUpWithPassword})
+ *
+ * Each hook returns a function for sending up the credentials and a `pending`
+ * value that is flipped to `true` while the credentials are being validated.
+ *
+ * @module
+ */
+"use client";
+
+import { useAction } from "convex/react";
+import { FunctionReference } from "convex/server";
+import { useCallback, useState } from "react";
+import { useAuthActions } from "../../react";
+import type { SignInResult, SignUpResult } from "./setup";
+
+/** The `(username, password)` pair both flows accept. */
+type Credentials = { username: string; password: string };
+
+/**
+ * The `signInWithPassword` action the app re-exports from its `setupCore`.
+ */
+type SignInWithPasswordAction = FunctionReference<
+  "action",
+  "public",
+  Credentials,
+  SignInResult
+>;
+
+/**
+ * The `signUpWithPassword` action the app re-exports from its `setupCore`.
+ */
+type SignUpWithPasswordAction = FunctionReference<
+  "action",
+  "public",
+  Credentials,
+  SignUpResult
+>;
+
+/**
+ * Client for the password provider's sign-in flow: wire the app's
+ * `signInWithPassword` action to the core client.
+ *
+ * The returned `signIn` runs the action with the given credentials and, on
+ * success, establishes an authenticated session with your Convex backend.
+ *
+ * The `pending` flag returned will let you know if the credentials are
+ * currently being validated.
+ *
+ * After calling `signIn`, check the `success` flag on the return value to see
+ * whether the sign-in was successful or if you need to handle an error.
+ *
+ * ```tsx
+ * import { useSignInWithPassword } from "@convex-dev/auth/providers/password/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * function LogIn() {
+ *   const { signIn, pending } = useSignInWithPassword(api.auth.signInWithPassword);
+ *   return (
+ *     <form
+ *       onSubmit={async (e) => {
+ *         e.preventDefault();
+ *         const result = await signIn({ username, password });
+ *         if (!result.success) {
+ *           // map result.userError to a message
+ *         }
+ *       }}
+ *     >
+ *       <button disabled={pending}>Log in</button>
+ *     </form>
+ *   );
+ * }
+ * ```
+ *
+ * @param signInAction The app's `signInWithPassword` action reference.
+ */
+export function useSignInWithPassword(signInAction: SignInWithPasswordAction) {
+  const { run, pending } = usePasswordFlow(signInAction);
+  return { signIn: run, pending };
+}
+
+/**
+ * Client for the password provider's sign-up flow: wire the app's
+ * `signUpWithPassword` action to the core client.
+ *
+ * The returned `signUp` runs the action with the given credentials and, on
+ * success, establishes an authenticated session with your Convex backend.
+ *
+ * The `pending` flag returned will let you know if the credentials are
+ * currently being validated.
+ *
+ * After calling `signUp`, check the `success` flag on the return value to see
+ * whether the sign-up was successful or if you need to handle an error.
+ *
+ * ```tsx
+ * import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * function SignUp() {
+ *   const { signUp, pending } = useSignUpWithPassword(api.auth.signUpWithPassword);
+ *   // ...same shape as useSignInWithPassword
+ * }
+ * ```
+ *
+ * @param signUpAction The app's `signUpWithPassword` action reference.
+ */
+export function useSignUpWithPassword(signUpAction: SignUpWithPasswordAction) {
+  const { run, pending } = usePasswordFlow(signUpAction);
+  return { signUp: run, pending };
+}
+
+/**
+ * Shared internals for sign-in and sign-up: run the action, adopt the session
+ * on success, and track in-flight state. The two flows are structurally
+ * identical and differ only in the action they call and the name they expose
+ * the callback under.
+ */
+function usePasswordFlow<Result extends SignInResult | SignUpResult>(
+  action: FunctionReference<"action", "public", Credentials, Result>,
+) {
+  const { setSession } = useAuthActions();
+  const runAction = useAction(action);
+  const [pending, setPending] = useState(false);
+
+  const run = useCallback(
+    async (credentials: Credentials) => {
+      setPending(true);
+      try {
+        const result = await runAction(credentials);
+        if (result.success) {
+          await setSession(result.tokens);
+        }
+        return result;
+      } finally {
+        // Reset even if the action throws, so the caller's own catch can
+        // surface an unexpected failure without leaving the form stuck.
+        setPending(false);
+      }
+    },
+    [runAction, setSession],
+  );
+
+  return { run, pending };
+}

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -104,7 +104,22 @@ export type SignUpWithPasswordResult = SignUpResult | UnexpectedFailure;
  */
 export function useSignInWithPassword(signInAction: SignInWithPasswordAction) {
   const { run, pending } = usePasswordFlow(signInAction);
-  return { signIn: run, pending };
+  return {
+    /**
+     * Passes up the given crendentials to perform a username/password sign in.
+     *
+     * Returns an object with a `success` boolean flag.
+     *
+     * If it is `true` the sign-in was successful and the client will establish
+     * an authenticated session with the Convex backend server.
+     *
+     * If it is `false` the returned object will have a `userError` field with
+     * additional details about why sign-in failed.
+     */
+    signIn: run,
+    /** `true` if the sign-in attempt is being validated. */
+    pending,
+  };
 }
 
 /**
@@ -134,7 +149,22 @@ export function useSignInWithPassword(signInAction: SignInWithPasswordAction) {
  */
 export function useSignUpWithPassword(signUpAction: SignUpWithPasswordAction) {
   const { run, pending } = usePasswordFlow(signUpAction);
-  return { signUp: run, pending };
+  return {
+    /**
+     * Passes up the given crendentials to perform a username/password sign up.
+     *
+     * Returns an object with a `success` boolean flag.
+     *
+     * If it is `true` the sign-up was successful and the client will establish
+     * an authenticated session with the Convex backend server.
+     *
+     * If it is `false` the returned object will have a `userError` field with
+     * additional details about why sign-up failed.
+     */
+    signUp: run,
+    /** `true` if the sign-up attempt is being validated. */
+    pending,
+  };
 }
 
 /**

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -37,7 +37,13 @@ const signInResult = v.union(
     ),
   }),
 );
-type SignInResult = Infer<typeof signInResult>;
+
+/**
+ * The result of `signInWithPassword`.
+ *
+ * On success the minted session tokens, otherwise a user-facing `userError`.
+ */
+export type SignInResult = Infer<typeof signInResult>;
 
 const signUpResult = v.union(
   v.object({ success: v.literal(true), tokens: vTokenBundle }),
@@ -49,7 +55,13 @@ const signUpResult = v.union(
     ),
   }),
 );
-type SignUpResult = Infer<typeof signUpResult>;
+
+/**
+ * The result of `signUpWithPassword`.
+ *
+ * On success the minted session tokens, otherwise a user-facing `userError`.
+ */
+export type SignUpResult = Infer<typeof signUpResult>;
 
 /**
  * The simplest password recipe: every account is a `(username, password)` pair,


### PR DESCRIPTION
I think this is beneficial for a few reasons:

1. We take on some boilerplate that every app would need to replicate
2. `setSession` feels kind of low-level and not something app developers should be commonly reaching for
3. Apps can just handle the `pending` state rather than ensuring it's updated correctly
4. Having a common hook-based API for providers should make using each one feel somewhat familiar

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
