### PR TITLE
Add OAuth callback leg: code exchange, id_token validation, one-time tickets

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -8,9 +8,9 @@ Probably all public routes need rate limiting of some sort.
 
 ## OAuth component rows are never cleaned up, and `startSignIn` is unauthenticated
 
-Expired authorization requests are only deleted when their state is later
-presented (`packages/core/src/oauth/component/provider.ts`), so abandoned
-flows accumulate forever.
+Expired authorization requests and tickets are only deleted when their
+secret is later presented (`packages/core/src/oauth/component/provider.ts`),
+so abandoned flows accumulate forever.
 
 ## OAuth sign-in requires a backend with system env vars in components
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -29,3 +29,15 @@ No action item, just here for awareness.
 (`myapp://`, `exp://`) have a `"null"` origin under the URL standard and are
 rejected at setup (`packages/core/src/oauth/component/setup.ts`), so React
 Native apps must return via https universal links / app links.
+
+## Apple sign-in isn't supported yet
+
+Two gaps. The callback route only accepts GET redirects, and Apple POSTs the
+callback (`response_mode=form_post`) whenever name/email scopes are
+requested. And Apple has no static client secret: it requires a short-lived
+ES256 client-secret JWT, signed with a registered key and rotated, where the
+catalogs assume a static `CLIENT_SECRET` binding.
+
+Fix direction, wanted for launch: accept POST on the callback route
+(`packages/core/src/oauth/component/http.ts`), and add a signed-secret
+mechanism to the catalog config (`packages/core/src/oauth/component/setup.ts`).

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -38,6 +38,6 @@ requested. And Apple has no static client secret: it requires a short-lived
 ES256 client-secret JWT, signed with a registered key and rotated, where the
 catalogs assume a static `CLIENT_SECRET` binding.
 
-Fix direction, wanted for launch: accept POST on the callback route
+Potential fix direction: accept POST on the callback route
 (`packages/core/src/oauth/component/http.ts`), and add a signed-secret
 mechanism to the catalog config (`packages/core/src/oauth/component/setup.ts`).

