### PR TITLE
Add Google and GitHub OAuth catalogs

### DIFF
--- a/packages/core/src/oauth/component/_generated/api.ts
+++ b/packages/core/src/oauth/component/_generated/api.ts
@@ -10,6 +10,8 @@
 
 import type * as constants from "../constants.js";
 import type * as crypto from "../crypto.js";
+import type * as github from "../github.js";
+import type * as google from "../google.js";
 import type * as http from "../http.js";
 import type * as provider from "../provider.js";
 import type * as setup from "../setup.js";
@@ -24,6 +26,8 @@ import { anyApi, componentsGeneric } from "convex/server";
 const fullApi: ApiFromModules<{
   constants: typeof constants;
   crypto: typeof crypto;
+  github: typeof github;
+  google: typeof google;
   http: typeof http;
   provider: typeof provider;
   setup: typeof setup;

--- a/packages/core/src/oauth/component/github.test.ts
+++ b/packages/core/src/oauth/component/github.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { normalizeGithubProfile } from "./github";
+
+/** Call the mapping with the userinfo responses the callback would pass. */
+function normalize(
+  user: Record<string, unknown>,
+  emails?: Array<{ email: string; primary: boolean; verified: boolean }>,
+) {
+  return normalizeGithubProfile(undefined, { user, emails });
+}
+
+describe("normalizeGithubProfile", () => {
+  test("prefers the primary verified email", () => {
+    const profile = normalize({ id: 1, login: "octocat" }, [
+      { email: "secondary@example.com", primary: false, verified: true },
+      { email: "primary@example.com", primary: true, verified: true },
+      { email: "unverified@example.com", primary: false, verified: false },
+    ]);
+    expect(profile.email).toBe("primary@example.com");
+    expect(profile.emailVerified).toBe(true);
+  });
+
+  test("falls back to any verified email when none is primary", () => {
+    const profile = normalize({ id: 1, login: "octocat" }, [
+      { email: "unverified@example.com", primary: true, verified: false },
+      { email: "verified@example.com", primary: false, verified: true },
+    ]);
+    expect(profile.email).toBe("verified@example.com");
+    expect(profile.emailVerified).toBe(true);
+  });
+
+  test("falls back to the user endpoint email, marked unverified", () => {
+    const profile = normalize(
+      { id: 1, login: "octocat", email: "user@example.com" },
+      [{ email: "unverified@example.com", primary: true, verified: false }],
+    );
+    expect(profile.email).toBe("user@example.com");
+    expect(profile.emailVerified).toBe(false);
+  });
+
+  test("stringifies the id and falls back name to the login", () => {
+    const profile = normalize({
+      id: 42,
+      login: "octocat",
+      avatar_url: "https://a/x.png",
+    });
+    expect(profile.id).toBe("42");
+    expect(profile.login).toBe("octocat");
+    expect(profile.name).toBe("octocat");
+    expect(profile.avatarUrl).toBe("https://a/x.png");
+    expect(profile.email).toBeUndefined();
+  });
+
+  test("uses the provided name when present", () => {
+    const profile = normalize({ id: 1, login: "octocat", name: "The Octocat" });
+    expect(profile.name).toBe("The Octocat");
+  });
+
+  test("throws when the user response is missing", () => {
+    expect(() => normalizeGithubProfile(undefined, {})).toThrow(
+      /missing the `user` entry/,
+    );
+  });
+});

--- a/packages/core/src/oauth/component/github.test.ts
+++ b/packages/core/src/oauth/component/github.test.ts
@@ -66,4 +66,8 @@ describe("normalizeGithubProfile", () => {
       normalizeGithubProfile(undefined, {} as GithubUserInfo),
     ).toThrow(/missing the `user` entry/);
   });
+
+  test("throws when the user response has no id", () => {
+    expect(() => normalize({ login: "octocat" })).toThrow(/missing an id/);
+  });
 });

