### PR TITLE
Add framework-agnostic server auth token verification

### DIFF
--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -71,6 +71,17 @@ export type SignOutFn = FunctionReference<
 >;
 
 /**
+ * The app's `isAuthenticated` query reference: reports whether the access token
+ * the query is called with identifies a signed-in user.
+ */
+export type IsAuthenticatedFn = FunctionReference<
+  "query",
+  "public",
+  Record<string, never>,
+  boolean
+>;
+
+/**
  * The auth mutations the app exports from `setupCore(...).attachUserCallback`.
  * Passed as references (not names) because an app may re-export them under any
  * names. Consumed by both SPA and SSR implementations.

--- a/packages/core/src/server/isAuthenticated.test.ts
+++ b/packages/core/src/server/isAuthenticated.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createServerAuthChecker } from "./isAuthenticated";
+
+// The checker verifies tokens through a `ConvexHttpClient`; stub it so the
+// tests exercise the gate/verify logic without a backend.
+const { isAuthenticatedQueryMock, setAuthMock } = vi.hoisted(() => ({
+  isAuthenticatedQueryMock: vi.fn(),
+  setAuthMock: vi.fn(),
+}));
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth = setAuthMock;
+    query = isAuthenticatedQueryMock;
+  },
+}));
+
+/** Build an unsigned JWT whose payload has the given `exp` (seconds). */
+function jwt(expSeconds: number): string {
+  const b64 = (obj: unknown) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${b64({ alg: "RS256", typ: "JWT" })}.${b64({ sub: "user-1", exp: expSeconds })}.sig`;
+}
+
+// Pin "now" so token-expiry math is deterministic.
+const NOW = 1_000_000; // seconds
+const nowMs = NOW * 1000;
+
+// A placeholder query reference; the mocked client ignores its shape.
+const fnRef = {} as never;
+const newChecker = () =>
+  createServerAuthChecker({
+    convexUrl: "https://x.convex.cloud",
+    isAuthenticated: fnRef,
+  });
+
+beforeEach(() => {
+  isAuthenticatedQueryMock.mockReset();
+  setAuthMock.mockReset();
+});
+
+describe("createServerAuthChecker", () => {
+  test("a null token is unauthenticated without a round trip", async () => {
+    const isAuthenticated = newChecker();
+    expect(await isAuthenticated(null)).toBe(false);
+    expect(isAuthenticatedQueryMock).not.toHaveBeenCalled();
+  });
+
+  test("an expired token is rejected by the local gate without a round trip", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const isAuthenticated = newChecker();
+    expect(await isAuthenticated(jwt(NOW - 1))).toBe(false);
+    expect(isAuthenticatedQueryMock).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  test("a non-expired token is verified against the backend, which accepts it", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    isAuthenticatedQueryMock.mockResolvedValue(true);
+    const token = jwt(NOW + 60);
+    const isAuthenticated = newChecker();
+
+    expect(await isAuthenticated(token)).toBe(true);
+    // The token is presented to the backend for signature verification.
+    expect(setAuthMock).toHaveBeenCalledWith(token);
+    expect(isAuthenticatedQueryMock).toHaveBeenCalledWith(fnRef, {});
+    vi.restoreAllMocks();
+  });
+
+  test("a forged token with a future exp is rejected by the backend", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    // The local gate passes it (future exp), but the backend rejects the
+    // signature, so the verdict is false.
+    isAuthenticatedQueryMock.mockResolvedValue(false);
+    const isAuthenticated = newChecker();
+
+    expect(await isAuthenticated(jwt(NOW + 60))).toBe(false);
+    expect(isAuthenticatedQueryMock).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
+  test("fails closed to false when the backend errors", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    isAuthenticatedQueryMock.mockRejectedValue(new Error("network down"));
+    const isAuthenticated = newChecker();
+
+    expect(await isAuthenticated(jwt(NOW + 60))).toBe(false);
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/core/src/server/isAuthenticated.ts
+++ b/packages/core/src/server/isAuthenticated.ts
@@ -1,0 +1,54 @@
+/**
+ * The framework-agnostic server-side authentication check.
+ *
+ * It lets SSR hosts answer the question: is this request signed in? {@link
+ * createServerAuthChecker} builds a checker that verifies the token against
+ * the backend (which checks the signature) before answering.
+ *
+ * @module
+ */
+
+import { ConvexHttpClient } from "convex/browser";
+import type { IsAuthenticatedFn } from "../lib/types";
+import { isTokenExpiring } from "./jwt";
+
+/** Configuration for {@link createServerAuthChecker}. */
+export interface ServerAuthCheckerConfig {
+  /** The Convex deployment URL used server-side. */
+  convexUrl: string;
+  /** The app's `isAuthenticated` query reference. Called with the access token
+   * so the backend can verify its signature. */
+  isAuthenticated: IsAuthenticatedFn;
+}
+
+/** Reports whether a JWT `accessToken` is a valid, signed-in session (`null` =
+ * no token = not signed in). */
+export type ServerAuthChecker = (
+  accessToken: string | null,
+) => Promise<boolean>;
+
+/**
+ * Build a {@link ServerAuthChecker} that verifies a JWT access token against
+ * the backend.
+ *
+ * The returned checker treats an absent or already-expired token as
+ * unauthenticated without a round trip (a cheap local gate); otherwise it asks
+ * the backend, which verifies the token's signature. Any error (network,
+ * rejected token) fails closed to `false`.
+ */
+export function createServerAuthChecker(
+  config: ServerAuthCheckerConfig,
+): ServerAuthChecker {
+  return async (accessToken) => {
+    // Cheap local gate: an absent or already-expired token needs no round trip.
+    if (accessToken === null || isTokenExpiring(accessToken, 0)) return false;
+
+    const client = new ConvexHttpClient(config.convexUrl);
+    client.setAuth(accessToken);
+    try {
+      return await client.query(config.isAuthenticated, {});
+    } catch {
+      return false;
+    }
+  };
+}


### PR DESCRIPTION
This will be used by SSR code to validate authentication status in middleware and server components.