### PR TITLE
Add OAuth redemption: completeSignIn, profile mapping contract

### DIFF
--- a/packages/core/src/oauth/component/_generated/component.ts
+++ b/packages/core/src/oauth/component/_generated/component.ts
@@ -36,7 +36,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           codeVerifier?: string;
-          issuer?: string;
+          issuers?: Array<string>;
           providerName: string;
           redirectTo: string;
           stateHash: string;

--- a/packages/core/src/oauth/component/http.test.ts
+++ b/packages/core/src/oauth/component/http.test.ts
@@ -38,7 +38,7 @@ const BASE_REQUEST = {
 /** Identity from validated id_token claims. */
 const ID_TOKEN_REQUEST = {
   ...BASE_REQUEST,
-  issuer: "https://provider.example.com",
+  issuers: ["https://provider.example.com"],
 } satisfies FlowRequest;
 
 /** No id_token; identity spread across two endpoints. */
@@ -155,7 +155,7 @@ function unsignedJwt(claims: Record<string, unknown>): string {
 /** Valid id_token claims, overridable per test. */
 function idTokenClaims(overrides: Record<string, unknown> = {}) {
   return {
-    iss: ID_TOKEN_REQUEST.issuer,
+    iss: ID_TOKEN_REQUEST.issuers[0],
     aud: CLIENT_ID,
     exp: Math.floor(Date.now() / 1000) + 3600,
     sub: "sub-1",
@@ -496,6 +496,22 @@ describe("oauth callback", () => {
         "oauth_error",
       );
       expect(loggedText(errors)).toContain("no issuer is configured");
+    });
+
+    test("an id_token from any of the configured issuers is accepted", async () => {
+      const t = setup();
+      const request = {
+        ...BASE_REQUEST,
+        issuers: ["https://provider.example.com", "provider.example.com"],
+      } satisfies FlowRequest;
+      const response = await callbackWithIdToken(
+        t,
+        request,
+        unsignedJwt(idTokenClaims({ iss: "provider.example.com" })),
+      );
+      expect(redirectParams(response).get(OAUTH_CODE_PARAM)).toEqual(
+        expect.any(String),
+      );
     });
 
     test("an issuer mismatch is refused", async () => {

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -154,10 +154,7 @@ function validateIdToken(
     );
   }
   const claims = decodeJwtPayloadUnverified(idToken);
-  if (
-    typeof claims.iss !== "string" ||
-    !expectedIssuers.includes(claims.iss)
-  ) {
+  if (typeof claims.iss !== "string" || !expectedIssuers.includes(claims.iss)) {
     throw new Error("id_token issuer does not match the configured issuer");
   }
   const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];

--- a/packages/core/src/oauth/component/http.ts
+++ b/packages/core/src/oauth/component/http.ts
@@ -131,9 +131,9 @@ async function exchangeCode(args: {
 /**
  * Decode an id_token and check its claims:
  *
- * - `iss` must match the configured `issuer`, which is required whenever an
- *   id_token comes back: `sub` is only unique within an issuer, and a shared
- *   or multi-tenant token endpoint can serve several.
+ * - `iss` must match one of the configured `issuers`, which are required
+ *   whenever an id_token comes back: `sub` is only unique within an issuer,
+ *   and a shared or multi-tenant token endpoint can serve several.
  * - `aud` must be exactly CLIENT_ID. Multi-audience tokens are rejected
  *   because no other audience is trusted.
  * - `azp`, when present, must be CLIENT_ID.
@@ -145,16 +145,19 @@ async function exchangeCode(args: {
  */
 function validateIdToken(
   idToken: IssuerDeliveredJwt,
-  expectedIssuer: string | undefined,
+  expectedIssuers: string[] | undefined,
   clientId: string,
 ): Record<string, unknown> {
-  if (expectedIssuer === undefined) {
+  if (expectedIssuers === undefined) {
     throw new Error(
       "The provider returned an id_token but no issuer is configured; set `issuer` in the provider options so the token can be validated",
     );
   }
   const claims = decodeJwtPayloadUnverified(idToken);
-  if (claims.iss !== expectedIssuer) {
+  if (
+    typeof claims.iss !== "string" ||
+    !expectedIssuers.includes(claims.iss)
+  ) {
     throw new Error("id_token issuer does not match the configured issuer");
   }
   const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
@@ -277,7 +280,7 @@ async function handleCallback(
     const claims =
       idToken === undefined
         ? undefined
-        : validateIdToken(idToken, authRequest.issuer, env.CLIENT_ID);
+        : validateIdToken(idToken, authRequest.issuers, env.CLIENT_ID);
 
     if (
       authRequest.userInfoEndpoints !== undefined &&

--- a/packages/core/src/oauth/component/provider.ts
+++ b/packages/core/src/oauth/component/provider.ts
@@ -26,7 +26,7 @@ export const createAuthorizationRequest = mutation({
     codeVerifier: v.optional(v.string()),
     tokenEndpoint: v.string(),
     userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
-    issuer: v.optional(v.string()),
+    issuers: v.optional(v.array(v.string())),
   },
   returns: v.object({
     clientId: v.string(),
@@ -83,7 +83,7 @@ export const claimAuthorizationRequest = internalMutation({
       codeVerifier: v.optional(v.string()),
       tokenEndpoint: v.string(),
       userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
-      issuer: v.optional(v.string()),
+      issuers: v.optional(v.array(v.string())),
     }),
   ),
   handler: async (ctx, args) => {
@@ -107,7 +107,7 @@ export const claimAuthorizationRequest = internalMutation({
       codeVerifier: request.codeVerifier,
       tokenEndpoint: request.tokenEndpoint,
       userInfoEndpoints: request.userInfoEndpoints,
-      issuer: request.issuer,
+      issuers: request.issuers,
     };
   },
 });

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -1,0 +1,353 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { makeFunctionReference } from "convex/server";
+import { api, internal } from "./_generated/api.js";
+import type { ComponentApi } from "./_generated/component.js";
+import schema from "./schema.js";
+import { setupOauth, type OauthProfile } from "./setup";
+import { encryptTicketPayload, generateRandomToken } from "./crypto";
+import { sha256Hex } from "../../lib/crypto";
+import type { AuthClaims, ProviderHelpers, TokenBundle } from "../../lib/types";
+
+/**
+ * Tests for the app-side `completeSignIn` mutation that `setupOauth`
+ * produces, run against the real component (real `claimTicket`, real ticket
+ * crypto). The seam into the core — `helpers.completeSignIn`, which turns
+ * verified claims into a session — is faked and spied here; the real one is
+ * covered by the core's own suite (components/core/core.test.ts).
+ */
+
+/**
+ * Test-only spy state for the fake helpers, mirroring the core suite's
+ * testApp pattern: the suite runs in one process, so module-level state read
+ * and reset directly is a stable spy.
+ */
+const completeSignInCalls: AuthClaims[] = [];
+
+/**
+ * When set, the fake `helpers.completeSignIn` throws this instead of
+ * returning a bundle — modeling the app rejecting the sign-in from its
+ * `createOrUpdateUser` callback.
+ */
+const helperFailure = { error: undefined as Error | undefined };
+
+/** The bundle the fake helpers mint on success. */
+const FAKE_BUNDLE: TokenBundle = {
+  accessToken: "access-token-1",
+  accessTokenExpiresAt: 253402300800000,
+  refreshToken: "refresh-token-1",
+  refreshTokenExpiresAt: 253402300800000,
+  userId: "user-1",
+};
+
+/**
+ * Fake {@link ProviderHelpers}: `completeSignIn` records the claims it was
+ * handed and returns {@link FAKE_BUNDLE} (or throws per
+ * {@link helperFailure}). `resolveUserId` is never reached by redemption.
+ */
+const fakeHelpers: ProviderHelpers = {
+  completeSignIn: async (_ctx, claims) => {
+    completeSignInCalls.push({ ...claims });
+    if (helperFailure.error !== undefined) {
+      throw helperFailure.error;
+    }
+    return FAKE_BUNDLE;
+  },
+  resolveUserId: async () => null,
+};
+
+/**
+ * Provider options for every instance under test. The component's own
+ * generated `api` stands in for the app-side mount reference
+ * (`components.oauthAcme`): the harness root IS the component, so its
+ * self-references resolve exactly like a mount's would. The cast bridges the
+ * generated api's "public" visibility to the mount type's "internal".
+ */
+const OPTIONS = {
+  component: api as unknown as ComponentApi,
+  allowedRedirectOrigins: ["https://app.example.com"],
+};
+
+/** An OIDC-style catalog whose profile maps id_token claims (like Google). */
+const CLAIMS_CATALOG = {
+  authorizationEndpoint: "https://provider.example/authorize",
+  tokenEndpoint: "https://provider.example/token",
+  issuer: "https://provider.example",
+  scopes: ["openid"],
+  pkce: false,
+  profile: ((claims) => ({
+    id: claims!.sub,
+    email: claims?.email,
+    name: claims?.name,
+  })) satisfies OauthProfile,
+};
+
+/**
+ * A plain-OAuth catalog whose profile reads typed userinfo responses (like
+ * GitHub), exercising the `UserInfo` generic end to end.
+ */
+const USERINFO_CATALOG = {
+  authorizationEndpoint: "https://provider.example/authorize",
+  tokenEndpoint: "https://provider.example/token",
+  userInfoEndpoints: { user: "https://provider.example/user" },
+  scopes: [],
+  pkce: false,
+  profile: ((_claims, userInfoResponses) => ({
+    id: String(userInfoResponses!.user.id),
+    login: userInfoResponses!.user.login,
+  })) satisfies OauthProfile<{ user: { id: number; login: string } }>,
+};
+
+/** A catalog whose profile mapping returns an empty id. */
+const EMPTY_ID_CATALOG = {
+  ...CLAIMS_CATALOG,
+  profile: (() => ({ id: "" })) satisfies OauthProfile,
+};
+
+/**
+ * A catalog whose profile mapping omits the id entirely — modeling an untyped
+ * (plain JS) mapping, which the cast stands in for since `OauthProfile`'s
+ * return type makes this unwritable directly.
+ */
+const MISSING_ID_CATALOG = {
+  ...CLAIMS_CATALOG,
+  profile: (() => ({})) as unknown as OauthProfile,
+};
+
+/**
+ * The app-side functions under test, named statically the way a catalog
+ * module names them. They aren't component modules (in a real deployment
+ * they live in the app), so they can't come from the module glob; instead
+ * they're injected below as a synthetic `testApp` module, which convex-test
+ * invokes like any registered function (argument and return validation,
+ * transactions, and all). A real testApp.ts in this directory would leak
+ * public mutations into the component's generated API.
+ */
+const testApp = {
+  completeSignInAcme: setupOauth("acme", CLAIMS_CATALOG, fakeHelpers, OPTIONS)
+    .completeSignIn,
+  completeSignInAcmeInfo: setupOauth(
+    "acmeInfo",
+    USERINFO_CATALOG,
+    fakeHelpers,
+    OPTIONS,
+  ).completeSignIn,
+  completeSignInEmptyId: setupOauth(
+    "emptyId",
+    EMPTY_ID_CATALOG,
+    fakeHelpers,
+    OPTIONS,
+  ).completeSignIn,
+  completeSignInMissingId: setupOauth(
+    "missingId",
+    MISSING_ID_CATALOG,
+    fakeHelpers,
+    OPTIONS,
+  ).completeSignIn,
+};
+
+const modules = {
+  ...import.meta.glob("./**/*.ts"),
+  "./testApp.ts": async () => testApp,
+};
+
+const completeSignInAcme = makeFunctionReference<"mutation">(
+  "testApp:completeSignInAcme",
+);
+const completeSignInAcmeInfo = makeFunctionReference<"mutation">(
+  "testApp:completeSignInAcmeInfo",
+);
+const completeSignInEmptyId = makeFunctionReference<"mutation">(
+  "testApp:completeSignInEmptyId",
+);
+const completeSignInMissingId = makeFunctionReference<"mutation">(
+  "testApp:completeSignInMissingId",
+);
+
+function setup() {
+  return convexTest(schema, modules);
+}
+
+/** Valid id_token claims for the acme provider's payloads. */
+const CLAIMS = {
+  sub: "acme-sub-1",
+  email: "ada@example.com",
+  name: "Ada",
+};
+
+/**
+ * Mint a ticket the way the callback leg does after a successful exchange:
+ * real ticket code, hashes, and payload encryption. Returns the raw code,
+ * which is what the client presents at redemption.
+ */
+async function mintTicket(
+  t: ReturnType<typeof setup>,
+  args: {
+    providerName?: string;
+    state?: string;
+    payload?: Record<string, unknown>;
+  } = {},
+) {
+  const ticketCode = generateRandomToken();
+  await t.mutation(internal.provider.createTicket, {
+    providerName: args.providerName ?? "acme",
+    stateHash: await sha256Hex(args.state ?? "state-1"),
+    ticketCodeHash: await sha256Hex(ticketCode),
+    payload: await encryptTicketPayload(
+      ticketCode,
+      JSON.stringify(args.payload ?? { claims: CLAIMS }),
+    ),
+  });
+  return ticketCode;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  completeSignInCalls.length = 0;
+  helperFailure.error = undefined;
+});
+
+describe("completeSignIn", () => {
+  test("redeems a minted ticket into a session bundle via the profile mapping", async () => {
+    const t = setup();
+    const code = await mintTicket(t);
+
+    const bundle = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+
+    expect(bundle).toEqual(FAKE_BUNDLE);
+    // The decrypted payload flowed through the catalog's profile mapping
+    // into the core seam.
+    expect(completeSignInCalls).toEqual([
+      {
+        provider: "acme",
+        providerAccountId: "acme-sub-1",
+        profile: { id: "acme-sub-1", email: "ada@example.com", name: "Ada" },
+      },
+    ]);
+  });
+
+  test("passes userinfo responses to the profile mapping", async () => {
+    const t = setup();
+    const code = await mintTicket(t, {
+      providerName: "acmeInfo",
+      payload: { userInfoResponses: { user: { id: 42, login: "octocat" } } },
+    });
+
+    const bundle = await t.mutation(completeSignInAcmeInfo, {
+      code,
+      state: "state-1",
+    });
+
+    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(completeSignInCalls).toEqual([
+      {
+        provider: "acmeInfo",
+        providerAccountId: "42",
+        profile: { id: "42", login: "octocat" },
+      },
+    ]);
+  });
+
+  test("an unknown code returns null", async () => {
+    const t = setup();
+    const result = await t.mutation(completeSignInAcme, {
+      code: "never-minted",
+      state: "state-1",
+    });
+    expect(result).toBeNull();
+    expect(completeSignInCalls).toHaveLength(0);
+  });
+
+  test("a wrong state returns null and preserves the ticket", async () => {
+    const t = setup();
+    const code = await mintTicket(t);
+
+    const mismatched = await t.mutation(completeSignInAcme, {
+      code,
+      state: "someone-elses-state",
+    });
+    expect(mismatched).toBeNull();
+
+    // The ticket survives a mismatched attempt; the initiating client can
+    // still complete.
+    const bundle = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+    expect(bundle).toEqual(FAKE_BUNDLE);
+  });
+
+  test("a code redeems exactly once", async () => {
+    const t = setup();
+    const code = await mintTicket(t);
+
+    const first = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+    expect(first).toEqual(FAKE_BUNDLE);
+
+    const second = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+    expect(second).toBeNull();
+    expect(completeSignInCalls).toHaveLength(1);
+  });
+
+  test("an expired ticket returns null", async () => {
+    vi.useFakeTimers();
+    const t = setup();
+    const code = await mintTicket(t);
+    vi.advanceTimersByTime(3 * 60 * 1000); // past the 2-minute ticket TTL
+
+    const result = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+    expect(result).toBeNull();
+    expect(completeSignInCalls).toHaveLength(0);
+  });
+
+  test("a profile mapping that returns an empty id throws", async () => {
+    const t = setup();
+    const code = await mintTicket(t, { providerName: "emptyId" });
+
+    await expect(
+      t.mutation(completeSignInEmptyId, { code, state: "state-1" }),
+    ).rejects.toThrow(/returned no id/);
+  });
+
+  test("a profile mapping that omits the id throws", async () => {
+    const t = setup();
+    const code = await mintTicket(t, { providerName: "missingId" });
+
+    await expect(
+      t.mutation(completeSignInMissingId, { code, state: "state-1" }),
+    ).rejects.toThrow(/returned no id/);
+  });
+
+  test("an app rejection rolls back the ticket claim", async () => {
+    const t = setup();
+    const code = await mintTicket(t);
+
+    // The app rejects the sign-in (thrown from createOrUpdateUser, surfaced
+    // through the core seam)...
+    helperFailure.error = new Error("sign-ups are closed");
+    await expect(
+      t.mutation(completeSignInAcme, { code, state: "state-1" }),
+    ).rejects.toThrow("sign-ups are closed");
+
+    // ...and the claim rolled back with the rest of the mutation, so the
+    // ticket is not burned by the failed attempt.
+    helperFailure.error = undefined;
+    const bundle = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+    expect(bundle).toEqual(FAKE_BUNDLE);
+  });
+});

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -58,10 +58,11 @@ const fakeHelpers: ProviderHelpers = {
 
 /**
  * Provider options for every instance under test. The component's own
- * generated `api` stands in for the app-side mount reference
+ * generated `api` stands in for the app-side component reference
  * (`components.oauthAcme`): the harness root IS the component, so its
- * self-references resolve exactly like a mount's would. The cast bridges the
- * generated api's "public" visibility to the mount type's "internal".
+ * self-references resolve exactly like an installed component's would. The
+ * cast bridges the generated api's "public" visibility to the component
+ * type's "internal".
  */
 const OPTIONS = {
   component: api as unknown as ComponentApi,

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -194,7 +194,7 @@ async function mintTicket(
     providerName: args.providerName ?? "acme",
     stateHash: await sha256Hex(args.state ?? "state-1"),
     ticketCodeHash: await sha256Hex(ticketCode),
-    payload: await encryptTicketPayload(
+    encryptedPayload: await encryptTicketPayload(
       ticketCode,
       JSON.stringify(args.payload ?? { claims: CLAIMS }),
     ),

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -12,21 +12,20 @@ import type { AuthClaims, ProviderHelpers, TokenBundle } from "../../lib/types";
 /**
  * Tests for the app-side `completeSignIn` mutation that `setupOauth`
  * produces, run against the real component (real `claimTicket`, real ticket
- * crypto). The seam into the core — `helpers.completeSignIn`, which turns
- * verified claims into a session — is faked and spied here; the real one is
+ * crypto). The helpers that turn verified claims into a session
+ * (`helpers.completeSignIn`) are faked and spied here. The real helpers are
  * covered by the core's own suite (components/core/core.test.ts).
  */
 
 /**
- * Test-only spy state for the fake helpers, mirroring the core suite's
- * testApp pattern: the suite runs in one process, so module-level state read
- * and reset directly is a stable spy.
+ * Claims recorded by the fake `helpers.completeSignIn`. The suite runs in
+ * one process, so tests read and reset this directly.
  */
 const completeSignInCalls: AuthClaims[] = [];
 
 /**
  * When set, the fake `helpers.completeSignIn` throws this instead of
- * returning a bundle — modeling the app rejecting the sign-in from its
+ * returning a bundle, modeling the app rejecting the sign-in from its
  * `createOrUpdateUser` callback.
  */
 const helperFailure = { error: undefined as Error | undefined };
@@ -41,9 +40,8 @@ const FAKE_BUNDLE: TokenBundle = {
 };
 
 /**
- * Fake {@link ProviderHelpers}: `completeSignIn` records the claims it was
- * handed and returns {@link FAKE_BUNDLE} (or throws per
- * {@link helperFailure}). `resolveUserId` is never reached by redemption.
+ * Fake {@link ProviderHelpers}. `resolveUserId` is never reached by
+ * redemption.
  */
 const fakeHelpers: ProviderHelpers = {
   completeSignIn: async (_ctx, claims) => {
@@ -59,8 +57,8 @@ const fakeHelpers: ProviderHelpers = {
 /**
  * Provider options for every instance under test. The component's own
  * generated `api` stands in for the app-side component reference
- * (`components.oauthAcme`): the harness root IS the component, so its
- * self-references resolve exactly like an installed component's would. The
+ * (`components.oauthAcme`): the harness root is the component itself, so its
+ * self-references resolve the same way an installed component's would. The
  * cast bridges the generated api's "public" visibility to the component
  * type's "internal".
  */
@@ -106,9 +104,9 @@ const EMPTY_ID_CATALOG = {
 };
 
 /**
- * A catalog whose profile mapping omits the id entirely — modeling an untyped
- * (plain JS) mapping, which the cast stands in for since `OauthProfile`'s
- * return type makes this unwritable directly.
+ * A catalog whose profile mapping omits the id entirely, modeling an untyped
+ * (plain JS) mapping. `OauthProfile`'s return type makes this unwritable
+ * directly, so the cast fakes it.
  */
 const MISSING_ID_CATALOG = {
   ...CLAIMS_CATALOG,
@@ -118,7 +116,7 @@ const MISSING_ID_CATALOG = {
 /**
  * The app-side functions under test, named statically the way a catalog
  * module names them. They aren't component modules (in a real deployment
- * they live in the app), so they can't come from the module glob; instead
+ * they live in the app), so they can't come from the module glob. Instead
  * they're injected below as a synthetic `testApp` module, which convex-test
  * invokes like any registered function (argument and return validation,
  * transactions, and all). A real testApp.ts in this directory would leak
@@ -177,9 +175,9 @@ const CLAIMS = {
 };
 
 /**
- * Mint a ticket the way the callback leg does after a successful exchange:
- * real ticket code, hashes, and payload encryption. Returns the raw code,
- * which is what the client presents at redemption.
+ * Mint a ticket with real crypto: real ticket code, hashes, and payload
+ * encryption. Returns the raw code, which is what the client presents at
+ * redemption.
  */
 async function mintTicket(
   t: ReturnType<typeof setup>,
@@ -220,7 +218,7 @@ describe("completeSignIn", () => {
 
     expect(bundle).toEqual(FAKE_BUNDLE);
     // The decrypted payload flowed through the catalog's profile mapping
-    // into the core seam.
+    // into the fake helpers.
     expect(completeSignInCalls).toEqual([
       {
         provider: "acme",
@@ -272,7 +270,7 @@ describe("completeSignIn", () => {
     });
     expect(mismatched).toBeNull();
 
-    // The ticket survives a mismatched attempt; the initiating client can
+    // The ticket survives a mismatched attempt, so the initiating client can
     // still complete.
     const bundle = await t.mutation(completeSignInAcme, {
       code,
@@ -303,7 +301,7 @@ describe("completeSignIn", () => {
     vi.useFakeTimers();
     const t = setup();
     const code = await mintTicket(t);
-    vi.advanceTimersByTime(3 * 60 * 1000); // past the 2-minute ticket TTL
+    vi.advanceTimersByTime(3 * 60 * 1000); // well past the ticket TTL
 
     const result = await t.mutation(completeSignInAcme, {
       code,
@@ -335,8 +333,7 @@ describe("completeSignIn", () => {
     const t = setup();
     const code = await mintTicket(t);
 
-    // The app rejects the sign-in (thrown from createOrUpdateUser, surfaced
-    // through the core seam)...
+    // The app rejects the sign-in...
     helperFailure.error = new Error("sign-ups are closed");
     await expect(
       t.mutation(completeSignInAcme, { code, state: "state-1" }),

--- a/packages/core/src/oauth/component/schema.ts
+++ b/packages/core/src/oauth/component/schema.ts
@@ -29,10 +29,10 @@ export default defineSchema({
      */
     userInfoEndpoints: v.optional(v.record(v.string(), v.string())),
     /**
-     * Expected `iss` (the OIDC issuer claim) of the provider's id_tokens,
-     * copied from app-side config. Absent for non-oidc providers.
+     * Accepted `iss` (the OIDC issuer claim) values for the provider's
+     * id_tokens, copied from app-side config. Absent for non-oidc providers.
      */
-    issuer: v.optional(v.string()),
+    issuers: v.optional(v.array(v.string())),
     /** The callback rejects requests older than this. */
     expiresAt: v.number(),
   }).index("stateHash", ["stateHash"]),

--- a/packages/core/src/oauth/component/setup.test.ts
+++ b/packages/core/src/oauth/component/setup.test.ts
@@ -16,6 +16,7 @@ const CATALOG: OauthCatalog = {
   tokenEndpoint: "https://provider.example/token",
   scopes: [],
   pkce: false,
+  profile: () => ({ id: "account-1" }),
 };
 
 /**
@@ -43,6 +44,7 @@ describe("setupOauth validation", () => {
       ],
     });
     expect(api.startSignIn).toBeDefined();
+    expect(api.completeSignIn).toBeDefined();
   });
 
   test.each([

--- a/packages/core/src/oauth/component/setup.test.ts
+++ b/packages/core/src/oauth/component/setup.test.ts
@@ -59,6 +59,23 @@ describe("setupOauth validation", () => {
     );
   });
 
+  test("a redirect origin with a trailing slash is accepted", () => {
+    const api = setup({
+      allowedRedirectOrigins: ["https://app.example.com/"],
+    });
+    expect(api.startSignIn).toBeDefined();
+  });
+
+  test.each([
+    "https://app.example.com/admin",
+    "https://app.example.com/?q=1",
+    "https://app.example.com/#section",
+  ])("redirect origin %s with extra URL parts is rejected", (origin) => {
+    expect(() => setup({ allowedRedirectOrigins: [origin] })).toThrow(
+      /must be a bare origin/,
+    );
+  });
+
   test("an openid catalog scope without a catalog issuer is rejected", () => {
     expect(() => setup({}, { ...CATALOG, scopes: ["openid"] })).toThrow(
       /sets no issuer/,

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -271,7 +271,7 @@ export function setupOauth<
       // payload was encrypted under, so decryption only fails on
       // corruption.
       const { claims, userInfoResponses } = JSON.parse(
-        await decryptTicketPayload(args.code, ticket.payload),
+        await decryptTicketPayload(args.code, ticket.encryptedPayload),
       ) as {
         claims: OidcClaims | undefined;
         userInfoResponses: UserInfo | undefined;

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -14,8 +14,8 @@ import {
 import { sha256Hex } from "../../lib/crypto";
 
 /**
- * Standard OIDC id_token claims, loosely typed: the well-known ones are
- * named, everything else comes through the index signature.
+ * Standard OIDC id_token claims. The well-known ones are typed; any other
+ * claim the provider includes is present but untyped (`unknown`).
  */
 export type OidcClaims = {
   sub: string;
@@ -32,18 +32,33 @@ export type OidcClaims = {
  * configured (`undefined` unless the catalog sets `userInfoEndpoints`) — to the
  * account identity used at redemption. `id` becomes the provider account id.
  * Supplied by each provider's catalog.
+ *
+ * `UserInfo` is the catalog's declared shape for the userinfo responses,
+ * keyed like `userInfoEndpoints`. It types what the provider is trusted to
+ * return — the responses are provider-attested JSON and are not validated
+ * against it at runtime.
  */
-export type OauthProfile = (
-  claims: OidcClaims | undefined,
-  // `any` so mappings can dig into responses without casting.
+export type OauthProfile<
+  // `any` default so unparameterized mappings can dig into responses
+  // without casting.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userInfoResponses: Record<string, any> | undefined,
+  UserInfo extends Record<string, unknown> = Record<string, any>,
+> = (
+  claims: OidcClaims | undefined,
+  userInfoResponses: UserInfo | undefined,
 ) => { id: string; [key: string]: unknown };
 
 /**
  * Provider-defined config for interacting with an individual OAuth provider.
+ *
+ * `UserInfo` declares the shape of the userinfo responses, tying
+ * `userInfoEndpoints` keys to what `profile` receives (see
+ * {@link OauthProfile}).
  */
-export type OauthCatalog = {
+export type OauthCatalog<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UserInfo extends Record<string, unknown> = Record<string, any>,
+> = {
   /**
    * The provider's authorization endpoint (a full URL), e.g. Google's
    * `https://accounts.google.com/o/oauth2/v2/auth`.
@@ -65,9 +80,9 @@ export type OauthCatalog = {
    * Endpoints (full URLs) the callback fetches with the access token (GET
    * with a bearer token), keyed by the name the `profile` mapping reads
    * each response under. Present for providers whose identity comes from
-   * userinfo (GitHub).
+   * userinfo (GitHub). The keys must match `UserInfo`'s.
    */
-  userInfoEndpoints?: Record<string, string>;
+  userInfoEndpoints?: { [K in keyof UserInfo & string]: string };
   /** Scopes to request. */
   scopes: string[];
   /**
@@ -76,7 +91,7 @@ export type OauthCatalog = {
    */
   pkce: boolean;
   /** Map the provider's attested identity to the account profile. */
-  profile: OauthProfile;
+  profile: OauthProfile<UserInfo>;
 };
 
 /**
@@ -124,9 +139,12 @@ function parseUrl(value: string): URL | null {
  * requested) are not supported yet.
  * TODO: support response_mode=form_post (Apple) before launch.
  */
-export function setupOauth(
+export function setupOauth<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UserInfo extends Record<string, unknown> = Record<string, any>,
+>(
   providerName: string,
-  catalog: OauthCatalog,
+  catalog: OauthCatalog<UserInfo>,
   helpers: ProviderHelpers,
   options: OauthProviderOptions,
 ) {
@@ -256,7 +274,7 @@ export function setupOauth(
         await decryptTicketPayload(args.code, ticket.payload),
       ) as {
         claims: OidcClaims | undefined;
-        userInfoResponses: Record<string, unknown> | undefined;
+        userInfoResponses: UserInfo | undefined;
       };
 
       const profile = catalog.profile(claims, userInfoResponses);

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -68,11 +68,12 @@ export type OauthCatalog<
   tokenEndpoint: string;
   /**
    * Expected `iss` (the OIDC issuer claim) of the provider's id_tokens, e.g.
-   * Google's `https://accounts.google.com`. Present for OIDC providers;
-   * absent for plain-OAuth providers (e.g., GitHub), where identity comes from
-   * userinfo.
+   * Google's `https://accounts.google.com`. Some providers document more than
+   * one form (Google also uses `accounts.google.com`); an array accepts any
+   * of them. Present for OIDC providers; absent for plain-OAuth providers
+   * (e.g., GitHub), where identity comes from userinfo.
    */
-  issuer?: string;
+  issuer?: string | string[];
   /**
    * Endpoints (full URLs) the callback fetches with the access token (GET
    * with a bearer token), keyed by the name the `profile` mapping reads
@@ -168,9 +169,15 @@ export function setupOauth<
     }
     return url.origin;
   });
+  const issuers =
+    catalog.issuer === undefined
+      ? undefined
+      : Array.isArray(catalog.issuer)
+        ? catalog.issuer
+        : [catalog.issuer];
   // Per OIDC, requesting the `openid` scope makes the provider return an
   // id_token, which must be validated against an expected issuer.
-  if (catalog.scopes.includes("openid") && catalog.issuer === undefined) {
+  if (catalog.scopes.includes("openid") && (issuers?.length ?? 0) === 0) {
     throw new Error(
       `Provider "${providerName}" requests the "openid" scope, so the provider will return an id_token, but its catalog sets no issuer to validate it against`,
     );
@@ -210,7 +217,7 @@ export function setupOauth<
           tokenEndpoint: catalog.tokenEndpoint,
           codeVerifier,
           userInfoEndpoints: catalog.userInfoEndpoints,
-          issuer: catalog.issuer,
+          issuers,
         },
       );
 

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -14,7 +14,7 @@ import {
 import { sha256Hex } from "../../lib/crypto";
 
 /**
- * Standard OIDC id_token claims. The well-known ones are typed; any other
+ * Standard OIDC id_token claims. The well-known ones are typed. Any other
  * claim the provider includes is present but untyped (`unknown`).
  */
 export type OidcClaims = {
@@ -27,15 +27,16 @@ export type OidcClaims = {
 };
 
 /**
- * Map what the provider told us about the user — id_token claims
- * (`undefined` for non-OIDC providers) and userinfo responses keyed as
- * configured (`undefined` unless the catalog sets `userInfoEndpoints`) — to the
- * account identity used at redemption. `id` becomes the provider account id.
- * Supplied by each provider's catalog.
+ * Map what the provider attested about the user to the account identity used
+ * at redemption. `claims` holds the id_token claims (`undefined` for
+ * non-OIDC providers). `userInfoResponses` holds the userinfo responses
+ * keyed as configured (`undefined` unless the catalog sets
+ * `userInfoEndpoints`). `id` becomes the provider account id. Supplied by
+ * each provider's catalog.
  *
  * `UserInfo` is the catalog's declared shape for the userinfo responses,
  * keyed like `userInfoEndpoints`. It types what the provider is trusted to
- * return — the responses are provider-attested JSON and are not validated
+ * return. The responses are provider-attested JSON and are not validated
  * against it at runtime.
  */
 export type OauthProfile<
@@ -237,15 +238,13 @@ export function setupOauth<
   /**
    * Complete an OAuth sign-in by redeeming the one-time `code` from
    * the callback redirect together with the state held since
-   * `startSignIn`. The state must be the value stored at sign-in
-   * time, never one read from a URL. Returns the session token
-   * bundle, or null when the code is unknown, already redeemed,
-   * expired, or the state doesn't match: all indistinguishable to
-   * the caller, like a failed `refreshSession`.
+   * `startSignIn`. Returns the session token bundle, or null when
+   * the code is unknown, already redeemed, expired, or the state
+   * doesn't match: all indistinguishable to the caller.
    *
    * The component calls are subtransactions of this mutation, so a
    * failure anywhere (including the app rejecting the sign-in from
-   * `createOrUpdateUser`) rolls back the ticket claim; only a
+   * `createOrUpdateUser`) rolls back the ticket claim. Only a
    * successful redemption consumes the ticket.
    */
   const completeSignIn = mutationGeneric({

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -1,9 +1,44 @@
 import { mutationGeneric } from "convex/server";
 import { v } from "convex/values";
-import type { ProviderHelpers } from "../../lib/types";
+import {
+  vTokenBundle,
+  type ProviderHelpers,
+  type TokenBundle,
+} from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
-import { generateRandomToken, sha256Base64Url } from "./crypto";
+import {
+  decryptTicketPayload,
+  generateRandomToken,
+  sha256Base64Url,
+} from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
+
+/**
+ * Standard OIDC id_token claims, loosely typed: the well-known ones are
+ * named, everything else comes through the index signature.
+ */
+export type OidcClaims = {
+  sub: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  picture?: string;
+  [claim: string]: unknown;
+};
+
+/**
+ * Map what the provider told us about the user — id_token claims
+ * (`undefined` for non-OIDC providers) and userinfo responses keyed as
+ * configured (`undefined` unless the catalog sets `userInfoEndpoints`) — to the
+ * account identity used at redemption. `id` becomes the provider account id.
+ * Supplied by each provider's catalog.
+ */
+export type OauthProfile = (
+  claims: OidcClaims | undefined,
+  // `any` so mappings can dig into responses without casting.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userInfoResponses: Record<string, any> | undefined,
+) => { id: string; [key: string]: unknown };
 
 /**
  * Provider-defined config for interacting with an individual OAuth provider.
@@ -28,8 +63,8 @@ export type OauthCatalog = {
   issuer?: string;
   /**
    * Endpoints (full URLs) the callback fetches with the access token (GET
-   * with a bearer token), keyed by the name the profile mapping reads each
-   * response under. Present for providers whose identity comes from
+   * with a bearer token), keyed by the name the `profile` mapping reads
+   * each response under. Present for providers whose identity comes from
    * userinfo (GitHub).
    */
   userInfoEndpoints?: Record<string, string>;
@@ -40,6 +75,8 @@ export type OauthCatalog = {
    * providers that support PKCE alongside the client secret.
    */
   pkce: boolean;
+  /** Map the provider's attested identity to the account profile. */
+  profile: OauthProfile;
 };
 
 /**
@@ -78,6 +115,9 @@ function parseUrl(value: string): URL | null {
  * 2. The provider redirects back to the component's HTTP callback
  *    (`<site><httpPrefix>/callback`), which claims the request, exchanges
  *    the code, and mints a one-time ticket.
+ * 3. `completeSignIn` (here): the client presents the one-time code from the
+ *    callback redirect plus its original state, and gets back the session
+ *    token bundle.
  *
  * The callback only accepts GET redirects. Providers that POST it
  * (`response_mode=form_post`, notably Apple when name/email scopes are
@@ -176,5 +216,63 @@ export function setupOauth(
     },
   });
 
-  return { startSignIn };
+  /**
+   * Complete an OAuth sign-in by redeeming the one-time `code` from
+   * the callback redirect together with the state held since
+   * `startSignIn`. The state must be the value stored at sign-in
+   * time, never one read from a URL. Returns the session token
+   * bundle, or null when the code is unknown, already redeemed,
+   * expired, or the state doesn't match: all indistinguishable to
+   * the caller, like a failed `refreshSession`.
+   *
+   * The component calls are subtransactions of this mutation, so a
+   * failure anywhere (including the app rejecting the sign-in from
+   * `createOrUpdateUser`) rolls back the ticket claim; only a
+   * successful redemption consumes the ticket.
+   */
+  const completeSignIn = mutationGeneric({
+    args: {
+      code: v.string(),
+      state: v.string(),
+    },
+    returns: v.union(vTokenBundle, v.null()),
+    handler: async (ctx, args): Promise<TokenBundle | null> => {
+      const ticket = await ctx.runMutation(
+        options.component.provider.claimTicket,
+        {
+          providerName,
+          ticketCodeHash: await sha256Hex(args.code),
+          stateHash: await sha256Hex(args.state),
+        },
+      );
+      if (ticket === null) {
+        return null;
+      }
+
+      // Finding the ticket by hash proves `code` is the value the
+      // payload was encrypted under, so decryption only fails on
+      // corruption.
+      const { claims, userInfoResponses } = JSON.parse(
+        await decryptTicketPayload(args.code, ticket.payload),
+      ) as {
+        claims: OidcClaims | undefined;
+        userInfoResponses: Record<string, unknown> | undefined;
+      };
+
+      const profile = catalog.profile(claims, userInfoResponses);
+      if (typeof profile.id !== "string" || profile.id === "") {
+        throw new Error(
+          `Profile mapping for provider "${providerName}" returned no id`,
+        );
+      }
+
+      return await helpers.completeSignIn(ctx, {
+        provider: providerName,
+        providerAccountId: profile.id,
+        profile,
+      });
+    },
+  });
+
+  return { startSignIn, completeSignIn };
 }

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -157,6 +157,15 @@ export function setupOauth<
           `"${allowed}" (custom schemes like "myapp://" are not supported yet)`,
       );
     }
+    // An entry with a path would silently allow the whole origin, which is
+    // broader than what the config appears to say. Require bare origins.
+    if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
+      throw new Error(
+        `allowedRedirectOrigins entry must be a bare origin with no path, ` +
+          `query, or fragment: "${allowed}" (use "${url.origin}" to allow ` +
+          `the whole origin)`,
+      );
+    }
     return url.origin;
   });
   // Per OIDC, requesting the `openid` scope makes the provider return an

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -40,10 +40,7 @@ export type OidcClaims = {
  * against it at runtime.
  */
 export type OauthProfile<
-  // `any` default so unparameterized mappings can dig into responses
-  // without casting.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  UserInfo extends Record<string, unknown> = Record<string, any>,
+  UserInfo extends Record<string, unknown> = Record<string, unknown>,
 > = (
   claims: OidcClaims | undefined,
   userInfoResponses: UserInfo | undefined,
@@ -57,8 +54,7 @@ export type OauthProfile<
  * {@link OauthProfile}).
  */
 export type OauthCatalog<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  UserInfo extends Record<string, unknown> = Record<string, any>,
+  UserInfo extends Record<string, unknown> = Record<string, unknown>,
 > = {
   /**
    * The provider's authorization endpoint (a full URL), e.g. Google's
@@ -141,8 +137,7 @@ function parseUrl(value: string): URL | null {
  * TODO: support response_mode=form_post (Apple) before launch.
  */
 export function setupOauth<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  UserInfo extends Record<string, unknown> = Record<string, any>,
+  UserInfo extends Record<string, unknown> = Record<string, unknown>,
 >(
   providerName: string,
   catalog: OauthCatalog<UserInfo>,


### PR DESCRIPTION
- Add `completeSignIn`, the app-side mutation that redeems the callback ticket into a session
- Providers declare a typed `profile` mapping from provider identity to the account profile