--- a/packages/core/src/oauth/component/github.test.ts
+++ b/packages/core/src/oauth/component/github.test.ts
@@ -4,10 +4,8 @@ import { normalizeGithubProfile } from "./github";
 type GithubUserInfo = NonNullable<Parameters<typeof normalizeGithubProfile>[1]>;
 
 /**
- * Call the mapping with the userinfo responses the callback would pass. The
- * cast lets tests feed loose and partial responses: the mapping's declared
- * shape is trusted typing, and these tests exercise the defensive paths
- * behind it.
+ * Call `normalizeGithubProfile` with fake userinfo responses. The cast lets
+ * tests feed loose and partial responses to exercise the defensive paths.
  */
 function normalize(
   user: Record<string, unknown>,

--- a/packages/core/src/oauth/component/github.test.ts
+++ b/packages/core/src/oauth/component/github.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "vitest";
 import { normalizeGithubProfile } from "./github";
 
-/** Call the mapping with the userinfo responses the callback would pass. */
+type GithubUserInfo = NonNullable<Parameters<typeof normalizeGithubProfile>[1]>;
+
+/**
+ * Call the mapping with the userinfo responses the callback would pass. The
+ * cast lets tests feed loose and partial responses: the mapping's declared
+ * shape is trusted typing, and these tests exercise the defensive paths
+ * behind it.
+ */
 function normalize(
   user: Record<string, unknown>,
   emails?: Array<{ email: string; primary: boolean; verified: boolean }>,
 ) {
-  return normalizeGithubProfile(undefined, { user, emails });
+  return normalizeGithubProfile(undefined, { user, emails } as GithubUserInfo);
 }
 
 describe("normalizeGithubProfile", () => {
@@ -57,8 +64,8 @@ describe("normalizeGithubProfile", () => {
   });
 
   test("throws when the user response is missing", () => {
-    expect(() => normalizeGithubProfile(undefined, {})).toThrow(
-      /missing the `user` entry/,
-    );
+    expect(() =>
+      normalizeGithubProfile(undefined, {} as GithubUserInfo),
+    ).toThrow(/missing the `user` entry/);
   });
 });

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -85,18 +85,20 @@ const githubCatalog: OauthCatalog = {
 };
 
 /**
- * Built-in GitHub OAuth provider. Register it with the shared oauth component:
+ * Built-in GitHub OAuth provider. Register it with its own oauth component
+ * mount:
  *
  * ```ts
  * provider(OauthGithub, {
- *   component: components.oauth,
- *   httpPrefix: "/oauth",
+ *   component: components.oauthGithub,
+ *   httpPrefix: "/oauth/github",
  *   allowedRedirectOrigins: ["https://app.example.com"],
  * })
  * ```
  *
- * Bind `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` on the oauth mount, and
- * register `<site-url>/oauth/github/callback` as the redirect URI with GitHub.
+ * Mount the component under `httpPrefix: "/oauth/github"` in
+ * convex.config.ts, binding GitHub's `CLIENT_ID`/`CLIENT_SECRET`, and register
+ * `<site-url>/oauth/github/callback` as the redirect URI with GitHub.
  *
  * Identity comes from the userinfo endpoints since GitHub returns no id_token.
  */

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -65,15 +65,15 @@ export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
     throw new Error("GitHub userinfo response is missing the `user` entry");
   }
   const emails = userInfoResponses?.emails ?? [];
-  const best =
+  const verifiedEmail =
     emails.find((entry) => entry.primary && entry.verified) ??
     emails.find((entry) => entry.verified);
   return {
     id: String(user.id),
     login: user.login,
     name: user.name ?? user.login,
-    email: best?.email ?? user.email ?? undefined,
-    emailVerified: best !== undefined,
+    email: verifiedEmail?.email ?? user.email ?? undefined,
+    emailVerified: verifiedEmail !== undefined,
     avatarUrl: user.avatar_url,
   };
 };
