### PR TITLE
Add react-manual-linking example

### DIFF
--- a/examples/react-manual-linking/.gitignore
+++ b/examples/react-manual-linking/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-manual-linking/README.md
+++ b/examples/react-manual-linking/README.md
@@ -1,0 +1,24 @@
+# react-manual-linking example
+
+A variant of the `react-minimal` example that demonstrates manual account
+linking: a user signs in anonymously and later links a username and password
+to the same account so they can sign back in. It mounts the anonymous and
+username/password providers alongside the core component.
+
+The auth system owns sessions, providers, accounts, and JWT minting;
+`convex/users.ts` owns the app side (the `upsertFromAuth` callback and a
+`loggedInUser` query). Providers from the auth system expose sign in methods.
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-manual-linking
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx @convex-dev/auth     # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+```
+
+## Test usage
+
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-manual-linking/convex/_generated/api.d.ts
+++ b/examples/react-manual-linking/convex/_generated/api.d.ts
@@ -1,0 +1,57 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as currentUser from "../currentUser.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  currentUser: typeof currentUser;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  authAnonymous: import("@convex-dev/auth/providers/anonymous/_generated/component.js").ComponentApi<"authAnonymous">;
+  authPasswordProvider: import("@convex-dev/auth/providers/password/_generated/component.js").ComponentApi<"authPasswordProvider">;
+};

--- a/examples/react-manual-linking/convex/_generated/api.js
+++ b/examples/react-manual-linking/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-manual-linking/convex/_generated/dataModel.d.ts
+++ b/examples/react-manual-linking/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-manual-linking/convex/_generated/server.d.ts
+++ b/examples/react-manual-linking/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-manual-linking/convex/_generated/server.js
+++ b/examples/react-manual-linking/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-manual-linking/convex/auth.config.ts
+++ b/examples/react-manual-linking/convex/auth.config.ts
@@ -1,0 +1,13 @@
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;

--- a/examples/react-manual-linking/convex/auth.test.ts
+++ b/examples/react-manual-linking/convex/auth.test.ts
@@ -1,0 +1,60 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi, afterEach } from "vitest";
+import { api } from "./_generated/api.js";
+import { registerAnonymousProvider } from "@convex-dev/auth/providers/testing/anonymous";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
+import { registerPasswordProvider } from "@convex-dev/auth/providers/testing/password";
+import schema from "./schema.js";
+import { generateKeyPair, exportPKCS8, exportJWK, decodeJwt } from "jose";
+import { randomUUID } from "crypto";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function setup() {
+  const { publicKey, privateKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const privatePem = await exportPKCS8(privateKey);
+  const pubJwk = await exportJWK(publicKey);
+  const kid = randomUUID();
+
+  const authPrivateKey = Buffer.from(privatePem).toString("base64");
+  const authJwks = JSON.stringify({
+    keys: [{ ...pubJwk, kid, alg: "RS256", use: "sig" }],
+  });
+
+  vi.stubEnv("AUTH_PRIVATE_KEY", authPrivateKey);
+  vi.stubEnv("AUTH_JWKS", authJwks);
+  vi.stubEnv("CONVEX_SITE_URL", "http://localhost:8080/");
+  const t = convexTest(schema, modules);
+  registerCore(t);
+  registerAnonymousProvider(t);
+  registerPasswordProvider(t);
+  return t;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("anonymous sign in", () => {
+  test("returns token bundle", async () => {
+    const t = await setup();
+    const result = await t.mutation(api.auth.signInAnonymous, {});
+    expect(result.userId).not.toBe(null);
+    expect(result.accessToken).not.toBe(null);
+    expect(result.accessTokenExpiresAt).not.toBe(null);
+    expect(result.refreshToken).not.toBe(null);
+    expect(result.refreshTokenExpiresAt).not.toBe(null);
+    expect(result.refreshTokenExpiresAt).toBeGreaterThan(
+      result.accessTokenExpiresAt,
+    );
+  });
+
+  test("returned access token is valid JWT", async () => {
+    const t = await setup();
+    const result = await t.mutation(api.auth.signInAnonymous, {});
+    const jwt = decodeJwt(result.accessToken);
+    expect(jwt.sub).toBe(result.userId);
+  });
+});

--- a/examples/react-manual-linking/convex/auth.ts
+++ b/examples/react-manual-linking/convex/auth.ts
@@ -1,0 +1,23 @@
+import { components, internal } from "./_generated/api";
+import { provider, setupCore } from "@convex-dev/auth/core/setup";
+import { Anonymous } from "@convex-dev/auth/providers/anonymous/setup";
+import { UsernamePassword } from "@convex-dev/auth/providers/password/setup";
+
+export const {
+  signOut,
+  refreshSession,
+  providers: {
+    anonymous: { signInAnonymous },
+    password: { signInWithPassword, linkWithPassword },
+  },
+} = setupCore({
+  component: components.core,
+  providers: [
+    provider(Anonymous, {
+      component: components.authAnonymous,
+    }),
+    provider(UsernamePassword, {
+      component: components.authPasswordProvider,
+    }),
+  ],
+}).attachUserCallback(internal.users.upsertFromAuth);

--- a/examples/react-manual-linking/convex/convex.config.ts
+++ b/examples/react-manual-linking/convex/convex.config.ts
@@ -1,0 +1,24 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+import anonymous from "@convex-dev/auth/providers/anonymous/convex.config.js";
+import passwordProvider from "@convex-dev/auth/providers/password/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(anonymous);
+app.use(passwordProvider);
+
+export default app;

--- a/examples/react-manual-linking/convex/currentUser.ts
+++ b/examples/react-manual-linking/convex/currentUser.ts
@@ -1,0 +1,24 @@
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+/**
+ * The currently signed-in user, or null.
+ *
+ * Demonstrates an authenticated query.
+ */
+export const loggedInUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+    const userId = identity.subject as Id<"users">;
+    const user = await ctx.db.get("users", userId);
+    if (user === null) {
+      return null;
+    }
+
+    return { id: user._id, username: user.username ?? null };
+  },
+});

