### PR TITLE
Add a username component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This is Convex Auth, an authentication framework built on top of Convex. We’re
 
 This is a pnpm monorepo:
 
-- `packages/core` — the auth package, published as `@convex-dev/auth`. Owns sessions, accounts, and JWT minting (the provider-agnostic core), plus the bundled providers: the anonymous provider and the password provider (which stores and verifies passwords keyed by an opaque user id).
+- `packages/core` — the auth package, published as `@convex-dev/auth`. Owns sessions, accounts, and JWT minting (the provider-agnostic core), plus the bundled providers: the anonymous provider and the password provider (which stores and verifies passwords keyed by an opaque user id). It also owns the username component, a non-provider component that maps a username onto an opaque user id.
 - `packages/argon2id-wasm` — the `argon2id-wasm` package wrapping the argon2id WASM hasher used by the password provider. Its `prepare` script builds the Rust/WASM output when it's missing.
 - `examples/` — example apps, each an in-repo Convex backend run from its own
   directory:

--- a/examples/react-password/convex/_generated/api.d.ts
+++ b/examples/react-password/convex/_generated/api.d.ts
@@ -53,4 +53,5 @@ export declare const internal: FilterApi<
 export declare const components: {
   core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
   authPasswordProvider: import("@convex-dev/auth/providers/password/_generated/component.js").ComponentApi<"authPasswordProvider">;
+  authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;
 };

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -13,6 +13,7 @@ export const {
   providers: [
     provider(UsernamePassword, {
       component: components.authPasswordProvider,
+      usernameComponent: components.authUsername,
     }),
   ],
 }).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-password/convex/convex.config.ts
+++ b/examples/react-password/convex/convex.config.ts
@@ -2,6 +2,7 @@ import { defineApp } from "convex/server";
 import { v } from "convex/values";
 import core from "@convex-dev/auth/core/convex.config.js";
 import passwordProvider from "@convex-dev/auth/providers/password/convex.config.js";