@@ -98,7 +98,7 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
  * ```ts
  * provider(OauthGithub, {
  *   component: components.oauthGithub,
- *   allowedRedirectOrigins: ["https://app.example.com"],
+ *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
  * })
  * ```
  *

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -8,21 +8,21 @@ import {
 } from "./setup";
 
 /**
- * The account profile the GitHub provider produces. GitHub is plain OAuth (no
- * id_token), so identity comes from its userinfo endpoints; this is the exact
- * shape the mapping emits, so the app can validate against it precisely.
+ * The account profile the GitHub provider produces. GitHub is plain OAuth
+ * (no id_token), so identity comes from its userinfo endpoints. This is the
+ * exact shape the mapping emits, so the app can validate against it
+ * precisely.
  */
 export const vGithubProfile = v.object({
-  /** GitHub's numeric user id, stringified — the stable provider account id. */
+  /** GitHub's numeric user id as a string, the stable provider account id. */
   id: v.string(),
   login: v.string(),
   name: v.optional(v.string()),
   email: v.optional(v.string()),
   /**
-   * True when the selected email came from a verified `/user/emails` entry.
-   * False means it fell back to the `/user` public profile email, whose
-   * verification status is unknown — either way, don't trust the email for
-   * account linking.
+   * True when the email came from a verified `/user/emails` entry. False
+   * means it fell back to the `/user` public profile email, whose
+   * verification status is unknown, so don't trust it for account linking.
    */
   emailVerified: v.boolean(),
   avatarUrl: v.optional(v.string()),
@@ -44,18 +44,11 @@ type GithubUser = {
 
 /**
  * The userinfo responses the catalog's endpoints produce, keyed like its
- * `userInfoEndpoints`. Trusted typing over what GitHub returns, not runtime
- * validation (see {@link OauthProfile}).
+ * `userInfoEndpoints` (see {@link OauthProfile}).
  */
 type GithubUserInfo = { user: GithubUser; emails: GithubEmail[] };
 
-/**
- * Map GitHub's userinfo responses to {@link GithubProfile}. `user` comes from
- * `/user` and `emails` from `/user/emails` (the endpoints the catalog fetches).
- * Email prefers the primary verified address, then any verified one, then
- * whatever `/user` returned — `emailVerified` reports whether the chosen
- * address came from a verified entry; `name` falls back to the login handle.
- */
+/** Map GitHub's userinfo responses to {@link GithubProfile}. */
 export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
   _claims,
   userInfoResponses,
@@ -78,7 +71,7 @@ export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
   };
 };
 
-/** How to talk to GitHub: endpoints, scopes, and the profile mapping. */
+/** GitHub's endpoints, scopes, and profile mapping. */
 const githubCatalog: OauthCatalog<GithubUserInfo> = {
   authorizationEndpoint: "https://github.com/login/oauth/authorize",
   tokenEndpoint: "https://github.com/login/oauth/access_token",
@@ -102,12 +95,15 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
  * })
  * ```
  *
- * Install the component under `httpPrefix: "/oauth/github"` in
- * convex.config.ts, binding GitHub's `CLIENT_ID`/`CLIENT_SECRET`, and register
- * `<site-url>/oauth/github/callback` as the redirect URI with GitHub. The
- * `httpPrefix` alone determines the callback URL.
+ * Setup:
  *
- * Identity comes from the userinfo endpoints since GitHub returns no id_token.
+ * 1. Install the component in convex.config.ts under
+ *    `httpPrefix: "/oauth/github"`, binding GitHub's `CLIENT_ID` and
+ *    `CLIENT_SECRET`.
+ * 2. Register `<site-url>/oauth/github/callback` as the redirect URI with
+ *    GitHub.
+ *
+ * The `httpPrefix` alone determines the callback URL.
  */
 export const OauthGithub = defineProvider({
   name: "github",

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -1,0 +1,117 @@
+import { Infer, v } from "convex/values";
+import { defineProvider } from "../../lib/types";
+import {
+  setupOauth,
+  type OauthCatalog,
+  type OauthProfile,
+  type OauthProviderOptions,
+} from "./setup";
+
+/**
+ * The account profile the GitHub provider produces. GitHub is plain OAuth (no
+ * id_token), so identity comes from its userinfo endpoints; this is the exact
+ * shape the mapping emits, so the app can validate against it precisely.
+ */
+export const vGithubProfile = v.object({
+  /** GitHub's numeric user id, stringified — the stable provider account id. */
+  id: v.string(),
+  login: v.string(),
+  name: v.optional(v.string()),
+  email: v.optional(v.string()),
+  /**
+   * True when the selected email came from a verified `/user/emails` entry.
+   * False means it fell back to the `/user` public profile email, whose
+   * verification status is unknown — either way, don't trust the email for
+   * account linking.
+   */
+  emailVerified: v.boolean(),
+  avatarUrl: v.optional(v.string()),
+});
+
+export type GithubProfile = Infer<typeof vGithubProfile>;
+
+/** A GitHub `/user/emails` entry, the fields the mapping reads. */
+type GithubEmail = { email: string; primary: boolean; verified: boolean };
+
+/** The GitHub `/user` fields the mapping reads. */
+type GithubUser = {
+  id: number | string;
+  login: string;
+  name?: string | null;
+  email?: string | null;
+  avatar_url?: string;
+};
+
+/**
+ * Map GitHub's userinfo responses to {@link GithubProfile}. `user` comes from
+ * `/user` and `emails` from `/user/emails` (the endpoints the catalog fetches).
+ * Email prefers the primary verified address, then any verified one, then
+ * whatever `/user` returned — `emailVerified` reports whether the chosen
+ * address came from a verified entry; `name` falls back to the login handle.
+ */
+export const normalizeGithubProfile: OauthProfile = (
+  _claims,
+  userInfoResponses,
+) => {
+  const user = userInfoResponses?.user as GithubUser | undefined;
+  if (user === undefined) {
+    throw new Error("GitHub userinfo response is missing the `user` entry");
+  }
+  const emails = (userInfoResponses?.emails ?? []) as GithubEmail[];
+  const best =
+    emails.find((entry) => entry.primary && entry.verified) ??
+    emails.find((entry) => entry.verified);
+  return {
+    id: String(user.id),
+    login: user.login,
+    name: user.name ?? user.login,
+    email: best?.email ?? user.email ?? undefined,
+    emailVerified: best !== undefined,
+    avatarUrl: user.avatar_url,
+  };
+};
+
+/** How to talk to GitHub: endpoints, scopes, and the profile mapping. */
+const githubCatalog: OauthCatalog = {
+  authorizationEndpoint: "https://github.com/login/oauth/authorize",
+  tokenEndpoint: "https://github.com/login/oauth/access_token",
+  scopes: ["read:user", "user:email"],
+  pkce: true,
+  userInfoEndpoints: {
+    user: "https://api.github.com/user",
+    emails: "https://api.github.com/user/emails",
+  },
+  profile: normalizeGithubProfile,
+};
+
+/**
+ * Built-in GitHub OAuth provider. Register it with the shared oauth component:
+ *
+ * ```ts
+ * provider(OauthGithub, {
+ *   component: components.oauth,
+ *   httpPrefix: "/oauth",
+ *   allowedRedirectOrigins: ["https://app.example.com"],
+ * })
+ * ```
+ *
+ * Bind `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` on the oauth mount, and
+ * register `<site-url>/oauth/github/callback` as the redirect URI with GitHub.
+ *
+ * Identity comes from the userinfo endpoints since GitHub returns no id_token.
+ */
+export const OauthGithub = defineProvider({
+  name: "github",
+  setup: (helpers, options: OauthProviderOptions) => {
+    const { startSignIn, completeSignIn } = setupOauth(
+      "github",
+      githubCatalog,
+      helpers,
+      options,
+    );
+    return {
+      startSignInGithub: startSignIn,
+      completeSignInGithub: completeSignIn,
+    };
+  },
+});

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -93,7 +93,7 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
 
 /**
  * Built-in GitHub OAuth provider. Register it with its own oauth component
- * mount:
+ * instance:
  *
  * ```ts
  * provider(OauthGithub, {
@@ -102,10 +102,10 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
  * })
  * ```
  *
- * Mount the component under `httpPrefix: "/oauth/github"` in
+ * Install the component under `httpPrefix: "/oauth/github"` in
  * convex.config.ts, binding GitHub's `CLIENT_ID`/`CLIENT_SECRET`, and register
  * `<site-url>/oauth/github/callback` as the redirect URI with GitHub. The
- * mount's prefix alone determines the callback URL.
+ * `httpPrefix` alone determines the callback URL.
  *
  * Identity comes from the userinfo endpoints since GitHub returns no id_token.
  */

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -57,6 +57,12 @@ export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
   if (user === undefined) {
     throw new Error("GitHub userinfo response is missing the `user` entry");
   }
+  // The response is untrusted JSON, and String() would turn a missing id
+  // into the literal string "undefined", collapsing every affected user
+  // into one account.
+  if (typeof user.id !== "number" && typeof user.id !== "string") {
+    throw new Error("GitHub userinfo `user` entry is missing an id");
+  }
   const emails = userInfoResponses?.emails ?? [];
   const verifiedEmail =
     emails.find((entry) => entry.primary && entry.verified) ??

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -91,14 +91,14 @@ const githubCatalog: OauthCatalog = {
  * ```ts
  * provider(OauthGithub, {
  *   component: components.oauthGithub,
- *   httpPrefix: "/oauth/github",
  *   allowedRedirectOrigins: ["https://app.example.com"],
  * })
  * ```
  *
  * Mount the component under `httpPrefix: "/oauth/github"` in
  * convex.config.ts, binding GitHub's `CLIENT_ID`/`CLIENT_SECRET`, and register
- * `<site-url>/oauth/github/callback` as the redirect URI with GitHub.
+ * `<site-url>/oauth/github/callback` as the redirect URI with GitHub. The
+ * mount's prefix alone determines the callback URL.
  *
  * Identity comes from the userinfo endpoints since GitHub returns no id_token.
  */

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -43,21 +43,28 @@ type GithubUser = {
 };
 
 /**
+ * The userinfo responses the catalog's endpoints produce, keyed like its
+ * `userInfoEndpoints`. Trusted typing over what GitHub returns, not runtime
+ * validation (see {@link OauthProfile}).
+ */
+type GithubUserInfo = { user: GithubUser; emails: GithubEmail[] };
+
+/**
  * Map GitHub's userinfo responses to {@link GithubProfile}. `user` comes from
  * `/user` and `emails` from `/user/emails` (the endpoints the catalog fetches).
  * Email prefers the primary verified address, then any verified one, then
  * whatever `/user` returned — `emailVerified` reports whether the chosen
  * address came from a verified entry; `name` falls back to the login handle.
  */
-export const normalizeGithubProfile: OauthProfile = (
+export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
   _claims,
   userInfoResponses,
 ) => {
-  const user = userInfoResponses?.user as GithubUser | undefined;
+  const user = userInfoResponses?.user;
   if (user === undefined) {
     throw new Error("GitHub userinfo response is missing the `user` entry");
   }
-  const emails = (userInfoResponses?.emails ?? []) as GithubEmail[];
+  const emails = userInfoResponses?.emails ?? [];
   const best =
     emails.find((entry) => entry.primary && entry.verified) ??
     emails.find((entry) => entry.verified);
@@ -72,7 +79,7 @@ export const normalizeGithubProfile: OauthProfile = (
 };
 
 /** How to talk to GitHub: endpoints, scopes, and the profile mapping. */
-const githubCatalog: OauthCatalog = {
+const githubCatalog: OauthCatalog<GithubUserInfo> = {
   authorizationEndpoint: "https://github.com/login/oauth/authorize",
   tokenEndpoint: "https://github.com/login/oauth/access_token",
   scopes: ["read:user", "user:email"],

--- a/packages/core/src/oauth/component/google.test.ts
+++ b/packages/core/src/oauth/component/google.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { normalizeGoogleProfile } from "./google";
+
+describe("normalizeGoogleProfile", () => {
+  test("maps validated id_token claims to the profile", () => {
+    const profile = normalizeGoogleProfile(
+      {
+        sub: "123",
+        email: "user@example.com",
+        email_verified: true,
+        name: "A User",
+        picture: "https://example.com/avatar.png",
+      },
+      undefined,
+    );
+    expect(profile).toEqual({
+      id: "123",
+      email: "user@example.com",
+      emailVerified: true,
+      name: "A User",
+      picture: "https://example.com/avatar.png",
+    });
+  });
+
+  test("treats an absent email_verified claim as unverified", () => {
+    const profile = normalizeGoogleProfile(
+      { sub: "123", email: "user@example.com" },
+      undefined,
+    );
+    expect(profile.emailVerified).toBe(false);
+  });
+
+  test("throws when there is no id_token to map", () => {
+    expect(() => normalizeGoogleProfile(undefined, undefined)).toThrow(
+      /no id_token/,
+    );
+  });
+});

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -56,18 +56,20 @@ const googleCatalog: OauthCatalog = {
 };
 
 /**
- * Built-in Google OAuth provider. Register it with the shared oauth component:
+ * Built-in Google OAuth provider. Register it with its own oauth component
+ * mount:
  *
  * ```ts
  * provider(OauthGoogle, {
- *   component: components.oauth,
- *   httpPrefix: "/oauth",
+ *   component: components.oauthGoogle,
+ *   httpPrefix: "/oauth/google",
  *   allowedRedirectOrigins: ["https://app.example.com"],
  * })
  * ```
  *
- * Bind `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` on the oauth mount, and
- * register `<site-url>/oauth/google/callback` as the redirect URI with Google.
+ * Mount the component under `httpPrefix: "/oauth/google"` in
+ * convex.config.ts, binding Google's `CLIENT_ID`/`CLIENT_SECRET`, and register
+ * `<site-url>/oauth/google/callback` as the redirect URI with Google.
  */
 export const OauthGoogle = defineProvider({
   name: "google",

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -9,17 +9,17 @@ import {
 
 /**
  * The account profile the Google provider produces. Google is OIDC, so
- * identity comes from validated id_token claims; this is the exact shape the
+ * identity comes from validated id_token claims. This is the exact shape the
  * mapping emits, so the app can validate against it precisely.
  */
 export const vGoogleProfile = v.object({
-  /** Google's `sub` claim — the stable provider account id. */
+  /** Google's `sub` claim, the stable provider account id. */
   id: v.string(),
   email: v.optional(v.string()),
   /**
    * True when Google attested the email as verified (the `email_verified`
-   * claim). False means unverified *or* the claim was absent — either way,
-   * don't trust the email for account linking.
+   * claim). False means unverified or the claim was absent, so don't trust
+   * the email for account linking.
    */
   emailVerified: v.boolean(),
   name: v.optional(v.string()),
@@ -29,8 +29,9 @@ export const vGoogleProfile = v.object({
 export type GoogleProfile = Infer<typeof vGoogleProfile>;
 
 /**
- * Map validated Google id_token claims to {@link GoogleProfile}. Google returns
- * an id_token, so `claims` is always present here; a missing one is a bug.
+ * Map validated Google id_token claims to {@link GoogleProfile}. Google
+ * returns an id_token, so `claims` is always present here. A missing one is
+ * a bug.
  */
 export const normalizeGoogleProfile: OauthProfile = (claims) => {
   if (claims === undefined) {
@@ -45,7 +46,7 @@ export const normalizeGoogleProfile: OauthProfile = (claims) => {
   };
 };
 
-/** How to talk to Google: endpoints, scopes, and the profile mapping. */
+/** Google's endpoints, scopes, and profile mapping. */
 const googleCatalog: OauthCatalog = {
   authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenEndpoint: "https://oauth2.googleapis.com/token",
@@ -66,10 +67,15 @@ const googleCatalog: OauthCatalog = {
  * })
  * ```
  *