--- a/examples/react-manual-linking/convex/schema.ts
+++ b/examples/react-manual-linking/convex/schema.ts
@@ -1,0 +1,9 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  users: defineTable({
+    // Set once a username/password account is linked or signed in.
+    username: v.optional(v.string()),
+  }),
+});

--- a/examples/react-manual-linking/convex/tsconfig.json
+++ b/examples/react-manual-linking/convex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-manual-linking/convex/users.ts
+++ b/examples/react-manual-linking/convex/users.ts
@@ -1,0 +1,40 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const upsertFromAuth = internalMutation({
+  args: {
+    provider: v.union(v.literal("anonymous"), v.literal("password")),
+    providerAccountId: v.string(),
+    profile: v.any(),
+    userId: v.union(v.string(), v.null()),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    switch (args.provider) {
+      case "anonymous": {
+        return ctx.db.insert("users", {});
+      }
+      case "password": {
+        const username =
+          typeof args.profile?.username === "string"
+            ? args.profile.username
+            : undefined;
+        // A non-null userId is a returning sign-in or, for a user that
+        // started out anonymous, a newly linked password account.
+        if (args.userId !== null) {
+          const userId = ctx.db.normalizeId("users", args.userId);
+          if (userId === null) {
+            throw new Error(`Unknown user id: ${args.userId}`);
+          }
+          await ctx.db.patch("users", userId, { username });
+          return userId;
+        }
+        return ctx.db.insert("users", { username });
+      }
+      default: {
+        const _exhaustive: never = args.provider;
+        return _exhaustive;
+      }
+    }
+  },
+});

