### PR TITLE
Add framework-agnostic SSR cookie and auth handlers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "@convex-dev/rate-limiter": "^0.3.2",
     "argon2id-wasm": "0.0.0-alpha.1",
     "commander": "^14.0.2",
+    "cookie": "1.1.1",
     "jose": "^5.2.2"
   },
   "devDependencies": {

--- a/packages/core/src/components/anonymous/_generated/api.ts
+++ b/packages/core/src/components/anonymous/_generated/api.ts
@@ -9,6 +9,8 @@
  */
 
 import type * as provider from "../provider.js";
+import type * as react from "../react.js";
+import type * as server from "../server.js";
 import type * as setup from "../setup.js";
 
 import type {
@@ -20,6 +22,8 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   provider: typeof provider;
+  react: typeof react;
+  server: typeof server;
   setup: typeof setup;
 }> = anyApi as any;
 

--- a/packages/core/src/components/anonymous/server.test.ts
+++ b/packages/core/src/components/anonymous/server.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { TokenBundle } from "../../lib/types";
 import { AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE } from "../../server/cookies";
-import { anonymousSignInHandler } from "./server";
+import { setupConvexAuthServer } from "../../server/setup";
+import { anonymous } from "./server";
 
 const { mutationMock } = vi.hoisted(() => ({ mutationMock: vi.fn() }));
 vi.mock("convex/browser", () => ({
@@ -20,15 +21,20 @@ const bundle: TokenBundle = {
 
 const fnRef = {} as never;
 
+const signInHandler = (secure: boolean) =>
+  setupConvexAuthServer({
+    convexUrl: "https://x.convex.cloud",
+    refreshSession: fnRef,
+    signOut: fnRef,
+    cookieOptions: { secure },
+  }).signInHandler(anonymous(fnRef));
+
 beforeEach(() => mutationMock.mockReset());
 
-describe("anonymousSignInHandler", () => {
+describe("anonymous sign-in via signInHandler", () => {
   test("mints server-side, cookies the refresh token, returns access-only", async () => {
     mutationMock.mockResolvedValue(bundle);
-    const handler = anonymousSignInHandler({
-      convexUrl: "https://x.convex.cloud",
-      signIn: fnRef,
-    });
+    const handler = signInHandler(true);
 
     const res = await handler(
       new Request("https://app.test/auth/signin/anonymous", { method: "POST" }),
@@ -53,5 +59,19 @@ describe("anonymousSignInHandler", () => {
     expect(jwt).toContain("access-1");
     expect(refresh).toContain("refresh-1");
     expect(refresh).toContain("HttpOnly");
+    // `secure: true` reaches the cookies the handler writes.
+    expect(jwt).toContain("Secure");
+    expect(refresh).toContain("Secure");
+  });
+
+  test("omits Secure when secure is false", async () => {
+    mutationMock.mockResolvedValue(bundle);
+    const handler = signInHandler(false);
+
+    const res = await handler(
+      new Request("https://app.test/auth/signin/anonymous", { method: "POST" }),
+    );
+    const setCookies = res.headers.getSetCookie();
+    expect(setCookies.every((c) => !c.includes("Secure"))).toBe(true);
   });
 });

--- a/packages/core/src/components/anonymous/server.test.ts
+++ b/packages/core/src/components/anonymous/server.test.ts
@@ -31,6 +31,15 @@ const signInHandler = (secure: boolean) =>
     cookieOptions: { secure },
   }).signInHandler(anonymous(fnRef));
 
+// Same-origin by default: the CSRF guard refuses any request whose Origin
+// doesn't match the Host, so a matching pair is the precondition for reaching
+// the sign-in logic under test.
+const signInRequest = (headers?: Record<string, string>) =>
+  new Request("https://app.test/auth/signin/anonymous", {
+    method: "POST",
+    headers: { origin: "https://app.test", host: "app.test", ...headers },
+  });
+
 beforeEach(() => signInMutationMock.mockReset());
 
 describe("anonymous sign-in via signInHandler", () => {
@@ -38,9 +47,8 @@ describe("anonymous sign-in via signInHandler", () => {
     signInMutationMock.mockResolvedValue(bundle);
     const handler = signInHandler(true);
 
-    const res = await handler(
-      new Request("https://app.test/auth/signin/anonymous", { method: "POST" }),
-    );
+    const res = await handler(signInRequest());
+    expect(res.status).toBe(200);
     const body = await res.json();
 
     // The response is a SlimTokenBundle with the access token.
@@ -72,10 +80,22 @@ describe("anonymous sign-in via signInHandler", () => {
     signInMutationMock.mockResolvedValue(bundle);
     const handler = signInHandler(false);
 
-    const res = await handler(
-      new Request("https://app.test/auth/signin/anonymous", { method: "POST" }),
-    );
+    const res = await handler(signInRequest());
+    expect(res.status).toBe(200);
     const setCookies = res.headers.getSetCookie();
+    expect(setCookies.length).toBeGreaterThan(0);
     expect(setCookies.every((c) => !c.includes("Secure"))).toBe(true);
+  });
+
+  // Login CSRF: a cross-site POST must not mint a session, or the response's
+  // Set-Cookie would store the attacker's session in the victim's browser.
+  test("refuses a cross-site request without signing in", async () => {
+    const handler = signInHandler(true);
+
+    const res = await handler(signInRequest({ origin: "https://evil.test" }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).tokens).toBeNull();
+    expect(signInMutationMock).not.toHaveBeenCalled();
+    expect(res.headers.getSetCookie()).toEqual([]);
   });
 });

--- a/packages/core/src/components/anonymous/server.test.ts
+++ b/packages/core/src/components/anonymous/server.test.ts
@@ -4,10 +4,12 @@ import { AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE } from "../../server/cookies";
 import { setupConvexAuthServer } from "../../server/setup";
 import { anonymous } from "./server";
 
-const { mutationMock } = vi.hoisted(() => ({ mutationMock: vi.fn() }));
+const { signInMutationMock } = vi.hoisted(() => ({
+  signInMutationMock: vi.fn(),
+}));
 vi.mock("convex/browser", () => ({
   ConvexHttpClient: class {
-    mutation = mutationMock;
+    mutation = signInMutationMock;
   },
 }));
 
@@ -29,11 +31,11 @@ const signInHandler = (secure: boolean) =>
     cookieOptions: { secure },
   }).signInHandler(anonymous(fnRef));
 
-beforeEach(() => mutationMock.mockReset());
+beforeEach(() => signInMutationMock.mockReset());
 
 describe("anonymous sign-in via signInHandler", () => {
-  test("mints server-side, cookies the refresh token, returns access-only", async () => {
-    mutationMock.mockResolvedValue(bundle);
+  test("mints server-side, adds refresh token to cookie, returns SlimTokenBundle", async () => {
+    signInMutationMock.mockResolvedValue(bundle);
     const handler = signInHandler(true);
 
     const res = await handler(
@@ -41,14 +43,14 @@ describe("anonymous sign-in via signInHandler", () => {
     );
     const body = await res.json();
 
-    // The browser only ever sees the access-only bundle.
+    // The response is a SlimTokenBundle with the access token.
     expect(body.tokens).toEqual({
       accessToken: "access-1",
       accessTokenExpiresAt: 1_000,
       userId: "user-1",
     });
     expect(body.tokens).not.toHaveProperty("refreshToken");
-    expect(mutationMock).toHaveBeenCalledWith(fnRef, {});
+    expect(signInMutationMock).toHaveBeenCalledWith(fnRef, {});
 
     // The refresh token lives only in an httpOnly cookie.
     const setCookies = res.headers.getSetCookie();
@@ -56,16 +58,18 @@ describe("anonymous sign-in via signInHandler", () => {
     const refresh = setCookies.find((c) =>
       c.startsWith(`${AUTH_REFRESH_COOKIE}=`),
     );
-    expect(jwt).toContain("access-1");
     expect(refresh).toContain("refresh-1");
     expect(refresh).toContain("HttpOnly");
     // `secure: true` reaches the cookies the handler writes.
     expect(jwt).toContain("Secure");
     expect(refresh).toContain("Secure");
+    // The JWT access token is also in an httpOnly cookie (for SSR host usage)
+    expect(jwt).toContain("access-1");
+    expect(jwt).toContain("HttpOnly");
   });
 
   test("omits Secure when secure is false", async () => {
-    mutationMock.mockResolvedValue(bundle);
+    signInMutationMock.mockResolvedValue(bundle);
     const handler = signInHandler(false);
 
     const res = await handler(

--- a/packages/core/src/components/anonymous/server.test.ts
+++ b/packages/core/src/components/anonymous/server.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TokenBundle } from "../../lib/types";
+import { AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE } from "../../server/cookies";
+import { anonymousSignInHandler } from "./server";
+
+const { mutationMock } = vi.hoisted(() => ({ mutationMock: vi.fn() }));
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    mutation = mutationMock;
+  },
+}));
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 1_000,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 2_000,
+  userId: "user-1",
+};
+
+const fnRef = {} as never;
+
+beforeEach(() => mutationMock.mockReset());
+
+describe("anonymousSignInHandler", () => {
+  test("mints server-side, cookies the refresh token, returns access-only", async () => {
+    mutationMock.mockResolvedValue(bundle);
+    const handler = anonymousSignInHandler({
+      convexUrl: "https://x.convex.cloud",
+      signIn: fnRef,
+    });
+
+    const res = await handler(
+      new Request("https://app.test/auth/signin/anonymous", { method: "POST" }),
+    );
+    const body = await res.json();
+
+    // The browser only ever sees the access-only bundle.
+    expect(body.tokens).toEqual({
+      accessToken: "access-1",
+      accessTokenExpiresAt: 1_000,
+      userId: "user-1",
+    });
+    expect(body.tokens).not.toHaveProperty("refreshToken");
+    expect(mutationMock).toHaveBeenCalledWith(fnRef, {});
+
+    // The refresh token lives only in an httpOnly cookie.
+    const setCookies = res.headers.getSetCookie();
+    const jwt = setCookies.find((c) => c.startsWith(`${AUTH_JWT_COOKIE}=`));
+    const refresh = setCookies.find((c) =>
+      c.startsWith(`${AUTH_REFRESH_COOKIE}=`),
+    );
+    expect(jwt).toContain("access-1");
+    expect(refresh).toContain("refresh-1");
+    expect(refresh).toContain("HttpOnly");
+  });
+});

--- a/packages/core/src/components/anonymous/server.ts
+++ b/packages/core/src/components/anonymous/server.ts
@@ -2,15 +2,15 @@
  * Server descriptor for the anonymous provider, exported at
  * `@convex-dev/auth/providers/anonymous/server`.
  *
- * It's the simplest possible provider: anonymous sign-in takes no arguments, so
- * the descriptor is just its mutation reference. Feed it to the auth server's
+ * It's the simplest possible provider: anonymous sign-in takes no arguments,
+ * so `run` is just the mutation call. Feed it to the auth server's
  * `signInHandler` to mount a route:
  *
  * ```ts
  * export const POST = auth.signInHandler(anonymous(api.auth.signInAnonymous));
  * ```
  *
- * A provider that needs input adds a `parseArgs` reading it off the request.
+ * A provider that needs input reads it off the request inside `run`.
  *
  * @module
  */
@@ -19,8 +19,8 @@ import type { SignInProvider } from "../../server/setup";
 import type { SignInAnonymousMutation } from "./react";
 
 /** Build the anonymous {@link SignInProvider} from its sign-in mutation. */
-export function anonymous(
-  signIn: SignInAnonymousMutation,
-): SignInProvider<Record<string, never>> {
-  return { signIn };
+export function anonymous(signIn: SignInAnonymousMutation): SignInProvider {
+  return {
+    run: async (client) => await client.mutation(signIn, {}),
+  };
 }

--- a/packages/core/src/components/anonymous/server.ts
+++ b/packages/core/src/components/anonymous/server.ts
@@ -1,41 +1,26 @@
 /**
- * Server handler for the anonymous provider, exported at
+ * Server descriptor for the anonymous provider, exported at
  * `@convex-dev/auth/providers/anonymous/server`.
  *
- * It's the simplest possible provider handler — anonymous sign-in takes no
- * arguments. A provider that needs input parses it from the request body.
+ * It's the simplest possible provider: anonymous sign-in takes no arguments, so
+ * the descriptor is just its mutation reference. Feed it to the auth server's
+ * `signInHandler` to mount a route:
+ *
+ * ```ts
+ * export const POST = auth.signInHandler(anonymous(api.auth.signInAnonymous));
+ * ```
+ *
+ * A provider that needs input adds a `parseArgs` reading it off the request.
  *
  * @module
  */
 
-import { ConvexHttpClient } from "convex/browser";
-import type { CookieOptions } from "../../server/cookies";
-import { type RequestHandler, signInResponse } from "../../server/handlers";
+import type { SignInProvider } from "../../server/setup";
 import type { SignInAnonymousMutation } from "./react";
 
-/** Configuration for {@link anonymousSignInHandler}. */
-export interface AnonymousSignInHandlerConfig {
-  /** The Convex deployment URL used server-side. */
-  convexUrl: string;
-  /** The app's `signInAnonymous` mutation reference. */
-  signIn: SignInAnonymousMutation;
-  /** Overrides the default auth cookie attributes. */
-  cookieOptions?: CookieOptions;
-}
-
-/**
- * A handler that runs the anonymous sign-in mutation server-side, moves the
- * minted refresh token into an httpOnly cookie, and replies with a bundle
- * containing only the access token (`{ tokens: SlimTokenBundle }`).
- */
-export function anonymousSignInHandler(
-  config: AnonymousSignInHandlerConfig,
-): RequestHandler {
-  return async (request) => {
-    const bundle = await new ConvexHttpClient(config.convexUrl).mutation(
-      config.signIn,
-      {},
-    );
-    return signInResponse(request, bundle, config.cookieOptions);
-  };
+/** Build the anonymous {@link SignInProvider} from its sign-in mutation. */
+export function anonymous(
+  signIn: SignInAnonymousMutation,
+): SignInProvider<Record<string, never>> {
+  return { signIn };
 }

--- a/packages/core/src/components/anonymous/server.ts
+++ b/packages/core/src/components/anonymous/server.ts
@@ -1,0 +1,41 @@
+/**
+ * Server handler for the anonymous provider, exported at
+ * `@convex-dev/auth/providers/anonymous/server`.
+ *
+ * It's the simplest possible provider handler — anonymous sign-in takes no
+ * arguments. A provider that needs input parses it from the request body.
+ *
+ * @module
+ */
+
+import { ConvexHttpClient } from "convex/browser";
+import type { CookieOptions } from "../../server/cookies";
+import { type RequestHandler, signInResponse } from "../../server/handlers";
+import type { SignInAnonymousMutation } from "./react";
+
+/** Configuration for {@link anonymousSignInHandler}. */
+export interface AnonymousSignInHandlerConfig {
+  /** The Convex deployment URL used server-side. */
+  convexUrl: string;
+  /** The app's `signInAnonymous` mutation reference. */
+  signIn: SignInAnonymousMutation;
+  /** Overrides the default auth cookie attributes. */
+  cookieOptions?: CookieOptions;
+}
+
+/**
+ * A handler that runs the anonymous sign-in mutation server-side, moves the
+ * minted refresh token into an httpOnly cookie, and replies with a bundle
+ * containing only the access token (`{ tokens: SlimTokenBundle }`).
+ */
+export function anonymousSignInHandler(
+  config: AnonymousSignInHandlerConfig,
+): RequestHandler {
+  return async (request) => {
+    const bundle = await new ConvexHttpClient(config.convexUrl).mutation(
+      config.signIn,
+      {},
+    );
+    return signInResponse(request, bundle, config.cookieOptions);
+  };
+}

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -1,7 +1,9 @@
 import {
   mutationGeneric,
+  queryGeneric,
   createFunctionHandle,
   RegisteredMutation,
+  RegisteredQuery,
 } from "convex/server";
 import { v } from "convex/values";
 import type { ComponentApi } from "./_generated/component";
@@ -63,6 +65,20 @@ type AuthApi<T extends readonly ProviderWithOptions[]> = {
     "public",
     { refreshToken: string },
     Promise<TokenBundle | null>
+  >;
+  /**
+   * Reports whether the caller's access token identifies a signed-in user.
+   *
+   * Convex verifies the token's signature (against the deployment's JWKS)
+   * before this query runs, so the result is a trustworthy authentication
+   * verdict. SSR hosts call it with the token from the auth cookie to decide
+   * authentication state, rather than trusting the (client-controlled) cookie
+   * by merely decoding it.
+   */
+  isAuthenticated: RegisteredQuery<
+    "public",
+    Record<string, never>,
+    Promise<boolean>
   >;
   /**
    * The auth APIs that each provider exposes.
@@ -251,9 +267,22 @@ export function setupCore<T extends readonly ProviderWithOptions[]>({
       },
     });
 
+    // Runs at the app deployment level (not inside the component) because only
+    // there does `ctx.auth` reflect the caller's verified identity: Convex
+    // checks the access token's signature against the deployment JWKS before
+    // the handler runs, so a forged/unsigned token yields no identity here.
+    const isAuthenticated = queryGeneric({
+      args: {},
+      returns: v.boolean(),
+      handler: async (ctx): Promise<boolean> => {
+        return (await ctx.auth.getUserIdentity()) !== null;
+      },
+    });
+
     return {
       refreshSession,
       signOut,
+      isAuthenticated,
       providers: result as ProviderApis<T>,
     };
   };

--- a/packages/core/src/server/cookies.test.ts
+++ b/packages/core/src/server/cookies.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import type { TokenBundle } from "../lib/types";
+import {
+  AUTH_JWT_COOKIE,
+  AUTH_REFRESH_COOKIE,
+  AuthCookieOptions,
+  CookieDeleteOptions,
+  CookieOptions,
+  CookieStore,
+  clearAuthCookies,
+  writeAuthCookies,
+} from "./cookies";
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 1_000_000,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 2_000_000,
+  userId: "user-1",
+};
+
+class FakeCookies implements CookieStore {
+  writes = new Map<string, CookieOptions | undefined>();
+  deletions = new Map<string, CookieDeleteOptions | undefined>();
+  get() {
+    return undefined;
+  }
+  set(name: string, _value: string, options?: CookieOptions) {
+    this.writes.set(name, options);
+  }
+  delete(name: string, options?: CookieDeleteOptions) {
+    this.deletions.set(name, options);
+  }
+}
+
+describe("writeAuthCookies", () => {
+  test("applies the invariant attributes and the caller's options", async () => {
+    const cookies = new FakeCookies();
+    await writeAuthCookies(cookies, bundle, {
+      secure: true,
+      path: "/app",
+      domain: "example.com",
+    });
+
+    for (const name of [AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE]) {
+      expect(cookies.writes.get(name)).toEqual({
+        httpOnly: true,
+        sameSite: "lax",
+        secure: true,
+        path: "/app",
+        domain: "example.com",
+        expires: new Date(bundle.refreshTokenExpiresAt),
+      });
+    }
+  });
+
+  test("a wider options object cannot override the invariants", async () => {
+    const cookies = new FakeCookies();
+    // Simulate an untyped JS caller passing disallowed attributes.
+    const hostile = {
+      secure: false,
+      httpOnly: false,
+      sameSite: "none",
+      maxAge: 5,
+      expires: new Date(0),
+    } as AuthCookieOptions;
+    await writeAuthCookies(cookies, bundle, hostile);
+
+    for (const name of [AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE]) {
+      const written = cookies.writes.get(name)!;
+      expect(written.httpOnly).toBe(true);
+      expect(written.sameSite).toBe("lax");
+      expect(written.maxAge).toBeUndefined();
+      expect(written.expires).toEqual(new Date(bundle.refreshTokenExpiresAt));
+    }
+  });
+});
+
+describe("clearAuthCookies", () => {
+  test("deletes both cookies with the configured path and domain", async () => {
+    const cookies = new FakeCookies();
+    await clearAuthCookies(cookies, {
+      secure: true,
+      path: "/app",
+      domain: "example.com",
+    });
+
+    for (const name of [AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE]) {
+      expect(cookies.deletions.get(name)).toEqual({
+        path: "/app",
+        domain: "example.com",
+      });
+    }
+  });
+
+  test("path defaults to / to match the write-side default", async () => {
+    const cookies = new FakeCookies();
+    await clearAuthCookies(cookies, { secure: true });
+    expect(cookies.deletions.get(AUTH_JWT_COOKIE)).toEqual({
+      path: "/",
+      domain: undefined,
+    });
+  });
+});

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -51,6 +51,13 @@ export type AuthCookieOptions = Omit<CookieOptions, "secure"> & {
 };
 
 /**
+ * The attributes that identify which cookie a deletion targets: browsers only
+ * remove a cookie when the deletion's `path` and `domain` match the ones it
+ * was written with. No other attribute takes part in matching.
+ */
+export type CookieDeleteOptions = Pick<CookieOptions, "path" | "domain">;
+
+/**
  * Read/write/delete cookies. Every method may be synchronous or return a
  * promise, so request/response cookie APIs that are async (e.g. `next/headers`
  * `cookies()`) work without ceremony.
@@ -64,8 +71,12 @@ export interface CookieStore {
     value: string,
     options?: CookieOptions,
   ) => void | Promise<void>;
-  /** Delete a cookie. */
-  delete: (name: string) => void | Promise<void>;
+  /** Delete a cookie. Must be given the same `path`/`domain` the cookie was
+   * written with, or the deletion won't match it. */
+  delete: (
+    name: string,
+    options?: CookieDeleteOptions,
+  ) => void | Promise<void>;
 }
 
 /**
@@ -115,8 +126,17 @@ export async function writeAuthCookies(
   });
 }
 
-/** Delete both auth cookies. The counterpart of {@link writeAuthCookies}. */
-export async function clearAuthCookies(cookies: CookieStore): Promise<void> {
-  await cookies.delete(AUTH_JWT_COOKIE);
-  await cookies.delete(AUTH_REFRESH_COOKIE);
+/**
+ * Delete both auth cookies. The counterpart of {@link writeAuthCookies}: it
+ * takes the same options so the deletions match the cookies the writes
+ * produced (a deletion only removes a cookie whose `path`/`domain` match).
+ */
+export async function clearAuthCookies(
+  cookies: CookieStore,
+  options: AuthCookieOptions,
+): Promise<void> {
+  // Mirror writeAuthCookies' merge, where path defaults to "/".
+  const { path = "/", domain } = options;
+  await cookies.delete(AUTH_JWT_COOKIE, { path, domain });
+  await cookies.delete(AUTH_REFRESH_COOKIE, { path, domain });
 }

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -73,10 +73,7 @@ export interface CookieStore {
   ) => void | Promise<void>;
   /** Delete a cookie. Must be given the same `path`/`domain` the cookie was
    * written with, or the deletion won't match it. */
-  delete: (
-    name: string,
-    options?: CookieDeleteOptions,
-  ) => void | Promise<void>;
+  delete: (name: string, options?: CookieDeleteOptions) => void | Promise<void>;
 }
 
 /**

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -39,23 +39,29 @@ export interface CookieOptions {
 }
 
 /**
- * The cookie options a framework integration must supply for auth cookies.
- *
- * `secure` is required. Whether auth cookies are HTTPS-only depends on the
- * deployment (HTTPS in production, plain http on localhost), so every
- * integration has to decide it explicitly rather than inherit a default that
- * would be wrong in one environment or the other.
- */
-export type AuthCookieOptions = Omit<CookieOptions, "secure"> & {
-  secure: boolean;
-};
-
-/**
  * The attributes that identify which cookie a deletion targets: browsers only
  * remove a cookie when the deletion's `path` and `domain` match the ones it
  * was written with. No other attribute takes part in matching.
  */
 export type CookieDeleteOptions = Pick<CookieOptions, "path" | "domain">;
+
+/**
+ * The cookie options a framework integration may supply for auth cookies:
+ * only the attributes that legitimately vary by deployment.
+ *
+ * `secure` is required. Whether auth cookies are HTTPS-only depends on the
+ * deployment (HTTPS in production, plain http on localhost), so every
+ * integration has to decide it explicitly rather than inherit a default that
+ * would be wrong in one environment or the other.
+ *
+ * The security-relevant attributes (`httpOnly`, `sameSite`) and the token
+ * lifetimes (`maxAge`, `expires`, which derive from the token bundle) are
+ * deliberately not configurable; {@link writeAuthCookies} always applies the
+ * invariant values.
+ */
+export type AuthCookieOptions = CookieDeleteOptions & {
+  secure: boolean;
+};
 
 /**
  * Read/write/delete cookies. Every method may be synchronous or return a
@@ -114,7 +120,14 @@ export async function writeAuthCookies(
   bundle: TokenBundle,
   options: AuthCookieOptions,
 ): Promise<void> {
-  const base = { ...invariantCookieOptions(), ...options };
+  // Pick the allowed fields rather than spreading, so a wider object
+  // (e.g. from untyped JS) cannot override the invariant attributes.
+  const base = {
+    ...invariantCookieOptions(),
+    path: options.path ?? "/",
+    domain: options.domain,
+    secure: options.secure,
+  };
   const expires = new Date(bundle.refreshTokenExpiresAt);
   await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, { ...base, expires });
   await cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {

--- a/packages/core/src/server/handlers.test.ts
+++ b/packages/core/src/server/handlers.test.ts
@@ -4,7 +4,8 @@ import { AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE } from "./cookies";
 import { refreshHandler, signOutHandler } from "./handlers";
 
 // The handlers talk to Convex through a `ConvexHttpClient`; stub it so the
-// tests exercise cookie behavior without a backend.
+// tests exercise cookie behavior without a backend. This mutation mock stands
+// in for the refresh or sign-out mutations, depending on the test case.
 const { mutationMock } = vi.hoisted(() => ({ mutationMock: vi.fn() }));
 vi.mock("convex/browser", () => ({
   ConvexHttpClient: class {
@@ -35,6 +36,7 @@ beforeEach(() => mutationMock.mockReset());
 
 describe("refreshHandler", () => {
   test("rotates the session and returns access-only tokens", async () => {
+    // Set up the refresh mutation to return new tokens.
     mutationMock.mockResolvedValue(bundle(2));
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
@@ -56,13 +58,14 @@ describe("refreshHandler", () => {
       refreshToken: "refresh-1",
     });
 
-    // Both cookies rewritten, refresh cookie httpOnly.
+    // Both cookies rewritten, both cookie httpOnly.
     const setCookies = res.headers.getSetCookie();
     const jwt = setCookies.find((c) => c.startsWith(`${AUTH_JWT_COOKIE}=`));
     const refresh = setCookies.find((c) =>
       c.startsWith(`${AUTH_REFRESH_COOKIE}=`),
     );
     expect(jwt).toContain("access-2");
+    expect(jwt).toContain("HttpOnly");
     expect(refresh).toContain("refresh-2");
     expect(refresh).toContain("HttpOnly");
   });
@@ -80,6 +83,7 @@ describe("refreshHandler", () => {
   });
 
   test("clears cookies when the refresh token is unknown", async () => {
+    // Set up the refresh mutation to not recognize the token and to return null.
     mutationMock.mockResolvedValue(null);
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",

--- a/packages/core/src/server/handlers.test.ts
+++ b/packages/core/src/server/handlers.test.ts
@@ -23,10 +23,18 @@ function bundle(n: number): TokenBundle {
   };
 }
 
-const requestWithRefresh = (token?: string) =>
+// Same-origin by default: the CSRF guard refuses any request whose Origin
+// doesn't match the Host, so a matching pair is the precondition for reaching
+// the handler logic under test. Cross-site tests override both headers.
+const requestWithRefresh = (token?: string, headers?: Record<string, string>) =>
   new Request("https://app.test/auth/refresh", {
     method: "POST",
-    headers: token ? { cookie: `${AUTH_REFRESH_COOKIE}=${token}` } : {},
+    headers: {
+      origin: "https://app.test",
+      host: "app.test",
+      ...(token ? { cookie: `${AUTH_REFRESH_COOKIE}=${token}` } : {}),
+      ...headers,
+    },
   });
 
 // A placeholder function reference; the mocked client ignores it.
@@ -45,6 +53,7 @@ describe("refreshHandler", () => {
     });
 
     const res = await handler(requestWithRefresh("refresh-1"));
+    expect(res.status).toBe(200);
     const body = await res.json();
 
     // Access-only: no refresh token in the response body.
@@ -78,6 +87,7 @@ describe("refreshHandler", () => {
     });
 
     const res = await handler(requestWithRefresh());
+    expect(res.status).toBe(200);
     expect((await res.json()).tokens).toBeNull();
     expect(mutationMock).not.toHaveBeenCalled();
   });
@@ -92,6 +102,7 @@ describe("refreshHandler", () => {
     });
 
     const res = await handler(requestWithRefresh("stale"));
+    expect(res.status).toBe(200);
     expect((await res.json()).tokens).toBeNull();
     const setCookies = res.headers.getSetCookie();
     expect(setCookies.some((c) => c.includes("Max-Age=0"))).toBe(true);
@@ -108,6 +119,7 @@ describe("signOutHandler", () => {
     });
 
     const res = await handler(requestWithRefresh("refresh-1"));
+    expect(res.status).toBe(200);
     expect((await res.json()).tokens).toBeNull();
     expect(mutationMock).toHaveBeenCalledWith(fnRef, {
       refreshToken: "refresh-1",
@@ -127,11 +139,79 @@ describe("signOutHandler", () => {
     });
 
     const res = await handler(requestWithRefresh());
+    expect(res.status).toBe(200);
     expect((await res.json()).tokens).toBeNull();
     expect(mutationMock).not.toHaveBeenCalled();
     const setCookies = res.headers.getSetCookie();
     expect(
       setCookies.filter((c) => c.includes("Max-Age=0")).length,
     ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// CSRF: both handlers must refuse a cross-site request before touching Convex
+// or the cookies. Sign-out is the interesting victim — it clears cookies
+// unconditionally, so without the guard a cross-site POST could force-logout.
+describe("cross-site requests", () => {
+  const crossSite = { origin: "https://evil.test", host: "app.test" };
+  const sameSite = { origin: "https://app.test", host: "app.test" };
+
+  test("refreshHandler refuses without calling Convex or writing cookies", async () => {
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+      cookieOptions: { secure: false },
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1", crossSite));
+    expect(res.status).toBe(403);
+    expect((await res.json()).tokens).toBeNull();
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(res.headers.getSetCookie()).toEqual([]);
+  });
+
+  test("signOutHandler refuses without revoking or clearing cookies", async () => {
+    const handler = signOutHandler({
+      convexUrl: "https://x.convex.cloud",
+      signOut: fnRef,
+      cookieOptions: { secure: false },
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1", crossSite));
+    expect(res.status).toBe(403);
+    expect(mutationMock).not.toHaveBeenCalled();
+    expect(res.headers.getSetCookie()).toEqual([]);
+  });
+
+  test("a same-site Origin is served", async () => {
+    mutationMock.mockResolvedValue(bundle(2));
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+      cookieOptions: { secure: false },
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1", sameSite));
+    expect(res.status).toBe(200);
+    expect((await res.json()).tokens).not.toBeNull();
+  });
+
+  test("allowedOrigins admits a cross-host but trusted Origin", async () => {
+    mutationMock.mockResolvedValue(bundle(2));
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+      cookieOptions: { secure: false },
+      allowedOrigins: ["https://public.test"],
+    });
+
+    const res = await handler(
+      requestWithRefresh("refresh-1", {
+        origin: "https://public.test",
+        host: "internal:8080",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).tokens).not.toBeNull();
   });
 });

--- a/packages/core/src/server/handlers.test.ts
+++ b/packages/core/src/server/handlers.test.ts
@@ -39,6 +39,7 @@ describe("refreshHandler", () => {
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
       refreshSession: fnRef,
+      cookieOptions: { secure: false },
     });
 
     const res = await handler(requestWithRefresh("refresh-1"));
@@ -70,6 +71,7 @@ describe("refreshHandler", () => {
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
       refreshSession: fnRef,
+      cookieOptions: { secure: false },
     });
 
     const res = await handler(requestWithRefresh());
@@ -82,6 +84,7 @@ describe("refreshHandler", () => {
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
       refreshSession: fnRef,
+      cookieOptions: { secure: false },
     });
 
     const res = await handler(requestWithRefresh("stale"));
@@ -97,6 +100,7 @@ describe("signOutHandler", () => {
     const handler = signOutHandler({
       convexUrl: "https://x.convex.cloud",
       signOut: fnRef,
+      cookieOptions: { secure: false },
     });
 
     const res = await handler(requestWithRefresh("refresh-1"));
@@ -115,6 +119,7 @@ describe("signOutHandler", () => {
     const handler = signOutHandler({
       convexUrl: "https://x.convex.cloud",
       signOut: fnRef,
+      cookieOptions: { secure: false },
     });
 
     const res = await handler(requestWithRefresh());

--- a/packages/core/src/server/handlers.test.ts
+++ b/packages/core/src/server/handlers.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TokenBundle } from "../lib/types";
+import { AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE } from "./cookies";
+import { refreshHandler, signOutHandler } from "./handlers";
+
+// The handlers talk to Convex through a `ConvexHttpClient`; stub it so the
+// tests exercise cookie behavior without a backend.
+const { mutationMock } = vi.hoisted(() => ({ mutationMock: vi.fn() }));
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    mutation = mutationMock;
+  },
+}));
+
+function bundle(n: number): TokenBundle {
+  return {
+    accessToken: `access-${n}`,
+    accessTokenExpiresAt: 1_000,
+    refreshToken: `refresh-${n}`,
+    refreshTokenExpiresAt: 2_000,
+    userId: "user-1",
+  };
+}
+
+const requestWithRefresh = (token?: string) =>
+  new Request("https://app.test/auth/refresh", {
+    method: "POST",
+    headers: token ? { cookie: `${AUTH_REFRESH_COOKIE}=${token}` } : {},
+  });
+
+// A placeholder function reference; the mocked client ignores it.
+const fnRef = {} as never;
+
+beforeEach(() => mutationMock.mockReset());
+
+describe("refreshHandler", () => {
+  test("rotates the session and returns access-only tokens", async () => {
+    mutationMock.mockResolvedValue(bundle(2));
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1"));
+    const body = await res.json();
+
+    // Access-only: no refresh token in the response body.
+    expect(body.tokens).toEqual({
+      accessToken: "access-2",
+      accessTokenExpiresAt: 1_000,
+      userId: "user-1",
+    });
+    expect(body.tokens).not.toHaveProperty("refreshToken");
+    expect(mutationMock).toHaveBeenCalledWith(fnRef, {
+      refreshToken: "refresh-1",
+    });
+
+    // Both cookies rewritten, refresh cookie httpOnly.
+    const setCookies = res.headers.getSetCookie();
+    const jwt = setCookies.find((c) => c.startsWith(`${AUTH_JWT_COOKIE}=`));
+    const refresh = setCookies.find((c) =>
+      c.startsWith(`${AUTH_REFRESH_COOKIE}=`),
+    );
+    expect(jwt).toContain("access-2");
+    expect(refresh).toContain("refresh-2");
+    expect(refresh).toContain("HttpOnly");
+  });
+
+  test("with no refresh cookie returns null without calling Convex", async () => {
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+    });
+
+    const res = await handler(requestWithRefresh());
+    expect((await res.json()).tokens).toBeNull();
+    expect(mutationMock).not.toHaveBeenCalled();
+  });
+
+  test("clears cookies when the refresh token is unknown", async () => {
+    mutationMock.mockResolvedValue(null);
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+    });
+
+    const res = await handler(requestWithRefresh("stale"));
+    expect((await res.json()).tokens).toBeNull();
+    const setCookies = res.headers.getSetCookie();
+    expect(setCookies.some((c) => c.includes("Max-Age=0"))).toBe(true);
+  });
+});
+
+describe("signOutHandler", () => {
+  test("revokes and clears both cookies", async () => {
+    mutationMock.mockResolvedValue(null);
+    const handler = signOutHandler({
+      convexUrl: "https://x.convex.cloud",
+      signOut: fnRef,
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1"));
+    expect((await res.json()).tokens).toBeNull();
+    expect(mutationMock).toHaveBeenCalledWith(fnRef, {
+      refreshToken: "refresh-1",
+    });
+
+    const setCookies = res.headers.getSetCookie();
+    expect(
+      setCookies.filter((c) => c.includes("Max-Age=0")).length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  test("with no refresh cookie clears without calling Convex", async () => {
+    const handler = signOutHandler({
+      convexUrl: "https://x.convex.cloud",
+      signOut: fnRef,
+    });
+
+    const res = await handler(requestWithRefresh());
+    expect((await res.json()).tokens).toBeNull();
+    expect(mutationMock).not.toHaveBeenCalled();
+    const setCookies = res.headers.getSetCookie();
+    expect(
+      setCookies.filter((c) => c.includes("Max-Age=0")).length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -11,6 +11,9 @@
  * Each handler takes only the one mutation reference it calls:
  * `refreshHandler` the app's `refreshSession`, `signOutHandler` its `signOut`.
  *
+ * Both refuse cross-site requests up front (403, before any Convex call or
+ * cookie write) by checking the `Origin` header via {@link isTrustedOrigin}.
+ *
  * A provider's *sign-in* handler is the per-provider counterpart (see e.g.
  * `@convex-dev/auth/providers/anonymous/server`); it mints a bundle and
  * delegates to {@link signInResponse} to properly build the response.
@@ -28,6 +31,7 @@ import {
   writeAuthCookies,
 } from "./cookies";
 import { httpCookies } from "./httpCookies";
+import { forbiddenOriginResponse, isTrustedOrigin } from "./origin";
 import { ServerAuthSession } from "./session";
 
 /** A WHATWG request handler. */
@@ -41,6 +45,10 @@ export interface RefreshHandlerConfig {
   refreshSession: RefreshSessionFn;
   /** Auth cookie attributes; `secure` is required. */
   cookieOptions: AuthCookieOptions;
+  /** Origins beyond the request's own `Host` trusted by the CSRF origin
+   * check, for deployments where the two differ (e.g. a proxy that rewrites
+   * `Host`). See {@link isTrustedOrigin}. */
+  allowedOrigins?: string[];
 }
 
 /**
@@ -50,6 +58,9 @@ export interface RefreshHandlerConfig {
 export function refreshHandler(config: RefreshHandlerConfig): RequestHandler {
   const client = new ConvexHttpClient(config.convexUrl);
   return async (request) => {
+    if (!isTrustedOrigin(request, config.allowedOrigins)) {
+      return forbiddenOriginResponse();
+    }
     const cookies = httpCookies(request);
     const session = new ServerAuthSession({
       refreshSession: (refreshToken) =>
@@ -74,6 +85,10 @@ export interface SignOutHandlerConfig {
   signOut: SignOutFn;
   /** Auth cookie attributes; `secure` is required. */
   cookieOptions: AuthCookieOptions;
+  /** Origins beyond the request's own `Host` trusted by the CSRF origin
+   * check, for deployments where the two differ (e.g. a proxy that rewrites
+   * `Host`). See {@link isTrustedOrigin}. */
+  allowedOrigins?: string[];
 }
 
 /**
@@ -83,6 +98,9 @@ export interface SignOutHandlerConfig {
 export function signOutHandler(config: SignOutHandlerConfig): RequestHandler {
   const client = new ConvexHttpClient(config.convexUrl);
   return async (request) => {
+    if (!isTrustedOrigin(request, config.allowedOrigins)) {
+      return forbiddenOriginResponse();
+    }
     const cookies = httpCookies(request);
     const refreshToken = (await cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
     if (refreshToken !== null) {

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -23,7 +23,7 @@ import type { RefreshSessionFn, SignOutFn, TokenBundle } from "../lib/types";
 import { makeSlimBundle } from "../lib/types";
 import {
   AUTH_REFRESH_COOKIE,
-  CookieOptions,
+  AuthCookieOptions,
   clearAuthCookies,
   writeAuthCookies,
 } from "./cookies";
@@ -39,8 +39,8 @@ export interface RefreshHandlerConfig {
   convexUrl: string;
   /** The app's `refreshSession` mutation reference. */
   refreshSession: RefreshSessionFn;
-  /** Overrides the default auth cookie attributes. */
-  cookieOptions?: CookieOptions;
+  /** Auth cookie attributes; `secure` is required. */
+  cookieOptions: AuthCookieOptions;
 }
 
 /**
@@ -72,8 +72,8 @@ export interface SignOutHandlerConfig {
   convexUrl: string;
   /** The app's `signOut` mutation reference. */
   signOut: SignOutFn;
-  /** Overrides the default auth cookie attributes. */
-  cookieOptions?: CookieOptions;
+  /** Auth cookie attributes; `secure` is required. */
+  cookieOptions: AuthCookieOptions;
 }
 
 /**
@@ -111,7 +111,7 @@ export function signOutHandler(config: SignOutHandlerConfig): RequestHandler {
 export async function signInResponse(
   request: Request,
   bundle: TokenBundle | null,
-  cookieOptions?: CookieOptions,
+  cookieOptions: AuthCookieOptions,
 ): Promise<Response> {
   const cookies = httpCookies(request);
   // Sign-in only writes cookies — it never refreshes or revokes — so it uses the

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -1,19 +1,19 @@
 /**
  * Framework-agnostic `(Request) => Response` auth handlers.
  *
- * These are the provider-*agnostic* halves of the SSR auth surface — refreshing
- * the access token and signing out — as plain WHATWG handlers a framework mounts
- * at routes of its choosing (e.g. `/auth/refresh`, `/auth/signout`). They read
- * the httpOnly refresh-token cookie from the request and reply with the
- * access-only {@link SlimTokenBundle} the browser is allowed to hold — the
- * refresh token stays in the cookie and never reaches the response body.
+ * These are the provider-*agnostic* halves of the SSR auth surface. This
+ * module exposes plain WHATWG handlers an application mounts at routes of its
+ * choosing (e.g. `/auth/refresh`, `/auth/signout`). They read the httpOnly
+ * refresh-token cookie from the request and reply with the access-only {@link
+ * SlimTokenBundle} the browser is allowed to hold. The refresh token stays in
+ * the cookie and never reaches the response body.
  *
- * Each handler takes only the one mutation reference it calls: `refreshHandler`
- * the app's `refreshSession`, `signOutHandler` its `signOut`.
+ * Each handler takes only the one mutation reference it calls:
+ * `refreshHandler` the app's `refreshSession`, `signOutHandler` its `signOut`.
  *
  * A provider's *sign-in* handler is the per-provider counterpart (see e.g.
- * `@convex-dev/auth/providers/anonymous/server`); it mints a bundle and defers
- * to {@link signInResponse} to cookie it and reply.
+ * `@convex-dev/auth/providers/anonymous/server`); it mints a bundle and
+ * delegates to {@link signInResponse} to properly build the response.
  *
  * @module
  */

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -1,0 +1,125 @@
+/**
+ * Framework-agnostic `(Request) => Response` auth handlers.
+ *
+ * These are the provider-*agnostic* halves of the SSR auth surface — refreshing
+ * the access token and signing out — as plain WHATWG handlers a framework mounts
+ * at routes of its choosing (e.g. `/auth/refresh`, `/auth/signout`). They read
+ * the httpOnly refresh-token cookie from the request and reply with the
+ * access-only {@link SlimTokenBundle} the browser is allowed to hold — the
+ * refresh token stays in the cookie and never reaches the response body.
+ *
+ * Each handler takes only the one mutation reference it calls: `refreshHandler`
+ * the app's `refreshSession`, `signOutHandler` its `signOut`.
+ *
+ * A provider's *sign-in* handler is the per-provider counterpart (see e.g.
+ * `@convex-dev/auth/providers/anonymous/server`); it mints a bundle and defers
+ * to {@link signInResponse} to cookie it and reply.
+ *
+ * @module
+ */
+
+import { ConvexHttpClient } from "convex/browser";
+import type { RefreshSessionFn, SignOutFn, TokenBundle } from "../lib/types";
+import { makeSlimBundle } from "../lib/types";
+import {
+  AUTH_REFRESH_COOKIE,
+  CookieOptions,
+  clearAuthCookies,
+  writeAuthCookies,
+} from "./cookies";
+import { httpCookies } from "./httpCookies";
+import { ServerAuthSession } from "./session";
+
+/** A WHATWG request handler. */
+export type RequestHandler = (request: Request) => Promise<Response>;
+
+/** Configuration for {@link refreshHandler}. */
+export interface RefreshHandlerConfig {
+  /** The Convex deployment URL used server-side. */
+  convexUrl: string;
+  /** The app's `refreshSession` mutation reference. */
+  refreshSession: RefreshSessionFn;
+  /** Overrides the default auth cookie attributes. */
+  cookieOptions?: CookieOptions;
+}
+
+/**
+ * A handler that rotates the session from the httpOnly refresh-token cookie and
+ * rewrites both cookies, replying `{ tokens: SlimTokenBundle | null }`.
+ */
+export function refreshHandler(config: RefreshHandlerConfig): RequestHandler {
+  const client = new ConvexHttpClient(config.convexUrl);
+  return async (request) => {
+    const cookies = httpCookies(request);
+    const session = new ServerAuthSession({
+      refreshSession: (refreshToken) =>
+        client.mutation(config.refreshSession, { refreshToken }),
+      cookies,
+      cookieOptions: config.cookieOptions,
+    });
+    const bundle = await session.refresh();
+    const res = Response.json({
+      tokens: bundle === null ? null : makeSlimBundle(bundle),
+    });
+    cookies.applyTo(res.headers);
+    return res;
+  };
+}
+
+/** Configuration for {@link signOutHandler}. */
+export interface SignOutHandlerConfig {
+  /** The Convex deployment URL used server-side. */
+  convexUrl: string;
+  /** The app's `signOut` mutation reference. */
+  signOut: SignOutFn;
+  /** Overrides the default auth cookie attributes. */
+  cookieOptions?: CookieOptions;
+}
+
+/**
+ * A handler that revokes the session from the httpOnly refresh-token cookie
+ * (best effort) and clears both cookies, replying `{ tokens: null }`.
+ */
+export function signOutHandler(config: SignOutHandlerConfig): RequestHandler {
+  const client = new ConvexHttpClient(config.convexUrl);
+  return async (request) => {
+    const cookies = httpCookies(request);
+    const refreshToken = (await cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
+    if (refreshToken !== null) {
+      try {
+        await client.mutation(config.signOut, { refreshToken });
+      } catch {
+        // Usually means we were already signed out, which is fine.
+      }
+    }
+    await clearAuthCookies(cookies);
+    const res = Response.json({ tokens: null });
+    cookies.applyTo(res.headers);
+    return res;
+  };
+}
+
+/**
+ * Build the response for a completed server-side sign-in: move the minted
+ * refresh token into an httpOnly cookie (and the access token into its cookie),
+ * and reply with the access-only {@link SlimTokenBundle} the browser may hold. A
+ * `null` bundle (sign-in failed) writes no cookies and replies `{ tokens: null }`.
+ *
+ * Every provider's sign-in handler mints its bundle, then defers to this, so the
+ * refresh token reaches only the cookie and the response is uniformly shaped.
+ */
+export async function signInResponse(
+  request: Request,
+  bundle: TokenBundle | null,
+  cookieOptions?: CookieOptions,
+): Promise<Response> {
+  const cookies = httpCookies(request);
+  // Sign-in only writes cookies — it never refreshes or revokes — so it uses the
+  // cookie primitive directly rather than a `ServerAuthSession`.
+  if (bundle !== null) await writeAuthCookies(cookies, bundle, cookieOptions);
+  const res = Response.json({
+    tokens: bundle === null ? null : makeSlimBundle(bundle),
+  });
+  cookies.applyTo(res.headers);
+  return res;
+}

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -110,7 +110,7 @@ export function signOutHandler(config: SignOutHandlerConfig): RequestHandler {
         // Usually means we were already signed out, which is fine.
       }
     }
-    await clearAuthCookies(cookies);
+    await clearAuthCookies(cookies, config.cookieOptions);
     const res = Response.json({ tokens: null });
     cookies.applyTo(res.headers);
     return res;

--- a/packages/core/src/server/httpCookies.test.ts
+++ b/packages/core/src/server/httpCookies.test.ts
@@ -28,6 +28,18 @@ describe("serializeCookie", () => {
   test("url-encodes the value", () => {
     expect(serializeCookie("t", "a b/c")).toContain("t=a%20b%2Fc");
   });
+
+  test("emits SameSite=None for cross-site cookies", () => {
+    expect(
+      serializeCookie("t", "abc", { sameSite: "none", secure: true }),
+    ).toContain("SameSite=None");
+  });
+
+  test("floors a non-integer maxAge rather than throwing", () => {
+    expect(serializeCookie("t", "abc", { maxAge: 60.7 })).toContain(
+      "Max-Age=60",
+    );
+  });
 });
 
 describe("httpCookies", () => {
@@ -41,6 +53,15 @@ describe("httpCookies", () => {
     expect(cookies.get("a")).toBe("1");
     expect(cookies.get("b")).toBe("hello world");
     expect(cookies.get("missing")).toBeUndefined();
+  });
+
+  test("a foreign cookie with malformed percent-encoding does not throw", () => {
+    // A `%` that isn't valid percent-encoding would make a hand-rolled
+    // decodeURIComponent throw and fail the whole request; `cookie` falls back
+    // to the raw value and still reads our own cookies.
+    const cookies = httpCookies(requestWith("other=100%; a=1"));
+    expect(cookies.get("other")).toBe("100%");
+    expect(cookies.get("a")).toBe("1");
   });
 
   test("writes reflect back to reads within the request", () => {

--- a/packages/core/src/server/httpCookies.test.ts
+++ b/packages/core/src/server/httpCookies.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import { httpCookies, serializeCookie } from "./httpCookies";
+
+describe("serializeCookie", () => {
+  test("emits the attributes it is given", () => {
+    const cookie = serializeCookie("tok", "abc", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60,
+      domain: "example.com",
+    });
+    expect(cookie).toContain("tok=abc");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Max-Age=60");
+    expect(cookie).toContain("Domain=example.com");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+  });
+
+  test("omits attributes that were not set", () => {
+    const cookie = serializeCookie("tok", "abc");
+    expect(cookie).toBe("tok=abc; Path=/");
+  });
+
+  test("url-encodes the value", () => {
+    expect(serializeCookie("t", "a b/c")).toContain("t=a%20b%2Fc");
+  });
+});
+
+describe("httpCookies", () => {
+  const requestWith = (cookieHeader?: string) =>
+    new Request("https://app.test/", {
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+
+  test("reads values from the request Cookie header", () => {
+    const cookies = httpCookies(requestWith("a=1; b=hello%20world"));
+    expect(cookies.get("a")).toBe("1");
+    expect(cookies.get("b")).toBe("hello world");
+    expect(cookies.get("missing")).toBeUndefined();
+  });
+
+  test("writes reflect back to reads within the request", () => {
+    const cookies = httpCookies(requestWith("a=1"));
+    cookies.set("a", "2");
+    cookies.set("c", "new");
+    expect(cookies.get("a")).toBe("2");
+    expect(cookies.get("c")).toBe("new");
+  });
+
+  test("a deleted cookie reads as undefined", () => {
+    const cookies = httpCookies(requestWith("a=1"));
+    cookies.delete("a");
+    expect(cookies.get("a")).toBeUndefined();
+  });
+
+  test("applyTo appends a Set-Cookie per write and delete", () => {
+    const cookies = httpCookies(requestWith());
+    cookies.set("tok", "abc", { httpOnly: true, path: "/" });
+    cookies.delete("stale");
+
+    const headers = new Headers();
+    cookies.applyTo(headers);
+    const setCookies = headers.getSetCookie();
+
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain("tok=abc");
+    expect(setCookies[0]).toContain("HttpOnly");
+    // Deletion expires the cookie in the past with Max-Age=0.
+    expect(setCookies[1]).toContain("stale=");
+    expect(setCookies[1]).toContain("Max-Age=0");
+    expect(setCookies[1]).toContain("Path=/");
+  });
+});

--- a/packages/core/src/server/httpCookies.test.ts
+++ b/packages/core/src/server/httpCookies.test.ts
@@ -78,6 +78,20 @@ describe("httpCookies", () => {
     expect(cookies.get("a")).toBeUndefined();
   });
 
+  test("delete emits the path and domain it is given, matching the write", () => {
+    const cookies = httpCookies(requestWith("a=1"));
+    cookies.delete("a", { path: "/app", domain: "example.com" });
+
+    const headers = new Headers();
+    cookies.applyTo(headers);
+    const [setCookie] = headers.getSetCookie();
+
+    expect(setCookie).toContain("a=");
+    expect(setCookie).toContain("Path=/app");
+    expect(setCookie).toContain("Domain=example.com");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
   test("applyTo appends a Set-Cookie per write and delete", () => {
     const cookies = httpCookies(requestWith());
     cookies.set("tok", "abc", { httpOnly: true, path: "/" });

--- a/packages/core/src/server/httpCookies.ts
+++ b/packages/core/src/server/httpCookies.ts
@@ -72,11 +72,12 @@ export function httpCookies(request: Request): HttpCookies {
       overlay.set(name, value);
       pending.push(serializeCookie(name, value, options));
     },
-    delete(name) {
+    delete(name, options) {
       overlay.set(name, null);
       pending.push(
         serializeCookie(name, "", {
-          path: "/",
+          path: options?.path ?? "/",
+          domain: options?.domain,
           maxAge: 0,
           expires: new Date(0),
         }),

--- a/packages/core/src/server/httpCookies.ts
+++ b/packages/core/src/server/httpCookies.ts
@@ -1,18 +1,3 @@
-/**
- * A framework-agnostic {@link CookieStore} over a WHATWG `Request`/`Response`.
- *
- * The shared {@link ServerAuthSession} reads and writes cookies through a
- * {@link CookieStore}. A framework that hands off raw WHATWG requests (a route
- * handler that is `(Request) => Response` — Next.js App Router, Remix, Hono, …)
- * can use {@link httpCookies} to adapt them: it parses the incoming `Cookie`
- * header for reads and buffers writes as `Set-Cookie` headers to apply to the
- * outgoing response.
- *
- * Nothing here depends on React, Next.js, or Convex.
- *
- * @module
- */
-
 import { parse, serialize } from "cookie";
 import { CookieOptions, CookieStore } from "./cookies";
 
@@ -54,7 +39,11 @@ export interface HttpCookies extends CookieStore {
 }
 
 /**
- * Adapt an incoming WHATWG {@link Request}'s cookies to a {@link CookieStore}.
+ * Adapt an incoming {@link Request}'s cookies to a {@link CookieStore}.
+ *
+ * The returned {@link HttpCookies} object allows applying changes to the
+ * cookies via the {@link HttpCookies#applyTo} function. Pass it {@link
+ * Response} `Headers` and it will write the cookie values.
  *
  * ```ts
  * const cookies = httpCookies(request);

--- a/packages/core/src/server/httpCookies.ts
+++ b/packages/core/src/server/httpCookies.ts
@@ -13,12 +13,14 @@
  * @module
  */
 
+import { parse, serialize } from "cookie";
 import { CookieOptions, CookieStore } from "./cookies";
-
-const SAME_SITE = { lax: "Lax", strict: "Strict", none: "None" } as const;
 
 /**
  * Serialize a cookie into a `Set-Cookie` header value.
+ *
+ * Thin adapter over the `cookie` package's `serialize` that maps our
+ * {@link CookieOptions} onto it.
  *
  * Deletion is expressed by the caller as an empty value with `maxAge: 0` (and a
  * past `expires`); see {@link httpCookies}'s `delete`.
@@ -28,36 +30,16 @@ export function serializeCookie(
   value: string,
   options: CookieOptions = {},
 ): string {
-  const parts = [`${name}=${encodeURIComponent(value)}`];
-  // Path first among attributes so a delete matches the write's default path.
-  parts.push(`Path=${options.path ?? "/"}`);
-  if (options.maxAge !== undefined) {
-    parts.push(`Max-Age=${Math.floor(options.maxAge)}`);
-  }
-  if (options.expires !== undefined) {
-    parts.push(`Expires=${options.expires.toUTCString()}`);
-  }
-  if (options.domain !== undefined) parts.push(`Domain=${options.domain}`);
-  if (options.httpOnly) parts.push("HttpOnly");
-  if (options.secure) parts.push("Secure");
-  if (options.sameSite !== undefined) {
-    parts.push(`SameSite=${SAME_SITE[options.sameSite]}`);
-  }
-  return parts.join("; ");
-}
-
-/** Parse a request `Cookie` header (`a=1; b=2`) into a name→value map. */
-function parseCookieHeader(header: string | null): Map<string, string> {
-  const jar = new Map<string, string>();
-  if (header === null) return jar;
-  for (const pair of header.split(";")) {
-    const eq = pair.indexOf("=");
-    if (eq === -1) continue;
-    const name = pair.slice(0, eq).trim();
-    if (name === "") continue;
-    jar.set(name, decodeURIComponent(pair.slice(eq + 1).trim()));
-  }
-  return jar;
+  return serialize(name, value, {
+    path: options.path ?? "/",
+    maxAge:
+      options.maxAge === undefined ? undefined : Math.floor(options.maxAge),
+    expires: options.expires,
+    domain: options.domain,
+    httpOnly: options.httpOnly,
+    secure: options.secure,
+    sameSite: options.sameSite,
+  });
 }
 
 /**
@@ -84,7 +66,10 @@ export interface HttpCookies extends CookieStore {
  * ```
  */
 export function httpCookies(request: Request): HttpCookies {
-  const jar = parseCookieHeader(request.headers.get("cookie"));
+  // `cookie`'s `parse` tolerates malformed percent-encoding on foreign cookies
+  // (falling back to the raw value) rather than throwing and failing the whole
+  // request.
+  const jar = parse(request.headers.get("cookie") ?? "");
   // Reflect writes back to reads within the same request, and remember them as
   // serialized Set-Cookie headers to flush onto the response.
   const overlay = new Map<string, string | null>();
@@ -92,7 +77,7 @@ export function httpCookies(request: Request): HttpCookies {
   return {
     get(name) {
       if (overlay.has(name)) return overlay.get(name) ?? undefined;
-      return jar.get(name);
+      return jar[name];
     },
     set(name, value, options) {
       overlay.set(name, value);

--- a/packages/core/src/server/httpCookies.ts
+++ b/packages/core/src/server/httpCookies.ts
@@ -1,0 +1,115 @@
+/**
+ * A framework-agnostic {@link CookieStore} over a WHATWG `Request`/`Response`.
+ *
+ * The shared {@link ServerAuthSession} reads and writes cookies through a
+ * {@link CookieStore}. A framework that hands off raw WHATWG requests (a route
+ * handler that is `(Request) => Response` — Next.js App Router, Remix, Hono, …)
+ * can use {@link httpCookies} to adapt them: it parses the incoming `Cookie`
+ * header for reads and buffers writes as `Set-Cookie` headers to apply to the
+ * outgoing response.
+ *
+ * Nothing here depends on React, Next.js, or Convex.
+ *
+ * @module
+ */
+
+import { CookieOptions, CookieStore } from "./cookies";
+
+const SAME_SITE = { lax: "Lax", strict: "Strict", none: "None" } as const;
+
+/**
+ * Serialize a cookie into a `Set-Cookie` header value.
+ *
+ * Deletion is expressed by the caller as an empty value with `maxAge: 0` (and a
+ * past `expires`); see {@link httpCookies}'s `delete`.
+ */
+export function serializeCookie(
+  name: string,
+  value: string,
+  options: CookieOptions = {},
+): string {
+  const parts = [`${name}=${encodeURIComponent(value)}`];
+  // Path first among attributes so a delete matches the write's default path.
+  parts.push(`Path=${options.path ?? "/"}`);
+  if (options.maxAge !== undefined) {
+    parts.push(`Max-Age=${Math.floor(options.maxAge)}`);
+  }
+  if (options.expires !== undefined) {
+    parts.push(`Expires=${options.expires.toUTCString()}`);
+  }
+  if (options.domain !== undefined) parts.push(`Domain=${options.domain}`);
+  if (options.httpOnly) parts.push("HttpOnly");
+  if (options.secure) parts.push("Secure");
+  if (options.sameSite !== undefined) {
+    parts.push(`SameSite=${SAME_SITE[options.sameSite]}`);
+  }
+  return parts.join("; ");
+}
+
+/** Parse a request `Cookie` header (`a=1; b=2`) into a name→value map. */
+function parseCookieHeader(header: string | null): Map<string, string> {
+  const jar = new Map<string, string>();
+  if (header === null) return jar;
+  for (const pair of header.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    const name = pair.slice(0, eq).trim();
+    if (name === "") continue;
+    jar.set(name, decodeURIComponent(pair.slice(eq + 1).trim()));
+  }
+  return jar;
+}
+
+/**
+ * A {@link CookieStore} that also knows how to write its buffered mutations onto
+ * a response's headers. Build one per request; after driving a
+ * {@link ServerAuthSession} with it, call {@link HttpCookies.applyTo} on the
+ * response you return.
+ */
+export interface HttpCookies extends CookieStore {
+  /** Append a `Set-Cookie` header for every write/delete made on this store. */
+  applyTo: (headers: Headers) => void;
+}
+
+/**
+ * Adapt an incoming WHATWG {@link Request}'s cookies to a {@link CookieStore}.
+ *
+ * ```ts
+ * const cookies = httpCookies(request);
+ * const session = new ServerAuthSession({ authApi, cookies });
+ * const bundle = await session.refresh();
+ * const res = Response.json({ tokens: bundle && makeSlimBundle(bundle) });
+ * cookies.applyTo(res.headers);
+ * return res;
+ * ```
+ */
+export function httpCookies(request: Request): HttpCookies {
+  const jar = parseCookieHeader(request.headers.get("cookie"));
+  // Reflect writes back to reads within the same request, and remember them as
+  // serialized Set-Cookie headers to flush onto the response.
+  const overlay = new Map<string, string | null>();
+  const pending: string[] = [];
+  return {
+    get(name) {
+      if (overlay.has(name)) return overlay.get(name) ?? undefined;
+      return jar.get(name);
+    },
+    set(name, value, options) {
+      overlay.set(name, value);
+      pending.push(serializeCookie(name, value, options));
+    },
+    delete(name) {
+      overlay.set(name, null);
+      pending.push(
+        serializeCookie(name, "", {
+          path: "/",
+          maxAge: 0,
+          expires: new Date(0),
+        }),
+      );
+    },
+    applyTo(headers) {
+      for (const cookie of pending) headers.append("set-cookie", cookie);
+    },
+  };
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -33,6 +33,7 @@ export {
 export {
   type ConvexAuthServerConfig,
   type SignInProvider,
+  InvalidSignInRequestError,
   setupConvexAuthServer,
 } from "./setup";
 export {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,9 +1,11 @@
 /**
  * Framework-agnostic server (SSR) building blocks for Convex Auth: a cookie
  * abstraction, a WHATWG `Request`/`Response` cookie adapter, access-token
- * inspection, the {@link ServerAuthSession} that ties them together, the
- * provider-agnostic `(Request) => Response` refresh/sign-out handlers, and the
- * {@link setupConvexAuthServer} factory that configures them (and sign-in) once.
+ * inspection, the {@link ServerAuthSession} that owns the refresh lifecycle,
+ * the {@link createServerAuthChecker} that verifies an access token against the
+ * backend, the provider-agnostic `(Request) => Response` refresh/sign-out
+ * handlers, and the {@link setupConvexAuthServer} factory that configures them
+ * (and sign-in) once.
  *
  * @module
  */
@@ -41,8 +43,14 @@ export {
   type RefreshSession,
   type ServerAuthSessionConfig,
 } from "./session";
+export {
+  createServerAuthChecker,
+  type ServerAuthChecker,
+  type ServerAuthCheckerConfig,
+} from "./isAuthenticated";
 export type {
   ConvexAuthApi,
+  IsAuthenticatedFn,
   RefreshSessionFn,
   SignOutFn,
   SlimTokenBundle,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,8 +1,9 @@
 /**
  * Framework-agnostic server (SSR) building blocks for Convex Auth: a cookie
  * abstraction, a WHATWG `Request`/`Response` cookie adapter, access-token
- * inspection, the {@link ServerAuthSession} that ties them together, and the
- * provider-agnostic `(Request) => Response` refresh/sign-out handlers.
+ * inspection, the {@link ServerAuthSession} that ties them together, the
+ * provider-agnostic `(Request) => Response` refresh/sign-out handlers, and the
+ * {@link setupConvexAuthServer} factory that configures them (and sign-in) once.
  *
  * @module
  */
@@ -25,6 +26,11 @@ export {
   signInResponse,
   signOutHandler,
 } from "./handlers";
+export {
+  type ConvexAuthServerConfig,
+  type SignInProvider,
+  setupConvexAuthServer,
+} from "./setup";
 export {
   type DecodedAccessToken,
   decodeAccessToken,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,7 +1,8 @@
 /**
  * Framework-agnostic server (SSR) building blocks for Convex Auth: a cookie
- * abstraction, access-token inspection, and the {@link ServerAuthSession} that
- * ties them together.
+ * abstraction, a WHATWG `Request`/`Response` cookie adapter, access-token
+ * inspection, the {@link ServerAuthSession} that ties them together, and the
+ * provider-agnostic `(Request) => Response` refresh/sign-out handlers.
  *
  * @module
  */
@@ -15,6 +16,15 @@ export {
   clearAuthCookies,
   writeAuthCookies,
 } from "./cookies";
+export { type HttpCookies, httpCookies, serializeCookie } from "./httpCookies";
+export {
+  type RefreshHandlerConfig,
+  type RequestHandler,
+  type SignOutHandlerConfig,
+  refreshHandler,
+  signInResponse,
+  signOutHandler,
+} from "./handlers";
 export {
   type DecodedAccessToken,
   decodeAccessToken,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -12,6 +12,7 @@
 
 export {
   type AuthCookieOptions,
+  type CookieDeleteOptions,
   type CookieOptions,
   type CookieStore,
   AUTH_JWT_COOKIE,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -20,6 +20,7 @@ export {
   writeAuthCookies,
 } from "./cookies";
 export { type HttpCookies, httpCookies, serializeCookie } from "./httpCookies";
+export { isTrustedOrigin } from "./origin";
 export {
   type RefreshHandlerConfig,
   type RequestHandler,

--- a/packages/core/src/server/origin.test.ts
+++ b/packages/core/src/server/origin.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { isTrustedOrigin } from "./origin";
+
+function request(headers: Record<string, string>): Request {
+  return new Request("https://app.test/auth/refresh", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("isTrustedOrigin", () => {
+  test("trusts an Origin matching the Host header", () => {
+    expect(
+      isTrustedOrigin(
+        request({ origin: "https://app.test", host: "app.test" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("host comparison includes the port", () => {
+    expect(
+      isTrustedOrigin(
+        request({ origin: "http://localhost:3000", host: "localhost:3000" }),
+      ),
+    ).toBe(true);
+    expect(
+      isTrustedOrigin(
+        request({ origin: "http://localhost:4000", host: "localhost:3000" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("refuses a cross-site Origin", () => {
+    expect(
+      isTrustedOrigin(request({ origin: "https://evil.test", host: "app.test" })),
+    ).toBe(false);
+  });
+
+  test("refuses a subdomain of the Host", () => {
+    expect(
+      isTrustedOrigin(
+        request({ origin: "https://sub.app.test", host: "app.test" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("refuses a missing Origin", () => {
+    expect(isTrustedOrigin(request({ host: "app.test" }))).toBe(false);
+  });
+
+  test('refuses the literal "null" origin (sandboxed iframe)', () => {
+    expect(
+      isTrustedOrigin(request({ origin: "null", host: "app.test" })),
+    ).toBe(false);
+  });
+
+  test("refuses an unparseable Origin", () => {
+    expect(
+      isTrustedOrigin(request({ origin: "not a url", host: "app.test" })),
+    ).toBe(false);
+  });
+
+  test("trusts a configured allowed origin", () => {
+    const req = request({ origin: "https://public.test", host: "internal" });
+    expect(isTrustedOrigin(req, ["https://public.test"])).toBe(true);
+    // A bare host works too.
+    expect(isTrustedOrigin(req, ["public.test"])).toBe(true);
+    expect(isTrustedOrigin(req, ["https://other.test"])).toBe(false);
+  });
+});

--- a/packages/core/src/server/origin.test.ts
+++ b/packages/core/src/server/origin.test.ts
@@ -69,4 +69,15 @@ describe("isTrustedOrigin", () => {
     expect(isTrustedOrigin(req, ["public.test"])).toBe(true);
     expect(isTrustedOrigin(req, ["https://other.test"])).toBe(false);
   });
+
+  test("trusts a configured localhost allowed origin", () => {
+    const req = request({
+      origin: "http://localhost:3000",
+      host: "http://app.test",
+    });
+    expect(isTrustedOrigin(req, ["http://localhost:3000"])).toBe(true);
+    // A bare host works too.
+    expect(isTrustedOrigin(req, ["localhost:3000"])).toBe(true);
+    expect(isTrustedOrigin(req, ["http://localhost:5173"])).toBe(false);
+  });
 });

--- a/packages/core/src/server/origin.test.ts
+++ b/packages/core/src/server/origin.test.ts
@@ -32,7 +32,9 @@ describe("isTrustedOrigin", () => {
 
   test("refuses a cross-site Origin", () => {
     expect(
-      isTrustedOrigin(request({ origin: "https://evil.test", host: "app.test" })),
+      isTrustedOrigin(
+        request({ origin: "https://evil.test", host: "app.test" }),
+      ),
     ).toBe(false);
   });
 
@@ -49,9 +51,9 @@ describe("isTrustedOrigin", () => {
   });
 
   test('refuses the literal "null" origin (sandboxed iframe)', () => {
-    expect(
-      isTrustedOrigin(request({ origin: "null", host: "app.test" })),
-    ).toBe(false);
+    expect(isTrustedOrigin(request({ origin: "null", host: "app.test" }))).toBe(
+      false,
+    );
   });
 
   test("refuses an unparseable Origin", () => {

--- a/packages/core/src/server/origin.ts
+++ b/packages/core/src/server/origin.ts
@@ -1,0 +1,62 @@
+/**
+ * CSRF protection for the auth handlers, by checking the `Origin` header.
+ *
+ * Every auth route is a state-changing POST whose effect rides on cookies:
+ * sign-in writes the session cookies, refresh rotates them, sign-out clears
+ * them. The cookies have the `SameSite=lax` attribute but that only prevents
+ * previously set cookies from being sent in a cross-site request.
+ *
+ * This code checks that requests originate from allowed origins (the current
+ * `Host` or specifically `allowedOrigins`). See
+ * https://auth.pilcrowonpaper.com/csrf).
+ *
+ * Browsers attach an `Origin` header to every cross-site POST, so the rule
+ * is: a request whose `Origin` matches neither the `Host` header it arrived
+ * at nor a configured allowed origin is refused, before any Convex call runs
+ * or cookie is written.
+ *
+ * @module
+ */
+
+/** An origin's host, tolerating a bare host (`"app.example.com"`) as input. */
+function hostOf(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}
+
+/**
+ * Whether a request may be served by a state-changing auth handler.
+ *
+ * Trusts a request when its `Origin` header matches the `Host` header it
+ * arrived at or one of
+ * `allowedOrigins` (for deployments where the two legitimately differ, e.g. a
+ * proxy that rewrites `Host`). Entries may be full origins
+ * (`"https://app.example.com"`) or bare hosts (`"app.example.com"`,
+ * `"localhost:3000"`).
+ */
+export function isTrustedOrigin(
+  request: Request,
+  allowedOrigins: string[] = [],
+): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin || origin === "null") return false;
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return false;
+  }
+  if (originHost === request.headers.get("host")) return true;
+  return allowedOrigins.some((allowed) => hostOf(allowed) === originHost);
+}
+
+/**
+ * The uniform reply for a refused cross-site request: 403, `{ tokens: null }`
+ * (the handlers' response shape), and no cookie headers.
+ */
+export function forbiddenOriginResponse(): Response {
+  return Response.json({ tokens: null }, { status: 403 });
+}

--- a/packages/core/src/server/origin.ts
+++ b/packages/core/src/server/origin.ts
@@ -18,8 +18,15 @@
  * @module
  */
 
-/** An origin's host, tolerating a bare host (`"app.example.com"`) as input. */
+/**
+ * Extracts just the host portion from an `origin`.
+ *
+ * Handles `origin` URLs but also allows bare hosts (passing them through).
+ */
 function hostOf(origin: string): string {
+  if (!origin.includes("://")) {
+    return origin;
+  }
   try {
     return new URL(origin).host;
   } catch {

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -145,18 +145,4 @@ describe("ServerAuthSession", () => {
     expect(cookies.options.get(AUTH_JWT_COOKIE)?.httpOnly).toBe(true);
     expect(cookies.options.get(AUTH_REFRESH_COOKIE)?.httpOnly).toBe(true);
   });
-
-  test("isAuthenticated reflects a non-expired JWT cookie", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    const cookies = new FakeCookies();
-    const { session } = newSession(undefined, cookies);
-    expect(await session.isAuthenticated()).toBe(false);
-
-    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
-    expect(await session.isAuthenticated()).toBe(true);
-
-    cookies.set(AUTH_JWT_COOKIE, jwt(NOW - 1));
-    expect(await session.isAuthenticated()).toBe(false);
-    vi.restoreAllMocks();
-  });
 });

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, vi } from "vitest";
 import type { TokenBundle } from "../lib/types";
 import {
+  AuthCookieOptions,
+  CookieDeleteOptions,
   CookieOptions,
   CookieStore,
   AUTH_JWT_COOKIE,
@@ -35,10 +37,11 @@ function newTokenBundle(
 }
 
 /** An in-memory {@link CookieStore} that also records the options each cookie
- * was written with, so tests can assert httpOnly etc. */
+ * was written or deleted with, so tests can assert httpOnly, path, etc. */
 class FakeCookies implements CookieStore {
   values = new Map<string, string>();
   options = new Map<string, CookieOptions | undefined>();
+  deletions = new Map<string, CookieDeleteOptions | undefined>();
   get(name: string) {
     return this.values.get(name);
   }
@@ -46,20 +49,22 @@ class FakeCookies implements CookieStore {
     this.values.set(name, value);
     this.options.set(name, options);
   }
-  delete(name: string) {
+  delete(name: string, options?: CookieDeleteOptions) {
     this.values.delete(name);
     this.options.delete(name);
+    this.deletions.set(name, options);
   }
 }
 
 function newSession(
   refreshSession: RefreshSession = async () => null,
   cookies = new FakeCookies(),
+  cookieOptions: AuthCookieOptions = { secure: false },
 ) {
   const session = new ServerAuthSession({
     refreshSession,
     cookies,
-    cookieOptions: { secure: false },
+    cookieOptions,
   });
   return { session, cookies };
 }
@@ -120,6 +125,27 @@ describe("ServerAuthSession", () => {
     expect(await session.getToken()).toBeNull();
     expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
     expect(cookies.get(AUTH_REFRESH_COOKIE)).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+
+  test("clearing on a failed refresh deletes with the configured path and domain", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5));
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession(async () => null, cookies, {
+      secure: false,
+      path: "/app",
+      domain: "example.com",
+    });
+
+    expect(await session.getToken()).toBeNull();
+    for (const name of [AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE]) {
+      expect(cookies.deletions.get(name)).toEqual({
+        path: "/app",
+        domain: "example.com",
+      });
+    }
     vi.restoreAllMocks();
   });
 

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -114,12 +114,6 @@ export class ServerAuthSession {
     await writeAuthCookies(this.#cookies, bundle, this.#cookieOptions);
   }
 
-  /** Whether a non-expired access token is present in cookies. */
-  async isAuthenticated(): Promise<boolean> {
-    const token = (await this.#cookies.get(AUTH_JWT_COOKIE)) ?? null;
-    return token !== null && !isTokenExpiring(token, 0);
-  }
-
   /** Deletes the cookies. This will be reflected in the eventual response. */
   async #clear(): Promise<void> {
     await clearAuthCookies(this.#cookies);

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -116,6 +116,6 @@ export class ServerAuthSession {
 
   /** Deletes the cookies. This will be reflected in the eventual response. */
   async #clear(): Promise<void> {
-    await clearAuthCookies(this.#cookies);
+    await clearAuthCookies(this.#cookies, this.#cookieOptions);
   }
 }

--- a/packages/core/src/server/setup.ts
+++ b/packages/core/src/server/setup.ts
@@ -1,0 +1,109 @@
+/**
+ * The framework-agnostic auth server factory, exported at
+ * `@convex-dev/auth/server`.
+ *
+ * {@link setupConvexAuthServer} takes the shared config once (deployment URL,
+ * the session mutations, and the cookie attributes) and returns the WHATWG
+ * `(Request) => Response` handlers a framework mounts as routes: refresh,
+ * sign-out, and a `signInHandler` that wraps any provider's {@link SignInProvider}.
+ *
+ * The whole surface shares one {@link AuthCookieOptions}, so `secure` is decided
+ * exactly once per integration and reaches every handler, including sign-in.
+ *
+ * @module
+ */
+
+import { ConvexHttpClient } from "convex/browser";
+import type { FunctionReference } from "convex/server";
+import type { RefreshSessionFn, SignOutFn, TokenBundle } from "../lib/types";
+import type { AuthCookieOptions } from "./cookies";
+import {
+  type RequestHandler,
+  refreshHandler,
+  signInResponse,
+  signOutHandler,
+} from "./handlers";
+
+/**
+ * A provider's server-side sign-in descriptor: the mutation that mints a
+ * {@link TokenBundle} and, when the sign-in takes args, how to read them off the
+ * request. {@link setupConvexAuthServer}'s `signInHandler` wraps it into a route.
+ *
+ * `parseArgs` is required exactly when the mutation takes arguments, and
+ * omittable when it does not (Convex treats `Record<string, never>` as "no
+ * args"). So a provider that takes args cannot forget to parse them, while a
+ * no-argument provider like anonymous stays a bare `{ signIn }`.
+ */
+export type SignInProvider<Args extends Record<string, any>> = {
+  /** The provider's sign-in mutation reference. */
+  signIn: FunctionReference<"mutation", "public", Args, TokenBundle | null>;
+} & (Args extends Record<string, never>
+  ? { parseArgs?: (request: Request) => Args | Promise<Args> }
+  : { parseArgs: (request: Request) => Args | Promise<Args> });
+
+/** Configuration for {@link setupConvexAuthServer}. */
+export interface ConvexAuthServerConfig {
+  /** The Convex deployment URL used server-side. */
+  convexUrl: string;
+  /** The app's `refreshSession` mutation reference. */
+  refreshSession: RefreshSessionFn;
+  /** The app's `signOut` mutation reference. */
+  signOut: SignOutFn;
+  /** Auth cookie attributes for every handler; `secure` is required. */
+  cookieOptions: AuthCookieOptions;
+}
+
+/**
+ * Configure the auth handlers once and get back the routes to mount.
+ *
+ * ```ts
+ * export const auth = setupConvexAuthServer({
+ *   convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL!,
+ *   refreshSession: api.auth.refreshSession,
+ *   signOut: api.auth.signOut,
+ *   cookieOptions: { secure: process.env.NODE_ENV === "production" },
+ * });
+ *
+ * // in a route file:
+ * export const POST = auth.signInHandler(anonymous(api.auth.signInAnonymous));
+ * ```
+ */
+export function setupConvexAuthServer(config: ConvexAuthServerConfig) {
+  const { convexUrl, cookieOptions } = config;
+  const client = new ConvexHttpClient(convexUrl);
+  return {
+    refreshHandler: refreshHandler({
+      convexUrl,
+      refreshSession: config.refreshSession,
+      cookieOptions,
+    }),
+    signOutHandler: signOutHandler({
+      convexUrl,
+      signOut: config.signOut,
+      cookieOptions,
+    }),
+    /** Build a sign-in route from a provider descriptor. */
+    signInHandler<Args extends Record<string, any>>(
+      provider: SignInProvider<Args>,
+    ): RequestHandler {
+      // Widen the conditionally-required descriptor so parseArgs reads uniformly.
+      const { signIn, parseArgs } = provider as {
+        signIn: FunctionReference<
+          "mutation",
+          "public",
+          Args,
+          TokenBundle | null
+        >;
+        parseArgs?: (request: Request) => Args | Promise<Args>;
+      };
+      return async (request) => {
+        const args = parseArgs ? await parseArgs(request) : ({} as Args);
+        // The descriptor type-checks the args; erase the reference's arg type
+        // here so the positional mutation call type-checks for any Args.
+        const ref = signIn as FunctionReference<"mutation", "public">;
+        const bundle: TokenBundle | null = await client.mutation(ref, args);
+        return signInResponse(request, bundle, cookieOptions);
+      };
+    },
+  };
+}

--- a/packages/core/src/server/setup.ts
+++ b/packages/core/src/server/setup.ts
@@ -23,6 +23,7 @@ import {
   signInResponse,
   signOutHandler,
 } from "./handlers";
+import { forbiddenOriginResponse, isTrustedOrigin } from "./origin";
 
 /**
  * A provider's server-side sign-in descriptor: the mutation that mints a
@@ -49,6 +50,10 @@ export interface ConvexAuthServerConfig {
   signOut: SignOutFn;
   /** Auth cookie attributes for every handler; `secure` is required. */
   cookieOptions: AuthCookieOptions;
+  /** Origins beyond the request's own `Host` trusted by every handler's CSRF
+   * origin check, for deployments where the two differ (e.g. a proxy that
+   * rewrites `Host`). See {@link isTrustedOrigin}. */
+  allowedOrigins?: string[];
 }
 
 /**
@@ -67,18 +72,20 @@ export interface ConvexAuthServerConfig {
  * ```
  */
 export function setupConvexAuthServer(config: ConvexAuthServerConfig) {
-  const { convexUrl, cookieOptions } = config;
+  const { convexUrl, cookieOptions, allowedOrigins } = config;
   const client = new ConvexHttpClient(convexUrl);
   return {
     refreshHandler: refreshHandler({
       convexUrl,
       refreshSession: config.refreshSession,
       cookieOptions,
+      allowedOrigins,
     }),
     signOutHandler: signOutHandler({
       convexUrl,
       signOut: config.signOut,
       cookieOptions,
+      allowedOrigins,
     }),
     /** Build a sign-in route from a provider descriptor. */
     signInHandler<Args extends Record<string, unknown>>(
@@ -95,6 +102,12 @@ export function setupConvexAuthServer(config: ConvexAuthServerConfig) {
         parseArgs?: (request: Request) => Args | Promise<Args>;
       };
       return async (request) => {
+        // The CSRF guard, before the provider even parses the request: a
+        // cross-site sign-in would store the minted session in the victim's
+        // browser (login CSRF), so it must be refused up front.
+        if (!isTrustedOrigin(request, allowedOrigins)) {
+          return forbiddenOriginResponse();
+        }
         const args = parseArgs ? await parseArgs(request) : ({} as Args);
         // The descriptor type-checks the args; erase the reference's arg type
         // here so the positional mutation call type-checks for any Args.

--- a/packages/core/src/server/setup.ts
+++ b/packages/core/src/server/setup.ts
@@ -14,7 +14,6 @@
  */
 
 import { ConvexHttpClient } from "convex/browser";
-import type { FunctionReference } from "convex/server";
 import type { RefreshSessionFn, SignOutFn, TokenBundle } from "../lib/types";
 import type { AuthCookieOptions } from "./cookies";
 import {
@@ -26,19 +25,48 @@ import {
 import { forbiddenOriginResponse, isTrustedOrigin } from "./origin";
 
 /**
- * A provider's server-side sign-in descriptor: the mutation that mints a
- * {@link TokenBundle} and, when the sign-in takes args, how to read them off the
- * request. {@link setupConvexAuthServer}'s `signInHandler` wraps it into a route.
+ * A provider's server-side sign-in descriptor: how to execute its sign-in
+ * against the deployment, given the incoming {@link Request}. {@link
+ * setupConvexAuthServer}'s `signInHandler` wraps it into a route.
  *
- * A `parseArgs` function that extracts args from the {@link Request} is
- * required if the mutation takes arguments.
+ * `run` owns the whole provider-specific half — reading any input off the
+ * request and making the mutation call that mints the {@link TokenBundle}. The
+ * handler stays provider-agnostic: it writes the bundle's tokens into cookies,
+ * never letting the refresh token reach the response body.
+ *
+ * A request that isn't even shaped like the provider's input is the caller's
+ * error, not a failed sign-in attempt — signal it by throwing {@link
+ * InvalidSignInRequestError}, which the handler turns into a 400.
  */
-export type SignInProvider<Args extends Record<string, unknown>> = {
-  /** The provider's sign-in mutation reference. */
-  signIn: FunctionReference<"mutation", "public", Args, TokenBundle | null>;
-} & (Args extends Record<string, never>
-  ? { parseArgs?: (request: Request) => Args | Promise<Args> }
-  : { parseArgs: (request: Request) => Args | Promise<Args> });
+export type SignInProvider = {
+  /** Execute the provider's sign-in against the deployment. */
+  run: (
+    client: ConvexHttpClient,
+    request: Request,
+  ) => Promise<TokenBundle | null>;
+};
+
+const INVALID_SIGN_IN_REQUEST_MARKER = "ConvexAuthInvalidSignInRequest";
+
+/**
+ * Thrown by a {@link SignInProvider}'s `run` when the request doesn't carry
+ * the input the provider expects (e.g. a body that isn't credentials-shaped).
+ * `signInHandler` replies 400 to it; any other error from `run` propagates as
+ * the server failure it is.
+ */
+export class InvalidSignInRequestError extends Error {
+  /** Marker consulted instead of `instanceof`, so detection survives
+   * duplicated copies of this package in one app. */
+  readonly [INVALID_SIGN_IN_REQUEST_MARKER] = true;
+}
+
+function isInvalidSignInRequestError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Record<string, unknown>)[INVALID_SIGN_IN_REQUEST_MARKER] === true
+  );
+}
 
 /** Configuration for {@link setupConvexAuthServer}. */
 export interface ConvexAuthServerConfig {
@@ -88,31 +116,21 @@ export function setupConvexAuthServer(config: ConvexAuthServerConfig) {
       allowedOrigins,
     }),
     /** Build a sign-in route from a provider descriptor. */
-    signInHandler<Args extends Record<string, unknown>>(
-      provider: SignInProvider<Args>,
-    ): RequestHandler {
-      // Widen the conditionally-required descriptor so parseArgs reads uniformly.
-      const { signIn, parseArgs } = provider as {
-        signIn: FunctionReference<
-          "mutation",
-          "public",
-          Args,
-          TokenBundle | null
-        >;
-        parseArgs?: (request: Request) => Args | Promise<Args>;
-      };
+    signInHandler(provider: SignInProvider): RequestHandler {
       return async (request) => {
-        // The CSRF guard, before the provider even parses the request: a
+        // The CSRF guard, before the provider even reads the request: a
         // cross-site sign-in would store the minted session in the victim's
         // browser (login CSRF), so it must be refused up front.
         if (!isTrustedOrigin(request, allowedOrigins)) {
           return forbiddenOriginResponse();
         }
-        const args = parseArgs ? await parseArgs(request) : ({} as Args);
-        // The descriptor type-checks the args; erase the reference's arg type
-        // here so the positional mutation call type-checks for any Args.
-        const ref = signIn as FunctionReference<"mutation", "public">;
-        const bundle: TokenBundle | null = await client.mutation(ref, args);
+        let bundle: TokenBundle | null;
+        try {
+          bundle = await provider.run(client, request);
+        } catch (error) {
+          if (!isInvalidSignInRequestError(error)) throw error;
+          return Response.json({ tokens: null }, { status: 400 });
+        }
         return signInResponse(request, bundle, cookieOptions);
       };
     },

--- a/packages/core/src/server/setup.ts
+++ b/packages/core/src/server/setup.ts
@@ -29,12 +29,10 @@ import {
  * {@link TokenBundle} and, when the sign-in takes args, how to read them off the
  * request. {@link setupConvexAuthServer}'s `signInHandler` wraps it into a route.
  *
- * `parseArgs` is required exactly when the mutation takes arguments, and
- * omittable when it does not (Convex treats `Record<string, never>` as "no
- * args"). So a provider that takes args cannot forget to parse them, while a
- * no-argument provider like anonymous stays a bare `{ signIn }`.
+ * A `parseArgs` function that extracts args from the {@link Request} is
+ * required if the mutation takes arguments.
  */
-export type SignInProvider<Args extends Record<string, any>> = {
+export type SignInProvider<Args extends Record<string, unknown>> = {
   /** The provider's sign-in mutation reference. */
   signIn: FunctionReference<"mutation", "public", Args, TokenBundle | null>;
 } & (Args extends Record<string, never>
@@ -83,7 +81,7 @@ export function setupConvexAuthServer(config: ConvexAuthServerConfig) {
       cookieOptions,
     }),
     /** Build a sign-in route from a provider descriptor. */
-    signInHandler<Args extends Record<string, any>>(
+    signInHandler<Args extends Record<string, unknown>>(
       provider: SignInProvider<Args>,
     ): RequestHandler {
       // Widen the conditionally-required descriptor so parseArgs reads uniformly.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       commander:
         specifier: ^14.0.2
         version: 14.0.3
+      cookie:
+        specifier: 1.1.1
+        version: 1.1.1
       jose:
         specifier: ^5.2.2
         version: 5.10.0


### PR DESCRIPTION
Add framework-agnostic SSR cookie and auth handlers

Uses the public `cookie` package (which would wind up as a transitive dependency once Next.js is integrated). Ensures that the refresh and access tokens are properly encoded in cookies (for use on the server) as well as returning a `SlimTokenBundle`for client use of the access token.

Exposes common configuration/setup for the handlers required to implement SSR with Convex Auth. The refresh, sign-out and sign-in handlers are standard `Request`/`Response` functions that should be able to be adapted to any SSR framework.