--- a/packages/core/src/lib/crypto.ts
+++ b/packages/core/src/lib/crypto.ts
@@ -4,7 +4,7 @@
 
 /**
  * SHA-256 hex digest. Used wherever a secret (refresh token, OAuth state,
- * one-time token) must be looked up later without persisting the raw value.
+ * ticket code) must be looked up later without persisting the raw value.
  */
 export async function sha256Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest(

--- a/packages/core/src/lib/oauthParams.ts
+++ b/packages/core/src/lib/oauthParams.ts
@@ -1,0 +1,23 @@
+/**
+ * The query params the OAuth component's callback appends when it redirects the
+ * browser back to the app, and that the browser client reads on mount.
+ *
+ * They are deliberately namespaced rather than the bare `code`/`error` an OAuth
+ * callback would normally use. The client's callback handler is registered
+ * unconditionally (every app that uses Convex Auth runs it on mount), so bare
+ * names would let it consume `?code=`/`?error=` params from an unrelated flow
+ * the app runs itself. A namespaced param is proof the redirect came from this
+ * component, which is also what keeps the client's `invalid_flow` detection
+ * meaningful.
+ *
+ * Shared by the component (which writes them) and the browser client (which
+ * reads them) so the two ends can never drift.
+ *
+ * @module
+ */
+
+/** Carries the one-time code the client redeems for a session. */
+export const OAUTH_CODE_PARAM = "convexAuthCode";
+
+/** Carries a normalized {@link OAuthFlowError} code when the flow failed. */
+export const OAUTH_ERROR_PARAM = "convexAuthError";

--- a/packages/core/src/lib/oauthParams.ts
+++ b/packages/core/src/lib/oauthParams.ts
@@ -8,7 +8,7 @@
  * handler is registered unconditionally (every app that uses Convex Auth runs
  * it on every page load), so bare names would let it consume
  * `?code=`/`?error=` params from an unrelated flow the app runs. A
- * `convexAuth`-prefixed param is proof the redirect came from this component,
+ * `convexAuth`-prefixed param signals the redirect came from this component,
  * which is also what keeps the client's `invalid_flow` detection meaningful.
  *
  * Shared by the component (which writes them) and the browser client (which

--- a/packages/core/src/lib/oauthParams.ts
+++ b/packages/core/src/lib/oauthParams.ts
@@ -1,14 +1,15 @@
 /**
- * The query params the OAuth component's callback appends when it redirects the
- * browser back to the app, and that the browser client reads on mount.
+ * URL query param names used by the OAuth component, appended to callback
+ * redirects back to the browser.
  *
- * They are deliberately namespaced rather than the bare `code`/`error` an OAuth
- * callback would normally use. The client's callback handler is registered
- * unconditionally (every app that uses Convex Auth runs it on mount), so bare
- * names would let it consume `?code=`/`?error=` params from an unrelated flow
- * the app runs itself. A namespaced param is proof the redirect came from this
- * component, which is also what keeps the client's `invalid_flow` detection
- * meaningful.
+ * They are deliberately prefixed with `convexAuth` rather than the bare
+ * `code`/`error` an OAuth callback would normally use, so they can't collide
+ * with URL params that an app may use for other reasons. The client's callback
+ * handler is registered unconditionally (every app that uses Convex Auth runs
+ * it on mount), so bare names would let it consume `?code=`/`?error=` params
+ * from an unrelated flow the app runs. A `convexAuth`-prefixed param is proof
+ * the redirect came from this component, which is also what keeps the client's
+ * `invalid_flow` detection meaningful.
  *
  * Shared by the component (which writes them) and the browser client (which
  * reads them) so the two ends can never drift.

--- a/packages/core/src/lib/oauthParams.ts
+++ b/packages/core/src/lib/oauthParams.ts
@@ -6,10 +6,10 @@
  * `code`/`error` an OAuth callback would normally use, so they can't collide
  * with URL params that an app may use for other reasons. The client's callback
  * handler is registered unconditionally (every app that uses Convex Auth runs
- * it on mount), so bare names would let it consume `?code=`/`?error=` params
- * from an unrelated flow the app runs. A `convexAuth`-prefixed param is proof
- * the redirect came from this component, which is also what keeps the client's
- * `invalid_flow` detection meaningful.
+ * it on every page load), so bare names would let it consume
+ * `?code=`/`?error=` params from an unrelated flow the app runs. A
+ * `convexAuth`-prefixed param is proof the redirect came from this component,
+ * which is also what keeps the client's `invalid_flow` detection meaningful.
  *
  * Shared by the component (which writes them) and the browser client (which
  * reads them) so the two ends can never drift.

--- a/packages/core/src/oauth/component/_generated/api.ts
+++ b/packages/core/src/oauth/component/_generated/api.ts
@@ -10,6 +10,7 @@
 
 import type * as constants from "../constants.js";
 import type * as crypto from "../crypto.js";
+import type * as http from "../http.js";
 import type * as provider from "../provider.js";
 import type * as setup from "../setup.js";
 
@@ -23,6 +24,7 @@ import { anyApi, componentsGeneric } from "convex/server";
 const fullApi: ApiFromModules<{
   constants: typeof constants;
   crypto: typeof crypto;
+  http: typeof http;
   provider: typeof provider;
   setup: typeof setup;
 }> = anyApi as any;

--- a/packages/core/src/oauth/component/_generated/component.ts
+++ b/packages/core/src/oauth/component/_generated/component.ts
@@ -24,6 +24,13 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     provider: {
+      claimTicket: FunctionReference<
+        "mutation",
+        "internal",
+        { ottHash: string; providerName: string; stateHash: string },
+        null | { payload: string },
+        Name
+      >;
       createAuthorizationRequest: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/oauth/component/_generated/component.ts
+++ b/packages/core/src/oauth/component/_generated/component.ts
@@ -28,7 +28,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         { providerName: string; stateHash: string; ticketCodeHash: string },
-        null | { payload: string },
+        null | { encryptedPayload: string },
         Name
       >;
       createAuthorizationRequest: FunctionReference<

--- a/packages/core/src/oauth/component/_generated/component.ts
+++ b/packages/core/src/oauth/component/_generated/component.ts
@@ -27,7 +27,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       claimTicket: FunctionReference<
         "mutation",
         "internal",
-        { ottHash: string; providerName: string; stateHash: string },
+        { providerName: string; stateHash: string; ticketCodeHash: string },
         null | { payload: string },
         Name
       >;

--- a/packages/core/src/oauth/component/crypto.ts
+++ b/packages/core/src/oauth/component/crypto.ts
@@ -49,16 +49,15 @@ export function decodeJwtPayloadUnverified(
 }
 
 /**
- * Derive an AES-256-GCM key from a raw one-time token. A domain-separated
- * SHA-256 suffices as the KDF: the token is itself 256 bits of CSPRNG
- * output, so no stretching is needed. The `convex-auth-ticket-payload`
- * context string binds derived keys to exactly this use — these helpers are
- * ticket-specific by construction, not general-purpose encryption.
+ * AES-256-GCM key for a ticket payload. The key is only as strong as the
+ * ticket code, which is 256 bits of randomness. The prefix is load-bearing:
+ * the ticket row stores SHA-256(code) as its lookup hash, so without it the
+ * stored hash would be the key.
  */
-async function deriveTicketKey(encodedToken: string): Promise<CryptoKey> {
+async function deriveTicketPayloadKey(ticketCode: string): Promise<CryptoKey> {
   const keyBytes = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(`convex-auth-ticket-payload:${encodedToken}`),
+    new TextEncoder().encode(`convex-auth-ticket-payload:${ticketCode}`),
   );
   return await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, [
     "encrypt",
@@ -67,22 +66,22 @@ async function deriveTicketKey(encodedToken: string): Promise<CryptoKey> {
 }
 
 /**
- * Encrypt a ticket payload with a key derived from the raw one-time token.
+ * Encrypt a ticket payload with a key derived from the raw ticket code.
  *
  * A ticket is the short-lived, one-time record the callback mints after a
  * successful code exchange (the `tickets` table in schema.ts); its payload
  * is the provider-attested identity JSON (`{ claims, userInfoResponses }`)
- * that redemption decrypts. Only the token's hash is persisted, and the raw
- * token — the only value the key can be derived from — travels solely in
- * the callback redirect URL, so database access alone cannot decrypt the
+ * that redemption decrypts. Only the code's hash is persisted, and the raw
+ * code (the only value the key can be derived from) travels solely in the
+ * callback redirect URL, so database access alone cannot decrypt the
  * result. Returns the random nonce followed by the ciphertext,
  * base64url-encoded.
  */
 export async function encryptTicketPayload(
-  encodedToken: string,
+  ticketCode: string,
   plaintext: string,
 ): Promise<string> {
-  const key = await deriveTicketKey(encodedToken);
+  const key = await deriveTicketPayloadKey(ticketCode);
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ciphertext = new Uint8Array(
     await crypto.subtle.encrypt(
@@ -98,14 +97,14 @@ export async function encryptTicketPayload(
 }
 
 /**
- * Decrypt {@link encryptTicketPayload} output. Throws when the token is
- * wrong or the payload was tampered with (AES-GCM authenticates).
+ * Decrypt {@link encryptTicketPayload} output. Throws when the ticket code
+ * is wrong or the payload was tampered with (AES-GCM authenticates).
  */
 export async function decryptTicketPayload(
-  encodedToken: string,
+  ticketCode: string,
   encrypted: string,
 ): Promise<string> {
-  const key = await deriveTicketKey(encodedToken);
+  const key = await deriveTicketPayloadKey(ticketCode);
   const combined = base64UrlDecode(encrypted);
   const plaintext = await crypto.subtle.decrypt(
     { name: "AES-GCM", iv: combined.slice(0, 12) },

--- a/packages/core/src/oauth/component/crypto.ts
+++ b/packages/core/src/oauth/component/crypto.ts
@@ -33,13 +33,23 @@ function base64UrlDecode(value: string): Uint8Array {
   return Uint8Array.from(binary, (c) => c.charCodeAt(0));
 }
 
+declare const issuerDelivered: unique symbol;
+
+/**
+ * A JWT received directly from the issuer over TLS. Cast to this type only at
+ * the fetch that received it; transport is what stands in for a signature
+ * check.
+ */
+export type IssuerDeliveredJwt = string & { [issuerDelivered]: true };
+
 /**
  * Decode a JWT's payload without verifying its signature. Only safe for
  * tokens received directly from the issuer over TLS (e.g. an id_token from
- * the token exchange), where transport authenticates the issuer.
+ * the token exchange), where transport authenticates the issuer; the branded
+ * argument type is what holds callers to that.
  */
 export function decodeJwtPayloadUnverified(
-  jwt: string,
+  jwt: IssuerDeliveredJwt,
 ): Record<string, unknown> {
   const parts = jwt.split(".");
   if (parts.length !== 3) {
@@ -50,11 +60,11 @@ export function decodeJwtPayloadUnverified(
 
 /**
  * AES-256-GCM key for a ticket payload. The key is only as strong as the
- * ticket code, which is 256 bits of randomness. The prefix is load-bearing:
- * the ticket row stores SHA-256(code) as its lookup hash, so without it the
- * stored hash would be the key.
+ * ticket code, which is 256 bits of randomness.
  */
 async function deriveTicketPayloadKey(ticketCode: string): Promise<CryptoKey> {
+  // The prefix matters: the ticket row stores SHA-256(code) as its lookup
+  // hash, so hashing the bare code here would make the stored hash the key.
   const keyBytes = await crypto.subtle.digest(
     "SHA-256",
     new TextEncoder().encode(`convex-auth-ticket-payload:${ticketCode}`),

--- a/packages/core/src/oauth/component/crypto.ts
+++ b/packages/core/src/oauth/component/crypto.ts
@@ -1,5 +1,6 @@
-// Crypto helpers for the OAuth provider. Used by the app-side recipe to mint
-// flow secrets (the state, the PKCE verifier and its challenge).
+// Crypto helpers for the OAuth provider. Used by both the app-side recipe
+// (PKCE, ticket decryption) and the component itself (ticket encryption,
+// decoding id_tokens).
 
 function base64UrlEncode(bytes: Uint8Array): string {
   const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
@@ -21,4 +22,88 @@ export async function sha256Base64Url(value: string): Promise<string> {
 /** Cryptographically random 256-bit opaque token, base64url encoded. */
 export function generateRandomToken(): string {
   return base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  const base64 = value
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+/**
+ * Decode a JWT's payload without verifying its signature. Only safe for
+ * tokens received directly from the issuer over TLS (e.g. an id_token from
+ * the token exchange), where transport authenticates the issuer.
+ */
+export function decodeJwtPayloadUnverified(
+  jwt: string,
+): Record<string, unknown> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed JWT");
+  }
+  return JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[1])));
+}
+
+/**
+ * Derive an AES-256-GCM key from a raw one-time token. A domain-separated
+ * SHA-256 suffices as the KDF: the token is itself 256 bits of CSPRNG
+ * output, so no stretching is needed.
+ */
+async function deriveTokenKey(encodedToken: string): Promise<CryptoKey> {
+  const keyBytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`convex-auth-ticket-payload:${encodedToken}`),
+  );
+  return await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+/**
+ * Encrypt a ticket payload with a key derived from the raw one-time token.
+ * Only the token's hash is persisted, and the raw token — the only value the
+ * key can be derived from — travels solely in the callback redirect URL, so
+ * database access alone cannot decrypt the result. Returns the random nonce
+ * followed by the ciphertext, base64url-encoded.
+ */
+export async function encryptWithToken(
+  encodedToken: string,
+  plaintext: string,
+): Promise<string> {
+  const key = await deriveTokenKey(encodedToken);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      new TextEncoder().encode(plaintext),
+    ),
+  );
+  const combined = new Uint8Array(iv.length + ciphertext.length);
+  combined.set(iv);
+  combined.set(ciphertext, iv.length);
+  return base64UrlEncode(combined);
+}
+
+/**
+ * Decrypt {@link encryptWithToken} output. Throws when the token is wrong
+ * or the payload was tampered with (AES-GCM authenticates).
+ */
+export async function decryptWithToken(
+  encodedToken: string,
+  encrypted: string,
+): Promise<string> {
+  const key = await deriveTokenKey(encodedToken);
+  const combined = base64UrlDecode(encrypted);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: combined.slice(0, 12) },
+    key,
+    combined.slice(12),
+  );
+  return new TextDecoder().decode(plaintext);
 }

--- a/packages/core/src/oauth/component/crypto.ts
+++ b/packages/core/src/oauth/component/crypto.ts
@@ -51,9 +51,11 @@ export function decodeJwtPayloadUnverified(
 /**
  * Derive an AES-256-GCM key from a raw one-time token. A domain-separated
  * SHA-256 suffices as the KDF: the token is itself 256 bits of CSPRNG
- * output, so no stretching is needed.
+ * output, so no stretching is needed. The `convex-auth-ticket-payload`
+ * context string binds derived keys to exactly this use — these helpers are
+ * ticket-specific by construction, not general-purpose encryption.
  */
-async function deriveTokenKey(encodedToken: string): Promise<CryptoKey> {
+async function deriveTicketKey(encodedToken: string): Promise<CryptoKey> {
   const keyBytes = await crypto.subtle.digest(
     "SHA-256",
     new TextEncoder().encode(`convex-auth-ticket-payload:${encodedToken}`),
@@ -66,16 +68,21 @@ async function deriveTokenKey(encodedToken: string): Promise<CryptoKey> {
 
 /**
  * Encrypt a ticket payload with a key derived from the raw one-time token.
- * Only the token's hash is persisted, and the raw token — the only value the
- * key can be derived from — travels solely in the callback redirect URL, so
- * database access alone cannot decrypt the result. Returns the random nonce
- * followed by the ciphertext, base64url-encoded.
+ *
+ * A ticket is the short-lived, one-time record the callback mints after a
+ * successful code exchange (the `tickets` table in schema.ts); its payload
+ * is the provider-attested identity JSON (`{ claims, userInfoResponses }`)
+ * that redemption decrypts. Only the token's hash is persisted, and the raw
+ * token — the only value the key can be derived from — travels solely in
+ * the callback redirect URL, so database access alone cannot decrypt the
+ * result. Returns the random nonce followed by the ciphertext,
+ * base64url-encoded.
  */
-export async function encryptWithToken(
+export async function encryptTicketPayload(
   encodedToken: string,
   plaintext: string,
 ): Promise<string> {
-  const key = await deriveTokenKey(encodedToken);
+  const key = await deriveTicketKey(encodedToken);
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ciphertext = new Uint8Array(
     await crypto.subtle.encrypt(
@@ -91,14 +98,14 @@ export async function encryptWithToken(
 }
 
 /**
- * Decrypt {@link encryptWithToken} output. Throws when the token is wrong
- * or the payload was tampered with (AES-GCM authenticates).
+ * Decrypt {@link encryptTicketPayload} output. Throws when the token is
+ * wrong or the payload was tampered with (AES-GCM authenticates).
  */
-export async function decryptWithToken(
+export async function decryptTicketPayload(
   encodedToken: string,
   encrypted: string,
 ): Promise<string> {
-  const key = await deriveTokenKey(encodedToken);
+  const key = await deriveTicketKey(encodedToken);
   const combined = base64UrlDecode(encrypted);
   const plaintext = await crypto.subtle.decrypt(
     { name: "AES-GCM", iv: combined.slice(0, 12) },

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -14,10 +14,16 @@ const DEFAULT_REDIRECT_TO = "https://app.example.com/after";
 
 function setup(providerName = "google") {
   // One instance serving one provider: the mount binds the provider's
-  // credentials. convex-test doesn't emulate mount env bindings, so the
-  // component-side names are stubbed directly.
+  // credentials. convex-test doesn't emulate mount env bindings or the
+  // backend's mount-prefixed CONVEX_SITE_URL override, so the component-side
+  // values are stubbed directly (CONVEX_SITE_URL with the prefix already
+  // applied, as the backend would present it).
   vi.stubEnv("CLIENT_ID", "test-client-id");
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
+  vi.stubEnv(
+    "CONVEX_SITE_URL",
+    `https://test.convex.site/oauth/${providerName}`,
+  );
   return convexTest(schema, modules);
 }
 
@@ -104,7 +110,6 @@ function googleClaims(overrides: Record<string, unknown> = {}) {
 type FlowOverrides = Partial<{
   providerName: string;
   redirectTo: string;
-  callbackUrl: string;
   codeVerifier: string;
   tokenEndpoint: string;
   userInfoEndpoints: Record<string, string>;
@@ -127,7 +132,6 @@ async function startFlow(
     providerName: "google",
     stateHash,
     redirectTo: DEFAULT_REDIRECT_TO,
-    callbackUrl: "https://test.convex.site/oauth/google/callback",
     tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
     issuer: "https://accounts.google.com" as string | undefined,
     ...overrides,
@@ -292,7 +296,6 @@ describe("oauth callback", () => {
     });
     const { state, stateHash } = await startFlow(t, {
       providerName: "github",
-      callbackUrl: "https://test.convex.site/oauth/github/callback",
       tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
       userInfoEndpoints: {
@@ -473,7 +476,6 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t, {
       providerName: "github",
-      callbackUrl: "https://test.convex.site/oauth/github/callback",
       tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
       userInfoEndpoints: {
@@ -496,7 +498,6 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t, {
       providerName: "github",
-      callbackUrl: "https://test.convex.site/oauth/github/callback",
       tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
       userInfoEndpoints: { user: "https://api.github.com/user" },

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -12,12 +12,12 @@ const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token";
 const DEFAULT_REDIRECT_TO = "https://app.example.com/after";
 
-function setup() {
-  // The single mount binds each provider's client credentials.
-  vi.stubEnv("GOOGLE_CLIENT_ID", "test-google-client-id");
-  vi.stubEnv("GOOGLE_CLIENT_SECRET", "test-google-client-secret");
-  vi.stubEnv("GITHUB_CLIENT_ID", "test-github-client-id");
-  vi.stubEnv("GITHUB_CLIENT_SECRET", "test-github-client-secret");
+function setup(providerName = "google") {
+  // One instance serving one provider: the mount binds the provider's
+  // credentials. convex-test doesn't emulate mount env bindings, so the
+  // component-side names are stubbed directly.
+  vi.stubEnv("CLIENT_ID", "test-client-id");
+  vi.stubEnv("CLIENT_SECRET", "test-client-secret");
   return convexTest(schema, modules);
 }
 
@@ -92,7 +92,7 @@ function unsignedJwt(claims: Record<string, unknown>): string {
 function googleClaims(overrides: Record<string, unknown> = {}) {
   return {
     iss: "https://accounts.google.com",
-    aud: "test-google-client-id",
+    aud: "test-client-id",
     exp: Math.floor(Date.now() / 1000) + 3600,
     sub: "google-sub-1",
     email: "ada@example.com",
@@ -142,13 +142,12 @@ async function startFlow(
   return { state, stateHash };
 }
 
-/** GET the provider's callback route the way the identity provider redirect would. */
+/** GET the mount's callback route the way the identity provider redirect would. */
 function callback(
   t: ReturnType<typeof setup>,
-  provider: string,
   params: Record<string, string>,
 ): Promise<Response> {
-  return t.fetch(`/${provider}/callback?${new URLSearchParams(params)}`);
+  return t.fetch(`/callback?${new URLSearchParams(params)}`);
 }
 
 /**
@@ -178,14 +177,14 @@ afterEach(() => {
 describe("oauth callback", () => {
   test("a request without state gets a bare 400", async () => {
     const t = setup();
-    const response = await t.fetch("/google/callback");
+    const response = await t.fetch("/callback");
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("This sign-in link is invalid");
   });
 
   test("an unknown state gets a 400: the flow is gone entirely", async () => {
     const t = setup();
-    const response = await callback(t, "google", {
+    const response = await callback(t, {
       state: "never-issued",
       code: "code-1",
     });
@@ -198,26 +197,15 @@ describe("oauth callback", () => {
     const t = setup();
     const { state } = await startFlow(t);
     vi.advanceTimersByTime(11 * 60 * 1000);
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("expired");
-  });
-
-  test("a request claimed via the wrong provider's route is refused before any exchange", async () => {
-    const t = setup();
-    const errors = spyConsoleError();
-    const calls = stubFetch({});
-    const { state } = await startFlow(t); // a google flow...
-    const response = await callback(t, "github", { state, code: "code-1" }); // ...on the github route
-    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
-    expect(loggedText(errors)).toContain("provider mismatch");
-    expect(calls).toHaveLength(0);
   });
 
   test("a provider error of access_denied passes through normalized", async () => {
     const t = setup();
     spyConsoleError();
     const { state } = await startFlow(t);
-    const response = await callback(t, "google", {
+    const response = await callback(t, {
       state,
       error: "access_denied",
     });
@@ -230,7 +218,7 @@ describe("oauth callback", () => {
     const t = setup();
     spyConsoleError();
     const { state } = await startFlow(t);
-    const response = await callback(t, "google", {
+    const response = await callback(t, {
       state,
       error: "temporarily_unavailable",
     });
@@ -241,7 +229,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     const { state } = await startFlow(t);
-    const response = await callback(t, "google", { state });
+    const response = await callback(t, { state });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("missing code");
   });
@@ -257,7 +245,7 @@ describe("oauth callback", () => {
       codeVerifier: "verifier-1",
     });
 
-    const response = await callback(t, "google", {
+    const response = await callback(t, {
       state,
       code: "auth-code-1",
     });
@@ -267,8 +255,8 @@ describe("oauth callback", () => {
     const body = calls[0].init.body as URLSearchParams;
     expect(body.get("grant_type")).toBe("authorization_code");
     expect(body.get("code")).toBe("auth-code-1");
-    expect(body.get("client_id")).toBe("test-google-client-id");
-    expect(body.get("client_secret")).toBe("test-google-client-secret");
+    expect(body.get("client_id")).toBe("test-client-id");
+    expect(body.get("client_secret")).toBe("test-client-secret");
     expect(body.get("redirect_uri")).toBe(
       "https://test.convex.site/oauth/google/callback",
     );
@@ -292,7 +280,7 @@ describe("oauth callback", () => {
   });
 
   test("a userinfo flow fetches each endpoint with the access token", async () => {
-    const t = setup();
+    const t = setup("github");
     const user = { id: 42, login: "octocat" };
     const emails = [
       { email: "ada@example.com", primary: true, verified: true },
@@ -313,7 +301,7 @@ describe("oauth callback", () => {
       },
     });
 
-    const response = await callback(t, "github", {
+    const response = await callback(t, {
       state,
       code: "auth-code-2",
     });
@@ -342,7 +330,7 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t, { redirectTo });
 
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     const params = redirectParams(response, redirectTo);
     expect(params.get(OAUTH_ERROR_PARAM)).toBeNull();
@@ -359,7 +347,7 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t);
 
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("Token exchange failed with 400");
@@ -380,7 +368,7 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t);
 
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("responded with a redirect");
@@ -398,7 +386,7 @@ describe("oauth callback", () => {
           jsonResponse({ id_token: idToken, access_token: "at-1" }),
       });
       const { state } = await startFlow(t, overrides);
-      return await callback(t, "google", { state, code: "code-1" });
+      return await callback(t, { state, code: "code-1" });
     }
 
     test("an id_token with no configured issuer is refused", async () => {
@@ -475,7 +463,7 @@ describe("oauth callback", () => {
   });
 
   test("a failed userinfo request redirects with oauth_error", async () => {
-    const t = setup();
+    const t = setup("github");
     const errors = spyConsoleError();
     stubFetch({
       [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "gh-at-1" }),
@@ -494,14 +482,14 @@ describe("oauth callback", () => {
       },
     });
 
-    const response = await callback(t, "github", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain('Userinfo request "user" failed');
   });
 
   test("userinfo endpoints without an access_token are refused", async () => {
-    const t = setup();
+    const t = setup("github");
     const errors = spyConsoleError();
     stubFetch({
       [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({}),
@@ -514,7 +502,7 @@ describe("oauth callback", () => {
       userInfoEndpoints: { user: "https://api.github.com/user" },
     });
 
-    const response = await callback(t, "github", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain(
@@ -531,7 +519,7 @@ describe("oauth callback", () => {
     // No id_token comes back and no userinfo endpoints are configured.
     const { state } = await startFlow(t, { issuer: undefined });
 
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain(
@@ -558,7 +546,7 @@ describe("oauth callback", () => {
     });
     const { state } = await startFlow(t);
 
-    const response = await callback(t, "google", { state, code: "code-1" });
+    const response = await callback(t, { state, code: "code-1" });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("aborted");
   });

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -9,7 +9,7 @@ import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams.js";
 
 const modules = import.meta.glob("./**/*.ts");
 
-/** Bound to the mount, so they can't come off a per-flow fixture. */
+/** Fixed per component instance, so they can't come off a per-flow fixture. */
 const CLIENT_ID = "test-client-id";
 const PROVIDER_NAME = "test-provider";
 
@@ -57,11 +57,11 @@ const COMBINED_REQUEST = {
 } satisfies FlowRequest;
 
 function setup() {
-  // One instance serving one provider: the mount binds the provider's
-  // credentials. convex-test doesn't emulate mount env bindings or the
-  // backend's mount-prefixed CONVEX_SITE_URL override, so the component-side
-  // values are stubbed directly (CONVEX_SITE_URL with the prefix already
-  // applied, as the backend would present it).
+  // One instance serving one provider: the component instance binds the
+  // provider's credentials. convex-test doesn't emulate component env
+  // bindings or the backend applying httpPrefix to CONVEX_SITE_URL, so the
+  // component-side values are stubbed directly (CONVEX_SITE_URL with the
+  // prefix already applied, as the backend would present it).
   vi.stubEnv("CLIENT_ID", CLIENT_ID);
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
   vi.stubEnv(
@@ -183,7 +183,7 @@ async function startFlow(
   return { state, stateHash };
 }
 
-/** GET the mount's callback route the way the identity provider redirect would. */
+/** GET the component's callback route the way the identity provider redirect would. */
 function callback(
   t: ReturnType<typeof setup>,
   params: Record<string, string>,

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -1,7 +1,7 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
-import { decryptWithToken } from "./crypto.js";
+import { decryptTicketPayload } from "./crypto.js";
 import schema from "./schema.js";
 import { sha256Hex } from "../../lib/crypto.js";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams.js";
@@ -34,7 +34,13 @@ type FetchCall = { url: string; init: RequestInit };
  * Stub global `fetch` with an exact-URL routing table. `t.fetch` dispatches
  * to the component's router directly without touching global `fetch`, so the
  * stub only ever sees the handler's outbound token/userinfo requests. An
- * unrouted URL throws, failing the test loudly.
+ * unrouted URL throws, failing the test loudly. The returned array records
+ * every outbound request so tests can assert the exact shape of the token
+ * exchange (body params, auth style).
+ *
+ * Intercepting outbound requests is required (the callback really calls the
+ * provider's endpoints and convex-test doesn't intercept network access); we
+ * stub global fetch, per convex-test's own guidance.
  */
 function stubFetch(
   routes: Record<string, (init: RequestInit) => Response | Promise<Response>>,
@@ -74,7 +80,12 @@ function spyConsoleError() {
   return vi.spyOn(console, "error").mockImplementation(() => {});
 }
 
-/** Everything a spied `console.error` logged, flattened to one string. */
+/** Like {@link spyConsoleError}, for the flow-level `console.warn` paths. */
+function spyConsoleWarn() {
+  return vi.spyOn(console, "warn").mockImplementation(() => {});
+}
+
+/** Everything a spied console method logged, flattened to one string. */
 function loggedText(spy: ReturnType<typeof spyConsoleError>): string {
   return spy.mock.calls.flat().map(String).join("\n");
 }
@@ -188,21 +199,25 @@ describe("oauth callback", () => {
 
   test("an unknown state gets a 400: the flow is gone entirely", async () => {
     const t = setup();
+    const warnSpy = spyConsoleWarn();
     const response = await callback(t, {
       state: "never-issued",
       code: "code-1",
     });
     expect(response.status).toBe(400);
     expect(await response.text()).toContain("expired or was already used");
+    expect(loggedText(warnSpy)).toContain("unknown or already-used state");
   });
 
   test("an expired request redirects back to the app with expired", async () => {
     vi.useFakeTimers();
     const t = setup();
+    const warnSpy = spyConsoleWarn();
     const { state } = await startFlow(t);
     vi.advanceTimersByTime(11 * 60 * 1000);
     const response = await callback(t, { state, code: "code-1" });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("expired");
+    expect(loggedText(warnSpy)).toContain("expired authorization request");
   });
 
   test("a provider error of access_denied passes through normalized", async () => {
@@ -270,7 +285,9 @@ describe("oauth callback", () => {
 
     // The redirect carries a one-time token that redeems (with the flow's
     // state) into the encrypted identity payload — the full contract the
-    // app-side completeSignIn depends on.
+    // app-side completeSignIn depends on. This leg only mints the ticket;
+    // claiming it here directly stands in for the app-side redemption
+    // covered by the redemption leg's tests.
     const ott = redirectParams(response).get(OAUTH_CODE_PARAM)!;
     expect(ott).toEqual(expect.any(String));
     const claimed = await t.mutation(api.provider.claimTicket, {
@@ -279,7 +296,9 @@ describe("oauth callback", () => {
       stateHash,
     });
     expect(claimed).not.toBeNull();
-    const payload = JSON.parse(await decryptWithToken(ott, claimed!.payload));
+    const payload = JSON.parse(
+      await decryptTicketPayload(ott, claimed!.payload),
+    );
     expect(payload).toEqual({ claims });
   });
 
@@ -320,11 +339,15 @@ describe("oauth callback", () => {
       ottHash: await sha256Hex(ott),
       stateHash,
     });
-    const payload = JSON.parse(await decryptWithToken(ott, claimed!.payload));
+    const payload = JSON.parse(
+      await decryptTicketPayload(ott, claimed!.payload),
+    );
     expect(payload).toEqual({ userInfoResponses: { user, emails } });
   });
 
   test("stale outcome params on redirectTo are replaced, app params kept", async () => {
+    // A retry after a failed attempt: the page URL the new flow snapshots as
+    // redirectTo still carries the previous attempt's outcome param.
     const t = setup();
     const redirectTo = `${DEFAULT_REDIRECT_TO}?${OAUTH_ERROR_PARAM}=expired&tab=settings`;
     stubFetch({

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -327,7 +327,7 @@ describe("oauth callback", () => {
     });
     expect(claimed).not.toBeNull();
     const payload = JSON.parse(
-      await decryptTicketPayload(ticketCode, claimed!.payload),
+      await decryptTicketPayload(ticketCode, claimed!.encryptedPayload),
     );
     expect(payload).toEqual({ claims });
   });
@@ -367,7 +367,7 @@ describe("oauth callback", () => {
       stateHash,
     });
     const payload = JSON.parse(
-      await decryptTicketPayload(ticketCode, claimed!.payload),
+      await decryptTicketPayload(ticketCode, claimed!.encryptedPayload),
     );
     expect(payload).toEqual({ userInfoResponses: { profile, emails } });
   });
@@ -406,7 +406,7 @@ describe("oauth callback", () => {
       stateHash,
     });
     const payload = JSON.parse(
-      await decryptTicketPayload(ticketCode, claimed!.payload),
+      await decryptTicketPayload(ticketCode, claimed!.encryptedPayload),
     );
     expect(payload).toEqual({
       claims,

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -626,7 +626,7 @@ describe("oauth callback", () => {
         });
         // The handler arms its timeout before calling fetch, so the timer is
         // live here; advancing past it fires the abort.
-        vi.advanceTimersByTime(30 * 1000);
+        vi.advanceTimersByTime(10 * 1000);
         return stalled;
       },
     });
@@ -659,7 +659,7 @@ describe("oauth callback", () => {
                 );
               },
               pull() {
-                vi.advanceTimersByTime(30 * 1000);
+                vi.advanceTimersByTime(10 * 1000);
               },
             },
             { highWaterMark: 0 },

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -283,21 +283,21 @@ describe("oauth callback", () => {
     const headers = calls[0].init.headers as Record<string, string>;
     expect(headers.Accept).toBe("application/json");
 
-    // The redirect carries a one-time token that redeems (with the flow's
-    // state) into the encrypted identity payload — the full contract the
+    // The redirect carries a ticket code that redeems (with the flow's
+    // state) into the encrypted identity payload, the full contract the
     // app-side completeSignIn depends on. This leg only mints the ticket;
     // claiming it here directly stands in for the app-side redemption
     // covered by the redemption leg's tests.
-    const ott = redirectParams(response).get(OAUTH_CODE_PARAM)!;
-    expect(ott).toEqual(expect.any(String));
+    const ticketCode = redirectParams(response).get(OAUTH_CODE_PARAM)!;
+    expect(ticketCode).toEqual(expect.any(String));
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "google",
-      ottHash: await sha256Hex(ott),
+      ticketCodeHash: await sha256Hex(ticketCode),
       stateHash,
     });
     expect(claimed).not.toBeNull();
     const payload = JSON.parse(
-      await decryptTicketPayload(ott, claimed!.payload),
+      await decryptTicketPayload(ticketCode, claimed!.payload),
     );
     expect(payload).toEqual({ claims });
   });
@@ -333,14 +333,14 @@ describe("oauth callback", () => {
     expect(headers.Authorization).toBe("Bearer gh-at-1");
     expect(headers["User-Agent"]).toBe("convex-auth");
 
-    const ott = redirectParams(response).get(OAUTH_CODE_PARAM)!;
+    const ticketCode = redirectParams(response).get(OAUTH_CODE_PARAM)!;
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "github",
-      ottHash: await sha256Hex(ott),
+      ticketCodeHash: await sha256Hex(ticketCode),
       stateHash,
     });
     const payload = JSON.parse(
-      await decryptTicketPayload(ott, claimed!.payload),
+      await decryptTicketPayload(ticketCode, claimed!.payload),
     );
     expect(payload).toEqual({ userInfoResponses: { user, emails } });
   });

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -1,4 +1,5 @@
 import { convexTest } from "convex-test";
+import { FunctionArgs } from "convex/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.js";
 import { decryptTicketPayload } from "./crypto.js";
@@ -8,16 +9,52 @@ import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams.js";
 
 const modules = import.meta.glob("./**/*.ts");
 
-// The component never branches on which provider it serves, so the fixtures
-// name none. What the handler does branch on is which identity sources a flow
-// has: id_token claims, userinfo responses, or both.
+/** Bound to the mount, so they can't come off a per-flow fixture. */
 const CLIENT_ID = "test-client-id";
 const PROVIDER_NAME = "test-provider";
-const ISSUER = "https://provider.example.com";
-const TOKEN_ENDPOINT = "https://provider.example.com/token";
-const PROFILE_ENDPOINT = "https://provider.example.com/profile";
-const EMAILS_ENDPOINT = "https://provider.example.com/emails";
-const DEFAULT_REDIRECT_TO = "https://app.example.com/after";
+
+/** Everything `createAuthorizationRequest` takes except the state hash. */
+type FlowRequest = Omit<
+  FunctionArgs<typeof api.provider.createAuthorizationRequest>,
+  "stateHash"
+>;
+
+/**
+ * The component never branches on which provider it serves, so no fixture
+ * names a real one. What the callback does branch on is where a flow's
+ * identity comes from, and these are the shapes that produces: an id_token,
+ * userinfo responses, both, or (as {@link BASE_REQUEST} alone) neither, which
+ * is a misconfiguration two tests exercise.
+ *
+ * These carry every field the real app-side `setupOauth` would send, so a test
+ * declares its whole flow and {@link startFlow} adds no defaults of its own.
+ */
+const BASE_REQUEST = {
+  providerName: PROVIDER_NAME,
+  redirectTo: "https://app.example.com/after",
+  tokenEndpoint: "https://provider.example.com/token",
+} satisfies FlowRequest;
+
+/** Identity from validated id_token claims. */
+const ID_TOKEN_REQUEST = {
+  ...BASE_REQUEST,
+  issuer: "https://provider.example.com",
+} satisfies FlowRequest;
+
+/** No id_token; identity spread across two endpoints. */
+const USERINFO_REQUEST = {
+  ...BASE_REQUEST,
+  userInfoEndpoints: {
+    profile: "https://provider.example.com/profile",
+    emails: "https://provider.example.com/emails",
+  },
+} satisfies FlowRequest;
+
+/** Both sources at once. */
+const COMBINED_REQUEST = {
+  ...ID_TOKEN_REQUEST,
+  ...USERINFO_REQUEST,
+} satisfies FlowRequest;
 
 function setup() {
   // One instance serving one provider: the mount binds the provider's
@@ -44,6 +81,9 @@ type FetchCall = { url: string; init: RequestInit };
  * unrouted URL throws, failing the test loudly. The returned array records
  * every outbound request so tests can assert the exact shape of the token
  * exchange (body params, auth style).
+ *
+ * Route keys come off the flow fixtures rather than repeating a URL, so a
+ * route can't drift from the endpoint the flow was configured with.
  *
  * Intercepting outbound requests is required (the callback really calls the
  * provider's endpoints and convex-test doesn't intercept network access); we
@@ -115,7 +155,7 @@ function unsignedJwt(claims: Record<string, unknown>): string {
 /** Valid id_token claims, overridable per test. */
 function idTokenClaims(overrides: Record<string, unknown> = {}) {
   return {
-    iss: ISSUER,
+    iss: ID_TOKEN_REQUEST.issuer,
     aud: CLIENT_ID,
     exp: Math.floor(Date.now() / 1000) + 3600,
     sub: "sub-1",
@@ -125,43 +165,21 @@ function idTokenClaims(overrides: Record<string, unknown> = {}) {
   };
 }
 
-type FlowOverrides = Partial<{
-  providerName: string;
-  redirectTo: string;
-  codeVerifier: string;
-  tokenEndpoint: string;
-  userInfoEndpoints: Record<string, string>;
-  issuer: string | undefined;
-}>;
-
 /**
  * Record an authorization request the way the app-side `startSignIn` would,
  * returning the raw `state` the provider echoes back to the callback plus
- * its hash (which binds redemption to the initiating client). Defaults model
- * an id_token flow; override `userInfoEndpoints` (and drop `issuer`) for a
- * userinfo flow.
+ * its hash (which binds redemption to the initiating client).
  */
 async function startFlow(
   t: ReturnType<typeof setup>,
-  overrides: FlowOverrides = {},
-) {
+  request: FlowRequest,
+): Promise<{ state: string; stateHash: string }> {
   const state = "state-raw-1";
   const stateHash = await sha256Hex(state);
-  const args = {
-    providerName: PROVIDER_NAME,
+  await t.mutation(api.provider.createAuthorizationRequest, {
+    ...request,
     stateHash,
-    redirectTo: DEFAULT_REDIRECT_TO,
-    tokenEndpoint: TOKEN_ENDPOINT,
-    issuer: ISSUER as string | undefined,
-    ...overrides,
-  };
-  await t.mutation(
-    api.provider.createAuthorizationRequest,
-    // An optional arg must be absent, not `undefined` (not a Convex value).
-    Object.fromEntries(
-      Object.entries(args).filter(([, value]) => value !== undefined),
-    ) as typeof args,
-  );
+  });
   return { state, stateHash };
 }
 
@@ -179,7 +197,7 @@ function callback(
  */
 function redirectParams(
   response: Response,
-  redirectTo = DEFAULT_REDIRECT_TO,
+  redirectTo = BASE_REQUEST.redirectTo,
 ): URLSearchParams {
   expect(response.status).toBe(302);
   const location = new URL(response.headers.get("Location")!);
@@ -221,7 +239,7 @@ describe("oauth callback", () => {
     vi.useFakeTimers();
     const t = setup();
     const warnSpy = spyConsoleWarn();
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
     vi.advanceTimersByTime(11 * 60 * 1000);
     const response = await callback(t, { state, code: "code-1" });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("expired");
@@ -231,7 +249,7 @@ describe("oauth callback", () => {
   test("a provider error of access_denied passes through normalized", async () => {
     const t = setup();
     spyConsoleError();
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
     const response = await callback(t, {
       state,
       error: "access_denied",
@@ -244,7 +262,7 @@ describe("oauth callback", () => {
   test("any other provider error normalizes to oauth_error", async () => {
     const t = setup();
     spyConsoleError();
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
     const response = await callback(t, {
       state,
       error: "temporarily_unavailable",
@@ -255,7 +273,7 @@ describe("oauth callback", () => {
   test("a callback with neither code nor error normalizes to oauth_error", async () => {
     const t = setup();
     const errors = spyConsoleError();
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
     const response = await callback(t, { state });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("missing code");
@@ -265,13 +283,14 @@ describe("oauth callback", () => {
     const t = setup();
     const claims = idTokenClaims();
     const calls = stubFetch({
-      [TOKEN_ENDPOINT]: () =>
+      [ID_TOKEN_REQUEST.tokenEndpoint]: () =>
         jsonResponse({
           id_token: unsignedJwt(claims),
           access_token: "access-token-1",
         }),
     });
     const { state, stateHash } = await startFlow(t, {
+      ...ID_TOKEN_REQUEST,
       codeVerifier: "verifier-1",
     });
 
@@ -314,33 +333,29 @@ describe("oauth callback", () => {
   });
 
   test("a userinfo flow fetches each endpoint with the access token", async () => {
-    // No id_token; identity comes from several endpoints instead, which is
-    // GitHub's shape. The asserted headers are provider-driven too: http.ts
-    // documents why Accept and User-Agent are sent at all.
+    // The asserted headers are provider-driven: http.ts documents why Accept
+    // and User-Agent are sent at all (GitHub needs both).
     const t = setup();
+    const { profile: profileUrl, emails: emailsUrl } =
+      USERINFO_REQUEST.userInfoEndpoints;
     const profile = { id: "user-1", name: "Ada" };
     const emails = [
       { email: "ada@example.com", primary: true, verified: true },
     ];
     const calls = stubFetch({
-      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
-      [PROFILE_ENDPOINT]: () => jsonResponse(profile),
-      [EMAILS_ENDPOINT]: () => jsonResponse(emails),
+      [USERINFO_REQUEST.tokenEndpoint]: () =>
+        jsonResponse({ access_token: "access-token-1" }),
+      [profileUrl]: () => jsonResponse(profile),
+      [emailsUrl]: () => jsonResponse(emails),
     });
-    const { state, stateHash } = await startFlow(t, {
-      issuer: undefined,
-      userInfoEndpoints: {
-        profile: PROFILE_ENDPOINT,
-        emails: EMAILS_ENDPOINT,
-      },
-    });
+    const { state, stateHash } = await startFlow(t, USERINFO_REQUEST);
 
     const response = await callback(t, {
       state,
       code: "auth-code-2",
     });
 
-    const profileCall = calls.find((c) => c.url === PROFILE_ENDPOINT);
+    const profileCall = calls.find((c) => c.url === profileUrl);
     const headers = profileCall!.init.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer access-token-1");
     expect(headers["User-Agent"]).toBe("convex-auth");
@@ -361,19 +376,23 @@ describe("oauth callback", () => {
     // The two sources are independent, so a provider can supply both. This is
     // the only case where both halves of the handler contribute to a payload.
     const t = setup();
+    const { profile: profileUrl, emails: emailsUrl } =
+      COMBINED_REQUEST.userInfoEndpoints;
     const claims = idTokenClaims();
     const profile = { id: "user-1", name: "Ada" };
+    const emails = [
+      { email: "ada@example.com", primary: true, verified: true },
+    ];
     stubFetch({
-      [TOKEN_ENDPOINT]: () =>
+      [COMBINED_REQUEST.tokenEndpoint]: () =>
         jsonResponse({
           id_token: unsignedJwt(claims),
           access_token: "access-token-1",
         }),
-      [PROFILE_ENDPOINT]: () => jsonResponse(profile),
+      [profileUrl]: () => jsonResponse(profile),
+      [emailsUrl]: () => jsonResponse(emails),
     });
-    const { state, stateHash } = await startFlow(t, {
-      userInfoEndpoints: { profile: PROFILE_ENDPOINT },
-    });
+    const { state, stateHash } = await startFlow(t, COMBINED_REQUEST);
 
     const response = await callback(t, {
       state,
@@ -389,19 +408,22 @@ describe("oauth callback", () => {
     const payload = JSON.parse(
       await decryptTicketPayload(ticketCode, claimed!.payload),
     );
-    expect(payload).toEqual({ claims, userInfoResponses: { profile } });
+    expect(payload).toEqual({
+      claims,
+      userInfoResponses: { profile, emails },
+    });
   });
 
   test("stale outcome params on redirectTo are replaced, app params kept", async () => {
     // A retry after a failed attempt: the page URL the new flow snapshots as
     // redirectTo still carries the previous attempt's outcome param.
     const t = setup();
-    const redirectTo = `${DEFAULT_REDIRECT_TO}?${OAUTH_ERROR_PARAM}=expired&tab=settings`;
+    const redirectTo = `${BASE_REQUEST.redirectTo}?${OAUTH_ERROR_PARAM}=expired&tab=settings`;
     stubFetch({
-      [TOKEN_ENDPOINT]: () =>
+      [ID_TOKEN_REQUEST.tokenEndpoint]: () =>
         jsonResponse({ id_token: unsignedJwt(idTokenClaims()) }),
     });
-    const { state } = await startFlow(t, { redirectTo });
+    const { state } = await startFlow(t, { ...ID_TOKEN_REQUEST, redirectTo });
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -415,9 +437,10 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [TOKEN_ENDPOINT]: () => new Response("bad request", { status: 400 }),
+      [ID_TOKEN_REQUEST.tokenEndpoint]: () =>
+        new Response("bad request", { status: 400 }),
     });
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -432,13 +455,13 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [TOKEN_ENDPOINT]: () =>
+      [ID_TOKEN_REQUEST.tokenEndpoint]: () =>
         new Response(null, {
           status: 302,
           headers: { Location: "https://elsewhere.example.com/token" },
         }),
     });
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -447,17 +470,17 @@ describe("oauth callback", () => {
   });
 
   describe("id_token validation", () => {
-    /** Run a flow whose token endpoint returns `idToken`. */
+    /** Run `request`'s flow against a token endpoint returning `idToken`. */
     async function callbackWithIdToken(
       t: ReturnType<typeof setup>,
+      request: FlowRequest,
       idToken: string,
-      overrides: FlowOverrides = {},
     ): Promise<Response> {
       stubFetch({
-        [TOKEN_ENDPOINT]: () =>
+        [request.tokenEndpoint]: () =>
           jsonResponse({ id_token: idToken, access_token: "access-token-1" }),
       });
-      const { state } = await startFlow(t, overrides);
+      const { state } = await startFlow(t, request);
       return await callback(t, { state, code: "code-1" });
     }
 
@@ -466,8 +489,8 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
+        BASE_REQUEST,
         unsignedJwt(idTokenClaims()),
-        { issuer: undefined },
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
         "oauth_error",
@@ -480,6 +503,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
+        ID_TOKEN_REQUEST,
         unsignedJwt(idTokenClaims({ iss: "https://evil.example.com" })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
@@ -495,6 +519,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
+        ID_TOKEN_REQUEST,
         unsignedJwt(idTokenClaims({ aud: [CLIENT_ID, "other-client"] })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
@@ -510,6 +535,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
+        ID_TOKEN_REQUEST,
         unsignedJwt(idTokenClaims({ azp: "other-client" })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
@@ -523,6 +549,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
+        ID_TOKEN_REQUEST,
         unsignedJwt(idTokenClaims({ exp: Math.floor(Date.now() / 1000) - 60 })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
@@ -535,18 +562,15 @@ describe("oauth callback", () => {
   test("a failed userinfo request redirects with oauth_error", async () => {
     const t = setup();
     const errors = spyConsoleError();
+    const { profile: profileUrl, emails: emailsUrl } =
+      USERINFO_REQUEST.userInfoEndpoints;
     stubFetch({
-      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
-      [PROFILE_ENDPOINT]: () => new Response("server error", { status: 500 }),
-      [EMAILS_ENDPOINT]: () => jsonResponse([]),
+      [USERINFO_REQUEST.tokenEndpoint]: () =>
+        jsonResponse({ access_token: "access-token-1" }),
+      [profileUrl]: () => new Response("server error", { status: 500 }),
+      [emailsUrl]: () => jsonResponse([]),
     });
-    const { state } = await startFlow(t, {
-      issuer: undefined,
-      userInfoEndpoints: {
-        profile: PROFILE_ENDPOINT,
-        emails: EMAILS_ENDPOINT,
-      },
-    });
+    const { state } = await startFlow(t, USERINFO_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -558,12 +582,9 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [TOKEN_ENDPOINT]: () => jsonResponse({}),
+      [USERINFO_REQUEST.tokenEndpoint]: () => jsonResponse({}),
     });
-    const { state } = await startFlow(t, {
-      issuer: undefined,
-      userInfoEndpoints: { profile: PROFILE_ENDPOINT },
-    });
+    const { state } = await startFlow(t, USERINFO_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -574,13 +595,15 @@ describe("oauth callback", () => {
   });
 
   test("a response with nothing to identify the user is refused", async () => {
+    // BASE_REQUEST configures neither identity source, and the exchange
+    // returns no id_token, so there is nothing to build an account from.
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
+      [BASE_REQUEST.tokenEndpoint]: () =>
+        jsonResponse({ access_token: "access-token-1" }),
     });
-    // No id_token comes back and no userinfo endpoints are configured.
-    const { state } = await startFlow(t, { issuer: undefined });
+    const { state } = await startFlow(t, BASE_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
 
@@ -595,7 +618,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [TOKEN_ENDPOINT]: (init) => {
+      [ID_TOKEN_REQUEST.tokenEndpoint]: (init) => {
         const stalled = new Promise<Response>((_resolve, reject) => {
           init.signal?.addEventListener("abort", () =>
             reject(new DOMException("The operation was aborted", "AbortError")),
@@ -607,7 +630,7 @@ describe("oauth callback", () => {
         return stalled;
       },
     });
-    const { state } = await startFlow(t);
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
 
     const response = await callback(t, { state, code: "code-1" });
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -8,21 +8,28 @@ import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams.js";
 
 const modules = import.meta.glob("./**/*.ts");
 
-const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
-const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token";
+// The component never branches on which provider it serves, so the fixtures
+// name none. What the handler does branch on is which identity sources a flow
+// has: id_token claims, userinfo responses, or both.
+const CLIENT_ID = "test-client-id";
+const PROVIDER_NAME = "test-provider";
+const ISSUER = "https://provider.example.com";
+const TOKEN_ENDPOINT = "https://provider.example.com/token";
+const PROFILE_ENDPOINT = "https://provider.example.com/profile";
+const EMAILS_ENDPOINT = "https://provider.example.com/emails";
 const DEFAULT_REDIRECT_TO = "https://app.example.com/after";
 
-function setup(providerName = "google") {
+function setup() {
   // One instance serving one provider: the mount binds the provider's
   // credentials. convex-test doesn't emulate mount env bindings or the
   // backend's mount-prefixed CONVEX_SITE_URL override, so the component-side
   // values are stubbed directly (CONVEX_SITE_URL with the prefix already
   // applied, as the backend would present it).
-  vi.stubEnv("CLIENT_ID", "test-client-id");
+  vi.stubEnv("CLIENT_ID", CLIENT_ID);
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
   vi.stubEnv(
     "CONVEX_SITE_URL",
-    `https://test.convex.site/oauth/${providerName}`,
+    `https://test.convex.site/oauth/${PROVIDER_NAME}`,
   );
   return convexTest(schema, modules);
 }
@@ -105,13 +112,13 @@ function unsignedJwt(claims: Record<string, unknown>): string {
   return `${header}.${payload}.signature`;
 }
 
-/** Valid google-style id_token claims, overridable per test. */
-function googleClaims(overrides: Record<string, unknown> = {}) {
+/** Valid id_token claims, overridable per test. */
+function idTokenClaims(overrides: Record<string, unknown> = {}) {
   return {
-    iss: "https://accounts.google.com",
-    aud: "test-client-id",
+    iss: ISSUER,
+    aud: CLIENT_ID,
     exp: Math.floor(Date.now() / 1000) + 3600,
-    sub: "google-sub-1",
+    sub: "sub-1",
     email: "ada@example.com",
     email_verified: true,
     ...overrides,
@@ -131,7 +138,8 @@ type FlowOverrides = Partial<{
  * Record an authorization request the way the app-side `startSignIn` would,
  * returning the raw `state` the provider echoes back to the callback plus
  * its hash (which binds redemption to the initiating client). Defaults model
- * the google catalog; override for github-style (userinfo) flows.
+ * an id_token flow; override `userInfoEndpoints` (and drop `issuer`) for a
+ * userinfo flow.
  */
 async function startFlow(
   t: ReturnType<typeof setup>,
@@ -140,11 +148,11 @@ async function startFlow(
   const state = "state-raw-1";
   const stateHash = await sha256Hex(state);
   const args = {
-    providerName: "google",
+    providerName: PROVIDER_NAME,
     stateHash,
     redirectTo: DEFAULT_REDIRECT_TO,
-    tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
-    issuer: "https://accounts.google.com" as string | undefined,
+    tokenEndpoint: TOKEN_ENDPOINT,
+    issuer: ISSUER as string | undefined,
     ...overrides,
   };
   await t.mutation(
@@ -255,10 +263,13 @@ describe("oauth callback", () => {
 
   test("an id_token flow exchanges the code and mints a redeemable ticket", async () => {
     const t = setup();
-    const claims = googleClaims();
+    const claims = idTokenClaims();
     const calls = stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: () =>
-        jsonResponse({ id_token: unsignedJwt(claims), access_token: "at-1" }),
+      [TOKEN_ENDPOINT]: () =>
+        jsonResponse({
+          id_token: unsignedJwt(claims),
+          access_token: "access-token-1",
+        }),
     });
     const { state, stateHash } = await startFlow(t, {
       codeVerifier: "verifier-1",
@@ -274,10 +285,10 @@ describe("oauth callback", () => {
     const body = calls[0].init.body as URLSearchParams;
     expect(body.get("grant_type")).toBe("authorization_code");
     expect(body.get("code")).toBe("auth-code-1");
-    expect(body.get("client_id")).toBe("test-client-id");
+    expect(body.get("client_id")).toBe(CLIENT_ID);
     expect(body.get("client_secret")).toBe("test-client-secret");
     expect(body.get("redirect_uri")).toBe(
-      "https://test.convex.site/oauth/google/callback",
+      "https://test.convex.site/oauth/test-provider/callback",
     );
     expect(body.get("code_verifier")).toBe("verifier-1");
     const headers = calls[0].init.headers as Record<string, string>;
@@ -291,7 +302,7 @@ describe("oauth callback", () => {
     const ticketCode = redirectParams(response).get(OAUTH_CODE_PARAM)!;
     expect(ticketCode).toEqual(expect.any(String));
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: await sha256Hex(ticketCode),
       stateHash,
     });
@@ -303,23 +314,24 @@ describe("oauth callback", () => {
   });
 
   test("a userinfo flow fetches each endpoint with the access token", async () => {
-    const t = setup("github");
-    const user = { id: 42, login: "octocat" };
+    // No id_token; identity comes from several endpoints instead, which is
+    // GitHub's shape. The asserted headers are provider-driven too: http.ts
+    // documents why Accept and User-Agent are sent at all.
+    const t = setup();
+    const profile = { id: "user-1", name: "Ada" };
     const emails = [
       { email: "ada@example.com", primary: true, verified: true },
     ];
     const calls = stubFetch({
-      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "gh-at-1" }),
-      "https://api.github.com/user": () => jsonResponse(user),
-      "https://api.github.com/user/emails": () => jsonResponse(emails),
+      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
+      [PROFILE_ENDPOINT]: () => jsonResponse(profile),
+      [EMAILS_ENDPOINT]: () => jsonResponse(emails),
     });
     const { state, stateHash } = await startFlow(t, {
-      providerName: "github",
-      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
       userInfoEndpoints: {
-        user: "https://api.github.com/user",
-        emails: "https://api.github.com/user/emails",
+        profile: PROFILE_ENDPOINT,
+        emails: EMAILS_ENDPOINT,
       },
     });
 
@@ -328,21 +340,56 @@ describe("oauth callback", () => {
       code: "auth-code-2",
     });
 
-    const userCall = calls.find((c) => c.url === "https://api.github.com/user");
-    const headers = userCall!.init.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer gh-at-1");
+    const profileCall = calls.find((c) => c.url === PROFILE_ENDPOINT);
+    const headers = profileCall!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer access-token-1");
     expect(headers["User-Agent"]).toBe("convex-auth");
 
     const ticketCode = redirectParams(response).get(OAUTH_CODE_PARAM)!;
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "github",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: await sha256Hex(ticketCode),
       stateHash,
     });
     const payload = JSON.parse(
       await decryptTicketPayload(ticketCode, claimed!.payload),
     );
-    expect(payload).toEqual({ userInfoResponses: { user, emails } });
+    expect(payload).toEqual({ userInfoResponses: { profile, emails } });
+  });
+
+  test("a flow with both identity sources carries each into one payload", async () => {
+    // The two sources are independent, so a provider can supply both. This is
+    // the only case where both halves of the handler contribute to a payload.
+    const t = setup();
+    const claims = idTokenClaims();
+    const profile = { id: "user-1", name: "Ada" };
+    stubFetch({
+      [TOKEN_ENDPOINT]: () =>
+        jsonResponse({
+          id_token: unsignedJwt(claims),
+          access_token: "access-token-1",
+        }),
+      [PROFILE_ENDPOINT]: () => jsonResponse(profile),
+    });
+    const { state, stateHash } = await startFlow(t, {
+      userInfoEndpoints: { profile: PROFILE_ENDPOINT },
+    });
+
+    const response = await callback(t, {
+      state,
+      code: "auth-code-3",
+    });
+
+    const ticketCode = redirectParams(response).get(OAUTH_CODE_PARAM)!;
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: PROVIDER_NAME,
+      ticketCodeHash: await sha256Hex(ticketCode),
+      stateHash,
+    });
+    const payload = JSON.parse(
+      await decryptTicketPayload(ticketCode, claimed!.payload),
+    );
+    expect(payload).toEqual({ claims, userInfoResponses: { profile } });
   });
 
   test("stale outcome params on redirectTo are replaced, app params kept", async () => {
@@ -351,8 +398,8 @@ describe("oauth callback", () => {
     const t = setup();
     const redirectTo = `${DEFAULT_REDIRECT_TO}?${OAUTH_ERROR_PARAM}=expired&tab=settings`;
     stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: () =>
-        jsonResponse({ id_token: unsignedJwt(googleClaims()) }),
+      [TOKEN_ENDPOINT]: () =>
+        jsonResponse({ id_token: unsignedJwt(idTokenClaims()) }),
     });
     const { state } = await startFlow(t, { redirectTo });
 
@@ -368,8 +415,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: () =>
-        new Response("bad request", { status: 400 }),
+      [TOKEN_ENDPOINT]: () => new Response("bad request", { status: 400 }),
     });
     const { state } = await startFlow(t);
 
@@ -386,7 +432,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: () =>
+      [TOKEN_ENDPOINT]: () =>
         new Response(null, {
           status: 302,
           headers: { Location: "https://elsewhere.example.com/token" },
@@ -401,15 +447,15 @@ describe("oauth callback", () => {
   });
 
   describe("id_token validation", () => {
-    /** Run a google-style flow whose token endpoint returns `idToken`. */
+    /** Run a flow whose token endpoint returns `idToken`. */
     async function callbackWithIdToken(
       t: ReturnType<typeof setup>,
       idToken: string,
       overrides: FlowOverrides = {},
     ): Promise<Response> {
       stubFetch({
-        [GOOGLE_TOKEN_ENDPOINT]: () =>
-          jsonResponse({ id_token: idToken, access_token: "at-1" }),
+        [TOKEN_ENDPOINT]: () =>
+          jsonResponse({ id_token: idToken, access_token: "access-token-1" }),
       });
       const { state } = await startFlow(t, overrides);
       return await callback(t, { state, code: "code-1" });
@@ -420,7 +466,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
-        unsignedJwt(googleClaims()),
+        unsignedJwt(idTokenClaims()),
         { issuer: undefined },
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
@@ -434,7 +480,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
-        unsignedJwt(googleClaims({ iss: "https://evil.example.com" })),
+        unsignedJwt(idTokenClaims({ iss: "https://evil.example.com" })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
         "oauth_error",
@@ -449,9 +495,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
-        unsignedJwt(
-          googleClaims({ aud: ["test-google-client-id", "other-client"] }),
-        ),
+        unsignedJwt(idTokenClaims({ aud: [CLIENT_ID, "other-client"] })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
         "oauth_error",
@@ -466,7 +510,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
-        unsignedJwt(googleClaims({ azp: "other-client" })),
+        unsignedJwt(idTokenClaims({ azp: "other-client" })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
         "oauth_error",
@@ -479,7 +523,7 @@ describe("oauth callback", () => {
       const errors = spyConsoleError();
       const response = await callbackWithIdToken(
         t,
-        unsignedJwt(googleClaims({ exp: Math.floor(Date.now() / 1000) - 60 })),
+        unsignedJwt(idTokenClaims({ exp: Math.floor(Date.now() / 1000) - 60 })),
       );
       expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
         "oauth_error",
@@ -489,41 +533,36 @@ describe("oauth callback", () => {
   });
 
   test("a failed userinfo request redirects with oauth_error", async () => {
-    const t = setup("github");
+    const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "gh-at-1" }),
-      "https://api.github.com/user": () =>
-        new Response("server error", { status: 500 }),
-      "https://api.github.com/user/emails": () => jsonResponse([]),
+      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
+      [PROFILE_ENDPOINT]: () => new Response("server error", { status: 500 }),
+      [EMAILS_ENDPOINT]: () => jsonResponse([]),
     });
     const { state } = await startFlow(t, {
-      providerName: "github",
-      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
       userInfoEndpoints: {
-        user: "https://api.github.com/user",
-        emails: "https://api.github.com/user/emails",
+        profile: PROFILE_ENDPOINT,
+        emails: EMAILS_ENDPOINT,
       },
     });
 
     const response = await callback(t, { state, code: "code-1" });
 
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
-    expect(loggedText(errors)).toContain('Userinfo request "user" failed');
+    expect(loggedText(errors)).toContain('Userinfo request "profile" failed');
   });
 
   test("userinfo endpoints without an access_token are refused", async () => {
-    const t = setup("github");
+    const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({}),
+      [TOKEN_ENDPOINT]: () => jsonResponse({}),
     });
     const { state } = await startFlow(t, {
-      providerName: "github",
-      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
       issuer: undefined,
-      userInfoEndpoints: { user: "https://api.github.com/user" },
+      userInfoEndpoints: { profile: PROFILE_ENDPOINT },
     });
 
     const response = await callback(t, { state, code: "code-1" });
@@ -538,7 +577,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "at-1" }),
+      [TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "access-token-1" }),
     });
     // No id_token comes back and no userinfo endpoints are configured.
     const { state } = await startFlow(t, { issuer: undefined });
@@ -556,7 +595,7 @@ describe("oauth callback", () => {
     const t = setup();
     const errors = spyConsoleError();
     stubFetch({
-      [GOOGLE_TOKEN_ENDPOINT]: (init) => {
+      [TOKEN_ENDPOINT]: (init) => {
         const stalled = new Promise<Response>((_resolve, reject) => {
           init.signal?.addEventListener("abort", () =>
             reject(new DOMException("The operation was aborted", "AbortError")),

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -636,4 +636,40 @@ describe("oauth callback", () => {
     expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
     expect(loggedText(errors)).toContain("aborted");
   });
+
+  test("a token endpoint that stalls mid-body is aborted", async () => {
+    // Simulates a provider that sends response headers but never sends the
+    // body. The callback must read the body while its fetch timeout is still
+    // armed. highWaterMark 0 keeps pull() from running until the body is
+    // read, so a callback that clears the timeout before reading the body
+    // hangs this test instead of passing it.
+    vi.useFakeTimers();
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [ID_TOKEN_REQUEST.tokenEndpoint]: (init) =>
+        new Response(
+          new ReadableStream(
+            {
+              start(controller) {
+                init.signal?.addEventListener("abort", () =>
+                  controller.error(
+                    new DOMException("The operation was aborted", "AbortError"),
+                  ),
+                );
+              },
+              pull() {
+                vi.advanceTimersByTime(30 * 1000);
+              },
+            },
+            { highWaterMark: 0 },
+          ),
+        ),
+    });
+    const { state } = await startFlow(t, ID_TOKEN_REQUEST);
+
+    const response = await callback(t, { state, code: "code-1" });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("aborted");
+  });
 });

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -1,0 +1,565 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { api } from "./_generated/api.js";
+import { decryptWithToken } from "./crypto.js";
+import schema from "./schema.js";
+import { sha256Hex } from "../../lib/crypto.js";
+import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token";
+const DEFAULT_REDIRECT_TO = "https://app.example.com/after";
+
+function setup() {
+  // The single mount binds each provider's client credentials.
+  vi.stubEnv("GOOGLE_CLIENT_ID", "test-google-client-id");
+  vi.stubEnv("GOOGLE_CLIENT_SECRET", "test-google-client-secret");
+  vi.stubEnv("GITHUB_CLIENT_ID", "test-github-client-id");
+  vi.stubEnv("GITHUB_CLIENT_SECRET", "test-github-client-secret");
+  return convexTest(schema, modules);
+}
+
+/** One recorded outbound request made by the callback handler. */
+type FetchCall = { url: string; init: RequestInit };
+
+/**
+ * Stub global `fetch` with an exact-URL routing table. `t.fetch` dispatches
+ * to the component's router directly without touching global `fetch`, so the
+ * stub only ever sees the handler's outbound token/userinfo requests. An
+ * unrouted URL throws, failing the test loudly.
+ */
+function stubFetch(
+  routes: Record<string, (init: RequestInit) => Response | Promise<Response>>,
+): FetchCall[] {
+  const calls: FetchCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const responder = routes[url];
+      if (responder === undefined) {
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+      calls.push({ url, init: init ?? {} });
+      return await responder(init ?? {});
+    }),
+  );
+  return calls;
+}
+
+/** A 200 response carrying `body` as JSON. */
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+/**
+ * Silence the handler's expected error logging and capture it, so failure
+ * tests can assert the specific cause behind the normalized `oauth_error`
+ * the user-visible redirect carries.
+ */
+function spyConsoleError() {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+/** Everything a spied `console.error` logged, flattened to one string. */
+function loggedText(spy: ReturnType<typeof spyConsoleError>): string {
+  return spy.mock.calls.flat().map(String).join("\n");
+}
+
+function base64UrlEncode(value: string): string {
+  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * A structurally valid JWT with an unverifiable signature. The callback
+ * deliberately skips signature verification (the token arrives from the
+ * provider's token endpoint over TLS), so this exercises every claim check.
+ */
+function unsignedJwt(claims: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "none" }));
+  const payload = base64UrlEncode(JSON.stringify(claims));
+  return `${header}.${payload}.signature`;
+}
+
+/** Valid google-style id_token claims, overridable per test. */
+function googleClaims(overrides: Record<string, unknown> = {}) {
+  return {
+    iss: "https://accounts.google.com",
+    aud: "test-google-client-id",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    sub: "google-sub-1",
+    email: "ada@example.com",
+    email_verified: true,
+    ...overrides,
+  };
+}
+
+type FlowOverrides = Partial<{
+  providerName: string;
+  redirectTo: string;
+  callbackUrl: string;
+  codeVerifier: string;
+  tokenEndpoint: string;
+  userInfoEndpoints: Record<string, string>;
+  issuer: string | undefined;
+}>;
+
+/**
+ * Record an authorization request the way the app-side `startSignIn` would,
+ * returning the raw `state` the provider echoes back to the callback plus
+ * its hash (which binds redemption to the initiating client). Defaults model
+ * the google catalog; override for github-style (userinfo) flows.
+ */
+async function startFlow(
+  t: ReturnType<typeof setup>,
+  overrides: FlowOverrides = {},
+) {
+  const state = "state-raw-1";
+  const stateHash = await sha256Hex(state);
+  const args = {
+    providerName: "google",
+    stateHash,
+    redirectTo: DEFAULT_REDIRECT_TO,
+    callbackUrl: "https://test.convex.site/oauth/google/callback",
+    tokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
+    issuer: "https://accounts.google.com" as string | undefined,
+    ...overrides,
+  };
+  await t.mutation(
+    api.provider.createAuthorizationRequest,
+    // An optional arg must be absent, not `undefined` (not a Convex value).
+    Object.fromEntries(
+      Object.entries(args).filter(([, value]) => value !== undefined),
+    ) as typeof args,
+  );
+  return { state, stateHash };
+}
+
+/** GET the provider's callback route the way the identity provider redirect would. */
+function callback(
+  t: ReturnType<typeof setup>,
+  provider: string,
+  params: Record<string, string>,
+): Promise<Response> {
+  return t.fetch(`/${provider}/callback?${new URLSearchParams(params)}`);
+}
+
+/**
+ * Assert `response` is a 302 back to `redirectTo` (ignoring query, which the
+ * handler rewrites) and return the Location's params for outcome assertions.
+ */
+function redirectParams(
+  response: Response,
+  redirectTo = DEFAULT_REDIRECT_TO,
+): URLSearchParams {
+  expect(response.status).toBe(302);
+  const location = new URL(response.headers.get("Location")!);
+  const expected = new URL(redirectTo);
+  expect(`${location.origin}${location.pathname}`).toBe(
+    `${expected.origin}${expected.pathname}`,
+  );
+  return location.searchParams;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("oauth callback", () => {
+  test("a request without state gets a bare 400", async () => {
+    const t = setup();
+    const response = await t.fetch("/google/callback");
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("This sign-in link is invalid");
+  });
+
+  test("an unknown state gets a 400: the flow is gone entirely", async () => {
+    const t = setup();
+    const response = await callback(t, "google", {
+      state: "never-issued",
+      code: "code-1",
+    });
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("expired or was already used");
+  });
+
+  test("an expired request redirects back to the app with expired", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    const { state } = await startFlow(t);
+    vi.advanceTimersByTime(11 * 60 * 1000);
+    const response = await callback(t, "google", { state, code: "code-1" });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("expired");
+  });
+
+  test("a request claimed via the wrong provider's route is refused before any exchange", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    const calls = stubFetch({});
+    const { state } = await startFlow(t); // a google flow...
+    const response = await callback(t, "github", { state, code: "code-1" }); // ...on the github route
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("provider mismatch");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a provider error of access_denied passes through normalized", async () => {
+    const t = setup();
+    spyConsoleError();
+    const { state } = await startFlow(t);
+    const response = await callback(t, "google", {
+      state,
+      error: "access_denied",
+    });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+      "access_denied",
+    );
+  });
+
+  test("any other provider error normalizes to oauth_error", async () => {
+    const t = setup();
+    spyConsoleError();
+    const { state } = await startFlow(t);
+    const response = await callback(t, "google", {
+      state,
+      error: "temporarily_unavailable",
+    });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+  });
+
+  test("a callback with neither code nor error normalizes to oauth_error", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    const { state } = await startFlow(t);
+    const response = await callback(t, "google", { state });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("missing code");
+  });
+
+  test("an id_token flow exchanges the code and mints a redeemable ticket", async () => {
+    const t = setup();
+    const claims = googleClaims();
+    const calls = stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: () =>
+        jsonResponse({ id_token: unsignedJwt(claims), access_token: "at-1" }),
+    });
+    const { state, stateHash } = await startFlow(t, {
+      codeVerifier: "verifier-1",
+    });
+
+    const response = await callback(t, "google", {
+      state,
+      code: "auth-code-1",
+    });
+
+    // The token exchange POST carries the snapshotted exchange config.
+    expect(calls).toHaveLength(1);
+    const body = calls[0].init.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("auth-code-1");
+    expect(body.get("client_id")).toBe("test-google-client-id");
+    expect(body.get("client_secret")).toBe("test-google-client-secret");
+    expect(body.get("redirect_uri")).toBe(
+      "https://test.convex.site/oauth/google/callback",
+    );
+    expect(body.get("code_verifier")).toBe("verifier-1");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Accept).toBe("application/json");
+
+    // The redirect carries a one-time token that redeems (with the flow's
+    // state) into the encrypted identity payload — the full contract the
+    // app-side completeSignIn depends on.
+    const ott = redirectParams(response).get(OAUTH_CODE_PARAM)!;
+    expect(ott).toEqual(expect.any(String));
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "google",
+      ottHash: await sha256Hex(ott),
+      stateHash,
+    });
+    expect(claimed).not.toBeNull();
+    const payload = JSON.parse(await decryptWithToken(ott, claimed!.payload));
+    expect(payload).toEqual({ claims });
+  });
+
+  test("a userinfo flow fetches each endpoint with the access token", async () => {
+    const t = setup();
+    const user = { id: 42, login: "octocat" };
+    const emails = [
+      { email: "ada@example.com", primary: true, verified: true },
+    ];
+    const calls = stubFetch({
+      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "gh-at-1" }),
+      "https://api.github.com/user": () => jsonResponse(user),
+      "https://api.github.com/user/emails": () => jsonResponse(emails),
+    });
+    const { state, stateHash } = await startFlow(t, {
+      providerName: "github",
+      callbackUrl: "https://test.convex.site/oauth/github/callback",
+      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
+      issuer: undefined,
+      userInfoEndpoints: {
+        user: "https://api.github.com/user",
+        emails: "https://api.github.com/user/emails",
+      },
+    });
+
+    const response = await callback(t, "github", {
+      state,
+      code: "auth-code-2",
+    });
+
+    const userCall = calls.find((c) => c.url === "https://api.github.com/user");
+    const headers = userCall!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer gh-at-1");
+    expect(headers["User-Agent"]).toBe("convex-auth");
+
+    const ott = redirectParams(response).get(OAUTH_CODE_PARAM)!;
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "github",
+      ottHash: await sha256Hex(ott),
+      stateHash,
+    });
+    const payload = JSON.parse(await decryptWithToken(ott, claimed!.payload));
+    expect(payload).toEqual({ userInfoResponses: { user, emails } });
+  });
+
+  test("stale outcome params on redirectTo are replaced, app params kept", async () => {
+    const t = setup();
+    const redirectTo = `${DEFAULT_REDIRECT_TO}?${OAUTH_ERROR_PARAM}=expired&tab=settings`;
+    stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: () =>
+        jsonResponse({ id_token: unsignedJwt(googleClaims()) }),
+    });
+    const { state } = await startFlow(t, { redirectTo });
+
+    const response = await callback(t, "google", { state, code: "code-1" });
+
+    const params = redirectParams(response, redirectTo);
+    expect(params.get(OAUTH_ERROR_PARAM)).toBeNull();
+    expect(params.get(OAUTH_CODE_PARAM)).toEqual(expect.any(String));
+    expect(params.get("tab")).toBe("settings");
+  });
+
+  test("a failed token exchange redirects with oauth_error and mints no ticket", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: () =>
+        new Response("bad request", { status: 400 }),
+    });
+    const { state } = await startFlow(t);
+
+    const response = await callback(t, "google", { state, code: "code-1" });
+
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("Token exchange failed with 400");
+    await t.run(async (ctx) => {
+      expect(await ctx.db.query("tickets").collect()).toHaveLength(0);
+    });
+  });
+
+  test("a token endpoint that redirects is refused", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://elsewhere.example.com/token" },
+        }),
+    });
+    const { state } = await startFlow(t);
+
+    const response = await callback(t, "google", { state, code: "code-1" });
+
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("responded with a redirect");
+  });
+
+  describe("id_token validation", () => {
+    /** Run a google-style flow whose token endpoint returns `idToken`. */
+    async function callbackWithIdToken(
+      t: ReturnType<typeof setup>,
+      idToken: string,
+      overrides: FlowOverrides = {},
+    ): Promise<Response> {
+      stubFetch({
+        [GOOGLE_TOKEN_ENDPOINT]: () =>
+          jsonResponse({ id_token: idToken, access_token: "at-1" }),
+      });
+      const { state } = await startFlow(t, overrides);
+      return await callback(t, "google", { state, code: "code-1" });
+    }
+
+    test("an id_token with no configured issuer is refused", async () => {
+      const t = setup();
+      const errors = spyConsoleError();
+      const response = await callbackWithIdToken(
+        t,
+        unsignedJwt(googleClaims()),
+        { issuer: undefined },
+      );
+      expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+        "oauth_error",
+      );
+      expect(loggedText(errors)).toContain("no issuer is configured");
+    });
+
+    test("an issuer mismatch is refused", async () => {
+      const t = setup();
+      const errors = spyConsoleError();
+      const response = await callbackWithIdToken(
+        t,
+        unsignedJwt(googleClaims({ iss: "https://evil.example.com" })),
+      );
+      expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+        "oauth_error",
+      );
+      expect(loggedText(errors)).toContain(
+        "issuer does not match the configured issuer",
+      );
+    });
+
+    test("a multi-audience token is refused even when it includes CLIENT_ID", async () => {
+      const t = setup();
+      const errors = spyConsoleError();
+      const response = await callbackWithIdToken(
+        t,
+        unsignedJwt(
+          googleClaims({ aud: ["test-google-client-id", "other-client"] }),
+        ),
+      );
+      expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+        "oauth_error",
+      );
+      expect(loggedText(errors)).toContain(
+        "audience must be exactly CLIENT_ID",
+      );
+    });
+
+    test("an azp for another party is refused", async () => {
+      const t = setup();
+      const errors = spyConsoleError();
+      const response = await callbackWithIdToken(
+        t,
+        unsignedJwt(googleClaims({ azp: "other-client" })),
+      );
+      expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+        "oauth_error",
+      );
+      expect(loggedText(errors)).toContain("authorized party does not match");
+    });
+
+    test("an expired id_token is refused", async () => {
+      const t = setup();
+      const errors = spyConsoleError();
+      const response = await callbackWithIdToken(
+        t,
+        unsignedJwt(googleClaims({ exp: Math.floor(Date.now() / 1000) - 60 })),
+      );
+      expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe(
+        "oauth_error",
+      );
+      expect(loggedText(errors)).toContain("id_token is expired");
+    });
+  });
+
+  test("a failed userinfo request redirects with oauth_error", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "gh-at-1" }),
+      "https://api.github.com/user": () =>
+        new Response("server error", { status: 500 }),
+      "https://api.github.com/user/emails": () => jsonResponse([]),
+    });
+    const { state } = await startFlow(t, {
+      providerName: "github",
+      callbackUrl: "https://test.convex.site/oauth/github/callback",
+      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
+      issuer: undefined,
+      userInfoEndpoints: {
+        user: "https://api.github.com/user",
+        emails: "https://api.github.com/user/emails",
+      },
+    });
+
+    const response = await callback(t, "github", { state, code: "code-1" });
+
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain('Userinfo request "user" failed');
+  });
+
+  test("userinfo endpoints without an access_token are refused", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GITHUB_TOKEN_ENDPOINT]: () => jsonResponse({}),
+    });
+    const { state } = await startFlow(t, {
+      providerName: "github",
+      callbackUrl: "https://test.convex.site/oauth/github/callback",
+      tokenEndpoint: GITHUB_TOKEN_ENDPOINT,
+      issuer: undefined,
+      userInfoEndpoints: { user: "https://api.github.com/user" },
+    });
+
+    const response = await callback(t, "github", { state, code: "code-1" });
+
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain(
+      "Token exchange returned no access_token",
+    );
+  });
+
+  test("a response with nothing to identify the user is refused", async () => {
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: () => jsonResponse({ access_token: "at-1" }),
+    });
+    // No id_token comes back and no userinfo endpoints are configured.
+    const { state } = await startFlow(t, { issuer: undefined });
+
+    const response = await callback(t, "google", { state, code: "code-1" });
+
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain(
+      "no id_token and no userInfoEndpoints",
+    );
+  });
+
+  test("a token endpoint that stalls past the timeout is aborted", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    const errors = spyConsoleError();
+    stubFetch({
+      [GOOGLE_TOKEN_ENDPOINT]: (init) => {
+        const stalled = new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted", "AbortError")),
+          );
+        });
+        // The handler arms its timeout before calling fetch, so the timer is
+        // live here; advancing past it fires the abort.
+        vi.advanceTimersByTime(30 * 1000);
+        return stalled;
+      },
+    });
+    const { state } = await startFlow(t);
+
+    const response = await callback(t, "google", { state, code: "code-1" });
+    expect(redirectParams(response).get(OAUTH_ERROR_PARAM)).toBe("oauth_error");
+    expect(loggedText(errors)).toContain("aborted");
+  });
+});

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -1,0 +1,357 @@
+import { GenericActionCtx, GenericDataModel, httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { CALLBACK_PATH } from "./constants";
+import { getCredentials, SUPPORTED_PROVIDERS } from "./credentials";
+import {
+  decodeJwtPayloadUnverified,
+  encryptWithToken,
+  generateRandomToken,
+} from "./crypto";
+import { sha256Hex } from "../../lib/crypto";
+import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams";
+
+// The component is mounted once (`app.use(oauth, { httpPrefix: "/oauth", ... })`)
+// and serves one callback per supported provider under
+// <prefix>/<provider>/callback — the redirect URI registered with that identity provider.
+const http = httpRouter();
+
+/** Outbound requests fail after this instead of pinning the callback to the platform limit. */
+const FETCH_TIMEOUT_MS = 30 * 1000;
+
+/** A 302 redirect response. */
+function redirect(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { Location: location },
+  });
+}
+
+/**
+ * 302 back to the app's `redirectTo` with outcome params. Stale outcome params
+ * from a previous attempt are removed first, so a `redirectTo` derived from the
+ * app's current URL can't carry a contradictory outcome. The params are
+ * namespaced ({@link OAUTH_CODE_PARAM}/{@link OAUTH_ERROR_PARAM}) so the app's
+ * always-on client callback handler can tell this redirect apart from an
+ * unrelated `?code=`/`?error=` the app uses for its own purposes.
+ */
+function redirectToApp(
+  redirectTo: string,
+  params: Record<string, string>,
+): Response {
+  const url = new URL(redirectTo);
+  url.searchParams.delete(OAUTH_CODE_PARAM);
+  url.searchParams.delete(OAUTH_ERROR_PARAM);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return redirect(url.toString());
+}
+
+/**
+ * Fetch that enforces a timeout and treats any HTTP redirect as an error.
+ * Token and userinfo endpoints never legitimately redirect; following one
+ * could forward credentials to an unintended host. The body is consumed
+ * while the timeout is still armed, so an endpoint that stalls before or
+ * after sending headers becomes a normal failure that redirects the user
+ * back to the app instead of pinning the callback until the platform limit.
+ */
+async function fetchRefusingRedirects(
+  url: string,
+  init: RequestInit,
+): Promise<{ ok: boolean; status: number; bodyText: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      throw new Error(`Request to ${url} responded with a redirect`);
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      bodyText: await response.text(),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Exchange an authorization code for tokens at the provider's token
+ * endpoint. Client credentials are sent in the POST body — empirically the
+ * most compatible style (HTTP Basic has a form-urlencoding ambiguity many
+ * providers get wrong).
+ */
+async function exchangeCode(args: {
+  tokenEndpoint: string;
+  code: string;
+  callbackUrl: string;
+  codeVerifier: string | undefined;
+  clientId: string;
+  clientSecret: string;
+}): Promise<{ idToken: string | undefined; accessToken: string | undefined }> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    // Must byte-match the redirect_uri from the authorization request, so
+    // it comes off the request row rather than being rebuilt here.
+    redirect_uri: args.callbackUrl,
+  });
+  if (args.codeVerifier !== undefined) {
+    body.set("code_verifier", args.codeVerifier);
+  }
+  const response = await fetchRefusingRedirects(args.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      // GitHub's token endpoint returns form-encoded output without this.
+      Accept: "application/json",
+    },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Token exchange failed with ${response.status}: ${response.bodyText}`,
+    );
+  }
+  const tokens = JSON.parse(response.bodyText) as Record<string, unknown>;
+  return {
+    idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
+    accessToken:
+      typeof tokens.access_token === "string" ? tokens.access_token : undefined,
+  };
+}
+
+/**
+ * Decode an id_token and check its claims:
+ *
+ * - `iss` must match the configured `issuer`, which is required whenever an
+ *   id_token comes back: `sub` is only unique within an issuer, and a shared
+ *   or multi-tenant token endpoint can serve several.
+ * - `aud` must be exactly CLIENT_ID. Multi-audience tokens are rejected
+ *   because no other audience is trusted.
+ * - `azp`, when present, must be CLIENT_ID.
+ * - `exp` must be in the future.
+ *
+ * Signature verification is deliberately skipped: the token came directly
+ * from the provider's token endpoint over TLS, which OIDC Core sanctions in
+ * place of checking the signature.
+ */
+function validateIdToken(
+  idToken: string,
+  expectedIssuer: string | undefined,
+  clientId: string,
+): Record<string, unknown> {
+  if (expectedIssuer === undefined) {
+    throw new Error(
+      "The provider returned an id_token but no issuer is configured; set `issuer` in the provider options so the token can be validated",
+    );
+  }
+  const claims = decodeJwtPayloadUnverified(idToken);
+  if (claims.iss !== expectedIssuer) {
+    throw new Error("id_token issuer does not match the configured issuer");
+  }
+  const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+  if (audiences.length !== 1 || audiences[0] !== clientId) {
+    throw new Error("id_token audience must be exactly CLIENT_ID");
+  }
+  if (claims.azp !== undefined && claims.azp !== clientId) {
+    throw new Error("id_token authorized party does not match CLIENT_ID");
+  }
+  if (typeof claims.exp !== "number" || claims.exp * 1000 < Date.now()) {
+    throw new Error("id_token is expired");
+  }
+  return claims;
+}
+
+/**
+ * Fetch each configured userinfo endpoint with the access token. All
+ * popular providers accept the same shape — GET with a bearer token — with
+ * provider variation living in the endpoint URL's query params.
+ */
+async function fetchUserInfo(
+  endpoints: Record<string, string>,
+  accessToken: string,
+): Promise<Record<string, unknown>> {
+  const responses = await Promise.all(
+    Object.entries(endpoints).map(async ([key, endpoint]) => {
+      const response = await fetchRefusingRedirects(endpoint, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json",
+          // GitHub's API rejects requests without a User-Agent.
+          "User-Agent": "convex-auth",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Userinfo request "${key}" failed with ${response.status}: ${response.bodyText}`,
+        );
+      }
+      return [key, JSON.parse(response.bodyText) as unknown] as const;
+    }),
+  );
+  return Object.fromEntries(responses);
+}
+
+/**
+ * Handle a provider callback. `pathProvider` is the provider whose route served
+ * this request (`/google/callback` → `"google"`); it must match the provider
+ * the claimed authorization request was issued for, or the flow is treated as a
+ * mix-up and sent back to the app as a normalized error.
+ */
+async function handleCallback(
+  ctx: GenericActionCtx<GenericDataModel>,
+  request: Request,
+  pathProvider: string,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const state = url.searchParams.get("state");
+  const code = url.searchParams.get("code");
+  const error = url.searchParams.get("error");
+
+  // Without state we can't identify the flow, so there's no stored
+  // redirectTo to send the user back to; a bare 400 is all we have.
+  if (state === null) {
+    return new Response(
+      "This sign-in link is invalid. Return to the app and try signing in again.",
+      { status: 400 },
+    );
+  }
+
+  // Claiming is atomic (find + delete in one mutation), so a replayed or
+  // raced callback finds nothing. Possession of the provider-echoed state
+  // is the only check here; binding to the initiating client happens at
+  // redemption.
+  const authRequest = await ctx.runMutation(
+    internal.provider.claimAuthorizationRequest,
+    { stateHash: await sha256Hex(state) },
+  );
+  // No row means the flow is gone entirely (already claimed, or forged);
+  // there is nowhere left to redirect to.
+  if (authRequest === null) {
+    return new Response(
+      "This sign-in link has expired or was already used. Return to the app and try signing in again.",
+      { status: 400 },
+    );
+  }
+  // An expired request still knows where the user came from; send them
+  // back to the app instead of stranding them here.
+  if (authRequest.expired) {
+    return redirectToApp(authRequest.redirectTo, {
+      [OAUTH_ERROR_PARAM]: "expired",
+    });
+  }
+
+  // The route that served this callback must match the provider the request
+  // was issued for. A mismatch means the redirect URI registered with an identity provider
+  // points at the wrong provider's route (or a forged flow); don't run the
+  // exchange under the wrong credentials.
+  if (authRequest.providerName !== pathProvider) {
+    console.error(
+      `OAuth callback provider mismatch: "${pathProvider}" route served a "${authRequest.providerName}" request`,
+    );
+    return redirectToApp(authRequest.redirectTo, {
+      [OAUTH_ERROR_PARAM]: "oauth_error",
+    });
+  }
+
+  // From here on the flow is legitimate, so failures go back to the app
+  // as a normalized error param; raw detail goes to logs only.
+  if (error !== null || code === null) {
+    console.error(
+      `OAuth callback error from provider "${authRequest.providerName}":`,
+      error ?? "missing code",
+      url.searchParams.get("error_description") ?? "",
+    );
+    const normalized =
+      error === "access_denied" ? "access_denied" : "oauth_error";
+    return redirectToApp(authRequest.redirectTo, {
+      [OAUTH_ERROR_PARAM]: normalized,
+    });
+  }
+
+  try {
+    const { clientId, clientSecret } = getCredentials(authRequest.providerName);
+    const { idToken, accessToken } = await exchangeCode({
+      tokenEndpoint: authRequest.tokenEndpoint,
+      code,
+      callbackUrl: authRequest.callbackUrl,
+      codeVerifier: authRequest.codeVerifier,
+      clientId,
+      clientSecret,
+    });
+
+    const claims =
+      idToken === undefined
+        ? undefined
+        : validateIdToken(idToken, authRequest.issuer, clientId);
+
+    if (
+      authRequest.userInfoEndpoints !== undefined &&
+      accessToken === undefined
+    ) {
+      throw new Error("Token exchange returned no access_token");
+    }
+    const userInfoResponses =
+      authRequest.userInfoEndpoints === undefined || accessToken === undefined
+        ? undefined
+        : await fetchUserInfo(authRequest.userInfoEndpoints, accessToken);
+
+    // A provider that returns no id_token and has no configured userinfo
+    // endpoints gives us nothing to identify the user with.
+    if (claims === undefined && userInfoResponses === undefined) {
+      throw new Error(
+        "Token exchange returned no id_token and no userInfoEndpoints are configured",
+      );
+    }
+
+    // Nothing user-visible exists yet; the ticket is a short-lived,
+    // one-time proof that provider authentication succeeded. Only the
+    // hash of the one-time token is stored, and the identity payload is
+    // encrypted with a key derived from the raw token, so database access
+    // alone can read neither.
+    const ott = generateRandomToken();
+    await ctx.runMutation(internal.provider.createTicket, {
+      providerName: authRequest.providerName,
+      stateHash: authRequest.stateHash,
+      ottHash: await sha256Hex(ott),
+      payload: await encryptWithToken(
+        ott,
+        JSON.stringify({ claims, userInfoResponses }),
+      ),
+    });
+
+    return redirectToApp(authRequest.redirectTo, { [OAUTH_CODE_PARAM]: ott });
+  } catch (exchangeError) {
+    console.error(
+      `OAuth exchange failed for provider "${authRequest.providerName}":`,
+      exchangeError,
+    );
+    return redirectToApp(authRequest.redirectTo, {
+      [OAUTH_ERROR_PARAM]: "oauth_error",
+    });
+  }
+}
+
+// One callback route per supported provider, under <mount prefix>/<provider>.
+// The provider name is captured from the route so the handler can match it
+// against the claimed request and select that provider's credentials.
+for (const provider of SUPPORTED_PROVIDERS) {
+  http.route({
+    path: `/${provider}${CALLBACK_PATH}`,
+    method: "GET",
+    handler: httpAction((ctx, request) =>
+      handleCallback(ctx, request, provider),
+    ),
+  });
+}
+
+export default http;

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -4,7 +4,7 @@ import { internal } from "./_generated/api";
 import { CALLBACK_PATH } from "./constants";
 import {
   decodeJwtPayloadUnverified,
-  encryptWithToken,
+  encryptTicketPayload,
   generateRandomToken,
 } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
@@ -49,17 +49,22 @@ function redirectToApp(
 }
 
 /**
- * Fetch that enforces a timeout and treats any HTTP redirect as an error.
- * Token and userinfo endpoints never legitimately redirect; following one
- * could forward credentials to an unintended host. The body is consumed
- * while the timeout is still armed, so an endpoint that stalls before or
- * after sending headers becomes a normal failure that redirects the user
- * back to the app instead of pinning the callback until the platform limit.
+ * Fetch that requires https, enforces a timeout, and treats any HTTP
+ * redirect as an error. Token and userinfo endpoints never legitimately
+ * redirect; following one could forward credentials to an unintended host,
+ * and a non-https endpoint would expose them in transit. The body is
+ * consumed while the timeout is still armed, so an endpoint that stalls
+ * before or after sending headers becomes a normal failure that redirects
+ * the user back to the app instead of pinning the callback until the
+ * platform limit.
  */
 async function fetchRefusingRedirects(
   url: string,
   init: RequestInit,
 ): Promise<{ ok: boolean; status: number; bodyText: string }> {
+  if (new URL(url).protocol !== "https:") {
+    throw new Error(`Refusing non-https request to ${url}`);
+  }
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -235,6 +240,9 @@ async function handleCallback(
   // No row means the flow is gone entirely (already claimed, or forged);
   // there is nowhere left to redirect to.
   if (authRequest === null) {
+    console.warn(
+      `OAuth callback at "${url.pathname}": unknown or already-used state`,
+    );
     return new Response(
       "This sign-in link has expired or was already used. Return to the app and try signing in again.",
       { status: 400 },
@@ -243,6 +251,9 @@ async function handleCallback(
   // An expired request still knows where the user came from; send them
   // back to the app instead of stranding them here.
   if (authRequest.expired) {
+    console.warn(
+      `OAuth callback at "${url.pathname}": expired authorization request`,
+    );
     return redirectToApp(authRequest.redirectTo, {
       [OAUTH_ERROR_PARAM]: "expired",
     });
@@ -307,7 +318,7 @@ async function handleCallback(
       providerName: authRequest.providerName,
       stateHash: authRequest.stateHash,
       ottHash: await sha256Hex(ott),
-      payload: await encryptWithToken(
+      payload: await encryptTicketPayload(
         ott,
         JSON.stringify({ claims, userInfoResponses }),
       ),

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -310,21 +310,23 @@ async function handleCallback(
 
     // Nothing user-visible exists yet; the ticket is a short-lived,
     // one-time proof that provider authentication succeeded. Only the
-    // hash of the one-time token is stored, and the identity payload is
-    // encrypted with a key derived from the raw token, so database access
+    // hash of the ticket code is stored, and the identity payload is
+    // encrypted with a key derived from the raw code, so database access
     // alone can read neither.
-    const ott = generateRandomToken();
+    const ticketCode = generateRandomToken();
     await ctx.runMutation(internal.provider.createTicket, {
       providerName: authRequest.providerName,
       stateHash: authRequest.stateHash,
-      ottHash: await sha256Hex(ott),
+      ticketCodeHash: await sha256Hex(ticketCode),
       payload: await encryptTicketPayload(
-        ott,
+        ticketCode,
         JSON.stringify({ claims, userInfoResponses }),
       ),
     });
 
-    return redirectToApp(authRequest.redirectTo, { [OAUTH_CODE_PARAM]: ott });
+    return redirectToApp(authRequest.redirectTo, {
+      [OAUTH_CODE_PARAM]: ticketCode,
+    });
   } catch (exchangeError) {
     console.error(
       `OAuth exchange failed for provider "${authRequest.providerName}":`,

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -10,16 +10,10 @@ import {
 import { sha256Hex } from "../../lib/crypto";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams";
 
-// Each per-provider mount (`app.use(oauth, { name: "oauthGoogle",
-// httpPrefix: "/oauth/google", ... })`) serves one callback at
-// <prefix>/callback — the redirect URI registered with that identity
-// provider.
 const http = httpRouter();
 
-/** Outbound requests fail after this instead of pinning the callback to the platform limit. */
 const FETCH_TIMEOUT_MS = 30 * 1000;
 
-/** A 302 redirect response. */
 function redirect(location: string): Response {
   return new Response(null, {
     status: 302,
@@ -30,10 +24,7 @@ function redirect(location: string): Response {
 /**
  * 302 back to the app's `redirectTo` with outcome params. Stale outcome params
  * from a previous attempt are removed first, so a `redirectTo` derived from the
- * app's current URL can't carry a contradictory outcome. The params are
- * namespaced ({@link OAUTH_CODE_PARAM}/{@link OAUTH_ERROR_PARAM}) so the app's
- * always-on client callback handler can tell this redirect apart from an
- * unrelated `?code=`/`?error=` the app uses for its own purposes.
+ * app's current URL can't carry a contradictory outcome.
  */
 function redirectToApp(
   redirectTo: string,
@@ -52,11 +43,7 @@ function redirectToApp(
  * Fetch that requires https, enforces a timeout, and treats any HTTP
  * redirect as an error. Token and userinfo endpoints never legitimately
  * redirect; following one could forward credentials to an unintended host,
- * and a non-https endpoint would expose them in transit. The body is
- * consumed while the timeout is still armed, so an endpoint that stalls
- * before or after sending headers becomes a normal failure that redirects
- * the user back to the app instead of pinning the callback until the
- * platform limit.
+ * and a non-https endpoint would expose them in transit.
  */
 async function fetchRefusingRedirects(
   url: string,
@@ -88,9 +75,8 @@ async function fetchRefusingRedirects(
 
 /**
  * Exchange an authorization code for tokens at the provider's token
- * endpoint. Client credentials are sent in the POST body — empirically the
- * most compatible style (HTTP Basic has a form-urlencoding ambiguity many
- * providers get wrong).
+ * endpoint. Credentials go in the POST body because HTTP Basic has a
+ * form-urlencoding ambiguity many providers get wrong.
  */
 async function exchangeCode(args: {
   tokenEndpoint: string;
@@ -177,9 +163,7 @@ function validateIdToken(
 }
 
 /**
- * Fetch each configured userinfo endpoint with the access token. All
- * popular providers accept the same shape — GET with a bearer token — with
- * provider variation living in the endpoint URL's query params.
+ * Fetch each configured userinfo endpoint with the access token.
  */
 async function fetchUserInfo(
   endpoints: Record<string, string>,
@@ -207,9 +191,7 @@ async function fetchUserInfo(
 }
 
 /**
- * Handle the provider callback. The mount serves exactly one provider, so
- * any claimed authorization request was issued by this instance for the
- * mount's provider; there's no cross-provider routing to check.
+ * Handle the provider callback.
  */
 async function handleCallback(
   ctx: GenericActionCtx<GenericDataModel>,
@@ -338,8 +320,6 @@ async function handleCallback(
   }
 }
 
-// The mount's single callback route; the instance's credentials come from
-// its env bindings.
 http.route({
   path: CALLBACK_PATH,
   method: "GET",

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -1,8 +1,7 @@
 import { GenericActionCtx, GenericDataModel, httpRouter } from "convex/server";
-import { httpAction } from "./_generated/server";
+import { env, httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { CALLBACK_PATH } from "./constants";
-import { getCredentials, SUPPORTED_PROVIDERS } from "./credentials";
 import {
   decodeJwtPayloadUnverified,
   encryptWithToken,
@@ -11,9 +10,10 @@ import {
 import { sha256Hex } from "../../lib/crypto";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams";
 
-// The component is mounted once (`app.use(oauth, { httpPrefix: "/oauth", ... })`)
-// and serves one callback per supported provider under
-// <prefix>/<provider>/callback — the redirect URI registered with that identity provider.
+// Each per-provider mount (`app.use(oauth, { name: "oauthGoogle",
+// httpPrefix: "/oauth/google", ... })`) serves one callback at
+// <prefix>/callback — the redirect URI registered with that identity
+// provider.
 const http = httpRouter();
 
 /** Outbound requests fail after this instead of pinning the callback to the platform limit. */
@@ -202,15 +202,13 @@ async function fetchUserInfo(
 }
 
 /**
- * Handle a provider callback. `pathProvider` is the provider whose route served
- * this request (`/google/callback` → `"google"`); it must match the provider
- * the claimed authorization request was issued for, or the flow is treated as a
- * mix-up and sent back to the app as a normalized error.
+ * Handle the provider callback. The mount serves exactly one provider, so
+ * any claimed authorization request was issued by this instance for the
+ * mount's provider; there's no cross-provider routing to check.
  */
 async function handleCallback(
   ctx: GenericActionCtx<GenericDataModel>,
   request: Request,
-  pathProvider: string,
 ): Promise<Response> {
   const url = new URL(request.url);
   const state = url.searchParams.get("state");
@@ -250,19 +248,6 @@ async function handleCallback(
     });
   }
 
-  // The route that served this callback must match the provider the request
-  // was issued for. A mismatch means the redirect URI registered with an identity provider
-  // points at the wrong provider's route (or a forged flow); don't run the
-  // exchange under the wrong credentials.
-  if (authRequest.providerName !== pathProvider) {
-    console.error(
-      `OAuth callback provider mismatch: "${pathProvider}" route served a "${authRequest.providerName}" request`,
-    );
-    return redirectToApp(authRequest.redirectTo, {
-      [OAUTH_ERROR_PARAM]: "oauth_error",
-    });
-  }
-
   // From here on the flow is legitimate, so failures go back to the app
   // as a normalized error param; raw detail goes to logs only.
   if (error !== null || code === null) {
@@ -279,20 +264,19 @@ async function handleCallback(
   }
 
   try {
-    const { clientId, clientSecret } = getCredentials(authRequest.providerName);
     const { idToken, accessToken } = await exchangeCode({
       tokenEndpoint: authRequest.tokenEndpoint,
       code,
       callbackUrl: authRequest.callbackUrl,
       codeVerifier: authRequest.codeVerifier,
-      clientId,
-      clientSecret,
+      clientId: env.CLIENT_ID,
+      clientSecret: env.CLIENT_SECRET,
     });
 
     const claims =
       idToken === undefined
         ? undefined
-        : validateIdToken(idToken, authRequest.issuer, clientId);
+        : validateIdToken(idToken, authRequest.issuer, env.CLIENT_ID);
 
     if (
       authRequest.userInfoEndpoints !== undefined &&
@@ -341,17 +325,12 @@ async function handleCallback(
   }
 }
 
-// One callback route per supported provider, under <mount prefix>/<provider>.
-// The provider name is captured from the route so the handler can match it
-// against the claimed request and select that provider's credentials.
-for (const provider of SUPPORTED_PROVIDERS) {
-  http.route({
-    path: `/${provider}${CALLBACK_PATH}`,
-    method: "GET",
-    handler: httpAction((ctx, request) =>
-      handleCallback(ctx, request, provider),
-    ),
-  });
-}
+// The mount's single callback route; the instance's credentials come from
+// its env bindings.
+http.route({
+  path: CALLBACK_PATH,
+  method: "GET",
+  handler: httpAction(handleCallback),
+});
 
 export default http;

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -6,13 +6,14 @@ import {
   decodeJwtPayloadUnverified,
   encryptTicketPayload,
   generateRandomToken,
+  type IssuerDeliveredJwt,
 } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../../lib/oauthParams";
 
 const http = httpRouter();
 
-const FETCH_TIMEOUT_MS = 30 * 1000;
+const FETCH_TIMEOUT_MS = 10 * 1000;
 
 function redirect(location: string): Response {
   return new Response(null, {
@@ -85,7 +86,10 @@ async function exchangeCode(args: {
   codeVerifier: string | undefined;
   clientId: string;
   clientSecret: string;
-}): Promise<{ idToken: string | undefined; accessToken: string | undefined }> {
+}): Promise<{
+  idToken: IssuerDeliveredJwt | undefined;
+  accessToken: string | undefined;
+}> {
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code: args.code,
@@ -114,7 +118,11 @@ async function exchangeCode(args: {
   }
   const tokens = JSON.parse(response.bodyText) as Record<string, unknown>;
   return {
-    idToken: typeof tokens.id_token === "string" ? tokens.id_token : undefined,
+    // Straight off the issuer's TLS response, which is what the brand attests.
+    idToken:
+      typeof tokens.id_token === "string"
+        ? (tokens.id_token as IssuerDeliveredJwt)
+        : undefined,
     accessToken:
       typeof tokens.access_token === "string" ? tokens.access_token : undefined,
   };
@@ -136,7 +144,7 @@ async function exchangeCode(args: {
  * place of checking the signature.
  */
 function validateIdToken(
-  idToken: string,
+  idToken: IssuerDeliveredJwt,
   expectedIssuer: string | undefined,
   clientId: string,
 ): Record<string, unknown> {

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -300,7 +300,7 @@ async function handleCallback(
       providerName: authRequest.providerName,
       stateHash: authRequest.stateHash,
       ticketCodeHash: await sha256Hex(ticketCode),
-      payload: await encryptTicketPayload(
+      encryptedPayload: await encryptTicketPayload(
         ticketCode,
         JSON.stringify({ claims, userInfoResponses }),
       ),

--- a/packages/core/src/oauth/component/oauth.test.ts
+++ b/packages/core/src/oauth/component/oauth.test.ts
@@ -10,20 +10,28 @@ import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
 
+// The component never branches on which provider it serves, so the fixtures
+// name none.
+const PROVIDER_NAME = "test-provider";
+const TOKEN_ENDPOINT = "https://provider.example.com/token";
+
 function setup() {
   vi.stubEnv("CLIENT_ID", "test-client-id");
   vi.stubEnv("CLIENT_SECRET", "test-client-secret");
-  vi.stubEnv("CONVEX_SITE_URL", "https://test.convex.site/oauth/google");
+  vi.stubEnv(
+    "CONVEX_SITE_URL",
+    `https://test.convex.site/oauth/${PROVIDER_NAME}`,
+  );
   const t = convexTest(schema, modules);
   return t;
 }
 
 /** Args for a valid authorization request, overridable per test. */
 const requestArgs = {
-  providerName: "google",
+  providerName: PROVIDER_NAME,
   stateHash: "0".repeat(64),
   redirectTo: "https://app.example.com/after",
-  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  tokenEndpoint: TOKEN_ENDPOINT,
 };
 
 afterEach(() => {
@@ -40,7 +48,7 @@ describe("oauth", () => {
     );
     expect(result).toEqual({
       clientId: "test-client-id",
-      callbackUrl: "https://test.convex.site/oauth/google/callback",
+      callbackUrl: "https://test.convex.site/oauth/test-provider/callback",
     });
     await t.run(async (ctx) => {
       const requests = await ctx.db.query("authorizationRequests").collect();
@@ -65,11 +73,11 @@ describe("oauth", () => {
     );
     expect(claimed).toEqual({
       expired: false,
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: requestArgs.stateHash,
       redirectTo: "https://app.example.com/after",
-      callbackUrl: "https://test.convex.site/oauth/google/callback",
-      tokenEndpoint: "https://oauth2.googleapis.com/token",
+      callbackUrl: "https://test.convex.site/oauth/test-provider/callback",
+      tokenEndpoint: TOKEN_ENDPOINT,
     });
     const second = await t.mutation(
       internal.provider.claimAuthorizationRequest,
@@ -109,7 +117,7 @@ describe("oauth", () => {
   test("createTicket stores hashed ticket code with expiry", async () => {
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
@@ -126,19 +134,19 @@ describe("oauth", () => {
   test("claimTicket returns the ticket exactly once", async () => {
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(claimed).toEqual({ payload: "encrypted-payload" });
     const second = await t.mutation(api.provider.claimTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
@@ -148,13 +156,13 @@ describe("oauth", () => {
   test("claimTicket returns null on state mismatch and preserves the ticket", async () => {
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
       stateHash: "f".repeat(64),
     });
@@ -168,13 +176,13 @@ describe("oauth", () => {
   test("claimTicket returns null on provider mismatch and preserves the ticket", async () => {
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "github",
+      providerName: "other-provider",
       ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
@@ -189,14 +197,14 @@ describe("oauth", () => {
     vi.useFakeTimers();
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     vi.advanceTimersByTime(3 * 60 * 1000);
     const claimed = await t.mutation(api.provider.claimTicket, {
-      providerName: "google",
+      providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });

--- a/packages/core/src/oauth/component/oauth.test.ts
+++ b/packages/core/src/oauth/component/oauth.test.ts
@@ -1,6 +1,11 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api.js";
+import {
+  decryptWithToken,
+  encryptWithToken,
+  generateRandomToken,
+} from "./crypto.js";
 import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -99,5 +104,117 @@ describe("oauth", () => {
       const requests = await ctx.db.query("authorizationRequests").collect();
       expect(requests).toHaveLength(0);
     });
+  });
+
+  test("createTicket stores hashed one-time token with expiry", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      providerName: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      payload: "encrypted-payload",
+    });
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+      expect(tickets[0].ottHash).toBe("a".repeat(64));
+      expect(tickets[0].payload).toBe("encrypted-payload");
+      expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
+    });
+  });
+
+  test("claimTicket returns the ticket exactly once", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      providerName: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      payload: "encrypted-payload",
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "google",
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(claimed).toEqual({ payload: "encrypted-payload" });
+    const second = await t.mutation(api.provider.claimTicket, {
+      providerName: "google",
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(second).toBeNull();
+  });
+
+  test("claimTicket returns null on state mismatch and preserves the ticket", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      providerName: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      payload: "encrypted-payload",
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "google",
+      ottHash: "a".repeat(64),
+      stateHash: "f".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+    });
+  });
+
+  test("claimTicket returns null on provider mismatch and preserves the ticket", async () => {
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      providerName: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      payload: "encrypted-payload",
+    });
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "github",
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(1);
+    });
+  });
+
+  test("claimTicket deletes but does not return an expired ticket", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    await t.mutation(internal.provider.createTicket, {
+      providerName: "google",
+      stateHash: "0".repeat(64),
+      ottHash: "a".repeat(64),
+      payload: "encrypted-payload",
+    });
+    vi.advanceTimersByTime(3 * 60 * 1000);
+    const claimed = await t.mutation(api.provider.claimTicket, {
+      providerName: "google",
+      ottHash: "a".repeat(64),
+      stateHash: "0".repeat(64),
+    });
+    expect(claimed).toBeNull();
+    await t.run(async (ctx) => {
+      const tickets = await ctx.db.query("tickets").collect();
+      expect(tickets).toHaveLength(0);
+    });
+  });
+
+  test("ticket payload encryption round-trips only with the right token", async () => {
+    const token = generateRandomToken();
+    const payload = JSON.stringify({ claims: { sub: "user-123" } });
+    const encrypted = await encryptWithToken(token, payload);
+    expect(encrypted).not.toContain("user-123");
+    expect(await decryptWithToken(token, encrypted)).toBe(payload);
+    await expect(
+      decryptWithToken(generateRandomToken(), encrypted),
+    ).rejects.toThrow();
   });
 });

--- a/packages/core/src/oauth/component/oauth.test.ts
+++ b/packages/core/src/oauth/component/oauth.test.ts
@@ -120,13 +120,13 @@ describe("oauth", () => {
       providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
-      payload: "encrypted-payload",
+      encryptedPayload: "encrypted-payload",
     });
     await t.run(async (ctx) => {
       const tickets = await ctx.db.query("tickets").collect();
       expect(tickets).toHaveLength(1);
       expect(tickets[0].ticketCodeHash).toBe("a".repeat(64));
-      expect(tickets[0].payload).toBe("encrypted-payload");
+      expect(tickets[0].encryptedPayload).toBe("encrypted-payload");
       expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
     });
   });
@@ -137,14 +137,14 @@ describe("oauth", () => {
       providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
-      payload: "encrypted-payload",
+      encryptedPayload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
-    expect(claimed).toEqual({ payload: "encrypted-payload" });
+    expect(claimed).toEqual({ encryptedPayload: "encrypted-payload" });
     const second = await t.mutation(api.provider.claimTicket, {
       providerName: PROVIDER_NAME,
       ticketCodeHash: "a".repeat(64),
@@ -159,7 +159,7 @@ describe("oauth", () => {
       providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
-      payload: "encrypted-payload",
+      encryptedPayload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: PROVIDER_NAME,
@@ -179,7 +179,7 @@ describe("oauth", () => {
       providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
-      payload: "encrypted-payload",
+      encryptedPayload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "other-provider",
@@ -200,7 +200,7 @@ describe("oauth", () => {
       providerName: PROVIDER_NAME,
       stateHash: "0".repeat(64),
       ticketCodeHash: "a".repeat(64),
-      payload: "encrypted-payload",
+      encryptedPayload: "encrypted-payload",
     });
     vi.advanceTimersByTime(3 * 60 * 1000);
     const claimed = await t.mutation(api.provider.claimTicket, {

--- a/packages/core/src/oauth/component/oauth.test.ts
+++ b/packages/core/src/oauth/component/oauth.test.ts
@@ -2,8 +2,8 @@ import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api.js";
 import {
-  decryptWithToken,
-  encryptWithToken,
+  decryptTicketPayload,
+  encryptTicketPayload,
   generateRandomToken,
 } from "./crypto.js";
 import schema from "./schema.js";
@@ -210,11 +210,11 @@ describe("oauth", () => {
   test("ticket payload encryption round-trips only with the right token", async () => {
     const token = generateRandomToken();
     const payload = JSON.stringify({ claims: { sub: "user-123" } });
-    const encrypted = await encryptWithToken(token, payload);
+    const encrypted = await encryptTicketPayload(token, payload);
     expect(encrypted).not.toContain("user-123");
-    expect(await decryptWithToken(token, encrypted)).toBe(payload);
+    expect(await decryptTicketPayload(token, encrypted)).toBe(payload);
     await expect(
-      decryptWithToken(generateRandomToken(), encrypted),
+      decryptTicketPayload(generateRandomToken(), encrypted),
     ).rejects.toThrow();
   });
 });

--- a/packages/core/src/oauth/component/oauth.test.ts
+++ b/packages/core/src/oauth/component/oauth.test.ts
@@ -106,18 +106,18 @@ describe("oauth", () => {
     });
   });
 
-  test("createTicket stores hashed one-time token with expiry", async () => {
+  test("createTicket stores hashed ticket code with expiry", async () => {
     const t = setup();
     await t.mutation(internal.provider.createTicket, {
       providerName: "google",
       stateHash: "0".repeat(64),
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     await t.run(async (ctx) => {
       const tickets = await ctx.db.query("tickets").collect();
       expect(tickets).toHaveLength(1);
-      expect(tickets[0].ottHash).toBe("a".repeat(64));
+      expect(tickets[0].ticketCodeHash).toBe("a".repeat(64));
       expect(tickets[0].payload).toBe("encrypted-payload");
       expect(tickets[0].expiresAt).toBeGreaterThan(Date.now());
     });
@@ -128,18 +128,18 @@ describe("oauth", () => {
     await t.mutation(internal.provider.createTicket, {
       providerName: "google",
       stateHash: "0".repeat(64),
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "google",
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(claimed).toEqual({ payload: "encrypted-payload" });
     const second = await t.mutation(api.provider.claimTicket, {
       providerName: "google",
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(second).toBeNull();
@@ -150,12 +150,12 @@ describe("oauth", () => {
     await t.mutation(internal.provider.createTicket, {
       providerName: "google",
       stateHash: "0".repeat(64),
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "google",
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       stateHash: "f".repeat(64),
     });
     expect(claimed).toBeNull();
@@ -170,12 +170,12 @@ describe("oauth", () => {
     await t.mutation(internal.provider.createTicket, {
       providerName: "google",
       stateHash: "0".repeat(64),
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "github",
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(claimed).toBeNull();
@@ -191,13 +191,13 @@ describe("oauth", () => {
     await t.mutation(internal.provider.createTicket, {
       providerName: "google",
       stateHash: "0".repeat(64),
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       payload: "encrypted-payload",
     });
     vi.advanceTimersByTime(3 * 60 * 1000);
     const claimed = await t.mutation(api.provider.claimTicket, {
       providerName: "google",
-      ottHash: "a".repeat(64),
+      ticketCodeHash: "a".repeat(64),
       stateHash: "0".repeat(64),
     });
     expect(claimed).toBeNull();

--- a/packages/core/src/oauth/component/provider.ts
+++ b/packages/core/src/oauth/component/provider.ts
@@ -123,7 +123,7 @@ export const createTicket = internalMutation({
     providerName: v.string(),
     stateHash: v.string(),
     ticketCodeHash: v.string(),
-    payload: v.string(),
+    encryptedPayload: v.string(),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -153,7 +153,7 @@ export const claimTicket = mutation({
   returns: v.union(
     v.null(),
     v.object({
-      payload: v.string(),
+      encryptedPayload: v.string(),
     }),
   ),
   handler: async (ctx, args) => {
@@ -177,6 +177,6 @@ export const claimTicket = mutation({
       return null;
     }
     await ctx.db.delete("tickets", ticket._id);
-    return { payload: ticket.payload };
+    return { encryptedPayload: ticket.encryptedPayload };
   },
 });

--- a/packages/core/src/oauth/component/provider.ts
+++ b/packages/core/src/oauth/component/provider.ts
@@ -114,15 +114,15 @@ export const claimAuthorizationRequest = internalMutation({
 
 /**
  * Mint a one-time redeemable ticket after a successful code exchange. The
- * caller (the callback) holds the raw one-time token; only its hash is
+ * caller (the callback) holds the raw ticket code; only its hash is
  * stored, and the identity payload arrives already encrypted with a key
- * derived from that token.
+ * derived from that code.
  */
 export const createTicket = internalMutation({
   args: {
     providerName: v.string(),
     stateHash: v.string(),
-    ottHash: v.string(),
+    ticketCodeHash: v.string(),
     payload: v.string(),
   },
   returns: v.null(),
@@ -136,7 +136,7 @@ export const createTicket = internalMutation({
 });
 
 /**
- * Claim a ticket by one-time token hash: find, check, delete, and return it
+ * Claim a ticket by ticket code hash: find, check, delete, and return it
  * in one transaction, so a replayed or raced redemption finds nothing.
  *
  * The caller must also present the hash of the state minted at sign-in,
@@ -144,14 +144,14 @@ export const createTicket = internalMutation({
  * name it expects, so a misconfigured or renamed provider instance can't
  * redeem a ticket into the wrong account namespace. A state or provider
  * mismatch returns null *without* deleting: someone holding a stolen
- * one-time token but not the state must not be able to burn the real
+ * ticket code but not the state must not be able to burn the real
  * client's ticket. An expired row is deleted but not returned. All failures
  * are indistinguishable to the caller.
  */
 export const claimTicket = mutation({
   args: {
     providerName: v.string(),
-    ottHash: v.string(),
+    ticketCodeHash: v.string(),
     stateHash: v.string(),
   },
   returns: v.union(
@@ -163,7 +163,9 @@ export const claimTicket = mutation({
   handler: async (ctx, args) => {
     const ticket = await ctx.db
       .query("tickets")
-      .withIndex("ottHash", (q) => q.eq("ottHash", args.ottHash))
+      .withIndex("ticketCodeHash", (q) =>
+        q.eq("ticketCodeHash", args.ticketCodeHash),
+      )
       .unique();
     if (ticket === null) {
       return null;

--- a/packages/core/src/oauth/component/provider.ts
+++ b/packages/core/src/oauth/component/provider.ts
@@ -113,7 +113,7 @@ export const claimAuthorizationRequest = internalMutation({
 });
 
 /**
- * Mint a one-time redeemable ticket after a successful code exchange. The
+ * Store a one-time redeemable ticket after a successful code exchange. The
  * caller (the callback) holds the raw ticket code; only its hash is
  * stored, and the identity payload arrives already encrypted with a key
  * derived from that code.
@@ -142,11 +142,7 @@ export const createTicket = internalMutation({
  * The caller must also present the hash of the state minted at sign-in,
  * binding redemption to the client that initiated the flow, and the provider
  * name it expects, so a misconfigured or renamed provider instance can't
- * redeem a ticket into the wrong account namespace. A state or provider
- * mismatch returns null *without* deleting: someone holding a stolen
- * ticket code but not the state must not be able to burn the real
- * client's ticket. An expired row is deleted but not returned. All failures
- * are indistinguishable to the caller.
+ * redeem a ticket into the wrong account namespace.
  */
 export const claimTicket = mutation({
   args: {

--- a/packages/core/src/oauth/component/provider.ts
+++ b/packages/core/src/oauth/component/provider.ts
@@ -5,6 +5,11 @@ import { CALLBACK_PATH } from "./constants";
 /** How long an authorization request stays claimable by the callback. */
 const AUTHORIZATION_REQUEST_TTL_MS = 10 * 60 * 1000; // 10m
 
+/** How long a minted ticket stays redeemable. Redemption is normally the
+ * page load right after the callback redirect, so this only needs slack
+ * for slow devices and networks. */
+const TICKET_TTL_MS = 2 * 60 * 1000;
+
 /**
  * Record an in-flight authorization request. Called by the app-side
  * `signIn` before it redirects the user to the provider; the provider
@@ -104,5 +109,76 @@ export const claimAuthorizationRequest = internalMutation({
       userInfoEndpoints: request.userInfoEndpoints,
       issuer: request.issuer,
     };
+  },
+});
+
+/**
+ * Mint a one-time redeemable ticket after a successful code exchange. The
+ * caller (the callback) holds the raw one-time token; only its hash is
+ * stored, and the identity payload arrives already encrypted with a key
+ * derived from that token.
+ */
+export const createTicket = internalMutation({
+  args: {
+    providerName: v.string(),
+    stateHash: v.string(),
+    ottHash: v.string(),
+    payload: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.insert("tickets", {
+      ...args,
+      expiresAt: Date.now() + TICKET_TTL_MS,
+    });
+    return null;
+  },
+});
+
+/**
+ * Claim a ticket by one-time token hash: find, check, delete, and return it
+ * in one transaction, so a replayed or raced redemption finds nothing.
+ *
+ * The caller must also present the hash of the state minted at sign-in,
+ * binding redemption to the client that initiated the flow, and the provider
+ * name it expects, so a misconfigured or renamed provider instance can't
+ * redeem a ticket into the wrong account namespace. A state or provider
+ * mismatch returns null *without* deleting: someone holding a stolen
+ * one-time token but not the state must not be able to burn the real
+ * client's ticket. An expired row is deleted but not returned. All failures
+ * are indistinguishable to the caller.
+ */
+export const claimTicket = mutation({
+  args: {
+    providerName: v.string(),
+    ottHash: v.string(),
+    stateHash: v.string(),
+  },
+  returns: v.union(
+    v.null(),
+    v.object({
+      payload: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const ticket = await ctx.db
+      .query("tickets")
+      .withIndex("ottHash", (q) => q.eq("ottHash", args.ottHash))
+      .unique();
+    if (ticket === null) {
+      return null;
+    }
+    if (ticket.expiresAt < Date.now()) {
+      await ctx.db.delete("tickets", ticket._id);
+      return null;
+    }
+    if (
+      ticket.stateHash !== args.stateHash ||
+      ticket.providerName !== args.providerName
+    ) {
+      return null;
+    }
+    await ctx.db.delete("tickets", ticket._id);
+    return { payload: ticket.payload };
   },
 });

--- a/packages/core/src/oauth/component/schema.ts
+++ b/packages/core/src/oauth/component/schema.ts
@@ -72,6 +72,6 @@ export default defineSchema({
      * database access alone cannot read the payload, and provider-chosen
      * JSON keys never become Convex field names.
      */
-    payload: v.string(),
+    encryptedPayload: v.string(),
   }).index("ticketCodeHash", ["ticketCodeHash"]),
 });

--- a/packages/core/src/oauth/component/schema.ts
+++ b/packages/core/src/oauth/component/schema.ts
@@ -36,4 +36,39 @@ export default defineSchema({
     /** The callback rejects requests older than this. */
     expiresAt: v.number(),
   }).index("stateHash", ["stateHash"]),
+
+  /**
+   * One-time redeemable proof that provider authentication succeeded. Minted
+   * by the callback after the code exchange, redeemed exactly once by a
+   * caller presenting the raw one-time token plus the original client state.
+   * Nothing user-visible (accounts, users, sessions) is created until
+   * redemption.
+   */
+  tickets: defineTable({
+    /** Provider that authenticated the user, e.g. "google". */
+    providerName: v.string(),
+    /**
+     * Carried over from the authorization request. Redemption re-checks the
+     * caller-presented state against it, binding completion to the browser
+     * or server that initiated the flow.
+     */
+    stateHash: v.string(),
+    /**
+     * sha256 of the server-minted one-time token. The raw value appears only
+     * in the callback redirect URL and is never stored.
+     */
+    ottHash: v.string(),
+    /** Tickets expire quickly (~2 minutes). */
+    expiresAt: v.number(),
+    /**
+     * The identity the provider attested: JSON of
+     * `{ claims, userInfoResponses }` (id_token claims when the provider
+     * returned one, userinfo responses keyed by the configured endpoint
+     * names; at least one is present), AES-GCM encrypted with a key derived
+     * from the raw one-time token. The raw token is never stored, so
+     * database access alone cannot read the payload, and provider-chosen
+     * JSON keys never become Convex field names.
+     */
+    payload: v.string(),
+  }).index("ottHash", ["ottHash"]),
 });

--- a/packages/core/src/oauth/component/schema.ts
+++ b/packages/core/src/oauth/component/schema.ts
@@ -58,7 +58,10 @@ export default defineSchema({
      * in the callback redirect URL and is never stored.
      */
     ottHash: v.string(),
-    /** Tickets expire quickly (~2 minutes). */
+    /**
+     * Redemption rejects tickets past this. Set at mint from
+     * `TICKET_TTL_MS` in provider.ts (2 minutes).
+     */
     expiresAt: v.number(),
     /**
      * The identity the provider attested: JSON of

--- a/packages/core/src/oauth/component/schema.ts
+++ b/packages/core/src/oauth/component/schema.ts
@@ -40,7 +40,7 @@ export default defineSchema({
   /**
    * One-time redeemable proof that provider authentication succeeded. Minted
    * by the callback after the code exchange, redeemed exactly once by a
-   * caller presenting the raw one-time token plus the original client state.
+   * caller presenting the raw ticket code plus the original client state.
    * Nothing user-visible (accounts, users, sessions) is created until
    * redemption.
    */
@@ -54,10 +54,10 @@ export default defineSchema({
      */
     stateHash: v.string(),
     /**
-     * sha256 of the server-minted one-time token. The raw value appears only
+     * sha256 of the server-minted ticket code. The raw value appears only
      * in the callback redirect URL and is never stored.
      */
-    ottHash: v.string(),
+    ticketCodeHash: v.string(),
     /**
      * Redemption rejects tickets past this. Set at mint from
      * `TICKET_TTL_MS` in provider.ts (2 minutes).
@@ -68,10 +68,10 @@ export default defineSchema({
      * `{ claims, userInfoResponses }` (id_token claims when the provider
      * returned one, userinfo responses keyed by the configured endpoint
      * names; at least one is present), AES-GCM encrypted with a key derived
-     * from the raw one-time token. The raw token is never stored, so
+     * from the raw ticket code. The raw code is never stored, so
      * database access alone cannot read the payload, and provider-chosen
      * JSON keys never become Convex field names.
      */
     payload: v.string(),
-  }).index("ottHash", ["ottHash"]),
+  }).index("ticketCodeHash", ["ticketCodeHash"]),
 });

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -70,11 +70,18 @@ function parseUrl(value: string): URL | null {
 /**
  * Set up OAuth sign-in against a single upstream identity provider.
  *
- * This is the first leg of the flow: `startSignIn` validates, mints `state`,
- * stores an authorization request record in the component, and returns the provider
- * authorization URL for the client to navigate to plus the state it must hold
- * onto. The provider later redirects back to the component's HTTP callback
- * (`<site><httpPrefix>/callback`), which claims the request by state hash.
+ * The flow:
+ *
+ * 1. `startSignIn` (here): validate, mint `state`, record an authorization
+ *    request in the component, and return the provider authorization URL for
+ *    the client to navigate to plus the state it must hold onto.
+ * 2. The provider redirects back to the component's HTTP callback
+ *    (`<site><httpPrefix>/callback`), which claims the request, exchanges
+ *    the code, and mints a one-time ticket.
+ *
+ * The callback only accepts GET redirects. Providers that POST it
+ * (`response_mode=form_post`, notably Apple when name/email scopes are
+ * requested) are not supported yet.
  */
 export function setupOauth(
   providerName: string,

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -82,6 +82,7 @@ function parseUrl(value: string): URL | null {
  * The callback only accepts GET redirects. Providers that POST it
  * (`response_mode=form_post`, notably Apple when name/email scopes are
  * requested) are not supported yet.
+ * TODO: support response_mode=form_post (Apple) before launch.
  */
 export function setupOauth(
   providerName: string,


### PR DESCRIPTION
- Add the provider callback route: verify state, exchange the code, validate the provider's response, and redirect back to the app with an encrypted one-time ticket