+import username from "@convex-dev/auth/username/convex.config.js";
 
 const app = defineApp({
   env: {
@@ -18,5 +19,6 @@ app.use(core, {
   },
 });
 app.use(passwordProvider);
+app.use(username);
 
 export default app;

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -1,9 +1,10 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
-import { api } from "./_generated/api.js";
+import { api, components } from "./_generated/api.js";
 import { registerCore } from "@convex-dev/auth/providers/testing/core";
 import { registerPasswordProvider } from "@convex-dev/auth/providers/testing/password";
+import { registerUsername } from "@convex-dev/auth/providers/testing/username";
 import schema from "./schema.js";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -31,6 +32,7 @@ async function setup() {
   const t = convexTest(schema, modules);
   registerCore(t);
   registerPasswordProvider(t);
+  registerUsername(t);
   return t;
 }
 
@@ -165,6 +167,26 @@ describe("setupUsernamePassword", () => {
       success: false,
       userError: { error: "USERNAME_TAKEN" },
     });
+  });
+
+  test("rejects an empty username at sign-up", async () => {
+    const t = await setup();
+    const up = await signUp(t, "", PASSWORD);
+    expect(up).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TOO_SHORT", minimumLength: 1 },
+    });
+  });
+
+  test("stores the username in the username component", async () => {
+    const t = await setup();
+    const up = await signUp(t, "Alice", PASSWORD);
+    const rows = await t.run(async (ctx) =>
+      ctx.runQuery(components.authUsername.public.getUsername, {
+        userId: (up as PasswordSuccess).tokens.userId,
+      }),
+    );
+    expect(rows).toBe("Alice");
   });
 
   test("rejects a too-short password at sign-up without creating an account", async () => {

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -24,6 +24,12 @@ export function SignUp() {
             switch (result.userError.error) {
               case "USERNAME_TAKEN":
                 return "That username is already taken.";
+              case "USERNAME_TOO_SHORT":
+                return `Username must be at least ${result.userError.minimumLength} characters.`;
+              case "USERNAME_HAS_SURROUNDING_WHITESPACE":
+                return "Username can't start or end with whitespace.";
+              case "USERNAME_HAS_INVALID_CHARACTERS":
+                return "Username contains characters that aren't allowed.";
               case "PASSWORD_TOO_SHORT":
                 return `Password must be at least ${result.userError.minimumLength} characters.`;
               case "PASSWORD_TOO_LONG":

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,8 @@
     "./lib/*": "./src/lib/*.ts",
     "./core/convex.config.js": "./src/components/core/convex.config.ts",
     "./core/*": "./src/components/core/*.ts",
+    "./username/convex.config.js": "./src/components/username/convex.config.ts",
+    "./username/*": "./src/components/username/*.ts",
     "./providers/anonymous/convex.config.js": "./src/components/anonymous/convex.config.ts",
     "./providers/anonymous/react": "./src/components/anonymous/react.tsx",
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -4,7 +4,6 @@ import { defineProvider, vTokenBundle } from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
 import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
 import {
-  normalizeUsername,
   setUsernameUserError,
   validateUsernameFormat,
 } from "../username/validation";
@@ -33,6 +32,10 @@ export type UsernamePasswordOptions = {
 
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "password";
+
+// A given user has only zero or one “provider account ID”,
+// so there is no need for having a value here.
+const PROVIDER_ACCOUNT_ID = "";
 
 const signInResult = v.union(
   v.object({ success: v.literal(true), tokens: vTokenBundle }),
@@ -137,7 +140,7 @@ export const UsernamePassword = defineProvider({
           // username. Give the account a stable, opaque id instead.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: normalizeUsername(username),
+            providerAccountId: PROVIDER_ACCOUNT_ID,
             profile: { username },
           });
 
@@ -214,7 +217,7 @@ export const UsernamePassword = defineProvider({
           // no longer needs to be keyed by the username.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: normalizeUsername(username),
+            providerAccountId: PROVIDER_ACCOUNT_ID,
             profile: { username },
           });
           return { success: true, tokens };

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -35,7 +35,7 @@ const PROVIDER_NAME = "password";
 
 // A given user has only zero or one “provider account ID”,
 // so there is no need for having a value here.
-const PROVIDER_ACCOUNT_ID = "";
+const EMPTY_PROVIDER_ACCOUNT_ID = "";
 
 const signInResult = v.union(
   v.object({ success: v.literal(true), tokens: vTokenBundle }),
@@ -140,7 +140,7 @@ export const UsernamePassword = defineProvider({
           // username. Give the account a stable, opaque id instead.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: PROVIDER_ACCOUNT_ID,
+            providerAccountId: EMPTY_PROVIDER_ACCOUNT_ID,
             profile: { username },
           });
 
@@ -217,7 +217,7 @@ export const UsernamePassword = defineProvider({
           // no longer needs to be keyed by the username.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: PROVIDER_ACCOUNT_ID,
+            providerAccountId: EMPTY_PROVIDER_ACCOUNT_ID,
             profile: { username },
           });
           return { success: true, tokens };

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -2,6 +2,12 @@ import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import { defineProvider, vTokenBundle } from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
+import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
+import {
+  normalizeUsername,
+  setUsernameUserError,
+  validateUsernameFormat,
+} from "../username/validation";
 import {
   validatePasswordInputFormat,
   setPasswordUserError,
@@ -17,15 +23,16 @@ export type UsernamePasswordOptions = {
    * recipe drives its `setPassword` / `verifyPassword` mutations.
    */
   component: ComponentApi;
+  /**
+   * The mounted username component (`components.authUsername`). The recipe
+   * uses it to map a username onto the app user id: it stores the username
+   * at sign-up and reads it back at sign-in.
+   */
+  usernameComponent: UsernameComponentApi;
 };
 
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "password";
-
-// Used to compare usernames case-insensitively.
-function normalizeUsername(username: string): string {
-  return username.toLowerCase();
-}
 
 const signInResult = v.union(
   v.object({ success: v.literal(true), tokens: vTokenBundle }),
@@ -49,10 +56,7 @@ const signUpResult = v.union(
   v.object({ success: v.literal(true), tokens: vTokenBundle }),
   v.object({
     success: v.literal(false),
-    userError: v.union(
-      setPasswordUserError,
-      v.object({ error: v.literal("USERNAME_TAKEN") }),
-    ),
+    userError: v.union(setPasswordUserError, setUsernameUserError),
   }),
 );
 
@@ -71,7 +75,10 @@ export type SignUpResult = Infer<typeof signUpResult>;
  * setupCore({
  *   component: components.core,
  *   providers: [
- *     provider(UsernamePassword, { component: components.authPasswordProvider }),
+ *     provider(UsernamePassword, {
+ *       component: components.authPasswordProvider,
+ *       usernameComponent: components.authUsername,
+ *     }),
  *   ],
  * }).attachUserCallback(internal.users.upsertFromAuth);
  * ```
@@ -79,51 +86,76 @@ export type SignUpResult = Infer<typeof signUpResult>;
  * The app re-exports the returned `signUpWithPassword` / `signInWithPassword`
  * mutations so its clients can call them.
  *
- * Account resolution (username → app user id) is owned by the core's `accounts`
- * table: the recipe uses the lowercased username as the provider account id, and
- * looks it up with the `resolveUserId` helper the core supplies. The password
- * component itself stores only `{ userId, passwordHash }` and knows nothing about
- * usernames.
+ * Account resolution (username → app user id) is owned by the username
+ * component: the recipe stores the username there at sign-up, and reads the
+ * user id back from it at sign-in. The password component itself stores only
+ * `{ userId, passwordHash }` and knows nothing about usernames.
  */
 export const UsernamePassword = defineProvider({
   name: PROVIDER_NAME,
-  setup: (
-    { completeSignIn, resolveUserId },
-    options: UsernamePasswordOptions,
-  ) => {
-    const { component } = options;
+  setup: ({ completeSignIn }, options: UsernamePasswordOptions) => {
+    const { component, usernameComponent } = options;
 
     return {
       /**
        * Create a new account: reject a taken username or an invalid password,
-       * otherwise create the user + session and store the password.
+       * otherwise create the user + session and store the username and the
+       * password.
        */
       signUpWithPassword: mutationGeneric({
         args: { username: v.string(), password: v.string() },
         returns: signUpResult,
         handler: async (ctx, { username, password }): Promise<SignUpResult> => {
-          // Validate the password *before* creating anything, so an invalid
-          // password never mints a session. (`setPassword` re-validates, but by
+          // Validate the username and the password *before* creating
+          // anything, so invalid input never mints a session.
+          // (`setUsername` and `setPassword` do the same checks again, but by
           // then the account would already exist.)
+          // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
+          const usernameError = validateUsernameFormat(username);
+          if (usernameError !== null) {
+            return { success: false, userError: usernameError };
+          }
           const userError = validatePasswordInputFormat(password);
           if (userError !== null) {
             return { success: false, userError };
           }
 
-          const normalizedUsername = normalizeUsername(username);
-          const existing = await resolveUserId(ctx, normalizedUsername);
+          const existing = await ctx.runQuery(
+            usernameComponent.public.getUserIdByUsername,
+            { username },
+          );
           if (existing !== null) {
             return { success: false, userError: { error: "USERNAME_TAKEN" } };
           }
 
           // Create the account + app user (via the app's createOrUpdateUser) and
           // mint the session. `profile.username` keeps the original casing for
-          // display; the account is keyed by the lowercased `id`.
+          // display; the account is keyed by the normalized `id`.
+          //
+          // TODO(nicolas) The username component now owns the username → user
+          // id mapping, so the account no longer needs to be keyed by the
+          // username. Give the account a stable, opaque id instead.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: normalizedUsername,
+            providerAccountId: normalizeUsername(username),
             profile: { username },
           });
+
+          const setUsernameResult = await ctx.runMutation(
+            usernameComponent.public.setUsername,
+            { userId: tokens.userId, username },
+          );
+          if (!setUsernameResult.success) {
+            // Unexpected: we validated the username above, and this handler
+            // is a mutation, thus the check for a conflict above and this
+            // call are in the same transaction.
+            // Throwing so that the transaction doesn’t commit.
+            throw new Error(
+              "Unexpected error when setting the username: " +
+                setUsernameResult.userError.error,
+              { cause: setUsernameResult.userError },
+            );
+          }
 
           const setResult = await ctx.runMutation(
             component.public.setPassword,
@@ -159,8 +191,10 @@ export const UsernamePassword = defineProvider({
         args: { username: v.string(), password: v.string() },
         returns: signInResult,
         handler: async (ctx, { username, password }): Promise<SignInResult> => {
-          const id = normalizeUsername(username);
-          const userId = await resolveUserId(ctx, id);
+          const userId = await ctx.runQuery(
+            usernameComponent.public.getUserIdByUsername,
+            { username },
+          );
           if (userId === null) {
             return {
               success: false,
@@ -176,9 +210,11 @@ export const UsernamePassword = defineProvider({
             return { success: false, userError: verifyResult.userError };
           }
 
+          // TODO(nicolas) See the TODO in `signUpWithPassword`: the account
+          // no longer needs to be keyed by the username.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: id,
+            providerAccountId: normalizeUsername(username),
             profile: { username },
           });
           return { success: true, tokens };

--- a/packages/core/src/components/testing/username.ts
+++ b/packages/core/src/components/testing/username.ts
@@ -1,0 +1,17 @@
+import type { TestConvex } from "convex-test";
+import type { GenericSchema, SchemaDefinition } from "convex/server";
+import schema from "../username/schema";
+const modules = import.meta.glob("../username/**/*.ts");
+
+/**
+ * Register the component with the test convex instance.
+ * @param t - The test convex instance, e.g. from calling `convexTest`.
+ * @param name - The name of the component, as registered in convex.config.ts.
+ */
+export function registerUsername(
+  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
+  name: string = "authUsername",
+) {
+  t.registerComponent(name, schema, modules);
+}
+export default { registerUsername, schema, modules };

--- a/packages/core/src/components/username/_generated/api.ts
+++ b/packages/core/src/components/username/_generated/api.ts
@@ -1,0 +1,52 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as public_ from "../public.js";
+import type * as validation from "../validation.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import { anyApi, componentsGeneric } from "convex/server";
+
+const fullApi: ApiFromModules<{
+  public: typeof public_;
+  validation: typeof validation;
+}> = anyApi as any;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+> = anyApi as any;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+> = anyApi as any;
+
+export const components = componentsGeneric() as unknown as {};

--- a/packages/core/src/components/username/_generated/component.ts
+++ b/packages/core/src/components/username/_generated/component.ts
@@ -1,0 +1,64 @@
+/* eslint-disable */
+/**
+ * Generated `ComponentApi` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type { FunctionReference } from "convex/server";
+
+/**
+ * A utility for referencing a Convex component's exposed API.
+ *
+ * Useful when expecting a parameter like `components.myComponent`.
+ * Usage:
+ * ```ts
+ * async function myFunction(ctx: QueryCtx, component: ComponentApi) {
+ *   return ctx.runQuery(component.someFile.someQuery, { ...args });
+ * }
+ * ```
+ */
+export type ComponentApi<Name extends string | undefined = string | undefined> =
+  {
+    public: {
+      deleteUsername: FunctionReference<
+        "mutation",
+        "internal",
+        { userId: string },
+        { deleted: boolean },
+        Name
+      >;
+      getUserIdByUsername: FunctionReference<
+        "query",
+        "internal",
+        { username: string },
+        string | null,
+        Name
+      >;
+      getUsername: FunctionReference<
+        "query",
+        "internal",
+        { userId: string },
+        string | null,
+        Name
+      >;
+      setUsername: FunctionReference<
+        "mutation",
+        "internal",
+        { userId: string; username: string },
+        | { previousUsername: string | null; success: true }
+        | {
+            success: false;
+            userError:
+              | { error: "USERNAME_TOO_SHORT"; minimumLength: number }
+              | { error: "USERNAME_HAS_SURROUNDING_WHITESPACE" }
+              | { error: "USERNAME_HAS_INVALID_CHARACTERS" }
+              | { error: "USERNAME_TAKEN" };
+          },
+        Name
+      >;
+    };
+  };

--- a/packages/core/src/components/username/_generated/dataModel.ts
+++ b/packages/core/src/components/username/_generated/dataModel.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/packages/core/src/components/username/_generated/server.ts
+++ b/packages/core/src/components/username/_generated/server.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query: QueryBuilder<DataModel, "public"> = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery: QueryBuilder<DataModel, "internal"> =
+  internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation: MutationBuilder<DataModel, "public"> = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation: MutationBuilder<DataModel, "internal"> =
+  internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action: ActionBuilder<DataModel, "public"> = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction: ActionBuilder<DataModel, "internal"> =
+  internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction: HttpActionBuilder = httpActionGeneric;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * If you're using code generation, use the `QueryCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ *
+ * If you're using code generation, use the `MutationCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/packages/core/src/components/username/convex.config.ts
+++ b/packages/core/src/components/username/convex.config.ts
@@ -1,0 +1,18 @@
+import { defineComponent } from "convex/server";
+
+/**
+ * The username component.
+ *
+ * The component owns the mapping between a username and an opaque app
+ * `userId`. It stores one username for each user, and makes sure that no
+ * two users have the same username.
+ *
+ * The component is not an auth provider. It knows nothing about
+ * credentials or sessions. An auth provider (for example the password
+ * provider) uses it to find the user that a username identifies.
+ *
+ * The component has no configuration.
+ */
+const component = defineComponent("authUsername");
+
+export default component;

--- a/packages/core/src/components/username/public.ts
+++ b/packages/core/src/components/username/public.ts
@@ -1,0 +1,140 @@
+import { mutation, query, QueryCtx } from "./_generated/server";
+import { Doc } from "./_generated/dataModel";
+import { Infer, v } from "convex/values";
+import {
+  normalizeUsername,
+  setUsernameUserError,
+  validateUsernameFormat,
+} from "./validation";
+
+const setUsernameResult = v.union(
+  v.object({
+    success: v.literal(true),
+    // The username that this user had before this call, or `null` when the
+    // user had no username.
+    previousUsername: v.union(v.string(), v.null()),
+  }),
+  v.object({ success: v.literal(false), userError: setUsernameUserError }),
+);
+type SetUsernameResult = Infer<typeof setUsernameResult>;
+
+/**
+ * Set the username of a user.
+ *
+ * This function can be used:
+ * - to give a username to a new user
+ * - to change the username of an existing user (a user has one username at most,
+ *   thus a new username replaces the previous one)
+ *
+ * The function first makes sure that no other user has this username. If a
+ * different user has it, the function returns a `USERNAME_TAKEN` user
+ * error and changes nothing. When the same user already has this username
+ * (possibly with a different case), the function keeps the new spelling
+ * and is otherwise a no-op.
+ */
+export const setUsername = mutation({
+  args: { userId: v.string(), username: v.string() },
+  returns: setUsernameResult,
+  handler: async (ctx, { userId, username }): Promise<SetUsernameResult> => {
+    const userError = validateUsernameFormat(username);
+    if (userError !== null) {
+      return { success: false, userError };
+    }
+
+    const usernameNormalized = normalizeUsername(username);
+    const conflict = await rowByNormalizedUsername(ctx, usernameNormalized);
+    if (conflict !== null && conflict.userId !== userId) {
+      return { success: false, userError: { error: "USERNAME_TAKEN" } };
+    }
+
+    const existing = await rowByUserId(ctx, userId);
+    if (existing !== null) {
+      await ctx.db.patch("usernames", existing._id, {
+        username,
+        usernameNormalized,
+      });
+      return { success: true, previousUsername: existing.username };
+    }
+    await ctx.db.insert("usernames", {
+      userId,
+      username,
+      usernameNormalized,
+    });
+    return { success: true, previousUsername: null };
+  },
+});
+
+/**
+ * Find the user that a username identifies.
+ *
+ * The lookup ignores the case and the Unicode normalization form of the
+ * `username` argument. The function returns `null` when no user has this
+ * username.
+ */
+export const getUserIdByUsername = query({
+  args: { username: v.string() },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, { username }): Promise<string | null> => {
+    const row = await rowByNormalizedUsername(ctx, normalizeUsername(username));
+    return row === null ? null : row.userId;
+  },
+});
+
+/**
+ * Get the username of a user, as the user supplied it.
+ *
+ * The function returns `null` when the user has no username.
+ */
+// TODO(nicolas) We could add a `getUsernames` function that takes a list of
+// user ids and returns the username of each one, for example to show the
+// usernames in a list of users.
+export const getUsername = query({
+  args: { userId: v.string() },
+  returns: v.union(v.string(), v.null()),
+  handler: async (ctx, { userId }): Promise<string | null> => {
+    const row = await rowByUserId(ctx, userId);
+    return row === null ? null : row.username;
+  },
+});
+
+/**
+ * Delete the username of a user.
+ *
+ * The function is idempotent: `deleted` is `false` when the user had no
+ * username. A user with no username can no longer be found with
+ * `getUserIdByUsername`, and the username becomes available again.
+ */
+export const deleteUsername = mutation({
+  args: { userId: v.string() },
+  returns: v.object({ deleted: v.boolean() }),
+  handler: async (ctx, { userId }): Promise<{ deleted: boolean }> => {
+    const row = await rowByUserId(ctx, userId);
+    if (row === null) {
+      return { deleted: false };
+    }
+    await ctx.db.delete("usernames", row._id);
+    return { deleted: true };
+  },
+});
+
+function rowByUserId(
+  ctx: QueryCtx,
+  userId: string,
+): Promise<Doc<"usernames"> | null> {
+  return ctx.db
+    .query("usernames")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .unique();
+}
+
+function rowByNormalizedUsername(
+  ctx: QueryCtx,
+  usernameNormalized: string,
+): Promise<Doc<"usernames"> | null> {
+  return ctx.db
+    .query("usernames")
+    .withIndex("by_usernameNormalized", (q) =>
+      q.eq("usernameNormalized", usernameNormalized),
+    )
+    .unique();
+}

--- a/packages/core/src/components/username/schema.ts
+++ b/packages/core/src/components/username/schema.ts
@@ -1,0 +1,21 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  // One row for each user that has a username. The component only sees an
+  // opaque app `userId` string.
+  usernames: defineTable({
+    userId: v.string(),
+    // The username as the user supplied it. Applications show this value.
+    username: v.string(),
+    // The username after normalization (see `normalizeUsername`). The
+    // component compares usernames with this value, so that two usernames
+    // that look the same to a user cannot both exist.
+    usernameNormalized: v.string(),
+  })
+    // A user has one username at most, and a username belongs to one user
+    // at most. The component keeps both properties true. Convex does not
+    // enforce unique indexes.
+    .index("by_userId", ["userId"])
+    .index("by_usernameNormalized", ["usernameNormalized"]),
+});

--- a/packages/core/src/components/username/username.test.ts
+++ b/packages/core/src/components/username/username.test.ts
@@ -1,0 +1,368 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+function setup() {
+  return convexTest(schema, modules);
+}
+
+describe("setUsername", () => {
+  test("sets a username for a user with no username", async () => {
+    const t = setup();
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "Alice",
+    });
+    expect(result).toEqual({ success: true, previousUsername: null });
+    expect(await t.query(api.public.getUsername, { userId: "user1" })).toBe(
+      "Alice",
+    );
+  });
+
+  test("renames a user and returns the previous username", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "Alice",
+    });
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "Bob",
+    });
+    expect(result).toEqual({ success: true, previousUsername: "Alice" });
+
+    // Only one row exists for the user, and the old username is free.
+    const count = await t.run(
+      async (ctx) => (await ctx.db.query("usernames").collect()).length,
+    );
+    expect(count).toBe(1);
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "alice" }),
+    ).toBe(null);
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "bob" }),
+    ).toBe("user1");
+  });
+
+  test("keeps the new spelling when the same user sets the same username", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "alice",
+    });
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "ALICE",
+    });
+    expect(result).toEqual({ success: true, previousUsername: "alice" });
+    expect(await t.query(api.public.getUsername, { userId: "user1" })).toBe(
+      "ALICE",
+    );
+  });
+
+  test("rejects a username that a different user has", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "alice",
+    });
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user2",
+      username: "alice",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+    expect(await t.query(api.public.getUsername, { userId: "user2" })).toBe(
+      null,
+    );
+  });
+
+  test("rejects a username that a different user has, in a different case", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "Alice",
+    });
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user2",
+      username: "ALICE",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("rejects an empty username", async () => {
+    const t = setup();
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TOO_SHORT", minimumLength: 1 },
+    });
+  });
+
+  test("accepts a one-character username and a very long username", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.public.setUsername, {
+        userId: "user1",
+        username: "a",
+      }),
+    ).toEqual({ success: true, previousUsername: null });
+    const long = "b".repeat(5000);
+    expect(
+      await t.mutation(api.public.setUsername, {
+        userId: "user2",
+        username: long,
+      }),
+    ).toEqual({ success: true, previousUsername: null });
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: long }),
+    ).toBe("user2");
+  });
+
+  test("rejects a username with surrounding whitespace", async () => {
+    const t = setup();
+    for (const username of [" alice", "alice ", "\talice", "alice\u3000"]) {
+      expect(
+        await t.mutation(api.public.setUsername, { userId: "user1", username }),
+      ).toEqual({
+        success: false,
+        userError: { error: "USERNAME_HAS_SURROUNDING_WHITESPACE" },
+      });
+    }
+  });
+
+  test("rejects a username that is only whitespace", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.public.setUsername, {
+        userId: "user1",
+        username: " ",
+      }),
+    ).toEqual({
+      success: false,
+      userError: { error: "USERNAME_HAS_SURROUNDING_WHITESPACE" },
+    });
+  });
+
+  test("accepts a space inside the username", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.public.setUsername, {
+        userId: "user1",
+        username: "alice smith",
+      }),
+    ).toEqual({ success: true, previousUsername: null });
+  });
+
+  test("rejects malformed characters", async () => {
+    const t = setup();
+    const malformed = {
+      "a NUL character": "ali\u0000ce",
+      "a line feed": "ali\nce",
+      "a delete character": "ali\u007fce",
+      "a C1 control": "ali\u009dce",
+      "a right-to-left override": "ali\u202ece",
+      "a zero-width space": "ali\u200bce",
+      "a byte order mark": "ali\ufeffce",
+      "a no-break space": "ali\u00a0ce",
+      "an ideographic space": "ali\u3000ce",
+      "a noncharacter": "ali\ufffece",
+      "a plane-end noncharacter": "ali\u{1fffe}ce",
+      "an unpaired surrogate": "ali\ud800ce",
+      "a leading combining mark": "\u0301alice",
+    };
+    for (const [description, username] of Object.entries(malformed)) {
+      expect(
+        await t.mutation(api.public.setUsername, { userId: "user1", username }),
+        description,
+      ).toEqual({
+        success: false,
+        userError: { error: "USERNAME_HAS_INVALID_CHARACTERS" },
+      });
+    }
+  });
+
+  test("accepts usernames of all scripts", async () => {
+    const t = setup();
+    const accepted = [
+      "أحمد", // Arabic
+      "中文名", // Chinese
+      "Алиса", // Cyrillic
+      "ひらがな", // Japanese
+      "Renée-Élise",
+      "user_name.42",
+      // A zero-width joiner is necessary for some scripts and for emoji
+      // sequences, thus it stays permitted.
+      "family\u{1f468}\u200d\u{1f469}\u200d\u{1f466}",
+    ];
+    let userId = 0;
+    for (const username of accepted) {
+      expect(
+        await t.mutation(api.public.setUsername, {
+          userId: `user${userId++}`,
+          username,
+        }),
+        username,
+      ).toEqual({ success: true, previousUsername: null });
+    }
+  });
+
+  test("counts an astral character as one character", async () => {
+    const t = setup();
+    // A single emoji is two UTF-16 units but one code point.
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "😀",
+    });
+    expect(result).toEqual({ success: true, previousUsername: null });
+  });
+});
+
+describe("Unicode normalization", () => {
+  // "café" spelled two ways: composed é (U+00E9) and decomposed
+  // e + combining acute (U+0301).
+  const composed = "caf\u00e9";
+  const decomposed = "cafe\u0301";
+
+  test("finds a user across differing normalization forms", async () => {
+    const t = setup();
+    expect(composed).not.toBe(decomposed);
+
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: composed,
+    });
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: decomposed }),
+    ).toBe("user1");
+  });
+
+  test("rejects the same username in a different normalization form", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: composed,
+    });
+    const result = await t.mutation(api.public.setUsername, {
+      userId: "user2",
+      username: decomposed,
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+
+  test("stores the username as the user supplied it", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "AlIcE",
+    });
+    const row = await t.run(
+      async (ctx) => await ctx.db.query("usernames").unique(),
+    );
+    expect(row?.username).toBe("AlIcE");
+    expect(row?.usernameNormalized).toBe("alice");
+  });
+});
+
+describe("getUserIdByUsername", () => {
+  test("ignores the case of the argument", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "Alice",
+    });
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "ALICE" }),
+    ).toBe("user1");
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "alice" }),
+    ).toBe("user1");
+  });
+
+  test("returns null for an unknown username", async () => {
+    const t = setup();
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "nobody" }),
+    ).toBe(null);
+  });
+});
+
+describe("getUsername", () => {
+  test("returns null for a user with no username", async () => {
+    const t = setup();
+    expect(await t.query(api.public.getUsername, { userId: "nobody" })).toBe(
+      null,
+    );
+  });
+});
+
+describe("deleteUsername", () => {
+  test("deletes the username of a user", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "alice",
+    });
+    expect(
+      await t.mutation(api.public.deleteUsername, { userId: "user1" }),
+    ).toEqual({ deleted: true });
+    expect(await t.query(api.public.getUsername, { userId: "user1" })).toBe(
+      null,
+    );
+    expect(
+      await t.query(api.public.getUserIdByUsername, { username: "alice" }),
+    ).toBe(null);
+  });
+
+  test("makes the username available to a different user", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "alice",
+    });
+    await t.mutation(api.public.deleteUsername, { userId: "user1" });
+    expect(
+      await t.mutation(api.public.setUsername, {
+        userId: "user2",
+        username: "alice",
+      }),
+    ).toEqual({ success: true, previousUsername: null });
+  });
+
+  test("reports deleted: false when the user has no username", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.public.deleteUsername, { userId: "nobody" }),
+    ).toEqual({ deleted: false });
+  });
+
+  test("deletes only the username of the given user", async () => {
+    const t = setup();
+    await t.mutation(api.public.setUsername, {
+      userId: "user1",
+      username: "alice",
+    });
+    await t.mutation(api.public.setUsername, {
+      userId: "user2",
+      username: "bob",
+    });
+    await t.mutation(api.public.deleteUsername, { userId: "user1" });
+    expect(await t.query(api.public.getUsername, { userId: "user2" })).toBe(
+      "bob",
+    );
+  });
+});