- * Install the component under `httpPrefix: "/oauth/google"` in
- * convex.config.ts, binding Google's `CLIENT_ID`/`CLIENT_SECRET`, and register
- * `<site-url>/oauth/google/callback` as the redirect URI with Google. The
- * `httpPrefix` alone determines the callback URL.
+ * Setup:
+ *
+ * 1. Install the component in convex.config.ts under
+ *    `httpPrefix: "/oauth/google"`, binding Google's `CLIENT_ID` and
+ *    `CLIENT_SECRET`.
+ * 2. Register `<site-url>/oauth/google/callback` as the redirect URI with
+ *    Google.
+ *
+ * The `httpPrefix` alone determines the callback URL.
  */
 export const OauthGoogle = defineProvider({
   name: "google",

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -1,0 +1,86 @@
+import { Infer, v } from "convex/values";
+import { defineProvider } from "../../lib/types";
+import {
+  setupOauth,
+  type OauthCatalog,
+  type OauthProfile,
+  type OauthProviderOptions,
+} from "./setup";
+
+/**
+ * The account profile the Google provider produces. Google is OIDC, so
+ * identity comes from validated id_token claims; this is the exact shape the
+ * mapping emits, so the app can validate against it precisely.
+ */
+export const vGoogleProfile = v.object({
+  /** Google's `sub` claim — the stable provider account id. */
+  id: v.string(),
+  email: v.optional(v.string()),
+  /**
+   * True when Google attested the email as verified (the `email_verified`
+   * claim). False means unverified *or* the claim was absent — either way,
+   * don't trust the email for account linking.
+   */
+  emailVerified: v.boolean(),
+  name: v.optional(v.string()),
+  picture: v.optional(v.string()),
+});
+
+export type GoogleProfile = Infer<typeof vGoogleProfile>;
+
+/**
+ * Map validated Google id_token claims to {@link GoogleProfile}. Google returns
+ * an id_token, so `claims` is always present here; a missing one is a bug.
+ */
+export const normalizeGoogleProfile: OauthProfile = (claims) => {
+  if (claims === undefined) {
+    throw new Error("Google returned no id_token to build a profile from");
+  }
+  return {
+    id: claims.sub,
+    email: claims.email,
+    emailVerified: claims.email_verified === true,
+    name: claims.name,
+    picture: claims.picture,
+  };
+};
+
+/** How to talk to Google: endpoints, scopes, and the profile mapping. */
+const googleCatalog: OauthCatalog = {
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  issuer: "https://accounts.google.com",
+  scopes: ["openid", "email", "profile"],
+  pkce: true,
+  profile: normalizeGoogleProfile,
+};
+
+/**
+ * Built-in Google OAuth provider. Register it with the shared oauth component:
+ *
+ * ```ts
+ * provider(OauthGoogle, {
+ *   component: components.oauth,
+ *   httpPrefix: "/oauth",
+ *   allowedRedirectOrigins: ["https://app.example.com"],
+ * })
+ * ```
+ *
+ * Bind `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` on the oauth mount, and
+ * register `<site-url>/oauth/google/callback` as the redirect URI with Google.
+ */
+export const OauthGoogle = defineProvider({
+  name: "google",
+  setup: (helpers, options: OauthProviderOptions) => {
+    const { startSignIn, completeSignIn } = setupOauth(
+      "google",
+      googleCatalog,
+      helpers,
+      options,
+    );
+    return {
+      startSignInGoogle: startSignIn,
+      completeSignInGoogle: completeSignIn,
+    };
+  },
+});

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -62,14 +62,14 @@ const googleCatalog: OauthCatalog = {
  * ```ts
  * provider(OauthGoogle, {
  *   component: components.oauthGoogle,
- *   httpPrefix: "/oauth/google",
  *   allowedRedirectOrigins: ["https://app.example.com"],
  * })
  * ```
  *
  * Mount the component under `httpPrefix: "/oauth/google"` in
  * convex.config.ts, binding Google's `CLIENT_ID`/`CLIENT_SECRET`, and register
- * `<site-url>/oauth/google/callback` as the redirect URI with Google.
+ * `<site-url>/oauth/google/callback` as the redirect URI with Google. The
+ * mount's prefix alone determines the callback URL.
  */
 export const OauthGoogle = defineProvider({
   name: "google",

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -57,7 +57,7 @@ const googleCatalog: OauthCatalog = {
 
 /**
  * Built-in Google OAuth provider. Register it with its own oauth component
- * mount:
+ * instance:
  *
  * ```ts
  * provider(OauthGoogle, {
@@ -66,10 +66,10 @@ const googleCatalog: OauthCatalog = {
  * })
  * ```
  *
- * Mount the component under `httpPrefix: "/oauth/google"` in
+ * Install the component under `httpPrefix: "/oauth/google"` in
  * convex.config.ts, binding Google's `CLIENT_ID`/`CLIENT_SECRET`, and register
  * `<site-url>/oauth/google/callback` as the redirect URI with Google. The
- * mount's prefix alone determines the callback URL.
+ * `httpPrefix` alone determines the callback URL.
  */
 export const OauthGoogle = defineProvider({
   name: "google",

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -50,7 +50,8 @@ export const normalizeGoogleProfile: OauthProfile = (claims) => {
 const googleCatalog: OauthCatalog = {
   authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenEndpoint: "https://oauth2.googleapis.com/token",
-  issuer: "https://accounts.google.com",
+  // Google documents both forms, with or without the https prefix.
+  issuer: ["https://accounts.google.com", "accounts.google.com"],
   scopes: ["openid", "email", "profile"],
   pkce: true,
   profile: normalizeGoogleProfile,

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -62,7 +62,7 @@ const googleCatalog: OauthCatalog = {
  * ```ts
  * provider(OauthGoogle, {
  *   component: components.oauthGoogle,
- *   allowedRedirectOrigins: ["https://app.example.com"],
+ *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
  * })
  * ```
  *

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -32,7 +32,7 @@ export type OidcClaims = {
  * non-OIDC providers). `userInfoResponses` holds the userinfo responses
  * keyed as configured (`undefined` unless the catalog sets
  * `userInfoEndpoints`). `id` becomes the provider account id. Supplied by
- * each provider's catalog.
+ * each provider's catalog (see `google.ts`, `github.ts`).
  *
  * `UserInfo` is the catalog's declared shape for the userinfo responses,
  * keyed like `userInfoEndpoints`. It types what the provider is trusted to


### PR DESCRIPTION
- Add built-in Google and GitHub provider definitions: endpoints, default scopes, and profile mapping
