### PR TITLE
return null on pre-verification code errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- fix: a failed OTP/magic-link sign-in no longer consumes the verification code
+  it rejected
+- fix: `signIn` called with only a `code` now resolves with `{ tokens: null }`
+  for every failure instead of rejecting for some
+
 ## 0.0.94
 
 - chore: bump `@auth/core` peer dependency (#320) @eden881

--- a/src/server/implementation/mutations/verifyCodeAndSignIn.ts
+++ b/src/server/implementation/mutations/verifyCodeAndSignIn.ts
@@ -129,7 +129,6 @@ async function verifyCodeOnly(
     logWithLevel(LOG_LEVELS.INFO, "Invalid verification code");
     return null;
   }
-  await ctx.db.delete(verificationCode._id);
   if (verificationCode.verifier !== verifier) {
     // Expected: e.g. a magic link opened in a different browser than it was requested
     // from. Normal sign-in failure.
@@ -139,6 +138,7 @@ async function verifyCodeOnly(
   if (verificationCode.expirationTime < Date.now()) {
     // Expected: the user took too long, or followed a stale magic link.
     logWithLevel(LOG_LEVELS.INFO, "Expired verification code");
+    await ctx.db.delete(verificationCode._id);
     return null;
   }
   const { accountId, emailVerified, phoneVerified } = verificationCode;
@@ -163,21 +163,49 @@ async function verifyCodeOnly(
     );
     return null;
   }
-  // OTP providers perform an additional check against the provided
-  // params.
-  const methodProvider = getProviderOrThrow(
+  const methodProvider = Provider.getProviderOrNull(
+    getProviderOrThrow,
     verificationCode.provider,
     allowExtraProviders,
   );
+  if (methodProvider === null) {
+    logWithLevel(
+      LOG_LEVELS.WARN,
+      `Provider "${verificationCode.provider}" which generated this \`code\` ` +
+        `is not available here`,
+    );
+    return null;
+  }
+
   if (
-    methodProvider !== null &&
     (methodProvider.type === "email" || methodProvider.type === "phone") &&
     methodProvider.authorize !== undefined
   ) {
-    await methodProvider.authorize(args.params, account);
+    try {
+      await methodProvider.authorize(args.params, account);
+    } catch (error) {
+      logWithLevel(
+        LOG_LEVELS.WARN,
+        "Verification code failed the provider's `authorize` check",
+        error,
+      );
+      return null;
+    }
   }
+  const provider = Provider.getProviderOrNull(
+    getProviderOrThrow,
+    account.provider,
+  );
+  if (provider === null) {
+    logWithLevel(
+      LOG_LEVELS.WARN,
+      `Provider "${account.provider}" for this account is not configured`,
+    );
+    return null;
+  }
+  // Every check passed, so consume the code.
+  await ctx.db.delete(verificationCode._id);
   let userId = account.userId;
-  const provider = getProviderOrThrow(account.provider);
   if (!(provider.type === "oauth" || provider.type === "oidc")) {
     ({ userId } = await upsertUserAndAccount(
       ctx,

--- a/src/server/implementation/provider.ts
+++ b/src/server/implementation/provider.ts
@@ -35,4 +35,16 @@ export type GetProviderOrThrowFunc = (
   allowExtraProviders?: boolean,
 ) => AuthProviderMaterializedConfig;
 
+export function getProviderOrNull(
+  getProviderOrThrow: GetProviderOrThrowFunc,
+  id: string,
+  allowExtraProviders?: boolean,
+): AuthProviderMaterializedConfig | null {
+  try {
+    return getProviderOrThrow(id, allowExtraProviders);
+  } catch {
+    return null;
+  }
+}
+
 export type Config = any;

--- a/test/convex/oauth.test.ts
+++ b/test/convex/oauth.test.ts
@@ -1,11 +1,13 @@
 import { convexTest } from "convex-test";
 import { expect, test } from "vitest";
+import { api } from "./_generated/api";
 import schema from "./schema";
 import {
   CONVEX_SITE_URL,
   JWKS,
   JWT_PRIVATE_KEY,
   signInViaGitHub,
+  startSignInViaGitHub,
 } from "./test.helpers";
 
 test("sign up with oauth", async () => {
@@ -61,6 +63,25 @@ test("sign in with oauth", async () => {
     const users = await ctx.db.query("users").collect();
     expect(users).toMatchObject([{ email: "tom@gmail.com", name: "Thomas" }]);
   });
+});
+
+test("an oauth code redeemed without its verifier is not consumed", async () => {
+  setupEnv();
+  const t = convexTest(schema);
+  const { code, verifier } = await startSignInViaGitHub(t, "github", {
+    email: "tom@gmail.com",
+    name: "Tom",
+    id: "someGitHubId",
+  });
+
+  const result = await t.action(api.auth.signIn, { params: { code } });
+  expect(result).toEqual({ tokens: null });
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    params: { code },
+    verifier,
+  });
+  expect(tokens).not.toBeNull();
 });
 
 test("redirectTo with oauth", async () => {

--- a/test/convex/otp.test.ts
+++ b/test/convex/otp.test.ts
@@ -22,7 +22,7 @@ test("sign in with otp", async () => {
   expect(tokens).not.toBeNull();
 });
 
-test("make sure OTP requires email check", async () => {
+test("a valid OTP code returns null instead of throwing without the email", async () => {
   setupEnv();
   const t = convexTest(schema);
 
@@ -36,14 +36,37 @@ test("make sure OTP requires email check", async () => {
       }),
   );
 
-  await expect(
+  const valid = await t.action(api.auth.signIn, { params: { code } });
+  const invalid = await t.action(api.auth.signIn, {
+    params: { code: "00000000" },
+  });
+
+  expect(valid).toEqual({ tokens: null });
+  expect(invalid).toEqual(valid);
+});
+
+test("a failed redemption does not consume the code", async () => {
+  setupEnv();
+  const t = convexTest(schema);
+
+  const { code } = await mockResendOTP(
     async () =>
       await t.action(api.auth.signIn, {
-        params: { code },
+        provider: "resend-otp",
+        params: {
+          email: "tom@gmail.com",
+        },
       }),
-  ).rejects.toThrowError(
-    "Token verification requires an `email` in params of `signIn`",
   );
+
+  await t.action(api.auth.signIn, { params: { code } });
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    provider: "resend-otp",
+    params: { code, email: "tom@gmail.com" },
+  });
+
+  expect(tokens).not.toBeNull();
 });
 
 function setupEnv() {

--- a/test/convex/passwords.test.ts
+++ b/test/convex/passwords.test.ts
@@ -127,11 +127,12 @@ test("password reset flow", async () => {
   });
 
   // Request password reset
-  const { code } = await mockResendOTP(async () =>
-    await t.action(api.auth.signIn, {
-      provider: "password-with-reset",
-      params: { email: "sarah@gmail.com", flow: "reset" },
-    }),
+  const { code } = await mockResendOTP(
+    async () =>
+      await t.action(api.auth.signIn, {
+        provider: "password-with-reset",
+        params: { email: "sarah@gmail.com", flow: "reset" },
+      }),
   );
 
   // Complete reset with new password
@@ -172,6 +173,43 @@ test("password reset flow", async () => {
   expect(tokens2).not.toBeNull();
 });
 
+test("a reset code redeemed without its provider is not consumed", async () => {
+  setupEnv();
+  const t = convexTest(schema);
+
+  await t.action(api.auth.signIn, {
+    provider: "password-with-reset",
+    params: {
+      email: "sarah@gmail.com",
+      password: "44448888",
+      flow: "signUp",
+    },
+  });
+
+  const { code } = await mockResendOTP(
+    async () =>
+      await t.action(api.auth.signIn, {
+        provider: "password-with-reset",
+        params: { email: "sarah@gmail.com", flow: "reset" },
+      }),
+  );
+
+  const result = await t.action(api.auth.signIn, { params: { code } });
+  expect(result).toEqual({ tokens: null });
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    provider: "password-with-reset",
+    params: {
+      email: "sarah@gmail.com",
+      code,
+      newPassword: "99991111",
+      flow: "reset-verification",
+    },
+  });
+
+  expect(tokens).not.toBeNull();
+});
+
 test("password reset code cannot be used for a different account", async () => {
   setupEnv();
   const t = convexTest(schema);
@@ -196,11 +234,12 @@ test("password reset code cannot be used for a different account", async () => {
   });
 
   // Attacker requests reset code for their own account
-  const { code } = await mockResendOTP(async () =>
-    await t.action(api.auth.signIn, {
-      provider: "password-with-reset",
-      params: { email: "attacker@gmail.com", flow: "reset" },
-    }),
+  const { code } = await mockResendOTP(
+    async () =>
+      await t.action(api.auth.signIn, {
+        provider: "password-with-reset",
+        params: { email: "attacker@gmail.com", flow: "reset" },
+      }),
   );
 
   // Attacker tries to use their code with victim's email
@@ -253,11 +292,12 @@ test("password reset code cannot be used for a different account (raw EmailConfi
   });
 
   // Attacker requests reset code for their own account
-  const { code } = await mockResendOTP(async () =>
-    await t.action(api.auth.signIn, {
-      provider: "password-raw-reset",
-      params: { email: "attacker@gmail.com", flow: "reset" },
-    }),
+  const { code } = await mockResendOTP(
+    async () =>
+      await t.action(api.auth.signIn, {
+        provider: "password-raw-reset",
+        params: { email: "attacker@gmail.com", flow: "reset" },
+      }),
   );
 
   // Attacker tries to use their code with victim's email.

--- a/test/convex/test.helpers.ts
+++ b/test/convex/test.helpers.ts
@@ -19,6 +19,33 @@ export async function signInViaGitHub(
     redirectTo?: string;
   } = {},
 ) {
+  const { code, verifier, url } = await startSignInViaGitHub(
+    t,
+    provider,
+    githubProfile,
+    params,
+  );
+
+  const { tokens } = await t.action(api.auth.signIn, {
+    params: { code },
+    verifier,
+  });
+  return { tokens, url };
+}
+
+/**
+ * Runs the OAuth flow up to the point where the client holds a `code` and its
+ * `verifier`, without redeeming them. Lets tests assert on how a code that is
+ * still in flight behaves.
+ */
+export async function startSignInViaGitHub(
+  t: TestConvexForDataModel<DataModel>,
+  provider: string,
+  githubProfile: Record<string, unknown>,
+  params: {
+    redirectTo?: string;
+  } = {},
+) {
   const { redirect, verifier } = await t.action(api.auth.signIn, {
     provider,
     params,
@@ -99,11 +126,7 @@ export async function signInViaGitHub(
   expect(finalRedirectedTo).not.toBeNull();
   const code = new URL(finalRedirectedTo!).searchParams.get("code");
 
-  const { tokens } = await t.action(api.auth.signIn, {
-    params: { code },
-    verifier,
-  });
-  return { tokens, url: finalRedirectedTo! };
+  return { code, verifier, url: finalRedirectedTo! };
 }
 
 export async function signInViaMagicLink(


### PR DESCRIPTION
- return null on pre-verification code errors
- avoid consuming verification codes on early failures that shouldn't lead to consumption