### PR TITLE
Allow a null provider account ID, and use it in the password provider

### DIFF
--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -11,7 +11,7 @@ import { internalMutation, query } from "./_generated/server";
 export const createOrUpdateUser = internalMutation({
   args: {
     provider: v.literal("anonymous"),
-    providerAccountId: v.string(),
+    providerAccountId: v.union(v.string(), v.null()),
     profile: v.any(),
     userId: v.union(v.string(), v.null()),
   },

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -4,7 +4,7 @@ import { v } from "convex/values";
 export const upsertFromAuth = internalMutation({
   args: {
     provider: v.union(v.literal("anonymous")),
-    providerAccountId: v.string(),
+    providerAccountId: v.union(v.string(), v.null()),
     profile: v.any(),
     userId: v.union(v.string(), v.null()),
   },

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -4,7 +4,7 @@ import { v } from "convex/values";
 export const createOrUpdateUser = internalMutation({
   args: {
     provider: v.literal("password"),
-    providerAccountId: v.string(),
+    providerAccountId: v.union(v.string(), v.null()),
     profile: v.any(),
     userId: v.union(v.string(), v.null()),
   },

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -26,6 +26,7 @@ export const Anonymous = defineProvider({
           return await completeSignIn(ctx, {
             provider: "anonymous",
             providerAccountId: anonymousId,
+            userId: null,
             profile: {},
           });
         },

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -54,7 +54,12 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           accessTokenTtlSeconds?: number;
-          claims: { profile: any; provider: string; providerAccountId: string };
+          claims: {
+            profile: any;
+            provider: string;
+            providerAccountId: string | null;
+            userId: string | null;
+          };
           createOrUpdateUserHandle: string;
           issuer: string;
           refreshTokenTtlSeconds?: number;

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -43,6 +43,7 @@ function claims(overrides: Partial<AuthClaims> = {}): AuthClaims {
   return {
     provider: "password",
     providerAccountId: "alice",
+    userId: null,
     profile: { name: "Alice" },
     ...overrides,
   };
@@ -130,6 +131,84 @@ describe("signIn", () => {
     expect(calls[0].profile).toEqual({ name: "Alice" });
     expect(calls[1].userId).toBe("alice");
     expect(calls[1].profile).toEqual({ name: "Alice 2.0" });
+  });
+
+  test("creates an account for a provider that has no account id", async () => {
+    const t = setup();
+    const bundle = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: null }),
+    );
+
+    const accounts = await t.run((ctx) => ctx.db.query("accounts").collect());
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].providerAccountId).toBeNull();
+    expect(accounts[0].userId).toBe(bundle.userId);
+  });
+
+  test("finds the account of a returning user with no account id", async () => {
+    const t = setup();
+    const first = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: null }),
+    );
+    // A returning user: the provider knows the user id, and the claims carry
+    // it in place of an account id.
+    const second = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: first.userId }),
+    );
+
+    expect(second.userId).toBe(first.userId);
+    const { accounts, sessions } = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+    }));
+    expect(accounts).toBe(1);
+    expect(sessions).toBe(2);
+  });
+
+  test("keeps the accounts of two users with no account id apart", async () => {
+    const t = setup();
+    const alice = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: null }),
+    );
+    const bob = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: null }),
+    );
+    expect(bob.userId).not.toBe(alice.userId);
+
+    const again = await signIn(
+      t,
+      claims({ providerAccountId: null, userId: alice.userId }),
+    );
+    expect(again.userId).toBe(alice.userId);
+    const accounts = await t.run((ctx) => ctx.db.query("accounts").collect());
+    expect(accounts).toHaveLength(2);
+  });
+
+  test("does not confuse the accounts of one user across providers", async () => {
+    const t = setup();
+    const first = await signIn(
+      t,
+      claims({ provider: "password", providerAccountId: null, userId: null }),
+    );
+    // The same user signs in with another provider that has no account id:
+    // that is a second account, not the first one.
+    await signIn(
+      t,
+      claims({
+        provider: "magiclink",
+        providerAccountId: null,
+        userId: first.userId,
+      }),
+    );
+
+    const accounts = await t.run((ctx) => ctx.db.query("accounts").collect());
+    expect(accounts).toHaveLength(2);
+    expect(accounts.every((a) => a.userId === first.userId)).toBe(true);
   });
 });
 

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -52,6 +52,24 @@ function accountByIdentity(
     .unique();
 }
 
