### PR TITLE
Fix password account collisions: key accounts by the app user id

### DIFF
--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -102,6 +102,27 @@ describe("setupUsernamePassword", () => {
     );
   });
 
+  test("two users get distinct accounts and sessions", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice", PASSWORD);
+    const bob = await signUp(t, "bob", "different horse battery staple");
+    expect(alice).toMatchObject({ success: true });
+    expect(bob).toMatchObject({ success: true });
+    expect((bob as PasswordSuccess).tokens.userId).not.toBe(
+      (alice as PasswordSuccess).tokens.userId,
+    );
+
+    // Each user signs in as themselves, not as the first user.
+    const aliceIn = await signIn(t, "alice", PASSWORD);
+    const bobIn = await signIn(t, "bob", "different horse battery staple");
+    expect((aliceIn as PasswordSuccess).tokens.userId).toBe(
+      (alice as PasswordSuccess).tokens.userId,
+    );
+    expect((bobIn as PasswordSuccess).tokens.userId).toBe(
+      (bob as PasswordSuccess).tokens.userId,
+    );
+  });
+
   test("rejects a wrong password with INVALID_CREDENTIALS", async () => {
     const t = await setup();
     await signUp(t, "alice", PASSWORD);

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -206,12 +206,25 @@ async function resolveAccount(
     profile: claims.profile,
     userId: null,
   });
+  const { provider } = claims;
+  const providerAccountId =
+    claims.providerAccountId === USE_USER_ID_AS_ACCOUNT_ID
+      ? userId
+      : claims.providerAccountId;
+  const existingAccount = await ctx.db
+    .query("accounts")
+    .withIndex("by_provider_account", (q) =>
+      q.eq("provider", provider).eq("providerAccountId", providerAccountId),
+    )
+    .first();
+  if (existingAccount !== null) {
+    throw new Error(
+      `Invariant violation: an account for provider = ${JSON.stringify(provider)} and provider account ID = ${JSON.stringify(providerAccountId)} already exists`,
+    );
+  }
   const accountId = await ctx.db.insert("accounts", {
-    provider: claims.provider,
-    providerAccountId:
-      claims.providerAccountId === USE_USER_ID_AS_ACCOUNT_ID
-        ? userId
-        : claims.providerAccountId,
+    provider,
+    providerAccountId,
     userId,
   });
   return { accountId, userId };

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -13,6 +13,7 @@ import {
   type AuthClaims,
   vTokenBundle,
   type TokenBundle,
+  USE_USER_ID_AS_ACCOUNT_ID,
 } from "../../lib/types";
 import { signJwt, generateRefreshToken } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
@@ -164,41 +165,53 @@ async function resolveAccount(
   claims: AuthClaims,
   createOrUpdateUser: CreateOrUpdateUserFunctionHandle,
 ): Promise<{ accountId: Id<"accounts">; userId: string }> {
-  const account = await accountByIdentity(
-    ctx,
-    claims.provider,
-    claims.providerAccountId,
-  );
-  if (account) {
-    // Returning identity: hand the app the latest claims with the known user id
-    // so it can update its own user record.
-    if (
-      account.userId !==
-      (await ctx.runMutation(createOrUpdateUser, {
-        provider: claims.provider,
-        providerAccountId: claims.providerAccountId,
-        profile: claims.profile,
-        userId: account.userId,
-      }))
-    ) {
-      throw new Error(
-        "createOrUpdateUser may not return a new userId for an existing user",
-      );
+  // `USE_USER_ID_AS_ACCOUNT_ID` means the provider keys the account by the
+  // app user id, which does not exist before this sign-in mints it. Such
+  // claims can never match an existing account (accounts are never stored
+  // with an empty identifier): on later sign-ins the provider puts the user
+  // id in the claims itself.
+  if (claims.providerAccountId !== USE_USER_ID_AS_ACCOUNT_ID) {
+    const account = await accountByIdentity(
+      ctx,
+      claims.provider,
+      claims.providerAccountId,
+    );
+    if (account) {
+      // Returning identity: hand the app the latest claims with the known user
+      // id so it can update its own user record.
+      if (
+        account.userId !==
+        (await ctx.runMutation(createOrUpdateUser, {
+          provider: claims.provider,
+          providerAccountId: claims.providerAccountId,
+          profile: claims.profile,
+          userId: account.userId,
+        }))
+      ) {
+        throw new Error(
+          "createOrUpdateUser may not return a new userId for an existing user",
+        );
+      }
+      return { accountId: account._id, userId: account.userId };
     }
-    return { accountId: account._id, userId: account.userId };
   }
 
   // First sign-in for this identity: ask the app to mint/return its user id,
   // then record the provider-identity -> user mapping.
   const userId = await ctx.runMutation(createOrUpdateUser, {
     provider: claims.provider,
+    // With `USE_USER_ID_AS_ACCOUNT_ID` the user id is not minted yet, so
+    // there is no meaningful value to hand the app here.
     providerAccountId: claims.providerAccountId,
     profile: claims.profile,
     userId: null,
   });
   const accountId = await ctx.db.insert("accounts", {
     provider: claims.provider,
-    providerAccountId: claims.providerAccountId,
+    providerAccountId:
+      claims.providerAccountId === USE_USER_ID_AS_ACCOUNT_ID
+        ? userId
+        : claims.providerAccountId,
     userId,
   });
   return { accountId, userId };

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -1,6 +1,10 @@
 import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
-import { defineProvider, vSignInSuccess } from "../../lib/types";
+import {
+  defineProvider,
+  vSignInSuccess,
+  USE_USER_ID_AS_ACCOUNT_ID,
+} from "../../lib/types";
 import type { ComponentApi } from "./_generated/component.js";
 import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
 import {
@@ -32,10 +36,6 @@ export type UsernamePasswordOptions = {
 
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "password";
-
-// A given user has only zero or one “provider account ID”,
-// so there is no need for having a value here.
-const EMPTY_PROVIDER_ACCOUNT_ID = "";
 
 const signInResult = v.union(
   vSignInSuccess,
@@ -131,16 +131,20 @@ export const UsernamePassword = defineProvider({
             return { success: false, userError: { error: "USERNAME_TAKEN" } };
           }
 
-          // Create the account + app user (via the app's createOrUpdateUser) and
-          // mint the session. `profile.username` keeps the original casing for
-          // display; the account is keyed by the normalized `id`.
+          // Create the account + app user (via the app's createOrUpdateUser)
+          // and mint the session. Password accounts are keyed by the app user
+          // id, which does not exist before this call mints it, hence the
+          // placeholder; sign-in passes the user id itself. `profile.username`
+          // keeps the original casing for display.
           //
-          // TODO(nicolas) The username component now owns the username → user
-          // id mapping, so the account no longer needs to be keyed by the
-          // username. Give the account a stable, opaque id instead.
+          // TODO(nicolas) The app's `createOrUpdateUser` callback should not
+          // receive a provider account ID for the password provider at all:
+          // the value is an internal key ("" at sign-up, the user id
+          // afterwards) with no meaning to the app. We will probably improve
+          // this when providers support typesafe profiles.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: EMPTY_PROVIDER_ACCOUNT_ID,
+            providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
             profile: { username },
           });
 
@@ -213,11 +217,9 @@ export const UsernamePassword = defineProvider({
             return { success: false, userError: verifyResult.userError };
           }
 
-          // TODO(nicolas) See the TODO in `signUpWithPassword`: the account
-          // no longer needs to be keyed by the username.
           const tokens = await completeSignIn(ctx, {
             provider: PROVIDER_NAME,
-            providerAccountId: EMPTY_PROVIDER_ACCOUNT_ID,
+            providerAccountId: userId,
             profile: { username },
           });
           return { success: true, tokens };

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -155,13 +155,25 @@ export type ConvexAuthApi = {
 export const vAuthClaims = v.object({
   /** Provider name, e.g. "password". */
   provider: v.string(),
-  /** Stable, provider-scoped account identifier (e.g. a username). */
+  /**
+   * Stable, provider-scoped account identifier (e.g. the Google account ID).
+   */
   providerAccountId: v.string(),
   /** Arbitrary profile data the provider learned about the user. */
   profile: v.any(),
 });
 
 export type AuthClaims = Infer<typeof vAuthClaims>;
+
+/**
+ * Pass this as `providerAccountId` to `completeSignIn` when the provider has
+ * no identifier of its own. The core then keys the new account by the app
+ * user id it mints during sign-in. On later sign-ins, pass that user id as
+ * the account identifier.
+ *
+ * @TODO(nicolas) Consider replacing this mechanism
+ */
+export const USE_USER_ID_AS_ACCOUNT_ID = "";
 
 export const vCreateOrUpdateUser = v.object({
   provider: v.string(),


### PR DESCRIPTION
In #446 I tried to change the password provider so that it uses `""` as a provider account ID.

I realized that with the current structure, it doesn't work, because the sign in flow assumes that providerAccountId is unique over all accounts. Hence, the current implementation would have collision issues when creating multiple accounts.

Instead of this, I’m using `""` only as a placeholder value before the account is created, and using the user’s own userId in the `accounts` table.

I agree this solution feels hacky, we probably want to have a better fix long-term (maybe after we have typesafe provider profiles?)

<img width="1317" height="200" alt="image" src="https://github.com/user-attachments/assets/165a1c6e-553d-4ec5-997d-8b479f3f845c" />
