### PR TITLE
Link to finishRegistration in finishAuthentication docs

### DIFF
--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -86,7 +86,8 @@ type FinishAuthenticationResult = Infer<typeof finishAuthenticationResult>;
 /**
  * Finish an authentication ceremony.
  *
- * The app supplies `expectedRpId` and `expectedOrigin`; see `finishRegistration`.
+ * The app supplies `expectedRpId` and `expectedOrigin`; see
+ * {@link finishRegistration}.
  *
  * The function finds the credential. Then it examines the authenticator
  * data, the client data, and the assertion signature. It deletes the

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -87,7 +87,7 @@ type FinishAuthenticationResult = Infer<typeof finishAuthenticationResult>;
  * Finish an authentication ceremony.
  *
  * The app supplies `expectedRpId` and `expectedOrigin`; see
- * {@link finishRegistration}.
+ * {@link import("./registration").finishRegistration}.
  *
  * The function finds the credential. Then it examines the authenticator
  * data, the client data, and the assertion signature. It deletes the


### PR DESCRIPTION
Addresses the remaining open docs comment on #437: use a `{@link ...}` directive pointing at `finishRegistration`, where `expectedRpId` and `expectedOrigin` are documented in detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)