+/**
+ * Look up the account that a user has with a provider. This is how the core
+ * finds the account of a returning user of a provider that has no account
+ * identifier of its own (`providerAccountId: null`).
+ */
+function accountByUser(
+  ctx: QueryCtx,
+  provider: string,
+  userId: string,
+): Promise<Doc<"accounts"> | null> {
+  return ctx.db
+    .query("accounts")
+    .withIndex("by_user_provider", (q) =>
+      q.eq("userId", userId).eq("provider", provider),
+    )
+    .unique();
+}
+
 /** Look up a session by the (current) hash of its refresh token. */
 function sessionByHash(
   ctx: QueryCtx,
@@ -157,17 +175,24 @@ type CreateOrUpdateUserFunctionHandle = FunctionHandle<
  * user record from the latest claims). The profile the core holds for the
  * account is refreshed to match. Returns just what minting a session needs: the
  * account id and its app user id.
+ *
+ * The claims identify the account in one of two ways. Most providers give a
+ * `providerAccountId`, and the core finds the account with it. A provider that
+ * has no identifier of its own gives `providerAccountId: null` plus the
+ * `userId` of the user it authenticated, and the core finds the account of
+ * that user. Claims with neither always start a new user and a new account.
  */
 async function resolveAccount(
   ctx: MutationCtx,
   claims: AuthClaims,
   createOrUpdateUser: CreateOrUpdateUserFunctionHandle,
 ): Promise<{ accountId: Id<"accounts">; userId: string }> {
-  const account = await accountByIdentity(
-    ctx,
-    claims.provider,
-    claims.providerAccountId,
-  );
+  const account =
+    claims.providerAccountId !== null
+      ? await accountByIdentity(ctx, claims.provider, claims.providerAccountId)
+      : claims.userId !== null
+        ? await accountByUser(ctx, claims.provider, claims.userId)
+        : null;
   if (account) {
     // Returning identity: hand the app the latest claims with the known user id
     // so it can update its own user record.
@@ -193,8 +218,13 @@ async function resolveAccount(
     provider: claims.provider,
     providerAccountId: claims.providerAccountId,
     profile: claims.profile,
-    userId: null,
+    userId: claims.userId,
   });
+  if (claims.userId !== null && userId !== claims.userId) {
+    throw new Error(
+      "createOrUpdateUser may not return a new userId for an existing user",
+    );
+  }
   const accountId = await ctx.db.insert("accounts", {
     provider: claims.provider,
     providerAccountId: claims.providerAccountId,
@@ -242,8 +272,10 @@ export const signIn = mutation({
  *
  * Providers use this (via the `resolveUserId` helper the core hands them) to look
  * up the user behind a `(provider, providerAccountId)` pair before authenticating
- * — e.g. a password provider needs the user id to verify a stored password *before*
- * a session is issued. Returns `null` when no account exists for the identity.
+ * — a provider that must check a credential of a known user *before* a session is
+ * issued needs that user id. Returns `null` when no account exists for the
+ * identity. Only providers that have an account identifier of their own can use
+ * this function.
  *
  * This is a component-internal function (callable by the app, not by end-user
  * clients), so it does not expose account existence to the outside world; the

--- a/packages/core/src/components/core/schema.ts
+++ b/packages/core/src/components/core/schema.ts
@@ -4,13 +4,21 @@ import { v } from "convex/values";
 export default defineSchema({
   // Maps a provider-scoped identity to an opaque app user id. The app owns the
   // actual users table; we only store the id string it gives us back.
+  //
+  // `providerAccountId` is `null` for a provider that has no identifier of its
+  // own (the password provider, for example, finds its users through the
+  // username component). The core then finds the account of a returning user
+  // with the `by_user_provider` index, and never looks a `null` identifier up
+  // in `by_provider_account`.
   accounts: defineTable({
     provider: v.string(),
-    providerAccountId: v.string(),
+    providerAccountId: v.union(v.string(), v.null()),
     userId: v.string(),
   })
     .index("by_provider_account", ["provider", "providerAccountId"])
-    .index("by_user", ["userId"]),
+    // A user has one account per provider at most. Convex does not enforce
+    // unique indexes; the core keeps this property true.
+    .index("by_user_provider", ["userId", "provider"]),
 
   // One row per active refresh token (sessions). The raw refresh token is never
   // stored — only its SHA-256 hash.

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -15,6 +15,11 @@ import { Infer, v } from "convex/values";
 type CreateOrUpdateUserCall = Infer<typeof vCreateOrUpdateUser>;
 const createOrUpdateUserCalls: CreateOrUpdateUserCall[] = [];
 
+// Makes a distinct user id for each sign-in that gives neither a user id nor a
+// provider account id. A module-level counter (not the call log, which tests
+// reset) keeps the ids distinct for the whole suite.
+let mintedUserCount = 0;
+
 /** Read the recorded `createOrUpdateUser` calls (test-only). */
 export function getCreateOrUpdateUserCalls(): readonly CreateOrUpdateUserCall[] {
   return createOrUpdateUserCalls;
@@ -31,13 +36,16 @@ export function resetCreateOrUpdateUserCalls(): void {
  * every sign-in for an identity; like a minimal real app, it owns no users
  * table and just echoes the provider-scoped account id back as the app user id,
  * honoring an explicit `userId` when one is supplied (returning sign-in / link
- * path).
+ * path) and minting an id when the claims give neither.
  */
 export const createOrUpdateUser = internalMutation({
   args: vCreateOrUpdateUser,
   returns: v.string(),
   handler: async (_ctx, args) => {
     createOrUpdateUserCalls.push({ ...args });
-    return args.userId ?? args.providerAccountId;
+    if (args.userId !== null) {
+      return args.userId;
+    }
+    return args.providerAccountId ?? `user-${++mintedUserCount}`;
   },
 });

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -4,7 +4,6 @@ import { defineProvider, vTokenBundle } from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
 import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
 import {
-  normalizeUsername,
   setUsernameUserError,
   validateUsernameFormat,
 } from "../username/validation";
@@ -129,15 +128,13 @@ export const UsernamePassword = defineProvider({
           }
 
           // Create the account + app user (via the app's createOrUpdateUser) and
-          // mint the session. `profile.username` keeps the original casing for
-          // display; the account is keyed by the normalized `id`.
-          //
-          // TODO(nicolas) The username component now owns the username → user
-          // id mapping, so the account no longer needs to be keyed by the
-          // username. Give the account a stable, opaque id instead.
+          // mint the session. The username component owns the username → user
+          // id mapping, so the account has no identifier of its own; the
+          // `profile.username` keeps the original casing for display.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: normalizeUsername(username),
+            providerAccountId: null,
+            userId: null,
             profile: { username },
           });
 
@@ -210,11 +207,13 @@ export const UsernamePassword = defineProvider({
             return { success: false, userError: verifyResult.userError };
           }
 
-          // TODO(nicolas) See the TODO in `signUpWithPassword`: the account
-          // no longer needs to be keyed by the username.
+          // The user is already known (the username component found them), so
+          // the claims carry the `userId`: it is what lets the core find the
+          // account of this user, which has no identifier of its own.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: normalizeUsername(username),
+            providerAccountId: null,
+            userId,
             profile: { username },
           });
           return { success: true, tokens };

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -102,8 +102,21 @@ export type ConvexAuthApi = {
 export const vAuthClaims = v.object({
   /** Provider name, e.g. "password". */
   provider: v.string(),
-  /** Stable, provider-scoped account identifier (e.g. a username). */
-  providerAccountId: v.string(),
+  /**
+   * Stable, provider-scoped account identifier (e.g. an OAuth subject), or
+   * `null` for a provider that has no identifier of its own. A provider that
+   * gives `null` must give the `userId` of a returning user, because the core
+   * has no other way to find the account of that user.
+   */
+  providerAccountId: v.union(v.string(), v.null()),
+  /**
+   * The app user that this sign-in is for, when the provider already knows it
+   * (e.g. a password provider that found the user by their username and then
+   * verified their password). Give `null` when the provider does not know the
+   * user: the core then finds the account with `providerAccountId`, or creates
+   * a user and an account.
+   */
+  userId: v.union(v.string(), v.null()),
   /** Arbitrary profile data the provider learned about the user. */
   profile: v.any(),
 });
@@ -112,7 +125,7 @@ export type AuthClaims = Infer<typeof vAuthClaims>;
 
 export const vCreateOrUpdateUser = v.object({
   provider: v.string(),
-  providerAccountId: v.string(),
+  providerAccountId: v.union(v.string(), v.null()),
   profile: v.any(),
   userId: v.union(v.string(), v.null()),
 });
@@ -122,7 +135,7 @@ export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
   "internal",
   {
     provider: Provider;
-    providerAccountId: string;
+    providerAccountId: string | null;
     // TODO: dowski - investigate type safety for provider profile data.
     profile: unknown;
     userId: string | null;


### PR DESCRIPTION
The password provider keyed its accounts by the normalized username, but
the username component now owns the username -> user id mapping. The
provider has no identifier of its own to give.

`providerAccountId` is now `string | null`. A provider that gives `null`
gives the `userId` of a returning user instead: the core finds the
account of that user with the new `by_user_provider` index and never
looks a `null` identifier up in `by_provider_account`. Claims with
neither an account id nor a user id create a user and an account, which
is what the password sign-up flow does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>