### PR TITLE
Username+passkey provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This is a pnpm monorepo:
   directory:
   - `react-minimal` wires up the core with the anonymous provider.
   - `react-password` wires up the core with the password provider.
+  - `react-passkey` wires up the core with the passkey provider
+    (username + passkey, no password). It has no frontend yet.
 
 Use `pnpm install` at the root. Common tasks:
 

--- a/examples/react-passkey/.gitignore
+++ b/examples/react-passkey/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-passkey/README.md
+++ b/examples/react-passkey/README.md
@@ -1,0 +1,27 @@
+# react-passkey example
+
+This demo shows:
+
+- The core component.
+- The passkey component, through the `UsernamePasskey` provider.
+
+The flow is identifier-first. The user enters a username. When the
+username exists, the app asks for a passkey of that account. When the
+username is free, the app creates the account and immediately asks the
+user to register a passkey. There is no password and no recovery flow.
+
+The example has no frontend yet; it contains only the Convex backend.
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-passkey
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx @convex-dev/auth     # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+```
+
+## Test usage
+
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-passkey/convex/_generated/api.d.ts
+++ b/examples/react-passkey/convex/_generated/api.d.ts
@@ -1,0 +1,57 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as currentUser from "../currentUser.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  currentUser: typeof currentUser;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  authPasskey: import("@convex-dev/auth/providers/passkey/_generated/component.js").ComponentApi<"authPasskey">;
+  authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;
+};

--- a/examples/react-passkey/convex/_generated/api.js
+++ b/examples/react-passkey/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-passkey/convex/_generated/dataModel.d.ts
+++ b/examples/react-passkey/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-passkey/convex/_generated/server.d.ts
+++ b/examples/react-passkey/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-passkey/convex/_generated/server.js
+++ b/examples/react-passkey/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-passkey/convex/auth.config.ts
+++ b/examples/react-passkey/convex/auth.config.ts
@@ -1,0 +1,13 @@
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;

--- a/examples/react-passkey/convex/auth.ts
+++ b/examples/react-passkey/convex/auth.ts
@@ -1,0 +1,35 @@
+import { components, internal } from "./_generated/api";
+import { provider, setupCore } from "@convex-dev/auth/core/setup";
+import { UsernamePasskey } from "@convex-dev/auth/providers/passkey/setup";
+
+export const {
+  signOut,
+  refreshSession,
+  providers: {
+    passkey: {
+      startSignIn,
+      finishSignUp,
+      finishSignIn,
+      changeUsername,
+      startAddPasskey,
+      finishAddPasskey,
+      listPasskeys,
+      startDeletePasskey,
+      finishDeletePasskey,
+    },
+  },
+} = setupCore({
+  component: components.core,
+  providers: [
+    provider(UsernamePasskey, {
+      component: components.authPasskey,
+      usernameComponent: components.authUsername,
+      // The values below are for local development. In production, set the
+      // relying party ID to the registrable domain of the app (for
+      // example, "example.com") and the origin to the full app origin (for
+      // example, "https://app.example.com").
+      rpId: "localhost",
+      origin: "http://localhost:5173",
+    }),
+  ],
+}).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-passkey/convex/convex.config.ts
+++ b/examples/react-passkey/convex/convex.config.ts
@@ -1,0 +1,24 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+import passkeyProvider from "@convex-dev/auth/providers/passkey/convex.config.js";
+import username from "@convex-dev/auth/username/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(passkeyProvider);
+app.use(username);
+
+export default app;

--- a/examples/react-passkey/convex/currentUser.ts
+++ b/examples/react-passkey/convex/currentUser.ts
@@ -1,0 +1,24 @@
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+/**
+ * The currently signed-in user, or null.
+ *
+ * Demonstrates an authenticated query.
+ */
+export const loggedInUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+    const userId = identity.subject as Id<"users">;
+    const user = await ctx.db.get("users", userId);
+    if (user === null) {
+      return null;
+    }
+
+    return { id: user._id, username: user.username };
+  },
+});

--- a/examples/react-passkey/convex/schema.ts
+++ b/examples/react-passkey/convex/schema.ts
@@ -1,0 +1,12 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  users: defineTable({
+    // The username is optional: the passkey provider creates the user row
+    // before the WebAuthn ceremony, and the username arrives only when the
+    // ceremony completes. A row without a username is an abandoned
+    // registration; this leak is accepted by design.
+    username: v.optional(v.string()),
+  }),
+});

--- a/examples/react-passkey/convex/tsconfig.json
+++ b/examples/react-passkey/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-passkey/convex/users.ts
+++ b/examples/react-passkey/convex/users.ts
@@ -1,0 +1,71 @@
+import { internalMutation } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+import { v } from "convex/values";
+
+/**
+ * The app's user callback for Convex Auth. The passkey provider calls it
+ * with three shapes (see the `UsernamePasskey` documentation):
+ *
+ * 1. No arguments: create a new empty user row and return its id. The
+ *    provider makes this call before the WebAuthn ceremony, because the
+ *    row id is the WebAuthn user handle.
+ * 2. `userId: null` with `profile.existingUserId`: the first sign-in of a
+ *    new account. Return the row from shape 1 instead of a new row. The
+ *    value is trusted: it comes from the provider, not from the client.
+ * 3. `userId` set: a returning sign-in or a username change. Update the
+ *    stored username and return the same id.
+ */
+export const createOrUpdateUser = internalMutation({
+  args: {
+    provider: v.optional(v.literal("passkey")),
+    providerAccountId: v.optional(v.string()),
+    profile: v.optional(v.any()),
+    userId: v.optional(v.union(v.string(), v.null())),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    // Shape 1: a call with no arguments creates an empty user row.
+    if (args.provider === undefined && args.userId === undefined) {
+      return await ctx.db.insert("users", {});
+    }
+
+    const username =
+      typeof args.profile?.username === "string"
+        ? args.profile.username
+        : undefined;
+
+    const applyUsername = async (id: Id<"users">) => {
+      if (username !== undefined) {
+        await ctx.db.patch("users", id, { username });
+      }
+      return id;
+    };
+
+    // Shape 3: a returning user. Update the username from the profile.
+    if (typeof args.userId === "string") {
+      const existing = ctx.db.normalizeId("users", args.userId);
+      if (existing === null) {
+        throw new Error(`Unknown user id: ${args.userId}`);
+      }
+      return await applyUsername(existing);
+    }
+
+    // Shape 2: the first sign-in of a new account. The provider created
+    // the user row earlier and put its id into the profile.
+    const existingUserId =
+      typeof args.profile?.existingUserId === "string"
+        ? args.profile.existingUserId
+        : undefined;
+    if (existingUserId !== undefined) {
+      const existing = ctx.db.normalizeId("users", existingUserId);
+      if (existing === null) {
+        throw new Error(`Unknown user id: ${existingUserId}`);
+      }
+      return await applyUsername(existing);
+    }
+
+    // A first sign-in without an earlier user row. The passkey provider
+    // does not use this path, but a second provider could.
+    return await ctx.db.insert("users", { username });
+  },
+});