--- a/packages/core/src/components/username/validation.ts
+++ b/packages/core/src/components/username/validation.ts
@@ -1,0 +1,170 @@
+import { Infer, v } from "convex/values";
+
+// The component applies only the rules that are correct for all applications.
+// There is no maximum length, and characters of all scripts are permitted:
+// the component can be used in an international application.
+//
+// The component rejects only usernames that are clearly malformed.
+//
+// An application that wants more strict rules (only letters and digits, a
+// minimum length of 3, a list of reserved names, …) applies them before it
+// calls `setUsername`.
+export const MIN_USERNAME_LENGTH = 1;
+
+/**
+ * The user-facing errors for `setUsername`. An application can show these
+ * errors to the end user. The `error` field is a machine-readable code and
+ * the discriminant of the union.
+ */
+export const setUsernameUserError = v.union(
+  v.object({
+    error: v.literal("USERNAME_TOO_SHORT"),
+    minimumLength: v.number(),
+  }),
+  // The username starts or ends with a space or a different whitespace
+  // character.
+  v.object({ error: v.literal("USERNAME_HAS_SURROUNDING_WHITESPACE") }),
+  // The username contains a character that is not permitted. See
+  // `hasDisallowedCharacter` for the list.
+  v.object({ error: v.literal("USERNAME_HAS_INVALID_CHARACTERS") }),
+  // A different user already has this username.
+  v.object({ error: v.literal("USERNAME_TAKEN") }),
+);
+export type SetUsernameUserError = Infer<typeof setUsernameUserError>;
+
+// Characters that make the text direction or the position of the subsequent
+// characters different. An attacker uses them to show a username that is not
+// the username that the component stores. The list does not contain the
+// zero-width joiner (U+200D) and the zero-width non-joiner (U+200C). These
+// two characters are necessary to write some scripts correctly, and also to
+// write emoji sequences.
+const BIDI_AND_INVISIBLE_CONTROLS = new Set([
+  0x061c, // arabic letter mark
+  0x200b, // zero-width space
+  0x200e, // left-to-right mark
+  0x200f, // right-to-left mark
+  0x202a, // left-to-right embedding
+  0x202b, // right-to-left embedding
+  0x202c, // pop directional formatting
+  0x202d, // left-to-right override
+  0x202e, // right-to-left override
+  0x2066, // left-to-right isolate
+  0x2067, // right-to-left isolate
+  0x2068, // first strong isolate
+  0x2069, // pop directional isolate
+  0xfeff, // zero-width no-break space (byte order mark)
+]);
+
+// Whitespace characters that are not the ASCII space. Each one looks the
+// same as a space, thus two usernames that a person cannot distinguish
+// would be two different accounts. A space in the middle of a username
+// stays permitted.
+const NON_ASCII_WHITESPACE = new Set([
+  0x00a0, // no-break space
+  0x1680, // ogham space mark
+  0x2000, // en quad
+  0x2001, // em quad
+  0x2002, // en space
+  0x2003, // em space
+  0x2004, // three-per-em space
+  0x2005, // four-per-em space
+  0x2006, // six-per-em space
+  0x2007, // figure space
+  0x2008, // punctuation space
+  0x2009, // thin space
+  0x200a, // hair space
+  0x202f, // narrow no-break space
+  0x205f, // medium mathematical space
+  0x3000, // ideographic space
+]);
+
+/**
+ * Tell if the code point is never permitted in a username.
+ */
+function isDisallowedCodePoint(codePoint: number): boolean {
+  // The C0 controls and the tab, the line feed and the carriage return.
+  if (codePoint <= 0x1f) {
+    return true;
+  }
+  // The delete character and the C1 controls.
+  if (codePoint >= 0x7f && codePoint <= 0x9f) {
+    return true;
+  }
+  // An unpaired surrogate. The text is then not correct Unicode.
+  if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+    return true;
+  }
+  if (BIDI_AND_INVISIBLE_CONTROLS.has(codePoint)) {
+    return true;
+  }
+  if (NON_ASCII_WHITESPACE.has(codePoint)) {
+    return true;
+  }
+  // The noncharacters. These code points are permanently reserved, and
+  // applications are not required to show them.
+  if (codePoint >= 0xfdd0 && codePoint <= 0xfdef) {
+    return true;
+  }
+  // The last two code points of each plane (U+FFFE, U+FFFF, U+1FFFE, …).
+  if ((codePoint & 0xfffe) === 0xfffe) {
+    return true;
+  }
+  return false;
+}
+
+function hasDisallowedCharacter(username: string): boolean {
+  // The `for … of` loop gives the code points, and not the UTF-16 units.
+  for (const character of username) {
+    if (isDisallowedCodePoint(character.codePointAt(0)!)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Examine a username against the requirements. Return a
+ * `SetUsernameUserError` for the first violation, or `null` when the
+ * username is correct.
+ */
+export function validateUsernameFormat(
+  username: string,
+): SetUsernameUserError | null {
+  // Reject whitespace at the start and at the end. The `u` flag makes `\s`
+  // match all Unicode whitespace. A comparison with `username.trim()` does
+  // not find some of these characters.
+  if (/^\s|\s$/u.test(username)) {
+    return { error: "USERNAME_HAS_SURROUNDING_WHITESPACE" };
+  }
+  if (hasDisallowedCharacter(username)) {
+    return { error: "USERNAME_HAS_INVALID_CHARACTERS" };
+  }
+  // A combining mark at the first position shows on the character before
+  // the username. An attacker uses this to change how a different text
+  // shows, for example in a list of users.
+  if (/^\p{M}/u.test(username)) {
+    return { error: "USERNAME_HAS_INVALID_CHARACTERS" };
+  }
+  // The length is a count of Unicode code points (`[...username].length`)
+  // and not of UTF-16 units. Thus a character outside the basic plane (an
+  // emoji, for example) counts as one character. The length is measured
+  // after normalization, because normalization can make the username
+  // shorter.
+  if ([...normalizeUsername(username)].length < MIN_USERNAME_LENGTH) {
+    return { error: "USERNAME_TOO_SHORT", minimumLength: MIN_USERNAME_LENGTH };
+  }
+  return null;
+}
+
+/**
+ * Normalize a username for comparisons.
+ *
+ * The function first makes the username lowercase, so that usernames are
+ * not case-sensitive. Then it applies NFC normalization, so that two
+ * inputs that a user sees as the same but that use different Unicode
+ * normalization forms compare as equal. The order is important: the
+ * lowercase operation can make a string that is not in the NFC form.
+ */
+export function normalizeUsername(username: string): string {
+  return username.toLowerCase().normalize("NFC");
+}

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -29,13 +29,15 @@ First, follow the [Getting Started](/getting-started) guide:
 
 <Step>
 
-### Install the component
+### Install the components
 
-Register the password component alongside the core in `convex/convex.config.ts`:
+Register the password component and the username component alongside the core
+in `convex/convex.config.ts`. The username component stores which user each
+username identifies:
 
 <include
   lang="ts"
-  meta='title="convex/convex.config.ts" highlight="import passwordProvider from" highlight="app.use(passwordProvider)"'
+  meta='title="convex/convex.config.ts" highlight="import passwordProvider from" highlight="import username from" highlight="app.use(passwordProvider)" highlight="app.use(username)"'
 >
   ../../../../../examples/react-password/convex/convex.config.ts
 </include>


### PR DESCRIPTION
Right now, the “username + password” flow stores the username as an account ID in the core `accounts` table.

This is not conceptually right: for instance, in an app that uses both passwords and passkeys, the username shouldn’t “belong” to one of the two providers. Moreover, the current structure doesn't work well for apps that want to let users log in with their username _or_ their email address.

This PR is adding a new username component that is very simple: it only stores the user ID ↔ username mapping, and normalizes the value for allowing case-insensitive lookups.

The `accounts` table no longer needs to store an account ID, so I’m using `""` as a value for the password provider.

Validation logic:
- The username component doesn't implement opinionated validation rules. It implements a few validation rules that all apps will want (e.g. `1 ≤ length ≤ 100`, no control characters…), but doesn't do more opinionated things (like only accepting ASCII characters). We can add additional constraints in provider code (with possibly customization options).

Plans for future extensibility:
- We will other components that can each implement their own user lookup mechanism (e.g. email, phone number)
- If users want to implement flows such as “log in through username _or_ email address _or_ phone number”, they can do so in app code (with a sign in function that queries the relevant components, or multiple of them until it finds a match)