### PR TITLE
Erase expired passkey challenges in the background

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@convex-dev/auth": "workspace:*",
-    "convex": "^1.41.0",
+    "convex": "^1.43.0",
     "jose": "^5.10.0",
     "next": "^16.0.0",
     "react": "^19.2.7",

--- a/examples/react-minimal/package.json
+++ b/examples/react-minimal/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@convex-dev/auth": "workspace:*",
-    "convex": "^1.41.0",
+    "convex": "^1.43.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
@@ -21,7 +21,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.3",
-    "convex-test": "^0.0.53",
+    "convex-test": "^0.0.55",
     "jose": "^5.10.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"

--- a/examples/react-password/package.json
+++ b/examples/react-password/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@convex-dev/auth": "workspace:*",
-    "convex": "^1.41.0",
+    "convex": "^1.43.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1"
@@ -24,7 +24,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.3",
-    "convex-test": "^0.0.53",
+    "convex-test": "^0.0.55",
     "jose": "^5.10.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^2.0.0",
     "@eslint/js": "^10.0.1",
-    "convex": "^1.41.0",
+    "convex": "^1.43.0",
     "eslint": "^10.6.0",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@convex-dev/batch-worker": "^0.2.0",
+    "@convex-dev/batch-worker": "^0.3.0",
     "@convex-dev/rate-limiter": "^0.3.2",
     "argon2id-wasm": "0.0.0-alpha.1",
     "commander": "^14.0.2",
@@ -70,8 +70,8 @@
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.17",
-    "convex": "^1.41.0",
-    "convex-test": "^0.0.53",
+    "convex": "^1.43.0",
+    "convex-test": "^0.0.55",
     "hash-wasm": "^4.12.0",
     "jsdom": "^29.1.1",
     "next": "^16.0.0",