--- a/examples/react-manual-linking/index.html
+++ b/examples/react-manual-linking/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convex Auth — react-manual-linking</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-manual-linking/package.json
+++ b/examples/react-manual-linking/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "example-react-manual-linking",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "convex": "^1.41.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "scripts": {
+    "dev": "convex dev --start vite",
+    "build": "vite build && tsc -p convex --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p convex --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@convex-dev/rate-limiter": "^0.3.2",
+    "@types/node": "^24.12.4",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "convex-test": "^0.0.53",
+    "jose": "^5.10.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/react-manual-linking/src/App.tsx
+++ b/examples/react-manual-linking/src/App.tsx
@@ -1,0 +1,125 @@
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useAuthActions,
+  useAuthToken,
+} from "@convex-dev/auth/react";
+import { useAnonymousAuth } from "@convex-dev/auth/providers/anonymous/react";
+import {
+  useLinkWithPassword,
+  useSignInWithPassword,
+} from "@convex-dev/auth/providers/password/react";
+import { useQuery } from "convex/react";
+import { FormEvent, useState } from "react";
+import { api } from "../convex/_generated/api";
+import "./index.css";
+
+export function App() {
+  return (
+    <main>
+      <h1>Convex Auth — minimal client</h1>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <SignIn />
+      </Unauthenticated>
+      <Authenticated>
+        <Dashboard />
+      </Authenticated>
+    </main>
+  );
+}
+
+function credentials(e: FormEvent<HTMLFormElement>) {
+  const data = new FormData(e.currentTarget);
+  return {
+    username: data.get("username") as string,
+    password: data.get("password") as string,
+  };
+}
+
+function SignIn() {
+  const { signInAnonymous } = useAnonymousAuth(api.auth.signInAnonymous);
+  const { signIn, pending } = useSignInWithPassword(
+    api.auth.signInWithPassword,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <>
+      <p>You are signed out.</p>
+      <button onClick={() => signInAnonymous()}>Sign in anonymously</button>
+      <p>Or sign in with a username and password you linked earlier:</p>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const result = await signIn(credentials(e));
+          setError(result.success ? null : result.userError.error);
+        }}
+      >
+        <input name="username" placeholder="Username" required />
+        <input
+          name="password"
+          type="password"
+          placeholder="Password"
+          required
+        />
+        <button disabled={pending}>Sign in</button>
+      </form>
+      {error !== null && <p>Sign-in failed: {error}</p>}
+    </>
+  );
+}
+
+function Dashboard() {
+  const user = useQuery(api.currentUser.loggedInUser);
+  const token = useAuthToken();
+  const { signOut } = useAuthActions();
+  return (
+    <>
+      <p>
+        Signed in as <strong>{user ? user.id : "…"}</strong>
+      </p>
+      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
+      {user &&
+        (user.username === null ? (
+          <LinkAccount />
+        ) : (
+          <p>
+            Linked username: <strong>{user.username}</strong>
+          </p>
+        ))}
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}
+
+function LinkAccount() {
+  const { link, pending } = useLinkWithPassword(api.auth.linkWithPassword);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <>
+      <p>Link a username and password to this account to sign back in later:</p>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const result = await link(credentials(e));
+          setError(result.success ? null : result.userError.error);
+        }}
+      >
+        <input name="username" placeholder="Username" required />
+        <input
+          name="password"
+          type="password"
+          placeholder="Password"
+          required
+        />
+        <button disabled={pending}>Link account</button>
+      </form>
+      {error !== null && <p>Linking failed: {error}</p>}
+    </>
+  );
+}

--- a/examples/react-manual-linking/src/index.css
+++ b/examples/react-manual-linking/src/index.css
@@ -1,0 +1,11 @@
+body {
+  background-color: oklch(96.8% 0.007 247.896);
+}
+
+main {
+  font-family: system-ui, sans-serif;
+  max-width: 480px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}

--- a/examples/react-manual-linking/src/main.tsx
+++ b/examples/react-manual-linking/src/main.tsx
@@ -1,0 +1,22 @@
+import { ConvexAuthProvider } from "@convex-dev/auth/react";
+import { ConvexReactClient } from "convex/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { api } from "../convex/_generated/api";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexAuthProvider
+      client={convex}
+      api={{
+        refreshSession: api.auth.refreshSession,
+        signOut: api.auth.signOut,
+      }}
+    >
+      <App />
+    </ConvexAuthProvider>
+  </StrictMode>,
+);

--- a/examples/react-manual-linking/tsconfig.json
+++ b/examples/react-manual-linking/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["convex/**/*", "src/**/*", "vite.config.ts"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/examples/react-manual-linking/vite.config.ts
+++ b/examples/react-manual-linking/vite.config.ts
@@ -1,0 +1,8 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Dev/build config for the example frontend. Tests use `vitest.config.ts`
+// (Vitest prefers it over this file), so the two don't interfere.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,49 @@ importers:
         specifier: ^4.1.0
         version: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@26.1.0)(jsdom@29.1.1)(vite@8.1.2(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0))
 
+  examples/react-manual-linking:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      convex:
+        specifier: ^1.41.0
+        version: 1.42.1(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.42.1(react@19.2.7))
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   examples/react-minimal:
     dependencies:
       '@convex-dev/auth':


### PR DESCRIPTION
A standalone copy of react-minimal that demonstrates manual account
linking: sign in anonymously, then link a username and password to the
same account and sign back in with it later.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>