--- a/examples/react-passkey/package.json
+++ b/examples/react-passkey/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "example-react-passkey",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "convex": "^1.41.0"
+  },
+  "scripts": {
+    "dev": "convex dev",
+    "typecheck": "tsc -p convex --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
+    "@types/node": "^24.12.4",
+    "convex-test": "^0.0.53",
+    "jose": "^5.10.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.0"
+  }
+}

--- a/examples/react-passkey/tsconfig.json
+++ b/examples/react-passkey/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["convex/**/*"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -24,6 +24,13 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     public: {
+      getProviderAccountId: FunctionReference<
+        "query",
+        "internal",
+        { provider: string; userId: string },
+        string | null,
+        Name
+      >;
       getUserIdByAccount: FunctionReference<
         "query",
         "internal",
@@ -47,6 +54,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           refreshTokenExpiresAt: number;
           userId: string;
         } | null,
+        Name
+      >;
+      renameAccount: FunctionReference<
+        "mutation",
+        "internal",
+        { newProviderAccountId: string; provider: string; userId: string },
+        { success: true } | { reason: "ACCOUNT_ID_TAKEN"; success: false },
         Name
       >;
       signIn: FunctionReference<

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -262,6 +262,95 @@ export const getUserIdByAccount = query({
 });
 
 /**
+ * Find the single account of `provider` that belongs to `userId`.
+ *
+ * Returns `null` when the user has no account for the provider. Throws when
+ * the user has more than one account for the provider: callers use this for
+ * providers that keep at most one account for each user, so more than one
+ * account shows corrupted data.
+ */
+async function singleAccountByUser(
+  ctx: QueryCtx,
+  provider: string,
+  userId: string,
+): Promise<Doc<"accounts"> | null> {
+  const accounts = await ctx.db
+    .query("accounts")
+    .withIndex("by_user", (q) => q.eq("userId", userId))
+    .collect();
+  const matches = accounts.filter((account) => account.provider === provider);
+  if (matches.length > 1) {
+    throw new Error(`User ${userId} has more than one "${provider}" account.`);
+  }
+  return matches[0] ?? null;
+}
+
+/**
+ * Resolve an app user id to its provider account id. This is the reverse of
+ * `getUserIdByAccount`.
+ *
+ * Providers use this (via the `resolveProviderAccountId` helper) when they
+ * know the user but not the account. For example, the passkey provider
+ * finds the username of an authenticated credential this way. Returns
+ * `null` when no account exists. Throws when the user has more than one
+ * account for the provider, so use it only with providers that keep at
+ * most one account for each user.
+ */
+export const getProviderAccountId = query({
+  args: { provider: v.string(), userId: v.string() },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, { provider, userId }): Promise<string | null> => {
+    const account = await singleAccountByUser(ctx, provider, userId);
+    return account?.providerAccountId ?? null;
+  },
+});
+
+const renameAccountResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({
+    success: v.literal(false),
+    reason: v.literal("ACCOUNT_ID_TAKEN"),
+  }),
+);
+
+/**
+ * Change the provider account id of a user's account. For example, the
+ * passkey provider stores the username as the account id, so a username
+ * change is a rename of the account.
+ *
+ * The rename fails with `ACCOUNT_ID_TAKEN` when a different account of the
+ * same provider already uses the new id. A rename to the current id is a
+ * no-op that succeeds. Sessions point at the account row by id, so they
+ * stay valid across the rename. Throws when the user has no account for
+ * the provider, because that shows a caller bug, not a user error.
+ */
+export const renameAccount = mutation({
+  args: {
+    provider: v.string(),
+    userId: v.string(),
+    newProviderAccountId: v.string(),
+  },
+  returns: renameAccountResult,
+  handler: async (ctx, { provider, userId, newProviderAccountId }) => {
+    const account = await singleAccountByUser(ctx, provider, userId);
+    if (account === null) {
+      throw new Error(`User ${userId} has no "${provider}" account.`);
+    }
+    if (account.providerAccountId === newProviderAccountId) {
+      return { success: true as const };
+    }
+    const taken = await accountByIdentity(ctx, provider, newProviderAccountId);
+    if (taken !== null) {
+      return { success: false as const, reason: "ACCOUNT_ID_TAKEN" as const };
+    }
+    await ctx.db.patch("accounts", account._id, {
+      providerAccountId: newProviderAccountId,
+    });
+    return { success: true as const };
+  },
+});
+
+/**
  * Rotate a refresh token and mint a fresh access token. Returns `null` when the
  * session can't be refreshed. That can happen with an unknown token, or one
  * past its refresh-token lifetime. A dead session is a normal outcome the

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -13,6 +13,9 @@ import {
   ProviderConfig,
   CompleteSignInFunc,
   ResolveUserIdFunc,
+  ResolveProviderAccountIdFunc,
+  RenameProviderAccountFunc,
+  RunCreateOrUpdateUserFunc,
   CreateOrUpdateUserFn,
 } from "../../lib/types";
 
@@ -230,6 +233,19 @@ export function setupCore<T extends readonly ProviderWithOptions[]>({
       });
     };
 
+    // Runs the app's `createOrUpdateUser` mutation directly, without an
+    // account row and without a session. A provider calls it with no `args`
+    // to make the app create a new empty user row (see the passkey
+    // provider), and with the full `args` to make the app update its user
+    // record. Provider code runs at the app level, so the reference is
+    // callable directly.
+    const runCreateOrUpdateUser: RunCreateOrUpdateUserFunc = async (
+      ctx,
+      args,
+    ) => {
+      return await ctx.runMutation(createOrUpdateUser, args ?? {});
+    };
+
     const result: Record<string, unknown> = {};
     for (const [config, options] of providers) {
       const resolveUserId: ResolveUserIdFunc = (ctx, providerAccountId) =>
@@ -237,8 +253,28 @@ export function setupCore<T extends readonly ProviderWithOptions[]>({
           provider: config.name,
           providerAccountId,
         });
+      const resolveProviderAccountId: ResolveProviderAccountIdFunc = (
+        ctx,
+        userId,
+      ) =>
+        ctx.runQuery(component.public.getProviderAccountId, {
+          provider: config.name,
+          userId,
+        });
+      const renameProviderAccount: RenameProviderAccountFunc = (ctx, args) =>
+        ctx.runMutation(component.public.renameAccount, {
+          provider: config.name,
+          userId: args.userId,
+          newProviderAccountId: args.newProviderAccountId,
+        });
       result[config.name] = config.setup(
-        { completeSignIn, resolveUserId },
+        {
+          completeSignIn,
+          resolveUserId,
+          resolveProviderAccountId,
+          renameProviderAccount,
+          createOrUpdateUser: runCreateOrUpdateUser,
+        },
         options,
       );
     }

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -31,13 +31,14 @@ export function resetCreateOrUpdateUserCalls(): void {
  * every sign-in for an identity; like a minimal real app, it owns no users
  * table and just echoes the provider-scoped account id back as the app user id,
  * honoring an explicit `userId` when one is supplied (returning sign-in / link
- * path).
+ * path). A call with no arguments asks for a new empty user, so it returns a
+ * fresh random id (see `vCreateOrUpdateUser`).
  */
 export const createOrUpdateUser = internalMutation({
   args: vCreateOrUpdateUser,
   returns: v.string(),
   handler: async (_ctx, args) => {
     createOrUpdateUserCalls.push({ ...args });
-    return args.userId ?? args.providerAccountId;
+    return args.userId ?? args.providerAccountId ?? crypto.randomUUID();
   },
 });

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -11,6 +11,7 @@
 import type * as authentication from "../authentication.js";
 import type * as helpers from "../helpers.js";
 import type * as registration from "../registration.js";