@@ -82,7 +82,7 @@
     "vitest": "^4.1.0"
   },
   "peerDependencies": {
-    "convex": "^1.41.0",
+    "convex": "^1.43.0",
     "next": "^16.0.0",
     "react": "^18.0.0 || ^19.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@convex-dev/batch-worker": "^0.2.0",
     "@convex-dev/rate-limiter": "^0.3.2",
     "argon2id-wasm": "0.0.0-alpha.1",
     "commander": "^14.0.2",

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as authentication from "../authentication.js";
+import type * as cleanup from "../cleanup.js";
 import type * as helpers from "../helpers.js";
 import type * as registration from "../registration.js";
 import type * as testAuthenticator from "../testAuthenticator.js";
@@ -23,6 +24,7 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   authentication: typeof authentication;
+  cleanup: typeof cleanup;
   helpers: typeof helpers;
   registration: typeof registration;
   testAuthenticator: typeof testAuthenticator;
@@ -55,4 +57,6 @@ export const internal: FilterApi<
   FunctionReference<any, "internal">
 > = anyApi as any;
 
-export const components = componentsGeneric() as unknown as {};
+export const components = componentsGeneric() as unknown as {
+  batchWorker: import("@convex-dev/batch-worker/_generated/component.js").ComponentApi<"batchWorker">;
+};

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api";
 import { CHALLENGE_TTL_MS } from "./validation";
 import { expectSameBytes, setup } from "../passkeyTestSetup";
@@ -12,6 +12,12 @@ import {
 } from "./testAuthenticator";
 
 const EXPECTED = { expectedRpId: RP_ID, expectedOrigin: ORIGIN };
+
+// Only the expiry test moves the clock, but the restore is global to keep the
+// other tests on the real clock.
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("startAuthentication", () => {
   test("stores a user-bound challenge and returns the user's credential IDs", async () => {
@@ -241,13 +247,11 @@ describe("finishAuthentication", () => {
       api.authentication.startAuthentication,
       { userId: "user1" },
     );
-    await t.run(async (ctx) => {
-      const row = await ctx.db.query("challenges").unique();
-      await ctx.db.patch(row!._id, {
-        createdAt: row!.createdAt - CHALLENGE_TTL_MS - 1000,
-      });
-    });
     const assertion = await buildAssertion(credential, challenge);
+    // The age of a challenge is the age of its `_creationTime`, thus the
+    // clock is the only way to make the challenge expire.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + CHALLENGE_TTL_MS + 1000);
     const result = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
       ...assertion,

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -1,7 +1,7 @@
-import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
-import schema from "./schema";
+import { CHALLENGE_TTL_MS } from "./validation";
+import { expectSameBytes, setup } from "../passkeyTestSetup";
 import {
   ORIGIN,
   RP_ID,
@@ -11,15 +11,7 @@ import {
   register,
 } from "./testAuthenticator";
 
-const modules = import.meta.glob("./**/*.ts");
-
-const CHALLENGE_TTL_MS = 10 * 60 * 1000;
-
 const EXPECTED = { expectedRpId: RP_ID, expectedOrigin: ORIGIN };
-
-function setup() {
-  return convexTest(schema, modules);
-}
 
 describe("startAuthentication", () => {
   test("stores a user-bound challenge and returns the user's credential IDs", async () => {
@@ -32,9 +24,7 @@ describe("startAuthentication", () => {
     );
     expect(new Uint8Array(challenge).length).toBe(32);
     expect(allowCredentials).toHaveLength(1);
-    expect(new Uint8Array(allowCredentials[0])).toEqual(
-      credential.credentialId,
-    );
+    expectSameBytes(allowCredentials[0], credential.credentialId);
     const [row] = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(row.kind).toBe("authentication");
     expect(row.kind === "authentication" && row.userId).toBe("user1");

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -54,7 +54,6 @@ export const startAuthentication = mutation({
       kind: "authentication",
       challenge,
       userId,
-      createdAt: Date.now(),
     });
     await scheduleChallengeCleanup(ctx);
     if (userId === undefined) {

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -20,6 +20,7 @@ import {
 import { sha256 } from "../../vendor/oslo/crypto/sha2";
 import { finishAuthenticationUserError } from "./validation";
 import { consumeChallenge, randomChallenge } from "./helpers";
+import { scheduleChallengeCleanup } from "./cleanup";
 
 // The challenge and the credential IDs travel as raw bytes (Convex
 // `v.bytes()` carries `ArrayBuffer`s end to end). The WebAuthn API in the
@@ -55,6 +56,7 @@ export const startAuthentication = mutation({
       userId,
       createdAt: Date.now(),
     });
+    await scheduleChallengeCleanup(ctx);
     if (userId === undefined) {
       // Discoverable credentials: no allow-list. The authenticator decides.
       return { challenge, allowCredentials: [] };

--- a/packages/core/src/components/passkey/cleanup.test.ts
+++ b/packages/core/src/components/passkey/cleanup.test.ts
@@ -4,30 +4,31 @@ import { WORKER_NAME } from "./cleanup";
 import { CHALLENGE_TTL_MS } from "./validation";
 import { setup } from "../passkeyTestSetup";
 
-// The `challenges` rows are a union, so the tests write a full row.
-function registrationChallenge(byte: number, createdAt: number) {
-  return {
-    kind: "registration" as const,
-    challenge: new Uint8Array(32).fill(byte).buffer,
-    createdAt,
-  };
-}
+const START = new Date("2026-01-01T00:00:00Z").getTime();
 
-/** Insert a registration challenge, as `startRegistration` does. */
+/**
+ * Insert a registration challenge, as `startRegistration` does. The age of a
+ * challenge is the age of its `_creationTime`, thus the tests set the clock to
+ * `createdAt` before the insert.
+ */
 function insertRegistration(
   t: ReturnType<typeof setup>,
   byte: number,
   createdAt: number,
 ) {
+  vi.setSystemTime(createdAt);
   return t.run((ctx) =>
-    ctx.db.insert("challenges", registrationChallenge(byte, createdAt)),
+    ctx.db.insert("challenges", {
+      // The `challenges` rows are a union, so the tests write a full row.
+      kind: "registration" as const,
+      challenge: new Uint8Array(32).fill(byte).buffer,
+    }),
   );
 }
 
 beforeEach(() => {
   vi.useFakeTimers();
-  // A fixed time keeps `createdAt` predictable.
-  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  vi.setSystemTime(START);
 });
 
 afterEach(() => {
@@ -45,16 +46,16 @@ describe("getExpiredChallenges", () => {
 
   test("returns only the challenges that are expired", async () => {
     const t = setup();
-    const now = Date.now();
     const expiredId = await insertRegistration(
       t,
       1,
-      now - CHALLENGE_TTL_MS - 1,
+      START - CHALLENGE_TTL_MS - 1,
     );
     // One millisecond before the TTL the challenge is still usable.
-    await insertRegistration(t, 2, now - CHALLENGE_TTL_MS + 1);
-    await insertRegistration(t, 3, now);
+    await insertRegistration(t, 2, START - CHALLENGE_TTL_MS + 1);
+    await insertRegistration(t, 3, START);
 
+    vi.setSystemTime(START);
     const result = await t.query(internal.cleanup.getExpiredChallenges, {
       name: WORKER_NAME,
     });
@@ -63,12 +64,10 @@ describe("getExpiredChallenges", () => {
 
   test("goes idle until just after the oldest challenge expires", async () => {
     const t = setup();
-    const now = Date.now();
-    await t.run(async (ctx) => {
-      await ctx.db.insert("challenges", registrationChallenge(1, now - 1000));
-      await ctx.db.insert("challenges", registrationChallenge(2, now));
-    });
+    await insertRegistration(t, 1, START - 1000);
+    await insertRegistration(t, 2, START);
 
+    vi.setSystemTime(START);
     const result = await t.query(internal.cleanup.getExpiredChallenges, {
       name: WORKER_NAME,
     });
@@ -80,12 +79,16 @@ describe("getExpiredChallenges", () => {
 
   test("a wake-up at exactly the TTL boundary finds work", async () => {
     const t = setup();
-    const now = Date.now();
     // A challenge at exactly the TTL is expired. A wake-up at the deadline
     // must find the row, or the loop would go idle with `timeoutMs: 0`
     // forever.
-    const challengeId = await insertRegistration(t, 1, now - CHALLENGE_TTL_MS);
+    const challengeId = await insertRegistration(
+      t,
+      1,
+      START - CHALLENGE_TTL_MS,
+    );
 
+    vi.setSystemTime(START);
     const result = await t.query(internal.cleanup.getExpiredChallenges, {
       name: WORKER_NAME,
     });
@@ -96,13 +99,12 @@ describe("getExpiredChallenges", () => {
 describe("deleteExpiredChallenges", () => {
   test("erases the rows of the batch and keeps the others", async () => {
     const t = setup();
-    const now = Date.now();
     const expiredId = await insertRegistration(
       t,
       1,
-      now - CHALLENGE_TTL_MS - 1,
+      START - CHALLENGE_TTL_MS - 1,
     );
-    const freshId = await insertRegistration(t, 2, now);
+    const freshId = await insertRegistration(t, 2, START);
 
     await t.mutation(internal.cleanup.deleteExpiredChallenges, {
       ids: [expiredId],
@@ -113,31 +115,18 @@ describe("deleteExpiredChallenges", () => {
     );
     expect(remaining.map((row) => row._id)).toEqual([freshId]);
   });
-
-  test("ignores a row that a ceremony consumed in the meantime", async () => {
-    const t = setup();
-    const now = Date.now();
-    const challengeId = await insertRegistration(
-      t,
-      1,
-      now - CHALLENGE_TTL_MS - 1,
-    );
-    await t.run((ctx) => ctx.db.delete("challenges", challengeId));
-
-    await expect(
-      t.mutation(internal.cleanup.deleteExpiredChallenges, {
-        ids: [challengeId],
-      }),
-    ).resolves.toBeNull();
-  });
 });
 
 describe("the cleanup loop", () => {
   test("starting a ceremony erases the challenges that expired", async () => {
     const t = setup();
-    const now = Date.now();
-    const staleId = await insertRegistration(t, 1, now - CHALLENGE_TTL_MS - 1);
+    const staleId = await insertRegistration(
+      t,
+      1,
+      START - CHALLENGE_TTL_MS - 1,
+    );
 
+    vi.setSystemTime(START);
     await t.mutation(api.registration.startRegistration, {});
     // The loop runs in scheduled functions; let them all complete.
     await t.finishAllScheduledFunctions(() => vi.runAllTimers());

--- a/packages/core/src/components/passkey/cleanup.test.ts
+++ b/packages/core/src/components/passkey/cleanup.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { api, internal } from "./_generated/api";
+import { WORKER_NAME } from "./cleanup";
+import { CHALLENGE_TTL_MS } from "./validation";
+import { setup } from "../passkeyTestSetup";
+
+// The `challenges` rows are a union, so the tests write a full row.
+function registrationChallenge(byte: number, createdAt: number) {
+  return {
+    kind: "registration" as const,
+    challenge: new Uint8Array(32).fill(byte).buffer,
+    createdAt,
+  };
+}
+
+/** Insert a registration challenge, as `startRegistration` does. */
+function insertRegistration(
+  t: ReturnType<typeof setup>,
+  byte: number,
+  createdAt: number,
+) {
+  return t.run((ctx) =>
+    ctx.db.insert("challenges", registrationChallenge(byte, createdAt)),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // A fixed time keeps `createdAt` predictable.
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("getExpiredChallenges", () => {
+  test("goes idle with no timeout when the table is empty", async () => {
+    const t = setup();
+    const result = await t.query(internal.cleanup.getExpiredChallenges, {
+      name: WORKER_NAME,
+    });
+    expect(result).toEqual({ kind: "idle" });
+  });
+
+  test("returns only the challenges that are expired", async () => {
+    const t = setup();
+    const now = Date.now();
+    const expiredId = await insertRegistration(
+      t,
+      1,
+      now - CHALLENGE_TTL_MS - 1,
+    );
+    // One millisecond before the TTL the challenge is still usable.
+    await insertRegistration(t, 2, now - CHALLENGE_TTL_MS + 1);
+    await insertRegistration(t, 3, now);
+
+    const result = await t.query(internal.cleanup.getExpiredChallenges, {
+      name: WORKER_NAME,
+    });
+    expect(result).toEqual({ kind: "work", batch: { ids: [expiredId] } });
+  });
+
+  test("goes idle until just after the oldest challenge expires", async () => {
+    const t = setup();
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("challenges", registrationChallenge(1, now - 1000));
+      await ctx.db.insert("challenges", registrationChallenge(2, now));
+    });
+
+    const result = await t.query(internal.cleanup.getExpiredChallenges, {
+      name: WORKER_NAME,
+    });
+    expect(result).toEqual({
+      kind: "idle",
+      timeoutMs: CHALLENGE_TTL_MS - 1000,
+    });
+  });
+
+  test("a wake-up at exactly the TTL boundary finds work", async () => {
+    const t = setup();
+    const now = Date.now();
+    // A challenge at exactly the TTL is expired. A wake-up at the deadline
+    // must find the row, or the loop would go idle with `timeoutMs: 0`
+    // forever.
+    const challengeId = await insertRegistration(t, 1, now - CHALLENGE_TTL_MS);
+
+    const result = await t.query(internal.cleanup.getExpiredChallenges, {
+      name: WORKER_NAME,
+    });
+    expect(result).toEqual({ kind: "work", batch: { ids: [challengeId] } });
+  });
+});
+
+describe("deleteExpiredChallenges", () => {
+  test("erases the rows of the batch and keeps the others", async () => {
+    const t = setup();
+    const now = Date.now();
+    const expiredId = await insertRegistration(
+      t,
+      1,
+      now - CHALLENGE_TTL_MS - 1,
+    );
+    const freshId = await insertRegistration(t, 2, now);
+
+    await t.mutation(internal.cleanup.deleteExpiredChallenges, {
+      ids: [expiredId],
+    });
+
+    const remaining = await t.run((ctx) =>
+      ctx.db.query("challenges").collect(),
+    );
+    expect(remaining.map((row) => row._id)).toEqual([freshId]);
+  });
+
+  test("ignores a row that a ceremony consumed in the meantime", async () => {
+    const t = setup();
+    const now = Date.now();
+    const challengeId = await insertRegistration(
+      t,
+      1,
+      now - CHALLENGE_TTL_MS - 1,
+    );
+    await t.run((ctx) => ctx.db.delete("challenges", challengeId));
+
+    await expect(
+      t.mutation(internal.cleanup.deleteExpiredChallenges, {
+        ids: [challengeId],
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("the cleanup loop", () => {
+  test("starting a ceremony erases the challenges that expired", async () => {
+    const t = setup();
+    const now = Date.now();
+    const staleId = await insertRegistration(t, 1, now - CHALLENGE_TTL_MS - 1);
+
+    await t.mutation(api.registration.startRegistration, {});
+    // The loop runs in scheduled functions; let them all complete.
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+
+    const remaining = await t.run((ctx) =>
+      ctx.db.query("challenges").collect(),
+    );
+    expect(remaining.map((row) => row._id)).not.toContain(staleId);
+    // `runAllTimers` also moves the clock past the TTL of the challenge that
+    // the ceremony made, thus the loop erases that challenge too. The tests
+    // above show that an unexpired challenge stays.
+    expect(remaining).toEqual([]);
+  });
+});

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -47,10 +47,12 @@ export const getExpiredChallenges = internalQuery({
     // the batch erases.
     const expired = await ctx.db
       .query("challenges")
-      .withIndex("by_creation_time", (q) =>
-        // The boundary matches `isChallengeExpired`: at exactly the TTL, a
-        // challenge is expired. A wake-up at the deadline thus finds work.
-        q.lte("_creationTime", now - CHALLENGE_TTL_MS),
+      .withIndex(
+        "by_creation_time",
+        (q) =>
+          // The boundary matches `isChallengeExpired`: at exactly the TTL, a
+          // challenge is expired. A wake-up at the deadline thus finds work.
+          q.lte("_creationTime", now - CHALLENGE_TTL_MS), // FIXME: we could consider using the batch worker cursor here to avoid tombstones
       )
       .take(BATCH_SIZE);
     if (expired.length > 0) {

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+import { ping, vBatchQueryArgs, vBatchResult } from "@convex-dev/batch-worker";
+import { components, internal } from "./_generated/api";
+import { internalMutation, internalQuery } from "./_generated/server";
+import type { MutationCtx } from "./_generated/server";
+import { CHALLENGE_TTL_MS } from "./validation";
+import { isChallengeExpired } from "./helpers";
+
+// The name of the batch worker loop that erases expired challenges. Only one
+// loop is necessary, so the name is constant.
+export const WORKER_NAME = "expiredChallenges";
+
+// How many challenges one worker mutation erases. The worker runs again
+// immediately while more expired rows stay, so this value only sets the
+// size of each transaction.
+const BATCH_SIZE = 64;
+
+/**
+ * Make sure that the background cleanup loop runs.
+ *
+ * Call this function after you write a challenge. The call is cheap: it does
+ * nothing while the loop already runs. The loop stops when no expired
+ * challenge stays.
+ */
+export async function scheduleChallengeCleanup(ctx: MutationCtx) {
+  await ping(ctx, components.batchWorker, {
+    name: WORKER_NAME,
+    workQuery: internal.cleanup.getExpiredChallenges,
+    workerMutation: internal.cleanup.deleteExpiredChallenges,
+  });
+}
+
+/**
+ * Find the next batch of expired challenges.
+ *
+ * When no challenge is expired, the loop goes idle. If unexpired challenges
+ * stay, the loop also gets a timeout: it then wakes up again when the oldest
+ * of them expires, even if no new ceremony starts.
+ */
+export const getExpiredChallenges = internalQuery({
+  args: vBatchQueryArgs,
+  returns: vBatchResult(v.object({ ids: v.array(v.id("challenges")) })),
+  handler: async (ctx) => {
+    const now = Date.now();
+    // One indexed read answers both questions: which rows are expired, and
+    // when the oldest row expires. The index sorts by `createdAt`, so the
+    // batch holds the oldest rows.
+    const oldestRows = await ctx.db
+      .query("challenges")
+      .withIndex("by_createdAt")
+      .take(BATCH_SIZE);
+    const expired = oldestRows.filter((row) => isChallengeExpired(row, now));
+    if (expired.length > 0) {
+      return {
+        kind: "work" as const,
+        batch: { ids: expired.map((row) => row._id) },
+      };
+    }
+    // Nothing to erase now. The oldest remaining challenge is the first one
+    // that expires.
+    const oldest = oldestRows[0];
+    if (oldest === undefined) {
+      return { kind: "idle" as const };
+    }
+    return {
+      kind: "idle" as const,
+      timeoutMs: Math.max(0, oldest.createdAt + CHALLENGE_TTL_MS - now),
+    };
+  },
+});
+
+/**
+ * Erase one batch of expired challenges.
+ *
+ * The worker owns the cleanup of the rows that it processes. A challenge can
+ * also be consumed between the query and this mutation, thus the rows that no
+ * longer exist are ignored.
+ */
+export const deleteExpiredChallenges = internalMutation({
+  args: { ids: v.array(v.id("challenges")) },
+  returns: v.null(),
+  handler: async (ctx, { ids }) => {
+    for (const id of ids) {
+      if ((await ctx.db.get("challenges", id)) !== null) {
+        await ctx.db.delete("challenges", id);
+      }
+    }
+    return null;
+  },
+});

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -4,7 +4,6 @@ import { components, internal } from "./_generated/api";
 import { internalMutation, internalQuery } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { CHALLENGE_TTL_MS } from "./validation";
-import { isChallengeExpired } from "./helpers";
 
 // The name of the batch worker loop that erases expired challenges. Only one
 // loop is necessary, so the name is constant.
@@ -12,8 +11,9 @@ export const WORKER_NAME = "expiredChallenges";
 
 // How many challenges one worker mutation erases. The worker runs again
 // immediately while more expired rows stay, so this value only sets the
-// size of each transaction.
-const BATCH_SIZE = 64;
+// size of each transaction. A challenge row is tiny, and the query only
+// reads rows that are expired, thus a large batch stays cheap.
+const BATCH_SIZE = 1024;
 
 /**
  * Make sure that the background cleanup loop runs.
@@ -42,14 +42,17 @@ export const getExpiredChallenges = internalQuery({
   returns: vBatchResult(v.object({ ids: v.array(v.id("challenges")) })),
   handler: async (ctx) => {
     const now = Date.now();
-    // One indexed read answers both questions: which rows are expired, and
-    // when the oldest row expires. The index sorts by `createdAt`, so the
-    // batch holds the oldest rows.
-    const oldestRows = await ctx.db
+    // A challenge expires at a fixed age, thus the creation-time index sorts
+    // the rows by their expiry too. The bound keeps the read to the rows that
+    // the batch erases.
+    const expired = await ctx.db
       .query("challenges")
-      .withIndex("by_createdAt")
+      .withIndex("by_creation_time", (q) =>
+        // The boundary matches `isChallengeExpired`: at exactly the TTL, a
+        // challenge is expired. A wake-up at the deadline thus finds work.
+        q.lte("_creationTime", now - CHALLENGE_TTL_MS),
+      )
       .take(BATCH_SIZE);
-    const expired = oldestRows.filter((row) => isChallengeExpired(row, now));
     if (expired.length > 0) {
       return {
         kind: "work" as const,
@@ -57,14 +60,15 @@ export const getExpiredChallenges = internalQuery({
       };
     }
     // Nothing to erase now. The oldest remaining challenge is the first one
-    // that expires.
-    const oldest = oldestRows[0];
-    if (oldest === undefined) {
+    // that expires, thus the loop wakes up again at its deadline even if no
+    // new ceremony starts.
+    const oldest = await ctx.db.query("challenges").order("asc").first();
+    if (oldest === null) {
       return { kind: "idle" as const };
     }
     return {
       kind: "idle" as const,
-      timeoutMs: Math.max(0, oldest.createdAt + CHALLENGE_TTL_MS - now),
+      timeoutMs: Math.max(0, oldest._creationTime + CHALLENGE_TTL_MS - now),
     };
   },
 });
@@ -72,18 +76,16 @@ export const getExpiredChallenges = internalQuery({
 /**
  * Erase one batch of expired challenges.
  *
- * The worker owns the cleanup of the rows that it processes. A challenge can
- * also be consumed between the query and this mutation, thus the rows that no
- * longer exist are ignored.
+ * The worker owns the cleanup of the rows that it processes. The query runs on
+ * the snapshot of this transaction, and each delete takes a read dependency on
+ * its row, thus every row of the batch still exists here.
  */
 export const deleteExpiredChallenges = internalMutation({
   args: { ids: v.array(v.id("challenges")) },
   returns: v.null(),
   handler: async (ctx, { ids }) => {
     for (const id of ids) {
-      if ((await ctx.db.get("challenges", id)) !== null) {
-        await ctx.db.delete("challenges", id);
-      }
+      await ctx.db.delete("challenges", id);
     }
     return null;
   },

--- a/packages/core/src/components/passkey/convex.config.ts
+++ b/packages/core/src/components/passkey/convex.config.ts
@@ -1,4 +1,5 @@
 import { defineComponent } from "convex/server";
+import batchWorker from "@convex-dev/batch-worker/convex.config.js";
 
 /**
  * The passkey (WebAuthn) provider component.
@@ -8,10 +9,14 @@ import { defineComponent } from "convex/server";
  * server. It stores credentials with an opaque `userId` only: the app owns
  * the users table.
  *
+ * The component mounts the batch worker component. It runs the background
+ * loop that erases the expired challenges (see cleanup.ts).
+ *
  * The component has no configuration. The app passes the relying party ID
  * and the origin as arguments to `finishRegistration` and
  * `finishAuthentication`.
  */
 const component = defineComponent("authPasskey");
+component.use(batchWorker);
 
 export default component;

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -59,7 +59,6 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
       expect(row).not.toBe(null);
@@ -87,7 +86,6 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "authentication", challenge);
       expect(row).toBe(null);
@@ -103,7 +101,6 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "authentication",
         challenge: toArrayBuffer(challenge),
-        createdAt: Date.now(),
       });
       expect(await consumeChallenge(ctx, "authentication", challenge)).not.toBe(
         null,
@@ -114,17 +111,32 @@ describe("consumeChallenge", () => {
     });
   });
 
-  test("rejects and deletes an expired challenge", async () => {
+  /**
+   * Insert a registration challenge, then move the clock forward by `ageMs`.
+   * The age of a challenge is the age of its `_creationTime`, thus the clock
+   * is the only way to make a challenge old.
+   */
+  async function insertAndAge(
+    t: ReturnType<typeof setup>,
+    challenge: Uint8Array,
+    ageMs: number,
+  ) {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
-    const t = setup();
-    const challenge = crypto.getRandomValues(new Uint8Array(32));
-    await t.run(async (ctx) => {
-      await ctx.db.insert("challenges", {
+    await t.run((ctx) =>
+      ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        createdAt: Date.now() - CHALLENGE_TTL_MS - 1,
-      });
+      }),
+    );
+    vi.setSystemTime(1_700_000_000_000 + ageMs);
+  }
+
+  test("rejects and deletes an expired challenge", async () => {
+    const t = setup();
+    const challenge = crypto.getRandomValues(new Uint8Array(32));
+    await insertAndAge(t, challenge, CHALLENGE_TTL_MS + 1);
+    await t.run(async (ctx) => {
       const row = await consumeChallenge(ctx, "registration", challenge);
       expect(row).toBe(null);
       // The expired row was deleted on the way out.
@@ -133,34 +145,22 @@ describe("consumeChallenge", () => {
   });
 
   test("rejects a challenge exactly at the TTL boundary", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_700_000_000_000);
     const t = setup();
     const challenge = crypto.getRandomValues(new Uint8Array(32));
+    await insertAndAge(t, challenge, CHALLENGE_TTL_MS);
+    // A challenge is valid for strictly less than the TTL: at exactly
+    // the TTL, it is expired. This is the same boundary that the cleanup
+    // loop uses.
     await t.run(async (ctx) => {
-      await ctx.db.insert("challenges", {
-        kind: "registration",
-        challenge: toArrayBuffer(challenge),
-        createdAt: Date.now() - CHALLENGE_TTL_MS,
-      });
-      // A challenge is valid for strictly less than the TTL: at exactly
-      // the TTL, it is expired. This is the same boundary that the cleanup
-      // loop uses.
       expect(await consumeChallenge(ctx, "registration", challenge)).toBe(null);
     });
   });
 
   test("accepts a challenge one millisecond before the TTL boundary", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(1_700_000_000_000);
     const t = setup();
     const challenge = crypto.getRandomValues(new Uint8Array(32));
+    await insertAndAge(t, challenge, CHALLENGE_TTL_MS - 1);
     await t.run(async (ctx) => {
-      await ctx.db.insert("challenges", {
-        kind: "registration",
-        challenge: toArrayBuffer(challenge),
-        createdAt: Date.now() - CHALLENGE_TTL_MS + 1,
-      });
       expect(await consumeChallenge(ctx, "registration", challenge)).not.toBe(
         null,
       );

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -132,7 +132,7 @@ describe("consumeChallenge", () => {
     });
   });
 
-  test("accepts a challenge exactly at the TTL boundary", async () => {
+  test("rejects a challenge exactly at the TTL boundary", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
     const t = setup();
@@ -142,6 +142,24 @@ describe("consumeChallenge", () => {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
         createdAt: Date.now() - CHALLENGE_TTL_MS,
+      });
+      // A challenge is valid for strictly less than the TTL: at exactly
+      // the TTL, it is expired. This is the same boundary that the cleanup
+      // loop uses.
+      expect(await consumeChallenge(ctx, "registration", challenge)).toBe(null);
+    });
+  });
+
+  test("accepts a challenge one millisecond before the TTL boundary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    const t = setup();
+    const challenge = crypto.getRandomValues(new Uint8Array(32));
+    await t.run(async (ctx) => {
+      await ctx.db.insert("challenges", {
+        kind: "registration",
+        challenge: toArrayBuffer(challenge),
+        createdAt: Date.now() - CHALLENGE_TTL_MS + 1,
       });
       expect(await consumeChallenge(ctx, "registration", challenge)).not.toBe(
         null,

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -58,5 +58,5 @@ export function isChallengeExpired(
   // A challenge is valid for strictly less than the TTL: at exactly the
   // TTL, it is expired. The cleanup loop (see cleanup.ts) uses the same
   // boundary, so a wake-up at the deadline always finds work.
-  return now - row.createdAt >= CHALLENGE_TTL_MS;
+  return now - row._creationTime >= CHALLENGE_TTL_MS;
 }

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -1,12 +1,6 @@
 import { Doc } from "./_generated/dataModel";
 import { MutationCtx } from "./_generated/server";
-
-// How long a stored challenge stays valid. The WebAuthn spec recommends
-// ceremony timeouts of 5–10 minutes to leave room for user interaction
-// (PIN entry, cross-device flows); we match the upper bound. Expiring
-// challenges bounds the window for replay of an intercepted challenge.
-// https://www.w3.org/TR/webauthn-3/#sctn-timeout-recommended-range
-const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+import { CHALLENGE_TTL_MS } from "./validation";
 
 export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
@@ -48,8 +42,21 @@ export async function consumeChallenge(
   }
   // One use only: a consumed (or expired) challenge is deleted.
   await ctx.db.delete("challenges", row._id);
-  if (Date.now() - row.createdAt > CHALLENGE_TTL_MS) {
+  if (isChallengeExpired(row)) {
     return null;
   }
   return row;
+}
+
+/**
+ * Tell if a stored challenge is too old to redeem.
+ */
+export function isChallengeExpired(
+  row: Doc<"challenges">,
+  now: number = Date.now(),
+): boolean {
+  // A challenge is valid for strictly less than the TTL: at exactly the
+  // TTL, it is expired. The cleanup loop (see cleanup.ts) uses the same
+  // boundary, so a wake-up at the deadline always finds work.
+  return now - row.createdAt >= CHALLENGE_TTL_MS;
 }

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -1,9 +1,9 @@
-import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { decodePKCS1RSAPublicKey } from "../../vendor/oslo/crypto/rsa";
 import { api } from "./_generated/api";
 import { toArrayBuffer } from "./helpers";
-import schema from "./schema";
+import { CHALLENGE_TTL_MS } from "./validation";
+import { setup } from "../passkeyTestSetup";
 import {
   ORIGIN,
   RP_ID,
@@ -15,14 +15,6 @@ import {
   generateRS256Credential,
   register,
 } from "./testAuthenticator";
-
-const modules = import.meta.glob("./**/*.ts");
-
-const CHALLENGE_TTL_MS = 10 * 60 * 1000;
-
-function setup() {
-  return convexTest(schema, modules);
-}
 
 /** Build valid `finishRegistration` args, with overridable pieces. */
 async function registrationArgs(

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { decodePKCS1RSAPublicKey } from "../../vendor/oslo/crypto/rsa";
 import { api } from "./_generated/api";
 import { toArrayBuffer } from "./helpers";
@@ -65,6 +65,12 @@ async function registrationArgs(
     },
   };
 }
+
+// Only the expiry tests move the clock, but the restore is global to keep the
+// other tests on the real clock.
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("startRegistration", () => {
   test("returns a 32-byte challenge and stores an anonymous registration row", async () => {
@@ -178,12 +184,10 @@ describe("finishRegistration", () => {
   test("returns CHALLENGE_EXPIRED for an expired challenge and deletes it", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1");
-    await t.run(async (ctx) => {
-      const row = await ctx.db.query("challenges").unique();
-      await ctx.db.patch(row!._id, {
-        createdAt: row!.createdAt - CHALLENGE_TTL_MS - 1000,
-      });
-    });
+    // The age of a challenge is the age of its `_creationTime`, thus the
+    // clock is the only way to make the challenge expire.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + CHALLENGE_TTL_MS + 1000);
     const result = await t.mutation(api.registration.finishRegistration, args);
     expect(result).toEqual({
       success: false,

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -46,7 +46,6 @@ export const startRegistration = mutation({
     await ctx.db.insert("challenges", {
       kind: "registration",
       challenge,
-      createdAt: Date.now(),
     });
     await scheduleChallengeCleanup(ctx);
     let excludeCredentials: ArrayBuffer[] = [];

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -15,6 +15,7 @@ import {
   deletePasskeyUserError,
 } from "./validation";
 import { consumeChallenge, randomChallenge, toArrayBuffer } from "./helpers";
+import { scheduleChallengeCleanup } from "./cleanup";
 
 // The challenge and the credential IDs travel as raw bytes (Convex
 // `v.bytes()` carries `ArrayBuffer`s end to end). The WebAuthn API in the
@@ -47,6 +48,7 @@ export const startRegistration = mutation({
       challenge,
       createdAt: Date.now(),
     });
+    await scheduleChallengeCleanup(ctx);
     let excludeCredentials: ArrayBuffer[] = [];
     if (userId !== undefined) {
       const rows = await ctx.db

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -43,6 +43,13 @@ export default defineSchema({
         createdAt: v.number(),
       }),
     ),
-    // TODO(nicolas) Automatically erase expired challenges in the background
-  ).index("by_challenge", ["challenge"]),
+  )
+    .index("by_challenge", ["challenge"])
+    // Used by the background cleanup loop (see cleanup.ts) to find the
+    // challenges that are expired, oldest first.
+    .index("by_createdAt", ["createdAt"])
+    // Used by `deleteUser` to erase the authentication challenges that are
+    // bound to a user. Registration rows have no `userId` field, so a probe
+    // with a user ID string never matches them.
+    .index("by_userId", ["userId"]),
 });

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -25,13 +25,15 @@ export default defineSchema({
     .index("by_userId", ["userId"]),
 
   // The WebAuthn challenges that are active. Each challenge is for one use
-  // only: the finish step deletes it.
+  // only: the finish step deletes it. A challenge expires a fixed time after
+  // its creation (see CHALLENGE_TTL_MS), thus `_creationTime` is the age of
+  // the challenge and the built-in `by_creation_time` index gives the
+  // background cleanup loop (see cleanup.ts) the oldest challenges first.
   challenges: defineTable(
     v.union(
       v.object({
         kind: v.literal("registration"),
         challenge: v.bytes(), // 32 random bytes
-        createdAt: v.number(), // challenges expire (see CHALLENGE_TTL_MS)
       }),
       v.object({
         kind: v.literal("authentication"),
@@ -40,16 +42,7 @@ export default defineSchema({
         // The field is not set for discoverable-credential ceremonies. In
         // that flow, the assertion identifies the user.
         userId: v.optional(v.string()),
-        createdAt: v.number(),
       }),
     ),
-  )
-    .index("by_challenge", ["challenge"])
-    // Used by the background cleanup loop (see cleanup.ts) to find the
-    // challenges that are expired, oldest first.
-    .index("by_createdAt", ["createdAt"])
-    // Used by `deleteUser` to erase the authentication challenges that are
-    // bound to a user. Registration rows have no `userId` field, so a probe
-    // with a user ID string never matches them.
-    .index("by_userId", ["userId"]),
+  ).index("by_challenge", ["challenge"]),
 });

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -1,5 +1,12 @@
 import { Infer, v } from "convex/values";
 
+// How long a stored challenge stays valid. The WebAuthn spec recommends
+// ceremony timeouts of 5–10 minutes to leave room for user interaction
+// (PIN entry, cross-device flows); we match the upper bound. Expiring
+// challenges bounds the window for replay of an intercepted challenge.
+// https://www.w3.org/TR/webauthn-3/#sctn-timeout-recommended-range
+export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
 /**
  * The user-facing errors for `finishRegistration`. An app can show these
  * errors to the end user. The `error` field is a machine-readable code and

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -1,0 +1,25 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { expect } from "vitest";
+import { register as registerBatchWorker } from "@convex-dev/batch-worker/test";
+import schema from "./passkey/schema";
+
+export const modules = import.meta.glob("./passkey/**/*.ts");
+
+/**
+ * Make a test instance of the component. The component mounts the batch
+ * worker (the ceremony mutations ping the cleanup loop), so register it
+ * with the test instance too.
+ */
+export function setup(): TestConvex<typeof schema> {
+  const t = convexTest(schema, modules);
+  registerBatchWorker(t);
+  return t;
+}
+
+/** Assert that two byte buffers hold the same bytes. */
+export function expectSameBytes(
+  a: ArrayBuffer | Uint8Array,
+  b: ArrayBuffer | Uint8Array,
+): void {
+  expect(new Uint8Array(a)).toEqual(new Uint8Array(b));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     devDependencies:
       '@convex-dev/eslint-plugin':
         specifier: ^2.0.0
-        version: 2.0.0(convex@1.42.1(react@19.2.7))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 2.0.0(convex@1.43.0(react@19.2.7))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
       convex:
-        specifier: ^1.41.0
-        version: 1.42.1(react@19.2.7)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       convex:
-        specifier: ^1.41.0
-        version: 1.42.1(react@19.2.7)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
       jose:
         specifier: ^5.10.0
         version: 5.10.0
@@ -59,7 +59,7 @@ importers:
     devDependencies:
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
-        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+        version: 0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.2
@@ -79,8 +79,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       convex:
-        specifier: ^1.41.0
-        version: 1.42.1(react@19.2.7)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -101,8 +101,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       convex-test:
-        specifier: ^0.0.53
-        version: 0.0.53(convex@1.42.1(react@19.2.7))
+        specifier: ^0.0.55
+        version: 0.0.55(convex@1.43.0(react@19.2.7))
       jose:
         specifier: ^5.10.0
         version: 5.10.0
@@ -119,8 +119,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       convex:
-        specifier: ^1.41.0
-        version: 1.42.1(react@19.2.7)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -133,7 +133,7 @@ importers:
     devDependencies:
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
-        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+        version: 0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
@@ -150,8 +150,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       convex-test:
-        specifier: ^0.0.53
-        version: 0.0.53(convex@1.42.1(react@19.2.7))
+        specifier: ^0.0.55
+        version: 0.0.55(convex@1.43.0(react@19.2.7))
       jose:
         specifier: ^5.10.0
         version: 5.10.0
@@ -174,11 +174,11 @@ importers:
   packages/core:
     dependencies:
       '@convex-dev/batch-worker':
-        specifier: ^0.2.0
-        version: 0.2.0(convex@1.42.1(react@19.2.7))(react@19.2.7)
+        specifier: ^0.3.0
+        version: 0.3.0(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
-        version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
+        version: 0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)
       argon2id-wasm:
         specifier: 0.0.0-alpha.1
         version: 0.0.0-alpha.1
@@ -208,11 +208,11 @@ importers:
         specifier: ^19.2.17
         version: 19.2.17
       convex:
-        specifier: ^1.41.0
-        version: 1.42.1(react@19.2.7)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
       convex-test:
-        specifier: ^0.0.53
-        version: 0.0.53(convex@1.42.1(react@19.2.7))
+        specifier: ^0.0.55
+        version: 0.0.55(convex@1.43.0(react@19.2.7))
       hash-wasm:
         specifier: ^4.12.0
         version: 4.12.0
@@ -360,10 +360,10 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@convex-dev/batch-worker@0.2.0':
-    resolution: {integrity: sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==}
+  '@convex-dev/batch-worker@0.3.0':
+    resolution: {integrity: sha512-9CNwrhooFw59vRFEBiibD2/S0VEe6BiPDyJPlvybVkxEzeCKHjGwzaHtez6FuD6wIJ+GglWGqvlu4fOAEh9+pg==}
     peerDependencies:
-      convex: ^1.36.1
+      convex: ^1.43.0
       react: ^18.3.1 || ^19.0.0
 
   '@convex-dev/eslint-plugin@2.0.0':
@@ -1064,24 +1064,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.10':
     resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.10':
     resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.10':
     resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.10':
     resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
@@ -1661,13 +1665,35 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  convex-test@0.0.53:
-    resolution: {integrity: sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==}
+  convex-helpers@0.1.123:
+    resolution: {integrity: sha512-E9W4tscZy6ZtNnwPDdL5UhMc7Rj9aUYlzjdYiKsfVIAwdarABWqvPB8+St3Q6IwS83r+QIGSO1lTidTamDdyPQ==}
+    hasBin: true
     peerDependencies:
-      convex: ^1.32.0
+      '@standard-schema/spec': ^1.0.0
+      convex: ^1.43.0
+      hono: ^4.0.5
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      typescript: ^5.5 || ^6.0.0 || ^7.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@standard-schema/spec':
+        optional: true
+      hono:
+        optional: true
+      react:
+        optional: true
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
-  convex@1.42.1:
-    resolution: {integrity: sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug==}
+  convex-test@0.0.55:
+    resolution: {integrity: sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw==}
+    peerDependencies:
+      convex: ^1.43.0
+
+  convex@1.43.0:
+    resolution: {integrity: sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -3080,24 +3106,30 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@convex-dev/batch-worker@0.2.0(convex@1.42.1(react@19.2.7))(react@19.2.7)':
+  '@convex-dev/batch-worker@0.3.0(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
-      convex: 1.42.1(react@19.2.7)
+      convex: 1.43.0(react@19.2.7)
+      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
       react: 19.2.7
+    transitivePeerDependencies:
+      - '@standard-schema/spec'
+      - hono
+      - typescript
+      - zod
 
-  '@convex-dev/eslint-plugin@2.0.0(convex@1.42.1(react@19.2.7))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@convex-dev/eslint-plugin@2.0.0(convex@1.43.0(react@19.2.7))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/utils': 8.58.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      convex: 1.42.1(react@19.2.7)
+      convex: 1.43.0(react@19.2.7)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  '@convex-dev/rate-limiter@0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)':
+  '@convex-dev/rate-limiter@0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)':
     dependencies:
-      convex: 1.42.1(react@19.2.7)
+      convex: 1.43.0(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
 
@@ -4120,11 +4152,20 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-test@0.0.53(convex@1.42.1(react@19.2.7)):
+  convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3):
     dependencies:
-      convex: 1.42.1(react@19.2.7)
+      convex: 1.43.0(react@19.2.7)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      react: 19.2.7
+      typescript: 6.0.3
+      zod: 4.4.3
 
-  convex@1.42.1(react@19.2.7):
+  convex-test@0.0.55(convex@1.43.0(react@19.2.7)):
+    dependencies:
+      convex: 1.43.0(react@19.2.7)
+
+  convex@1.43.0(react@19.2.7):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.9.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@convex-dev/batch-worker':
+        specifier: ^0.2.0
+        version: 0.2.0(convex@1.42.1(react@19.2.7))(react@19.2.7)
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
         version: 0.3.2(convex@1.42.1(react@19.2.7))(react@19.2.7)
@@ -356,6 +359,12 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@convex-dev/batch-worker@0.2.0':
+    resolution: {integrity: sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==}
+    peerDependencies:
+      convex: ^1.36.1
+      react: ^18.3.1 || ^19.0.0
 
   '@convex-dev/eslint-plugin@2.0.0':
     resolution: {integrity: sha512-GxYe0b5RoAb7c7JzcAX3t+UrdT6edQDtSgJ2F9UPECLyQGU0TeTkyGsDXNm3HK+MnWYi8isRlqaqoYTUD0Ko+Q==}
@@ -3070,6 +3079,11 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@convex-dev/batch-worker@0.2.0(convex@1.42.1(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      convex: 1.42.1(react@19.2.7)
+      react: 19.2.7
 
   '@convex-dev/eslint-plugin@2.0.0(convex@1.42.1(react@19.2.7))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
The current implementation of the passkey component has a `challenges` table. Challenges are only valid for 10 minutes, and the current implementation never deletes challenges that were started but then never claimed.

This PR fixes the row leak problem by deleting expired challenges through [`@convex-dev/batch-worker`](https://www.npmjs.com/package/@convex-dev/batch-worker).

