### PR TITLE
Passkey component: store the owner on the registration challenge

### DIFF
--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -11,6 +11,7 @@
 import type * as authentication from "../authentication.js";
 import type * as helpers from "../helpers.js";
 import type * as registration from "../registration.js";
+import type * as testAuthenticator from "../testAuthenticator.js";
 import type * as validation from "../validation.js";
 
 import type {
@@ -24,6 +25,7 @@ const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   helpers: typeof helpers;
   registration: typeof registration;
+  testAuthenticator: typeof testAuthenticator;
   validation: typeof validation;
 }> = anyApi as any;
 

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -73,7 +73,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           name?: string;
           verifiedUserId: string;
         },
-        | { passkeyId: string; success: true }
+        | { passkeyId: string; success: true; userId: string }
         | {
             success: false;
             userError:
@@ -98,7 +98,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       startRegistration: FunctionReference<
         "mutation",
         "internal",
-        { userId?: string },
+        { userId: string },
         { challenge: ArrayBuffer; excludeCredentials: Array<ArrayBuffer> },
         Name
       >;

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -59,6 +59,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        userId: "user1",
         createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
@@ -87,6 +88,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        userId: "user1",
         createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "authentication", challenge);
@@ -123,6 +125,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        userId: "user1",
         createdAt: Date.now() - CHALLENGE_TTL_MS - 1,
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
@@ -141,6 +144,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        userId: "user1",
         createdAt: Date.now() - CHALLENGE_TTL_MS,
       });
       expect(await consumeChallenge(ctx, "registration", challenge)).not.toBe(

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -59,7 +59,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        userId: "user1",
+        userId: "j57ecdxq7j2yp8q3c31x7c54898bqyrk",
         createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
@@ -88,7 +88,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        userId: "user1",
+        userId: "j57ecdxq7j2yp8q3c31x7c54898bqyrk",
         createdAt: Date.now(),
       });
       const row = await consumeChallenge(ctx, "authentication", challenge);