+import type * as setup from "../setup.js";
 import type * as testAuthenticator from "../testAuthenticator.js";
 import type * as validation from "../validation.js";
 
@@ -25,6 +26,7 @@ const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   helpers: typeof helpers;
   registration: typeof registration;
+  setup: typeof setup;
   testAuthenticator: typeof testAuthenticator;
   validation: typeof validation;
 }> = anyApi as any;

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -7,6 +7,7 @@ import schema from "./schema";
 import {
   ORIGIN,
   RP_ID,
+  buildAssertion,
   buildAttestationObject,
   buildAuthenticatorData,
   buildClientDataJSON,
@@ -371,6 +372,48 @@ describe("deletePasskey", () => {
   test("deletes the user's own passkey", async () => {
     const t = setup();
     const { passkeyId } = await register(t, "user1");
+    const result = await t.mutation(api.registration.deletePasskey, {
+      userId: "user1",
+      passkeyId,
+    });
+    expect(result).toEqual({ success: true });
+    const passkeys = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(passkeys).toEqual([]);
+  });
+
+  // The two tests below pin a documented pitfall: the component applies no
+  // deletion policy. The app must apply its own policy (see the function
+  // comment on `deletePasskey`).
+  test("deletes the last passkey of a user (the app owns the policy)", async () => {
+    const t = setup();
+    const { passkeyId } = await register(t, "user1");
+    // "user1" has exactly one passkey. The component still deletes it, and
+    // this can lock the user out of their account.
+    const result = await t.mutation(api.registration.deletePasskey, {
+      userId: "user1",
+      passkeyId,
+    });
+    expect(result).toEqual({ success: true });
+    const passkeys = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(passkeys).toEqual([]);
+  });
+
+  test("deletes the passkey that signed the most recent assertion (the app owns the policy)", async () => {
+    const t = setup();
+    const { credential, passkeyId } = await register(t, "user1");
+    // Authenticate with the passkey, then delete that same passkey. The
+    // component has no concept of "the passkey of the current session", so
+    // it accepts the deletion.
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { userId: "user1" },
+    );
+    const assertion = await buildAssertion(credential, challenge);
+    const authResult = await t.mutation(
+      api.authentication.finishAuthentication,
+      { expectedRpId: RP_ID, expectedOrigin: ORIGIN, ...assertion },
+    );
+    expect(authResult.success).toBe(true);
     const result = await t.mutation(api.registration.deletePasskey, {
       userId: "user1",
       passkeyId,

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -238,6 +238,14 @@ type DeletePasskeyResult = Infer<typeof deletePasskeyResult>;
  *
  * The `userId` check makes the function safe for an ID that comes directly
  * from the client: a user can only delete their own passkeys.
+ *
+ * Pitfall: the component applies no deletion policy. This function deletes
+ * the last passkey of a user, and it deletes the passkey that signed the
+ * most recent assertion. When the passkey is the only way to sign in, that
+ * can lock the user out of their account. The app must apply its own
+ * policy before it calls this function. For example, the username+passkey
+ * provider demands a fresh assertion from a *different* passkey of the
+ * same user.
  */
 export const deletePasskey = mutation({
   args: { userId: v.string(), passkeyId: v.string() },

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -1,0 +1,685 @@
+import { mutationGeneric, queryGeneric, type Auth } from "convex/server";
+import { Infer, v } from "convex/values";
+import { defineProvider, vTokenBundle } from "../../lib/types";
+import type { ComponentApi } from "./_generated/component.js";
+import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
+import {
+  setUsernameUserError,
+  validateUsernameFormat,
+} from "../username/validation";
+import {
+  finishAuthenticationUserError,
+  finishRegistrationUserError,
+} from "./validation";
+
+/**
+ * Options for {@link UsernamePasskey}.
+ */
+export type UsernamePasskeyOptions = {
+  /**
+   * The mounted passkey component (`components.authPasskey`). The provider
+   * drives its registration and authentication ceremonies.
+   */
+  component: ComponentApi;
+  /**
+   * The mounted username component (`components.authUsername`). The provider
+   * uses it to map a username onto the app user id: it stores the username
+   * at sign-up and reads it back at sign-in.
+   */
+  usernameComponent: UsernameComponentApi;
+  /**
+   * The WebAuthn relying party ID. This is usually the registrable domain
+   * that serves the app (for example, "example.com" or "localhost"). Only
+   * web pages on this domain, or on its subdomains, can use the passkeys.
+   * See https://web.dev/articles/webauthn-rp-id
+   */
+  rpId: string;
+  /**
+   * The expected web origin of each ceremony (for example,
+   * "https://app.example.com" or "http://localhost:5173").
+   */
+  origin: string;
+};
+
+// TODO: derive this from the component mount path rather than hardcoding it.
+const PROVIDER_NAME = "passkey";
+
+/**
+ * Read the signed-in user's id from the verified access token. Convex
+ * checks the token signature before the function runs, so the subject is a
+ * trustworthy value. Throws when no user is signed in: a correct client
+ * only calls the management functions with a session.
+ */
+async function requireUserId(ctx: { auth: Auth }): Promise<string> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity === null) {
+    throw new Error("This function requires a signed-in user.");
+  }
+  return identity.subject;
+}
+
+const startSignInResult = v.union(
+  // The username exists. The client must complete an authentication
+  // ceremony (`navigator.credentials.get`) and call `finishSignIn`.
+  v.object({
+    step: v.literal("authenticate"),
+    challenge: v.bytes(),
+    allowCredentials: v.array(v.bytes()),
+  }),
+  // The username is free. A new empty user row now exists, and the client
+  // must complete a registration ceremony (`navigator.credentials.create`)
+  // and call `finishSignUp`. `userHandle` is the new user's id; the client
+  // encodes it to bytes for the WebAuthn `user.id` field.
+  v.object({
+    step: v.literal("register"),
+    challenge: v.bytes(),
+    userHandle: v.string(),
+    excludeCredentials: v.array(v.bytes()),
+  }),
+);
+
+/**
+ * The result of `startSignIn`: the branch of the flow and the data for the
+ * matching WebAuthn ceremony.
+ */
+export type StartSignInResult = Infer<typeof startSignInResult>;
+
+const finishSignUpResult = v.union(
+  v.object({
+    success: v.literal(true),
+    tokens: vTokenBundle,
+    username: v.string(),
+  }),
+  v.object({
+    success: v.literal(false),
+    // `setUsernameUserError` covers `USERNAME_TAKEN` and the format errors
+    // of the username component.
+    userError: v.union(finishRegistrationUserError, setUsernameUserError),
+  }),
+);
+
+/**
+ * The result of `finishSignUp`.
+ *
+ * On success the minted session tokens, otherwise a user-facing `userError`.
+ */
+export type FinishSignUpResult = Infer<typeof finishSignUpResult>;
+
+const finishSignInResult = v.union(
+  // `username` is the username of the account, as the user supplied it. The
+  // client can pass it to the WebAuthn Signal API
+  // (`PublicKeyCredential.signalCurrentUserDetails`) so the authenticator
+  // shows a current name for the passkey.
+  v.object({
+    success: v.literal(true),
+    tokens: vTokenBundle,
+    username: v.string(),
+  }),
+  v.object({
+    success: v.literal(false),
+    userError: finishAuthenticationUserError,
+  }),
+);
+
+/**
+ * The result of `finishSignIn`.
+ *
+ * On success the minted session tokens, otherwise a user-facing `userError`.
+ */
+export type FinishSignInResult = Infer<typeof finishSignInResult>;
+
+const changeUsernameResult = v.union(
+  v.object({ success: v.literal(true), username: v.string() }),
+  v.object({ success: v.literal(false), userError: setUsernameUserError }),
+);
+
+/** The result of `changeUsername`. */
+export type ChangeUsernameResult = Infer<typeof changeUsernameResult>;
+
+const startAddPasskeyResult = v.object({
+  challenge: v.bytes(),
+  userHandle: v.string(),
+  excludeCredentials: v.array(v.bytes()),
+});
+
+/** The result of `startAddPasskey`. */
+export type StartAddPasskeyResult = Infer<typeof startAddPasskeyResult>;
+
+const finishAddPasskeyResult = v.union(
+  v.object({ success: v.literal(true), passkeyId: v.string() }),
+  v.object({
+    success: v.literal(false),
+    userError: finishRegistrationUserError,
+  }),
+);
+
+/** The result of `finishAddPasskey`. */
+export type FinishAddPasskeyResult = Infer<typeof finishAddPasskeyResult>;
+
+const listPasskeysResult = v.array(
+  v.object({
+    passkeyId: v.string(),
+    name: v.optional(v.string()),
+    credentialId: v.bytes(),
+    createdAt: v.number(),
+  }),
+);
+
+const startDeletePasskeyResult = v.union(
+  v.object({
+    success: v.literal(true),
+    challenge: v.bytes(),
+    // The user's other credential IDs. The passkey that is marked for
+    // deletion is not in the list, because it cannot approve its own
+    // deletion.
+    allowCredentials: v.array(v.bytes()),
+  }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(
+      v.object({ error: v.literal("PASSKEY_NOT_FOUND") }),
+      // The user has no other passkey. Deletion of the last passkey is not
+      // possible: it would lock the user out, and no recovery flow exists.
+      v.object({ error: v.literal("NO_OTHER_PASSKEY") }),
+    ),
+  }),
+);
+
+/** The result of `startDeletePasskey`. */
+export type StartDeletePasskeyResult = Infer<typeof startDeletePasskeyResult>;
+
+const finishDeletePasskeyResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(
+      finishAuthenticationUserError,
+      // The assertion comes from the passkey that is marked for deletion.
+      // A different passkey of the same user must approve the deletion.
+      v.object({ error: v.literal("SAME_PASSKEY") }),
+      v.object({ error: v.literal("PASSKEY_NOT_FOUND") }),
+    ),
+  }),
+);
+
+/** The result of `finishDeletePasskey`. */
+export type FinishDeletePasskeyResult = Infer<typeof finishDeletePasskeyResult>;
+
+/**
+ * The username+passkey recipe: each account is a username, and passkeys are
+ * the only way to sign in. There is no password, no email address, and no
+ * recovery flow. A user that loses all passkeys loses the account.
+ *
+ * Wire it into `setupCore`:
+ *
+ * ```ts
+ * setupCore({
+ *   component: components.core,
+ *   providers: [
+ *     provider(UsernamePasskey, {
+ *       component: components.authPasskey,
+ *       usernameComponent: components.authUsername,
+ *       rpId: "example.com",
+ *       origin: "https://app.example.com",
+ *     }),
+ *   ],
+ * }).attachUserCallback(internal.users.createOrUpdateUser);
+ * ```
+ *
+ * The app re-exports the returned functions so its clients can call them.
+ *
+ * ## The sign-in flow
+ *
+ * The flow is identifier-first. The user enters a username, and the client
+ * calls `startSignIn`:
+ *
+ * - When the username exists, the result is the `authenticate` step. The
+ *   client runs `navigator.credentials.get` and calls `finishSignIn`.
+ * - When the username is free, the provider creates a new empty user row
+ *   and the result is the `register` step. The client runs
+ *   `navigator.credentials.create` with the returned `userHandle` as
+ *   `user.id`, and calls `finishSignUp`.
+ *
+ * The user row must exist before the ceremony, because the WebAuthn user
+ * handle is the row id. The username becomes reserved only when
+ * `finishSignUp` succeeds. Two consequences are accepted by design:
+ *
+ * - An abandoned registration leaks an empty user row.
+ * - A different person can take the username while the ceremony runs. In
+ *   that case `finishSignUp` returns `USERNAME_TAKEN`, the challenge stays
+ *   valid, and the client can send the same ceremony result again with a
+ *   different username.
+ *
+ * ## The app's `createOrUpdateUser` contract
+ *
+ * The app's callback must handle three call shapes:
+ *
+ * 1. No arguments: create a new empty user row and return its id.
+ * 2. `userId: null` with `profile.existingUserId`: return that id. The
+ *    provider created the row in shape 1, and the first sign-in must not
+ *    create a second row. The value is trusted: it comes from the
+ *    provider, not from the client.
+ * 3. `userId` set: update the user record from `profile` (for example,
+ *    store `profile.username`) and return the same id.
+ *
+ * ## Management functions
+ *
+ * A signed-in user can change their username, add a passkey, list their
+ * passkeys, and delete a passkey. Deletion demands a fresh assertion from
+ * a *different* passkey of the same user, so the last passkey can never be
+ * deleted. There are no security notifications: the account has no
+ * out-of-band contact method.
+ *
+ * Account resolution (username → app user id) is owned by the username
+ * component: the provider stores the username there at sign-up, and reads
+ * the user id back from it at sign-in. The provider account id in the
+ * core's `accounts` table is the app user id itself: a stable, opaque
+ * value that a username change does not touch. The passkey component
+ * itself stores only opaque user ids and knows nothing about usernames.
+ */
+export const UsernamePasskey = defineProvider({
+  name: PROVIDER_NAME,
+  setup: (
+    { completeSignIn, createOrUpdateUser },
+    options: UsernamePasskeyOptions,
+  ) => {
+    const { component, usernameComponent, rpId, origin } = options;
+
+    return {
+      /**
+       * Start the identifier-first flow for a username. See the comment on
+       * {@link UsernamePasskey} for the two branches. The `register` branch
+       * creates an empty user row; an abandoned ceremony leaks that row,
+       * which is accepted by design.
+       */
+      startSignIn: mutationGeneric({
+        args: { username: v.string() },
+        returns: startSignInResult,
+        handler: async (ctx, { username }): Promise<StartSignInResult> => {
+          const existingUserId = await ctx.runQuery(
+            usernameComponent.public.getUserIdByUsername,
+            { username },
+          );
+          if (existingUserId !== null) {
+            const { challenge, allowCredentials } = await ctx.runMutation(
+              component.authentication.startAuthentication,
+              { userId: existingUserId },
+            );
+            return { step: "authenticate", challenge, allowCredentials };
+          }
+          // The username is free. Create the user row now: the row id is
+          // the WebAuthn user handle, and Convex mints ids only on insert.
+          // The username is not reserved yet; `finishSignUp` reserves it.
+          const userId = await createOrUpdateUser(ctx);
+          const { challenge, excludeCredentials } = await ctx.runMutation(
+            component.registration.startRegistration,
+            { userId },
+          );
+          return {
+            step: "register",
+            challenge,
+            userHandle: userId,
+            excludeCredentials,
+          };
+        },
+      }),
+
+      /**
+       * Finish a sign-up ceremony: examine the attestation, store the
+       * passkey, reserve the username, and mint a session.
+       *
+       * The whole step is one mutation, so it is atomic. On
+       * `USERNAME_TAKEN` nothing is stored and the challenge stays valid:
+       * the client can send the same ceremony result again with a
+       * different username.
+       */
+      finishSignUp: mutationGeneric({
+        args: {
+          username: v.string(),
+          name: v.optional(v.string()),
+          attestationObject: v.bytes(),
+          clientDataJSON: v.bytes(),
+        },
+        returns: finishSignUpResult,
+        handler: async (ctx, args): Promise<FinishSignUpResult> => {
+          // Check the username before the ceremony result is examined, so
+          // an invalid or taken username does not burn the challenge.
+          const usernameError = validateUsernameFormat(args.username);
+          if (usernameError !== null) {
+            return { success: false, userError: usernameError };
+          }
+          const takenBy = await ctx.runQuery(
+            usernameComponent.public.getUserIdByUsername,
+            { username: args.username },
+          );
+          if (takenBy !== null) {
+            return { success: false, userError: { error: "USERNAME_TAKEN" } };
+          }
+
+          const result = await ctx.runMutation(
+            component.registration.finishRegistration,
+            {
+              expectedRpId: rpId,
+              expectedOrigin: origin,
+              name: args.name,
+              attestationObject: args.attestationObject,
+              clientDataJSON: args.clientDataJSON,
+            },
+          );
+          if (!result.success) {
+            return { success: false, userError: result.userError };
+          }
+          // The challenge supplied the trusted owner of the new passkey:
+          // the user row that `startSignIn` created.
+          const userId = result.userId;
+          const existingUsername = await ctx.runQuery(
+            usernameComponent.public.getUsername,
+            { userId },
+          );
+          if (existingUsername !== null) {
+            // The challenge belongs to a user that already has a username
+            // (an add-passkey challenge sent to the wrong function). A
+            // correct client cannot cause this. The error rolls the whole
+            // mutation back, including the stored passkey.
+            throw new Error(
+              "The user of this registration challenge already has a username.",
+            );
+          }
+
+          // Reserve the username.
+          const setUsernameResult = await ctx.runMutation(
+            usernameComponent.public.setUsername,
+            { userId, username: args.username },
+          );
+          if (!setUsernameResult.success) {
+            // Unexpected: the format and the conflict were checked above,
+            // and this handler is a mutation, thus the checks and this call
+            // are in the same transaction. Throwing so that the transaction
+            // doesn't commit.
+            throw new Error(
+              "Unexpected error when setting the username: " +
+                setUsernameResult.userError.error,
+              { cause: setUsernameResult.userError },
+            );
+          }
+
+          // Mint the session. The provider account id is the app user id:
+          // the username component owns the username → user id mapping.
+          // `existingUserId` makes the app's callback reuse the row from
+          // `startSignIn` instead of creating a second user.
+          const tokens = await completeSignIn(ctx, {
+            provider: PROVIDER_NAME,
+            providerAccountId: userId,
+            profile: { username: args.username, existingUserId: userId },
+          });
+          if (tokens.userId !== userId) {
+            // The app's callback did not honor `profile.existingUserId`.
+            // Roll everything back instead of splitting the account across
+            // two user rows.
+            throw new Error(
+              "createOrUpdateUser must return profile.existingUserId for the passkey provider.",
+            );
+          }
+          return { success: true, tokens, username: args.username };
+        },
+      }),
+
+      /**
+       * Finish an authentication ceremony and mint a session. The
+       * component identifies the user from the credential; the username in
+       * the result comes from the user's account row.
+       */
+      finishSignIn: mutationGeneric({
+        args: {
+          credentialId: v.bytes(),
+          authenticatorData: v.bytes(),
+          clientDataJSON: v.bytes(),
+          signature: v.bytes(),
+        },
+        returns: finishSignInResult,
+        handler: async (ctx, args): Promise<FinishSignInResult> => {
+          const result = await ctx.runMutation(
+            component.authentication.finishAuthentication,
+            {
+              expectedRpId: rpId,
+              expectedOrigin: origin,
+              credentialId: args.credentialId,
+              authenticatorData: args.authenticatorData,
+              clientDataJSON: args.clientDataJSON,
+              signature: args.signature,
+            },
+          );
+          if (!result.success) {
+            return { success: false, userError: result.userError };
+          }
+          const username = await ctx.runQuery(
+            usernameComponent.public.getUsername,
+            { userId: result.userId },
+          );
+          if (username === null) {
+            // A passkey exists, but its user has no username. This state
+            // is not reachable through this provider: `startSignIn` binds
+            // authentication challenges only to users that have a
+            // username.
+            throw new Error("The passkey's user has no username.");
+          }
+          const tokens = await completeSignIn(ctx, {
+            provider: PROVIDER_NAME,
+            providerAccountId: result.userId,
+            profile: { username },
+          });
+          return { success: true, tokens, username };
+        },
+      }),
+
+      /**
+       * Change the signed-in user's username. The account keeps its
+       * sessions and its passkeys; only the username changes.
+       *
+       * After a success, the client should pass the new username to the
+       * WebAuthn Signal API, so the user's authenticators show the current
+       * name.
+       */
+      changeUsername: mutationGeneric({
+        args: { newUsername: v.string() },
+        returns: changeUsernameResult,
+        handler: async (
+          ctx,
+          { newUsername },
+        ): Promise<ChangeUsernameResult> => {
+          const userId = await requireUserId(ctx);
+          const setUsernameResult = await ctx.runMutation(
+            usernameComponent.public.setUsername,
+            { userId, username: newUsername },
+          );
+          if (!setUsernameResult.success) {
+            return { success: false, userError: setUsernameResult.userError };
+          }
+          // Tell the app about the new username, so it can update its own
+          // user record.
+          const returnedUserId = await createOrUpdateUser(ctx, {
+            provider: PROVIDER_NAME,
+            providerAccountId: userId,
+            profile: { username: newUsername },
+            userId,
+          });
+          if (returnedUserId !== userId) {
+            throw new Error(
+              "createOrUpdateUser may not return a new userId for an existing user",
+            );
+          }
+          return { success: true, username: newUsername };
+        },
+      }),
+
+      /**
+       * Start a ceremony that adds a passkey to the signed-in user's
+       * account. The client runs `navigator.credentials.create` with the
+       * returned `userHandle` as `user.id` and calls `finishAddPasskey`.
+       */
+      startAddPasskey: mutationGeneric({
+        args: {},
+        returns: startAddPasskeyResult,
+        handler: async (ctx): Promise<StartAddPasskeyResult> => {
+          const userId = await requireUserId(ctx);
+          const { challenge, excludeCredentials } = await ctx.runMutation(
+            component.registration.startRegistration,
+            { userId },
+          );
+          return { challenge, excludeCredentials, userHandle: userId };
+        },
+      }),
+
+      /**
+       * Finish a ceremony that adds a passkey to the signed-in user's
+       * account.
+       */
+      finishAddPasskey: mutationGeneric({
+        args: {
+          name: v.optional(v.string()),
+          attestationObject: v.bytes(),
+          clientDataJSON: v.bytes(),
+        },
+        returns: finishAddPasskeyResult,
+        handler: async (ctx, args): Promise<FinishAddPasskeyResult> => {
+          const userId = await requireUserId(ctx);
+          const result = await ctx.runMutation(
+            component.registration.finishRegistration,
+            {
+              expectedRpId: rpId,
+              expectedOrigin: origin,
+              name: args.name,
+              attestationObject: args.attestationObject,
+              clientDataJSON: args.clientDataJSON,
+            },
+          );
+          if (!result.success) {
+            return { success: false, userError: result.userError };
+          }
+          if (result.userId !== userId) {
+            // The challenge belongs to a different user. A correct client
+            // cannot cause this. The error rolls the mutation back,
+            // including the stored passkey.
+            throw new Error(
+              "The registration challenge belongs to a different user.",
+            );
+          }
+          return { success: true, passkeyId: result.passkeyId };
+        },
+      }),
+
+      /**
+       * List the signed-in user's passkeys, for example for a settings
+       * page. The result contains only public metadata.
+       */
+      listPasskeys: queryGeneric({
+        args: {},
+        returns: listPasskeysResult,
+        handler: async (ctx) => {
+          const userId = await requireUserId(ctx);
+          return await ctx.runQuery(component.registration.listPasskeys, {
+            userId,
+          });
+        },
+      }),
+
+      /**
+       * Start the deletion of one of the signed-in user's passkeys.
+       *
+       * A deletion demands a fresh assertion from a *different* passkey of
+       * the same user, so `allowCredentials` does not contain the marked
+       * passkey. A user with a single passkey gets `NO_OTHER_PASSKEY`: the
+       * last passkey can never be deleted, because no recovery flow
+       * exists.
+       */
+      startDeletePasskey: mutationGeneric({
+        args: { passkeyId: v.string() },
+        returns: startDeletePasskeyResult,
+        handler: async (
+          ctx,
+          { passkeyId },
+        ): Promise<StartDeletePasskeyResult> => {
+          const userId = await requireUserId(ctx);
+          const passkeys = await ctx.runQuery(
+            component.registration.listPasskeys,
+            { userId },
+          );
+          const target = passkeys.find(
+            (passkey) => passkey.passkeyId === passkeyId,
+          );
+          if (target === undefined) {
+            return {
+              success: false,
+              userError: { error: "PASSKEY_NOT_FOUND" },
+            };
+          }
+          const others = passkeys.filter(
+            (passkey) => passkey.passkeyId !== passkeyId,
+          );
+          if (others.length === 0) {
+            return {
+              success: false,
+              userError: { error: "NO_OTHER_PASSKEY" },
+            };
+          }
+          const { challenge } = await ctx.runMutation(
+            component.authentication.startAuthentication,
+            { userId },
+          );
+          return {
+            success: true,
+            challenge,
+            allowCredentials: others.map((passkey) => passkey.credentialId),
+          };
+        },
+      }),
+
+      /**
+       * Finish the deletion of a passkey. The assertion must come from a
+       * different passkey of the signed-in user (see
+       * `startDeletePasskey`).
+       */
+      finishDeletePasskey: mutationGeneric({
+        args: {
+          passkeyId: v.string(),
+          credentialId: v.bytes(),
+          authenticatorData: v.bytes(),
+          clientDataJSON: v.bytes(),
+          signature: v.bytes(),
+        },
+        returns: finishDeletePasskeyResult,
+        handler: async (ctx, args): Promise<FinishDeletePasskeyResult> => {
+          const userId = await requireUserId(ctx);
+          const result = await ctx.runMutation(
+            component.authentication.finishAuthentication,
+            {
+              expectedRpId: rpId,
+              expectedOrigin: origin,
+              credentialId: args.credentialId,
+              authenticatorData: args.authenticatorData,
+              clientDataJSON: args.clientDataJSON,
+              signature: args.signature,
+            },
+          );
+          if (!result.success) {
+            return { success: false, userError: result.userError };
+          }
+          if (result.userId !== userId) {
+            // The assertion comes from a passkey of a different user.
+            return {
+              success: false,
+              userError: { error: "VERIFICATION_FAILED" },
+            };
+          }
+          if (result.passkeyId === args.passkeyId) {
+            return { success: false, userError: { error: "SAME_PASSKEY" } };
+          }
+          return await ctx.runMutation(component.registration.deletePasskey, {
+            userId,
+            passkeyId: args.passkeyId,
+          });
+        },
+      }),
+    };
+  },
+});

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -110,22 +110,35 @@ export const vAuthClaims = v.object({
 
 export type AuthClaims = Infer<typeof vAuthClaims>;
 
+/**
+ * The arguments for the app's `createOrUpdateUser` mutation.
+ *
+ * The mutation accepts two call shapes:
+ *
+ * 1. A sign-in call. All the fields are set. The `userId` field is `null`
+ *    for the first sign-in of an account, and the app user id after that.
+ * 2. A call with no arguments. The app must create a new empty user row
+ *    and return its id. A provider makes this call when it must create a
+ *    user before an account exists. For example, the passkey provider
+ *    creates the user row before the WebAuthn ceremony, because the row id
+ *    is the WebAuthn user handle.
+ */
 export const vCreateOrUpdateUser = v.object({
-  provider: v.string(),
-  providerAccountId: v.string(),
-  profile: v.any(),
-  userId: v.union(v.string(), v.null()),
+  provider: v.optional(v.string()),
+  providerAccountId: v.optional(v.string()),
+  profile: v.optional(v.any()),
+  userId: v.optional(v.union(v.string(), v.null())),
 });
 
 export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
   "mutation",
   "internal",
   {
-    provider: Provider;
-    providerAccountId: string;
+    provider?: Provider;
+    providerAccountId?: string;
     // TODO: dowski - investigate type safety for provider profile data.
-    profile: unknown;
-    userId: string | null;
+    profile?: unknown;
+    userId?: string | null;
   },
   GenericId<"users">
 >;
@@ -138,9 +151,10 @@ export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
 type RunMutationCtx = Pick<GenericActionCtx<GenericDataModel>, "runMutation">;
 
 /**
- * The subset of a Convex `ctx` that {@link ResolveUserIdFunc} needs. It only
- * calls `runQuery`, so accepting this structural type lets a provider resolve
- * a user id from either a mutation or an action.
+ * The subset of a Convex `ctx` that the read-only provider helpers (for
+ * example {@link ResolveUserIdFunc}) need. They only call `runQuery`, so
+ * accepting this structural type lets a provider use them from a query, a
+ * mutation, or an action.
  */
 type RunQueryCtx = Pick<GenericActionCtx<GenericDataModel>, "runQuery">;
 
@@ -163,9 +177,65 @@ export type ResolveUserIdFunc = (
   providerAccountId: string,
 ) => Promise<string | null>;
 
+/**
+ * A function that finds the provider account ID (bound to a particular
+ * provider) that is associated with a user ID. This is the reverse of
+ * {@link ResolveUserIdFunc}.
+ *
+ * It returns `null` when the user has no account for the provider. It
+ * throws when the user has more than one account for the provider, so use
+ * it only with providers that keep at most one account for each user.
+ */
+export type ResolveProviderAccountIdFunc = (
+  ctx: RunQueryCtx,
+  userId: string,
+) => Promise<string | null>;
+
+/**
+ * A function that changes the provider account ID of a user's account
+ * (bound to a particular provider). A provider that keys its accounts by a
+ * user-visible identifier can use it when that identifier changes.
+ *
+ * The change fails when a different account of the same provider already
+ * uses the new account ID. Sessions stay valid across the change.
+ */
+export type RenameProviderAccountFunc = (
+  ctx: RunMutationCtx,
+  args: { userId: string; newProviderAccountId: string },
+) => Promise<
+  { success: true } | { success: false; reason: "ACCOUNT_ID_TAKEN" }
+>;
+
+/**
+ * The full argument set of a sign-in call to the app's `createOrUpdateUser`
+ * mutation. See {@link vCreateOrUpdateUser} for the two call shapes.
+ */
+export type CreateOrUpdateUserArgs = {
+  provider: string;
+  providerAccountId: string;
+  profile: unknown;
+  userId: string | null;
+};
+
+/**
+ * A function that runs the app's `createOrUpdateUser` mutation directly.
+ * It does not create an account row and it does not mint a session.
+ *
+ * Call it without `args` to make the app create a new empty user row and
+ * return its id. Call it with the full `args` to make the app update its
+ * user record, for example after a username change.
+ */
+export type RunCreateOrUpdateUserFunc = (
+  ctx: RunMutationCtx,
+  args?: CreateOrUpdateUserArgs,
+) => Promise<string>;
+
 export type ProviderHelpers = {
   completeSignIn: CompleteSignInFunc;
   resolveUserId: ResolveUserIdFunc;
+  resolveProviderAccountId: ResolveProviderAccountIdFunc;
+  renameProviderAccount: RenameProviderAccountFunc;
+  createOrUpdateUser: RunCreateOrUpdateUserFunc;
 };
 
 type ProviderSetupFunc<O, P> = (helpers: ProviderHelpers, options: O) => P;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,37 @@ importers:
         specifier: ^8.0.16
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
+  examples/react-passkey:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      convex:
+        specifier: ^1.41.0
+        version: 1.42.1(react@19.2.7)
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.42.1(react@19.2.7))
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@24.13.2)(jsdom@29.1.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+
   examples/react-password:
     dependencies:
       '@convex-dev/auth':


### PR DESCRIPTION
Add the UsernamePasskey provider: each account is a username, and
passkeys are the only way to sign in. The flow is identifier-first.
When the username exists, the user authenticates with a passkey of
that account. When the username is free, the provider creates a user
row and the user registers a passkey. The username becomes reserved
only when the registration completes.

A signed-in user can change their username, add a passkey, list their
passkeys, and delete a passkey. A deletion demands a fresh assertion
from a different passkey, so the last passkey can never be deleted.
There is no recovery flow.

Component and core changes that the provider requires:

- The passkey component stores the future owner on the registration
  challenge, and finishRegistration reads the owner from there instead
  of a verifiedUserId argument. This keeps the owner a trusted,
  server-side value. The deletePasskey documentation now names the
  policy pitfall, and two component tests pin it.
- The core component gains renameAccount (username change) and
  getProviderAccountId (reverse lookup on the by_user index).
- The provider helpers gain createOrUpdateUser (runs the app callback
  directly; with no arguments the app creates an empty user row),
  resolveProviderAccountId, and renameProviderAccount.

The new examples/react-passkey app shows the full wiring. It has no
frontend yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
