### PR TITLE
Passkey component: add an indirection for the ID used in the passkey (“handle”)

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -62,6 +62,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | { success: false; userError: { error: "PASSKEY_NOT_FOUND" } },
         Name
       >;
+      deleteUser: FunctionReference<
+        "mutation",
+        "internal",
+        { userId: string },
+        null,
+        Name
+      >;
       finishRegistration: FunctionReference<
         "mutation",
         "internal",
@@ -98,8 +105,12 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       startRegistration: FunctionReference<
         "mutation",
         "internal",
-        { userId?: string },
-        { challenge: ArrayBuffer; excludeCredentials: Array<ArrayBuffer> },
+        { userId: string | null },
+        {
+          challenge: ArrayBuffer;
+          excludeCredentials: Array<ArrayBuffer>;
+          userHandle: ArrayBuffer;
+        },
         Name
       >;
     };

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -159,7 +159,6 @@ export const finishAuthentication = mutation({
     // discoverable-credential ceremony. In that flow, each registered
     // passkey is acceptable, and the passkey identifies the user.
     if (
-      challengeRow.kind === "authentication" &&
       challengeRow.userId !== undefined &&
       challengeRow.userId !== passkey.userId
     ) {

--- a/packages/core/src/components/passkey/cleanup.test.ts
+++ b/packages/core/src/components/passkey/cleanup.test.ts
@@ -1,29 +1,48 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import { WORKER_NAME } from "./cleanup";
 import { CHALLENGE_TTL_MS } from "./validation";
 import { setup } from "../passkeyTestSetup";
 
 const START = new Date("2026-01-01T00:00:00Z").getTime();
 
+// A handle row for a registration challenge. Unlinked (`userId: null`)
+// until a completed ceremony links it to a user.
+function handle(byte: number, userId: string | null = null) {
+  return {
+    handle: new Uint8Array(64).fill(byte).buffer,
+    userId,
+  };
+}
+
 /**
- * Insert a registration challenge, as `startRegistration` does. The age of a
- * challenge is the age of its `_creationTime`, thus the tests set the clock to
- * `createdAt` before the insert.
+ * Insert a handle and a registration challenge that points at it, as
+ * `startRegistration` does. The age of a challenge is the age of its
+ * `_creationTime`, thus the tests set the clock to `createdAt` before the
+ * insert. The handle goes in one millisecond earlier, in its own transaction,
+ * so that the challenge gets `createdAt` exactly.
  */
-function insertRegistration(
+async function insertRegistration(
   t: ReturnType<typeof setup>,
   byte: number,
   createdAt: number,
-) {
+  userId: string | null = null,
+): Promise<{ challengeId: Id<"challenges">; handleId: Id<"handles"> }> {
+  vi.setSystemTime(createdAt - 1);
+  const handleId = await t.run((ctx) =>
+    ctx.db.insert("handles", handle(byte, userId)),
+  );
   vi.setSystemTime(createdAt);
-  return t.run((ctx) =>
+  const challengeId = await t.run((ctx) =>
     ctx.db.insert("challenges", {
       // The `challenges` rows are a union, so the tests write a full row.
       kind: "registration" as const,
       challenge: new Uint8Array(32).fill(byte).buffer,
+      handleId,
     }),
   );
+  return { challengeId, handleId };
 }
 
 beforeEach(() => {
@@ -46,7 +65,7 @@ describe("getExpiredChallenges", () => {
 
   test("returns only the challenges that are expired", async () => {
     const t = setup();
-    const expiredId = await insertRegistration(
+    const { challengeId: expiredId } = await insertRegistration(
       t,
       1,
       START - CHALLENGE_TTL_MS - 1,
@@ -82,7 +101,7 @@ describe("getExpiredChallenges", () => {
     // A challenge at exactly the TTL is expired. A wake-up at the deadline
     // must find the row, or the loop would go idle with `timeoutMs: 0`
     // forever.
-    const challengeId = await insertRegistration(
+    const { challengeId } = await insertRegistration(
       t,
       1,
       START - CHALLENGE_TTL_MS,
@@ -99,12 +118,12 @@ describe("getExpiredChallenges", () => {
 describe("deleteExpiredChallenges", () => {
   test("erases the rows of the batch and keeps the others", async () => {
     const t = setup();
-    const expiredId = await insertRegistration(
+    const { challengeId: expiredId } = await insertRegistration(
       t,
       1,
       START - CHALLENGE_TTL_MS - 1,
     );
-    const freshId = await insertRegistration(t, 2, START);
+    const { challengeId: freshId } = await insertRegistration(t, 2, START);
 
     await t.mutation(internal.cleanup.deleteExpiredChallenges, {
       ids: [expiredId],
@@ -115,19 +134,52 @@ describe("deleteExpiredChallenges", () => {
     );
     expect(remaining.map((row) => row._id)).toEqual([freshId]);
   });
+
+  test("erases the unlinked handle of an expired registration", async () => {
+    const t = setup();
+    const { challengeId, handleId } = await insertRegistration(
+      t,
+      1,
+      START - CHALLENGE_TTL_MS - 1,
+    );
+
+    await t.mutation(internal.cleanup.deleteExpiredChallenges, {
+      ids: [challengeId],
+    });
+
+    const remaining = await t.run((ctx) => ctx.db.get("handles", handleId));
+    expect(remaining).toBeNull();
+  });
+
+  test("keeps a handle that a completed ceremony linked to a user", async () => {
+    const t = setup();
+    const { challengeId, handleId } = await insertRegistration(
+      t,
+      1,
+      START - CHALLENGE_TTL_MS - 1,
+      "user1",
+    );
+
+    await t.mutation(internal.cleanup.deleteExpiredChallenges, {
+      ids: [challengeId],
+    });
+
+    const remaining = await t.run((ctx) => ctx.db.get("handles", handleId));
+    expect(remaining).not.toBeNull();
+  });
 });
 
 describe("the cleanup loop", () => {
   test("starting a ceremony erases the challenges that expired", async () => {
     const t = setup();
-    const staleId = await insertRegistration(
+    const { challengeId: staleId } = await insertRegistration(
       t,
       1,
       START - CHALLENGE_TTL_MS - 1,
     );
 
     vi.setSystemTime(START);
-    await t.mutation(api.registration.startRegistration, {});
+    await t.mutation(api.registration.startRegistration, { userId: null });
     // The loop runs in scheduled functions; let them all complete.
     await t.finishAllScheduledFunctions(() => vi.runAllTimers());
 
@@ -139,5 +191,8 @@ describe("the cleanup loop", () => {
     // the ceremony made, thus the loop erases that challenge too. The tests
     // above show that an unexpired challenge stays.
     expect(remaining).toEqual([]);
+    // The loop also erased the unlinked handles of both registrations.
+    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
+    expect(handles).toEqual([]);
   });
 });

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -4,6 +4,7 @@ import { components, internal } from "./_generated/api";
 import { internalMutation, internalQuery } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
 import { CHALLENGE_TTL_MS } from "./validation";
+import { deleteDeadChallenge } from "./helpers";
 
 // The name of the batch worker loop that erases expired challenges. Only one
 // loop is necessary, so the name is constant.
@@ -76,7 +77,7 @@ export const getExpiredChallenges = internalQuery({
 });
 
 /**
- * Erase one batch of expired challenges.
+ * Erase one batch of expired challenges, together with their unlinked handles.
  *
  * The worker owns the cleanup of the rows that it processes. The query runs on
  * the snapshot of this transaction, and each delete takes a read dependency on
@@ -87,7 +88,10 @@ export const deleteExpiredChallenges = internalMutation({
   returns: v.null(),
   handler: async (ctx, { ids }) => {
     for (const id of ids) {
-      await ctx.db.delete("challenges", id);
+      const challenge = await ctx.db.get("challenges", id);
+      if (challenge !== null) {
+        await deleteDeadChallenge(ctx, challenge);
+      }
     }
     return null;
   },

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -1,7 +1,19 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { consumeChallenge, randomChallenge, toArrayBuffer } from "./helpers";
+import {
+  consumeChallenge,
+  randomChallenge,
+  randomHandle,
+  toArrayBuffer,
+} from "./helpers";
 import schema from "./schema";
+import { MutationCtx } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+/** Insert an unlinked handle, as `startRegistration` does. */
+function insertHandle(ctx: MutationCtx): Promise<Id<"handles">> {
+  return ctx.db.insert("handles", { handle: randomHandle(), userId: null });
+}
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -59,11 +71,14 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        handleId: await insertHandle(ctx),
       });
       const row = await consumeChallenge(ctx, "registration", challenge);
       expect(row).not.toBe(null);
       expect(row!.kind).toBe("registration");
       expect(await ctx.db.query("challenges").collect()).toEqual([]);
+      // The challenge was not expired: its handle stays.
+      expect(await ctx.db.query("handles").collect()).toHaveLength(1);
     });
   });
 
@@ -86,6 +101,7 @@ describe("consumeChallenge", () => {
       await ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        handleId: await insertHandle(ctx),
       });
       const row = await consumeChallenge(ctx, "authentication", challenge);
       expect(row).toBe(null);
@@ -112,9 +128,11 @@ describe("consumeChallenge", () => {
   });
 
   /**
-   * Insert a registration challenge, then move the clock forward by `ageMs`.
-   * The age of a challenge is the age of its `_creationTime`, thus the clock
-   * is the only way to make a challenge old.
+   * Insert a handle and a registration challenge that points at it, then move
+   * the clock forward by `ageMs`. The age of a challenge is the age of its
+   * `_creationTime`, thus the clock is the only way to make a challenge old.
+   * The handle goes in one millisecond earlier, in its own transaction, so
+   * that the challenge gets the base time exactly.
    */
   async function insertAndAge(
     t: ReturnType<typeof setup>,
@@ -122,11 +140,14 @@ describe("consumeChallenge", () => {
     ageMs: number,
   ) {
     vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000 - 1);
+    const handleId = await t.run((ctx) => insertHandle(ctx));
     vi.setSystemTime(1_700_000_000_000);
     await t.run((ctx) =>
       ctx.db.insert("challenges", {
         kind: "registration",
         challenge: toArrayBuffer(challenge),
+        handleId,
       }),
     );
     vi.setSystemTime(1_700_000_000_000 + ageMs);
@@ -139,8 +160,10 @@ describe("consumeChallenge", () => {
     await t.run(async (ctx) => {
       const row = await consumeChallenge(ctx, "registration", challenge);
       expect(row).toBe(null);
-      // The expired row was deleted on the way out.
+      // The expired row was deleted on the way out, together with its
+      // unlinked handle.
       expect(await ctx.db.query("challenges").collect()).toEqual([]);
+      expect(await ctx.db.query("handles").collect()).toEqual([]);
     });
   });
 

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -1,4 +1,4 @@
-import { Doc } from "./_generated/dataModel";
+import { Doc, Id } from "./_generated/dataModel";
 import { MutationCtx } from "./_generated/server";
 import { CHALLENGE_TTL_MS } from "./validation";
 
@@ -82,19 +82,34 @@ export async function deleteDeadChallenge(
   await ctx.db.delete("challenges", row._id);
 
   if (row.kind === "registration") {
-    const handle = await ctx.db.get("handles", row.handleId);
+    await deleteUnlinkedHandle(ctx, row.handleId);
+  }
+}
 
-    // In most cases the handle should exist here, but in rare cases it can be deleted
-    // (if an existing user starts a passkey registration attempt, never completes it,
-    // and then deletes their account before the challenge expires)
-    if (handle === null) {
-      return;
-    }
+/**
+ * Delete the handle of a burned registration ceremony when no user owns it.
+ *
+ * A handle with `userId: null` comes from the new-account flow. When the
+ * ceremony fails, no other row points at the handle. Without this cleanup,
+ * the handle stays forever, because the challenge cleanup loop only finds
+ * handles through their challenge rows.
+ */
+export async function deleteUnlinkedHandle(
+  ctx: MutationCtx,
+  handleId: Id<"handles">,
+): Promise<void> {
+  const handle = await ctx.db.get("handles", handleId);
 
-    // If the handle is not linked to a user account,
-    // it means the user never existed and we can delete the handle
-    if (handle.userId === null) {
-      await ctx.db.delete("handles", handle._id);
-    }
+  // In most cases the handle should exist here, but in rare cases it can be deleted
+  // (if an existing user starts a passkey registration attempt, never completes it,
+  // and then deletes their account before the challenge expires)
+  if (handle === null) {
+    return;
+  }
+
+  // If the handle is not linked to a user account,
+  // it means the user never existed and we can delete the handle
+  if (handle.userId === null) {
+    await ctx.db.delete("handles", handle._id);
   }
 }

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -17,17 +17,26 @@ export function randomChallenge(): ArrayBuffer {
   return toArrayBuffer(challenge);
 }
 
+export function randomHandle(): ArrayBuffer {
+  // 64 bytes is the WebAuthn maximum length for `user.id`.
+  const handle = new Uint8Array(64);
+  crypto.getRandomValues(handle);
+  return toArrayBuffer(handle);
+}
+
 /**
  * Find a one-use challenge by its bytes. Make sure that the challenge has
  * the correct kind and is not too old. Delete the challenge and return the
  * row. Return `null` when no usable challenge exists (unknown, incorrect
  * kind, already used, or expired).
  */
-export async function consumeChallenge(
+export async function consumeChallenge<
+  Kind extends "registration" | "authentication",
+>(
   ctx: MutationCtx,
-  kind: "registration" | "authentication",
+  kind: Kind,
   challenge: Uint8Array,
-): Promise<Doc<"challenges"> | null> {
+): Promise<Extract<Doc<"challenges">, { kind: Kind }> | null> {
   const row = await ctx.db
     .query("challenges")
     .withIndex("by_challenge", (q) =>
@@ -40,12 +49,13 @@ export async function consumeChallenge(
   if (row === null || row.kind !== kind) {
     return null;
   }
-  // One use only: a consumed (or expired) challenge is deleted.
-  await ctx.db.delete("challenges", row._id);
   if (isChallengeExpired(row)) {
+    await deleteDeadChallenge(ctx, row);
     return null;
   }
-  return row;
+  // One use only: a consumed challenge is deleted.
+  await ctx.db.delete("challenges", row._id);
+  return row as Extract<Doc<"challenges">, { kind: Kind }>;
 }
 
 /**
@@ -59,4 +69,32 @@ export function isChallengeExpired(
   // TTL, it is expired. The cleanup loop (see cleanup.ts) uses the same
   // boundary, so a wake-up at the deadline always finds work.
   return now - row._creationTime >= CHALLENGE_TTL_MS;
+}
+
+/**
+ * Delete a challenge whose ceremony can never complete: an expired
+ * challenge, or a live challenge that a failed finish attempt burns.
+ */
+export async function deleteDeadChallenge(
+  ctx: MutationCtx,
+  row: Doc<"challenges">,
+): Promise<void> {
+  await ctx.db.delete("challenges", row._id);
+
+  if (row.kind === "registration") {
+    const handle = await ctx.db.get("handles", row.handleId);
+
+    // In most cases the handle should exist here, but in rare cases it can be deleted
+    // (if an existing user starts a passkey registration attempt, never completes it,
+    // and then deletes their account before the challenge expires)
+    if (handle === null) {
+      return;
+    }
+
+    // If the handle is not linked to a user account,
+    // it means the user never existed and we can delete the handle
+    if (handle.userId === null) {
+      await ctx.db.delete("handles", handle._id);
+    }
+  }
 }

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -350,6 +350,68 @@ describe("finishRegistration", () => {
     );
     expect(challenges).toEqual([]);
   });
+
+  test("deletes the unlinked handle when verification fails in the new-account flow", async () => {
+    const t = setup();
+    const { challenge } = await t.mutation(api.registration.startRegistration, {
+      userId: null,
+    });
+    const { args } = await registrationArgs(t, "user1", {
+      challenge,
+      userVerified: false,
+    });
+    const result = await t.mutation(api.registration.finishRegistration, args);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+    // The failure burned the challenge, so the cleanup loop cannot find the
+    // handle later. The mutation must delete the handle itself.
+    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
+    expect(handles).toEqual([]);
+    const challenges = await t.run((ctx) =>
+      ctx.db.query("challenges").collect(),
+    );
+    expect(challenges).toEqual([]);
+  });
+
+  test("deletes the unlinked handle for a duplicate credential in the new-account flow", async () => {
+    const t = setup();
+    const { credential } = await register(t, "user1");
+    const { challenge } = await t.mutation(api.registration.startRegistration, {
+      userId: null,
+    });
+    const { args } = await registrationArgs(t, "user2", {
+      challenge,
+      credential,
+    });
+    const result = await t.mutation(api.registration.finishRegistration, args);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "CREDENTIAL_ALREADY_REGISTERED" },
+    });
+    // Only the linked handle of user1 stays.
+    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
+    expect(handles).toHaveLength(1);
+    expect(handles[0].userId).toBe("user1");
+  });
+
+  test("keeps the linked handle when verification fails for an existing user", async () => {
+    const t = setup();
+    await register(t, "user1");
+    const { args } = await registrationArgs(t, "user1", {
+      userVerified: false,
+    });
+    const result = await t.mutation(api.registration.finishRegistration, args);
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+    // The handle belongs to user1, so the failed attempt must not remove it.
+    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
+    expect(handles).toHaveLength(1);
+    expect(handles[0].userId).toBe("user1");
+  });
 });
 
 describe("listPasskeys", () => {

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -94,7 +94,7 @@ describe("startRegistration", () => {
     await register(t, "user1");
     const { excludeCredentials } = await t.mutation(
       api.registration.startRegistration,
-      {},
+      { userId: null },
     );
     expect(excludeCredentials).toEqual([]);
   });
@@ -114,6 +114,30 @@ describe("startRegistration", () => {
     expect(ids).toHaveLength(2);
     expect(ids).toContain(first.credential.credentialId.join(","));
     expect(ids).toContain(second.credential.credentialId.join(","));
+  });
+
+  test("throws when a new handle collides with an existing handle", async () => {
+    const t = setup();
+    // Make each new handle the same bytes. Only the 64-byte values are
+    // handles: the challenges (32 bytes) stay random.
+    const getRandomValues = crypto.getRandomValues.bind(crypto);
+    const spy = vi
+      .spyOn(crypto, "getRandomValues")
+      .mockImplementation((array) =>
+        array !== null && array.byteLength === 64
+          ? (array as Uint8Array).fill(7)
+          : getRandomValues(array as Uint8Array),
+      );
+    try {
+      await t.mutation(api.registration.startRegistration, { userId: "user1" });
+      await expect(
+        t.mutation(api.registration.startRegistration, { userId: "user2" }),
+      ).rejects.toThrow("collides with an existing handle");
+    } finally {
+      spy.mockRestore();
+    }
+    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
+    expect(handles).toHaveLength(1);
   });
 });
 

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -67,7 +67,7 @@ export const startRegistration = mutation({
       handle = await ctx.db
         .query("handles")
         .withIndex("by_userId", (q) => q.eq("userId", userId))
-        .first();
+        .unique();
       const rows = await ctx.db
         .query("passkeys")
         .withIndex("by_userId", (q) => q.eq("userId", userId))

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -1,5 +1,6 @@
 import { Infer, v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
 import {
   ClientDataType,
   coseAlgorithmES256,
@@ -14,15 +15,22 @@ import {
   finishRegistrationUserError,
   deletePasskeyUserError,
 } from "./validation";
-import { consumeChallenge, randomChallenge, toArrayBuffer } from "./helpers";
+import {
+  consumeChallenge,
+  randomChallenge,
+  randomHandle,
+  toArrayBuffer,
+} from "./helpers";
 import { scheduleChallengeCleanup } from "./cleanup";
 
-// The challenge and the credential IDs travel as raw bytes (Convex
-// `v.bytes()` carries `ArrayBuffer`s end to end). The WebAuthn API in the
-// browser makes and accepts the same bytes, so no base64 conversion is
-// necessary.
+// The challenge, the credential IDs, and the user handle travel as raw bytes
+// (Convex `v.bytes()` carries `ArrayBuffer`s end to end). The WebAuthn API
+// in the browser makes and accepts the same bytes, so no base64 conversion
+// is necessary.
 const startRegistrationResult = v.object({
   challenge: v.bytes(),
+  // The WebAuthn user handle (`user.id`) for the `create()` call.
+  userHandle: v.bytes(),
   excludeCredentials: v.array(v.bytes()),
 });
 
@@ -33,30 +41,64 @@ const startRegistrationResult = v.object({
  * challenge bytes. The challenge has no identity: it is simply a random
  * string used to avoid replay attacks.
  *
- * Set `userId` when a known user adds a passkey to their account. The
- * function then also returns the existing credential IDs of the user.
- * This is used by the authenticator to ensure there isn’t already a
- * passkey that exists for the user.
+ * The function also returns the `userHandle` for the ceremony:
+ * - Give a `userId` when a known user adds a passkey to their account. The
+ *   function reuses the handle of the user, or makes one when the user has
+ *   none. It also returns the existing credential IDs of the user. This is
+ *   used by the authenticator to ensure there isn’t already a passkey that
+ *   exists for the user.
+ * - Give `null` in the new-account flow (the user row does not exist yet).
+ *   The function makes a new handle with no user. `finishRegistration` links
+ *   the handle to the verified user.
+ *
+ * The `userId` argument is required, not optional: the two flows behave
+ * differently, so the caller must state which flow it runs. (Compare with
+ * `startAuthentication`, where the argument is optional.)
  */
 export const startRegistration = mutation({
-  args: { userId: v.optional(v.string()) },
+  args: { userId: v.union(v.string(), v.null()) },
   returns: startRegistrationResult,
   handler: async (ctx, { userId }) => {
-    const challenge = randomChallenge();
-    await ctx.db.insert("challenges", {
-      kind: "registration",
-      challenge,
-    });
-    await scheduleChallengeCleanup(ctx);
+    let handle: { _id: Id<"handles">; handle: ArrayBuffer } | null = null;
     let excludeCredentials: ArrayBuffer[] = [];
-    if (userId !== undefined) {
+    if (userId !== null) {
+      // A user has a maximum of one handle: reuse it when it exists.
+      handle = await ctx.db
+        .query("handles")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first();
       const rows = await ctx.db
         .query("passkeys")
         .withIndex("by_userId", (q) => q.eq("userId", userId))
         .collect();
       excludeCredentials = rows.map((row) => row.credentialId);
     }
-    return { challenge, excludeCredentials };
+    if (handle === null) {
+      const bytes = randomHandle();
+      // A handle is 64 random bytes, so a collision is not expected. The
+      // check is here for safety: two users with the same handle would let
+      // one of them authenticate as the other.
+      const collision = await ctx.db
+        .query("handles")
+        .withIndex("by_handle", (q) => q.eq("handle", bytes))
+        .first();
+      if (collision !== null) {
+        throw new Error(
+          "The new user handle collides with an existing handle.",
+        );
+      }
+      const id = await ctx.db.insert("handles", { handle: bytes, userId });
+      handle = { _id: id, handle: bytes };
+    }
+
+    const challenge = randomChallenge();
+    await ctx.db.insert("challenges", {
+      kind: "registration",
+      challenge,
+      handleId: handle._id,
+    });
+    await scheduleChallengeCleanup(ctx);
+    return { challenge, userHandle: handle.handle, excludeCredentials };
   },
 });
 
@@ -177,6 +219,33 @@ export const finishRegistration = mutation({
       };
     }
 
+    // Link the handle of the ceremony to the verified user.
+    const handle = await ctx.db.get("handles", challengeRow.handleId);
+    if (handle === null) {
+      throw new Error("The handle of the challenge does not exist.");
+    }
+    if (handle.userId === null) {
+      // The new-account flow: the handle was made before the user existed.
+      const existingHandle = await ctx.db
+        .query("handles")
+        .withIndex("by_userId", (q) => q.eq("userId", args.verifiedUserId))
+        .first();
+      if (existingHandle !== null) {
+        // Invariant: the new-account flow only runs for a brand-new user,
+        // which cannot have a handle already.
+        throw new Error(
+          "Invariant violation: The user already has a different handle. finishRegistration is being called incorrectly.",
+        );
+      }
+      await ctx.db.patch("handles", handle._id, {
+        userId: args.verifiedUserId,
+      });
+    } else if (handle.userId !== args.verifiedUserId) {
+      throw new Error(
+        "Invariant violation: The handle belongs to a different user. finishRegistration is being called incorrectly.",
+      );
+    }
+
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.verifiedUserId,
       name: args.name,
@@ -229,6 +298,12 @@ type DeletePasskeyResult = Infer<typeof deletePasskeyResult>;
  *
  * The `userId` check makes the function safe for an ID that comes directly
  * from the client: a user can only delete their own passkeys.
+ *
+ * The function does not delete the handle of the user, not even when the
+ * user has no passkeys left. A passkey that the user creates later must
+ * reuse the same handle. Then an authenticator that still holds an old
+ * credential keeps working, and the user does not fork across two handles.
+ * Use `deleteUser` when the user is deleted permanently.
  */
 export const deletePasskey = mutation({
   args: { userId: v.string(), passkeyId: v.string() },
@@ -244,5 +319,49 @@ export const deletePasskey = mutation({
     }
     await ctx.db.delete("passkeys", id);
     return { success: true };
+  },
+});
+
+/**
+ * Delete all the passkey data of a user: their passkeys, their handle, and
+ * the authentication challenges bound to the user.
+ *
+ * The app calls this function when it deletes a user permanently. Do not
+ * call it in other cases: without the handle, an authenticator that still
+ * holds an old credential stops working (see `deletePasskey`).
+ *
+ * Caveat: an in-flight registration challenge that points at the handle of
+ * the user survives until its TTL. That is safe: `finishRegistration` throws
+ * when the handle of the challenge no longer exists, and the cleanup loop
+ * erases the challenge after the TTL.
+ */
+export const deleteUser = mutation({
+  args: { userId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { userId }) => {
+    const passkeys = await ctx.db
+      .query("passkeys")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    for (const passkey of passkeys) {
+      await ctx.db.delete("passkeys", passkey._id);
+    }
+    const handles = await ctx.db
+      .query("handles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    for (const handle of handles) {
+      await ctx.db.delete("handles", handle._id);
+    }
+    // Only authentication challenges carry a `userId`. Registration rows
+    // have no `userId` field, so the index probe never matches them.
+    const challenges = await ctx.db
+      .query("challenges")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    for (const challenge of challenges) {
+      await ctx.db.delete("challenges", challenge._id);
+    }
+    return null;
   },
 });

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -17,6 +17,7 @@ import {
 } from "./validation";
 import {
   consumeChallenge,
+  deleteUnlinkedHandle,
   randomChallenge,
   randomHandle,
   toArrayBuffer,
@@ -178,6 +179,9 @@ export const finishRegistration = mutation({
       throw new Error("Relying party ID hash mismatch.");
     }
     if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
+      // The challenge is consumed, so the cleanup loop cannot find the
+      // handle later. Remove it here when no user owns it.
+      await deleteUnlinkedHandle(ctx, challengeRow.handleId);
       return { success: false, userError: { error: "VERIFICATION_FAILED" } };
     }
     const credential = authenticatorData.credential;
@@ -213,6 +217,9 @@ export const finishRegistration = mutation({
       .withIndex("by_credentialId", (q) => q.eq("credentialId", credentialId))
       .first();
     if (existing !== null) {
+      // Same as VERIFICATION_FAILED above: the ceremony is burned, so
+      // remove the handle when no user owns it.
+      await deleteUnlinkedHandle(ctx, challengeRow.handleId);
       return {
         success: false,
         userError: { error: "CREDENTIAL_ALREADY_REGISTERED" },

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -55,6 +55,8 @@ const startRegistrationResult = v.object({
  * The `userId` argument is required, not optional: the two flows behave
  * differently, so the caller must state which flow it runs. (Compare with
  * `startAuthentication`, where the argument is optional.)
+ *
+ * TODO(nicolas) Split this into two methods
  */
 export const startRegistration = mutation({
   args: { userId: v.union(v.string(), v.null()) },

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -24,6 +24,28 @@ export default defineSchema({
     .index("by_credentialId", ["credentialId"])
     .index("by_userId", ["userId"]),
 
+  // The WebAuthn user handle of each user. The handle is the `user.id` that
+  // the authenticator stores with a discoverable credential. A user has a
+  // maximum of ONE handle: the registration code reuses an existing handle.
+  //
+  // The handle exists because the app user id cannot be the WebAuthn user
+  // handle in the auth flows where the user is created transactionally with
+  // the passkey registration: the user row does not exist yet when
+  // the registration ceremony starts. The handle is created first, and
+  // `finishRegistration` links it to the user.
+  handles: defineTable({
+    // 64 random bytes (the WebAuthn maximum length for `user.id`).
+    handle: v.bytes(),
+    // The app user that owns the handle, or `null` until the account exists.
+    userId: v.union(v.string(), v.null()),
+  })
+    .index("by_userId", ["userId"])
+    // Used to make sure that a new handle does not collide with an existing
+    // one. A collision of 64 random bytes is not expected to happen, but the
+    // registration code checks for it because a shared handle might cause
+    // authenticators to delete passkeys incorrectly.
+    .index("by_handle", ["handle"]),
+
   // The WebAuthn challenges that are active. Each challenge is for one use
   // only: the finish step deletes it. A challenge expires a fixed time after
   // its creation (see CHALLENGE_TTL_MS), thus `_creationTime` is the age of
@@ -34,6 +56,8 @@ export default defineSchema({
       v.object({
         kind: v.literal("registration"),
         challenge: v.bytes(), // 32 random bytes
+        // The handle that this ceremony registers a credential for.
+        handleId: v.id("handles"),
       }),
       v.object({
         kind: v.literal("authentication"),
@@ -44,5 +68,10 @@ export default defineSchema({
         userId: v.optional(v.string()),
       }),
     ),
-  ).index("by_challenge", ["challenge"]),
+  )
+    .index("by_challenge", ["challenge"])
+    // Used by `deleteUser` to erase the authentication challenges that are
+    // bound to a user. Registration rows have no `userId` field, so a probe
+    // with a user ID string never matches them.
+    .index("by_userId", ["userId"]),
 });


### PR DESCRIPTION
This PR adds a level of indirection for the IDs used in passkeys. Instead of associating the passkeys to the user ID (`Id<"users">`), we now generate a random 64-bytes value (the “handle”) that is associated with a user.

## Why are we doing this?
When creating a passkey in an authenticator, we need to provide a [user handle](https://www.w3.org/TR/webauthn-3/#user-handle) ([`PublicKeyCredentialUserEntity.id`](https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-user)), which identifies the account this passkey is authenticated with. This value must be unique for every user, and not contain any personally identifying information such as a email address or username. Moreover, the WebAuthn spec indicates that the user handle “ought to be the same for all credentials registered to the same user account.”

Initially, my intuition was to use the user ID (`Id<"users">`) as a user handle. However, this doesn’t work well for auth flows where the passkey is registered at the same time as the user creation (e.g. username + password). If we were using the user ID as the handle, it would mean that we would need to create the user before registering the first passkey. This situation is worse because it creates a temporary user where a user has no identity[^1] or auth methods[^2], and this user is never cleaned up if the registration process does not help.

[^1]: We don’t want to register the identity before the passkey creation challenge is over, otherwise we could have a sitaution where a username is registered and no one is able to access it (e.g. because the user was not able to finish the passkey registration).
[^2]: Because the passkey has not been registered at this point.

## How are handles implemented in practice?
The passkey component has a new `handles` table that links handles to users. Handles are 64-byte random values, which is what the WebAuthn spec [recommends doing](https://www.w3.org/TR/webauthn-3/#sctn-user-handle-privacy).

There are now two supported flows to register a passkey:
* The passkey is added to an existing user (`startRegistration` called with a `userId` parameter).
  * If it’s the first time this user receives a passkey, we generate a random handle.
  * If the user already had passkeys in the past, we reuse their previous handle.
* The passkey registration is for a user that isn’t created yet (`startRegistration` with no `userId`)
  * We create a handle that’s not associated with a user ID and store it in `handles`
  * When the passkey registration completes, we store the new user ID in the `handles` row. In this flow, the user is expected to be new at this point, so if the user already has a handle we throw an error.

When a passkey is deleted from the component, we don’t delete the handle (even if the user has no passkeys anymore), because an authenticator might still store an expired passkey that contains the handle. However, we still want to clean up handles for users that are deleted: this is done through the new `deleteUser` mutation, which deletes all passkeys for a user and also their handle.

## Are handles just another kind of user ID?
In design discussions for Convex Auth v2, a design goal I had is to avoid having multiple kinds of user ID (for instance a user ID in the app component and a separate user ID in the core component), as this can be confusing to users. But as I explained above, having user handles that are separate from the user ID is inevitable if we want to support transactional passkey-registration-on-sign-up auth flows.

Fortunately, **handles are scoped to the passkey component**. Server-side, they are only stored in the component, and they are only passed to the app code so that it can forward them to the frontend. We always call this identifier a *user handle*, the term used in the [WebAuthn spec](https://www.w3.org/TR/webauthn-3/#user-handle) and that won’t be mistaken for an ID. Additionally, we never look up a user by its passkey handle, as the handle value is only used by the authenticator itself to distinguish users.