@@ -125,7 +125,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        userId: "user1",
+        userId: "j57ecdxq7j2yp8q3c31x7c54898bqyrk",
         createdAt: Date.now() - CHALLENGE_TTL_MS - 1,
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
@@ -144,7 +144,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
-        userId: "user1",
+        userId: "j57ecdxq7j2yp8q3c31x7c54898bqyrk",
         createdAt: Date.now() - CHALLENGE_TTL_MS,
       });
       expect(await consumeChallenge(ctx, "registration", challenge)).not.toBe(

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -59,7 +59,6 @@ async function registrationArgs(
     args: {
       expectedRpId: RP_ID,
       expectedOrigin: ORIGIN,
-      verifiedUserId: userId,
       name: options.name,
       attestationObject: toArrayBuffer(buildAttestationObject(authData)),
       clientDataJSON: toArrayBuffer(
@@ -75,7 +74,7 @@ async function registrationArgs(
 }
 
 describe("startRegistration", () => {
-  test("returns a 32-byte challenge and stores an anonymous registration row", async () => {
+  test("returns a 32-byte challenge and stores a user-bound registration row", async () => {
     const t = setup();
     const { challenge } = await t.mutation(api.registration.startRegistration, {
       userId: "user1",
@@ -87,16 +86,16 @@ describe("startRegistration", () => {
     expect(new Uint8Array(rows[0].challenge)).toEqual(
       new Uint8Array(challenge),
     );
-    // Registration challenges carry no identity, even when a userId is given.
-    expect("userId" in rows[0]).toBe(false);
+    // The challenge records the future owner of the passkey.
+    expect(rows[0].kind === "registration" && rows[0].userId).toBe("user1");
   });
 
-  test("returns no excludeCredentials without a userId", async () => {
+  test("returns no excludeCredentials for a user with no passkeys", async () => {
     const t = setup();
     await register(t, "user1");
     const { excludeCredentials } = await t.mutation(
       api.registration.startRegistration,
-      {},
+      { userId: "user2" },
     );
     expect(excludeCredentials).toEqual([]);
   });
@@ -131,7 +130,12 @@ describe("finishRegistration", () => {
     const passkeys = await t.run((ctx) => ctx.db.query("passkeys").collect());
     expect(passkeys).toHaveLength(1);
     const row = passkeys[0];
-    expect(result).toEqual({ success: true, passkeyId: row._id });
+    // The owner comes from the challenge, and the result reports it.
+    expect(result).toEqual({
+      success: true,
+      passkeyId: row._id,
+      userId: "user1",
+    });
     expect(row.userId).toBe("user1");
     expect(row.algorithm).toBe("ES256");
     expect(new Uint8Array(row.credentialId)).toEqual(credential.credentialId);

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -26,41 +26,48 @@ const startRegistrationResult = v.object({
 });
 
 /**
- * Start a registration ceremony.
+ * Start a registration ceremony for the passkey's future owner.
  *
  * The function stores a one-use `registration` challenge and returns the
- * challenge bytes. The challenge has no identity: it is simply a random
- * string used to avoid replay attacks.
+ * challenge bytes. The challenge records the `userId`, and the finish step
+ * reads the owner from the challenge. The app must pass a trusted id: the
+ * id of the signed-in user, or the id of a user row that the app created
+ * for this registration. A client-supplied id is not safe here, because
+ * `finishRegistration` attaches the new passkey to this user.
  *
- * Set `userId` when a known user adds a passkey to their account. The
- * function then also returns the existing credential IDs of the user.
- * This is used by the authenticator to ensure there isn’t already a
- * passkey that exists for the user.
+ * The function also returns the existing credential IDs of the user. The
+ * authenticator uses them to refuse a second registration of a passkey
+ * that the user already has.
  */
 export const startRegistration = mutation({
-  args: { userId: v.optional(v.string()) },
+  args: { userId: v.string() },
   returns: startRegistrationResult,
   handler: async (ctx, { userId }) => {
     const challenge = randomChallenge();
     await ctx.db.insert("challenges", {
       kind: "registration",
       challenge,
+      userId,
       createdAt: Date.now(),
     });
-    let excludeCredentials: ArrayBuffer[] = [];
-    if (userId !== undefined) {
-      const rows = await ctx.db
-        .query("passkeys")
-        .withIndex("by_userId", (q) => q.eq("userId", userId))
-        .collect();
-      excludeCredentials = rows.map((row) => row.credentialId);
-    }
-    return { challenge, excludeCredentials };
+    const rows = await ctx.db
+      .query("passkeys")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    return {
+      challenge,
+      excludeCredentials: rows.map((row) => row.credentialId),
+    };
   },
 });
 
 const finishRegistrationResult = v.union(
-  v.object({ success: v.literal(true), passkeyId: v.string() }),
+  v.object({
+    success: v.literal(true),
+    passkeyId: v.string(),
+    // The owner of the new passkey, read from the challenge.
+    userId: v.string(),
+  }),
   v.object({
     success: v.literal(false),
     userError: finishRegistrationUserError,
@@ -79,12 +86,14 @@ type FinishRegistrationResult = Infer<typeof finishRegistrationResult>;
  *   See https://web.dev/articles/webauthn-rp-id
  * - `expectedOrigin`: the expected origin of the ceremony (for example,
  *   "https://app.example.com").
- * - `verifiedUserId`: the user that owns the new passkey. This must always be
- *   the user name of the current user (whether it is a user created in the
- *   same transaction, or the currently logged in user).
  * - `name`: an optional label for the credential. This can be automatically
  *   inferred by the client from the authenticator (e.g. “1Password”),
  *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
+ *
+ * The owner of the new passkey is not an argument. The function reads it
+ * from the challenge, where `startRegistration` stored it. This keeps the
+ * owner a server-side, trusted value: a client cannot attach its ceremony
+ * to a different user. The result contains the owner's `userId`.
  *
  * The function examines the attestation as
  * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
@@ -98,7 +107,6 @@ export const finishRegistration = mutation({
   args: {
     expectedRpId: v.string(),
     expectedOrigin: v.string(),
-    verifiedUserId: v.string(),
     name: v.optional(v.string()),
     attestationObject: v.bytes(),
     clientDataJSON: v.bytes(),
@@ -123,9 +131,11 @@ export const finishRegistration = mutation({
       "registration",
       clientData.challenge,
     );
-    if (challengeRow === null) {
+    if (challengeRow === null || challengeRow.kind !== "registration") {
       return { success: false, userError: { error: "CHALLENGE_EXPIRED" } };
     }
+    // The trusted owner of the new passkey (see the function comment).
+    const userId = challengeRow.userId;
 
     const attestationObject = parseAttestationObject(
       new Uint8Array(args.attestationObject),
@@ -177,14 +187,14 @@ export const finishRegistration = mutation({
     }
 
     const passkeyId = await ctx.db.insert("passkeys", {
-      userId: args.verifiedUserId,
+      userId,
       name: args.name,
       credentialId,
       algorithm,
       publicKey: toArrayBuffer(publicKey),
       counter: authenticatorData.signatureCounter,
     });
-    return { success: true, passkeyId };
+    return { success: true, passkeyId, userId };
   },
 });
 

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -31,6 +31,10 @@ export default defineSchema({
       v.object({
         kind: v.literal("registration"),
         challenge: v.bytes(), // 32 random bytes
+        // The user that will own the new passkey. The app supplies this id
+        // to `startRegistration`, so it is a trusted value. The finish step
+        // reads the owner from here, not from the client.
+        userId: v.string(),
         createdAt: v.number(), // challenges expire (see CHALLENGE_TTL_MS)
       }),
       v.object({

--- a/packages/core/src/components/passkey/testAuthenticator.ts
+++ b/packages/core/src/components/passkey/testAuthenticator.ts
@@ -253,7 +253,6 @@ export async function register(
   const result = await t.mutation(api.registration.finishRegistration, {
     expectedRpId: RP_ID,
     expectedOrigin: ORIGIN,
-    verifiedUserId: userId,
     name: options.name,
     attestationObject: toArrayBuffer(buildAttestationObject(authData)),
     clientDataJSON: toArrayBuffer(


### PR DESCRIPTION
startRegistration now requires a userId and stores it on the challenge
row. finishRegistration reads the owner from the challenge, and the
verifiedUserId argument is removed. The result reports the owner.

This keeps the owner a trusted, server-side value in flows where the
finish step runs without a session. The username+passkey flow creates
the user row before the ceremony, because the row id is the WebAuthn
user handle. Without the stored owner, the finish step would have to
trust a client-supplied id, and an attacker could attach their own
passkey to a different user. Authentication challenges already pin a
userId in the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
