### PR TITLE
Support private LAN hosts for local development

### DIFF
--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -7,6 +7,42 @@ export function requireEnv(name: string) {
 }
 
 export function isLocalHost(host?: string) {
-  return /(localhost|127\.0\.0\.1):\d+/.test(
-  host ?? "");
+  const hostname = getHostname(host);
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]"
+  ) {
+    return true;
+  }
+  if (process.env.NODE_ENV === "production") {
+    return false;
+  }
+  return isPrivateIpv4Address(hostname) || hostname.endsWith(".local");
+}
+
+function getHostname(host?: string) {
+  if (host === undefined) {
+    return "";
+  }
+  try {
+    return new URL(host.includes("://") ? host : `http://${host}`).hostname;
+  } catch {
+    return "";
+  }
+}
+
+function isPrivateIpv4Address(hostname: string) {
+  const octets = hostname.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
 }

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -33,9 +33,15 @@ function getHostname(host?: string) {
 }
 
 function isPrivateIpv4Address(hostname: string) {
-  const octets = hostname.split(".").map(Number);
+  const octetStrings = hostname.split(".");
   if (
-    octets.length !== 4 ||
+    octetStrings.length !== 4 ||
+    octetStrings.some((octet) => !/^\d{1,3}$/.test(octet))
+  ) {
+    return false;
+  }
+  const octets = octetStrings.map(Number);
+  if (
     octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
   ) {
     return false;

--- a/test/convex/utils.test.ts
+++ b/test/convex/utils.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { isLocalHost } from "../../src/server/utils";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isLocalHost", () => {
+  test.each([
+    "localhost",
+    "localhost:3000",
+    "http://localhost:3211",
+    "127.0.0.1:3000",
+    "http://127.0.0.1:3211",
+    "[::1]:3000",
+  ])("recognizes loopback host %s", (host) => {
+    expect(isLocalHost(host)).toBe(true);
+  });
+
+  test.each([
+    "10.0.0.1:3000",
+    "172.16.0.1:3000",
+    "172.31.255.255:3000",
+    "192.168.1.13:3000",
+    "http://192.168.1.13:3000",
+    "light-workers.local:3000",
+  ])("recognizes development host %s", (host) => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isLocalHost(host)).toBe(true);
+  });
+
+  test.each([
+    "172.15.255.255:3000",
+    "172.32.0.1:3000",
+    "192.169.1.13:3000",
+    "8.8.8.8:3000",
+    "example.com",
+    "999.168.1.13:3000",
+    undefined,
+  ])("rejects non-local host %s", (host) => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isLocalHost(host)).toBe(false);
+  });
+
+  test.each(["192.168.1.13:3000", "light-workers.local:3000"])(
+    "does not disable secure cookies for private production host %s",
+    (host) => {
+      vi.stubEnv("NODE_ENV", "production");
+      expect(isLocalHost(host)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- recognize RFC 1918 addresses and `.local` hostnames as local hosts during development
- handle both `Host` header values and full `CONVEX_SITE_URL` values
- preserve secure cookie behavior for private hosts in production
- recognize the IPv6 loopback address alongside `localhost` and `127.0.0.1`

## Problem

When a Next.js development server is opened from another device on the local
network (for example, Safari on an iPhone visiting
`http://192.168.1.13:3000`), Convex Auth currently treats the request as a
non-local host.

The auth response therefore uses `__Host-` cookie names and the `Secure`
attribute. Safari rejects those cookies over plain HTTP. OTP verification
succeeds on the backend, but the subsequent client refresh has no refresh
token and logs:

```text
Convex Auth: Unexpected missing refreshToken cookie during client refresh
```

This change applies the existing localhost cookie behavior to private LAN
addresses and mDNS `.local` hostnames in non-production environments. In
production, only loopback hosts retain that behavior.

## Verification

- `npm run build`
- `npm run lint`
- `npm run test:once` (60 passed, 1 todo)
