### PR TITLE
Passkey component: add a checkRegistration readonly function

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -54,6 +54,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       >;
     };
     registration: {
+      checkRegistration: FunctionReference<
+        "query",
+        "internal",
+        {
+          attestationObject: ArrayBuffer;
+          clientDataJSON: ArrayBuffer;
+          expectedOrigin: string;
+          expectedRpId: string;
+        },
+        | { success: true }
+        | {
+            success: false;
+            userError:
+              { error: "CHALLENGE_EXPIRED" } | { error: "VERIFICATION_FAILED" };
+          },
+        Name
+      >;
       deletePasskey: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -1,4 +1,3 @@
-import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   consumeChallenge,
@@ -6,21 +5,14 @@ import {
   randomHandle,
   toArrayBuffer,
 } from "./helpers";
-import schema from "./schema";
+import { CHALLENGE_TTL_MS } from "./validation";
+import { expectSameBytes, setup } from "../passkeyTestSetup";
 import { MutationCtx } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 
 /** Insert an unlinked handle, as `startRegistration` does. */
 function insertHandle(ctx: MutationCtx): Promise<Id<"handles">> {
   return ctx.db.insert("handles", { handle: randomHandle(), userId: null });
-}
-
-const modules = import.meta.glob("./**/*.ts");
-
-const CHALLENGE_TTL_MS = 10 * 60 * 1000;
-
-function setup() {
-  return convexTest(schema, modules);
 }
 
 describe("toArrayBuffer", () => {
@@ -35,10 +27,10 @@ describe("toArrayBuffer", () => {
     const view = full.subarray(1, 4);
     const result = toArrayBuffer(view);
     expect(result).not.toBe(full.buffer);
-    expect(new Uint8Array(result)).toEqual(new Uint8Array([2, 3, 4]));
+    expectSameBytes(result, new Uint8Array([2, 3, 4]));
     // The copy is independent from the original bytes.
     full[2] = 42;
-    expect(new Uint8Array(result)).toEqual(new Uint8Array([2, 3, 4]));
+    expectSameBytes(result, new Uint8Array([2, 3, 4]));
   });
 
   test("handles zero-length input", () => {

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -1,5 +1,5 @@
 import { Doc, Id } from "./_generated/dataModel";
-import { MutationCtx } from "./_generated/server";
+import { MutationCtx, QueryCtx } from "./_generated/server";
 import { CHALLENGE_TTL_MS } from "./validation";
 
 export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
@@ -25,15 +25,16 @@ export function randomHandle(): ArrayBuffer {
 }
 
 /**
- * Find a one-use challenge by its bytes. Make sure that the challenge has
- * the correct kind and is not too old. Delete the challenge and return the
- * row. Return `null` when no usable challenge exists (unknown, incorrect
- * kind, already used, or expired).
+ * Find a challenge by its bytes and its kind. Return `null` when no row
+ * matches.
+ *
+ * The function does not check the TTL, and can return expired challenges.
+ * Callers must check the TTL by themselves.
  */
-export async function consumeChallenge<
+export async function findChallenge<
   Kind extends "registration" | "authentication",
 >(
-  ctx: MutationCtx,
+  ctx: QueryCtx,
   kind: Kind,
   challenge: Uint8Array,
 ): Promise<Extract<Doc<"challenges">, { kind: Kind }> | null> {
@@ -49,13 +50,33 @@ export async function consumeChallenge<
   if (row === null || row.kind !== kind) {
     return null;
   }
+  return row as Extract<Doc<"challenges">, { kind: Kind }>;
+}
+
+/**
+ * Find a one-use challenge by its bytes. Make sure that the challenge has
+ * the correct kind and is not too old. Delete the challenge and return the
+ * row. Return `null` when no usable challenge exists (unknown, incorrect
+ * kind, already used, or expired).
+ */
+export async function consumeChallenge<
+  Kind extends "registration" | "authentication",
+>(
+  ctx: MutationCtx,
+  kind: Kind,
+  challenge: Uint8Array,
+): Promise<Extract<Doc<"challenges">, { kind: Kind }> | null> {
+  const row = await findChallenge(ctx, kind, challenge);
+  if (row === null) {
+    return null;
+  }
   if (isChallengeExpired(row)) {
     await deleteDeadChallenge(ctx, row);
     return null;
   }
   // One use only: a consumed challenge is deleted.
   await ctx.db.delete("challenges", row._id);
-  return row as Extract<Doc<"challenges">, { kind: Kind }>;
+  return row;
 }
 
 /**

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -49,13 +49,16 @@ async function registrationArgs(
     // `finishRegistration` knows the verified user.
     isNewAccountFlow?: boolean;
     // The user that `startRegistration` receives. It is `userId` by default.
-    startUserId?: string;
+    // `null` starts the new-account flow, which makes an unlinked handle.
+    startUserId?: string | null;
   } = {},
 ) {
   const credential = options.credential ?? (await generateES256Credential());
   const startUserId = options.isNewAccountFlow
     ? null
-    : (options.startUserId ?? userId);
+    : options.startUserId !== undefined
+      ? options.startUserId
+      : userId;
   let challenge: ArrayBuffer;
   let userHandle: ArrayBuffer | null;
   if (options.challenge !== undefined) {
@@ -114,9 +117,7 @@ describe("startRegistration", () => {
     const rows = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(rows).toHaveLength(1);
     expect(rows[0].kind).toBe("registration");
-    expect(new Uint8Array(rows[0].challenge)).toEqual(
-      new Uint8Array(challenge),
-    );
+    expectSameBytes(rows[0].challenge, challenge);
     // Registration challenges carry no identity, even when a userId is given:
     // they point at a handle instead.
     expect("userId" in rows[0]).toBe(false);
@@ -276,7 +277,7 @@ describe("finishRegistration", () => {
     expect(result).toEqual({ success: true, passkeyId: row._id });
     expect(row.userId).toBe("user1");
     expect(row.algorithm).toBe("ES256");
-    expect(new Uint8Array(row.credentialId)).toEqual(credential.credentialId);
+    expectSameBytes(row.credentialId, credential.credentialId);
     expect(row.counter).toBe(5);
     // SEC1 uncompressed P-256 point: 0x04 || x || y.
     const publicKey = new Uint8Array(row.publicKey);
@@ -499,6 +500,19 @@ describe("finishRegistration", () => {
     });
   });
 
+  test("erases the unlinked handle when the user is not verified", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      startUserId: null,
+      userVerified: false,
+    });
+    const result = await t.mutation(api.registration.finishRegistration, args);
+    expect(result.success).toBe(false);
+    // The failed attempt burned the challenge. The ceremony can never
+    // complete, thus its unlinked handle goes away too.
+    expect(await handleRows(t)).toEqual([]);
+  });
+
   test("keeps the linked handle when the user is not verified", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
@@ -625,6 +639,96 @@ describe("finishRegistration", () => {
   });
 });
 
+describe("checkRegistration", () => {
+  /** `checkRegistration` takes the finish arguments without the user fields. */
+  function checkArgs({
+    expectedRpId,
+    expectedOrigin,
+    attestationObject,
+    clientDataJSON,
+  }: Awaited<ReturnType<typeof registrationArgs>>["args"]) {
+    return { expectedRpId, expectedOrigin, attestationObject, clientDataJSON };
+  }
+
+  test("returns success for a valid attestation and writes nothing", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    const result = await t.query(
+      api.registration.checkRegistration,
+      checkArgs(args),
+    );
+    expect(result).toEqual({ success: true });
+    // A query cannot write: the challenge stays for the finish call.
+    const challenges = await t.run((ctx) =>
+      ctx.db.query("challenges").collect(),
+    );
+    expect(challenges).toHaveLength(1);
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+  });
+
+  test("returns CHALLENGE_EXPIRED for an expired challenge", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    expireChallenge();
+    const result = await t.query(
+      api.registration.checkRegistration,
+      checkArgs(args),
+    );
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "CHALLENGE_EXPIRED" },
+    });
+  });
+
+  test("returns VERIFICATION_FAILED when the user is not verified", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      userVerified: false,
+    });
+    const result = await t.query(
+      api.registration.checkRegistration,
+      checkArgs(args),
+    );
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+  });
+
+  test("throws for a duplicate credential ID", async () => {
+    const t = setup();
+    const { credential } = await register(t, "user1");
+    const { args } = await registrationArgs(t, "user2", { credential });
+    await expect(
+      t.query(api.registration.checkRegistration, checkArgs(args)),
+    ).rejects.toThrow("The credential is already registered.");
+  });
+
+  test("throws for an unexpected origin, like the finish call", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      origin: "https://evil.example.net",
+    });
+    await expect(
+      t.query(api.registration.checkRegistration, checkArgs(args)),
+    ).rejects.toThrow("Unexpected WebAuthn origin.");
+  });
+
+  test("a finish with the same arguments succeeds after a successful check", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", { startUserId: null });
+    const check = await t.query(
+      api.registration.checkRegistration,
+      checkArgs(args),
+    );
+    expect(check).toEqual({ success: true });
+    const finish = await t.mutation(api.registration.finishRegistration, args);
+    expect(finish.success).toBe(true);
+  });
+});
+
 describe("listPasskeys", () => {
   test("returns an empty array for an unknown user", async () => {
     const t = setup();
@@ -646,9 +750,7 @@ describe("listPasskeys", () => {
     expect(result).toHaveLength(1);
     expect(result[0].passkeyId).toBe(passkeyId);
     expect(result[0].name).toBe("MacBook");
-    expect(new Uint8Array(result[0].credentialId)).toEqual(
-      credential.credentialId,
-    );
+    expectSameBytes(result[0].credentialId, credential.credentialId);
     expect(typeof result[0].createdAt).toBe("number");
     // The key material never leaves the component.
     expect(result[0]).not.toHaveProperty("publicKey");

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -1,6 +1,6 @@
 import { Infer, v } from "convex/values";
-import { mutation, query } from "./_generated/server";
-import { Id } from "./_generated/dataModel";
+import { mutation, query, QueryCtx } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
 import {
   ClientDataType,
   coseAlgorithmES256,
@@ -13,11 +13,13 @@ import { ECDSAPublicKey, p256 } from "../../vendor/oslo/crypto/ecdsa";
 import { RSAPublicKey } from "../../vendor/oslo/crypto/rsa";
 import {
   finishRegistrationUserError,
+  FinishRegistrationUserError,
   deletePasskeyUserError,
 } from "./validation";
 import {
-  consumeChallenge,
-  deleteUnlinkedHandle,
+  deleteDeadChallenge,
+  findChallenge,
+  isChallengeExpired,
   randomChallenge,
   randomHandle,
   toArrayBuffer,
@@ -114,6 +116,176 @@ const finishRegistrationResult = v.union(
 );
 type FinishRegistrationResult = Infer<typeof finishRegistrationResult>;
 
+// The arguments that the shared verification helper examines.
+const registrationCheckArgs = {
+  expectedRpId: v.string(),
+  expectedOrigin: v.string(),
+  attestationObject: v.bytes(),
+  clientDataJSON: v.bytes(),
+};
+
+const vRegistrationCheckArgs = v.object(registrationCheckArgs);
+type RegistrationCheckArgs = Infer<typeof vRegistrationCheckArgs>;
+
+type RegistrationChallengeRow = Extract<
+  Doc<"challenges">,
+  { kind: "registration" }
+>;
+
+// The result of `verifyRegistration`. On a `userError`, `challengeRow` is
+// the raw challenge row when one exists (live or expired):
+// `finishRegistration` burns it. On success, `challengeRow` is the live row.
+type RegistrationVerification =
+  | {
+      userError: FinishRegistrationUserError;
+      challengeRow: RegistrationChallengeRow | null;
+    }
+  | {
+      userError: null;
+      challengeRow: RegistrationChallengeRow;
+      credentialId: ArrayBuffer;
+      algorithm: "ES256" | "RS256";
+      publicKey: ArrayBuffer;
+      counter: number;
+    };
+
+/**
+ * The complete verification body of `finishRegistration`, without any
+ * write: the client data checks, the challenge lookup with its TTL, the
+ * attestation checks, the key extraction, and the duplicate-credential
+ * check.
+ *
+ * The function takes a read-only ctx. `QueryCtx` is structurally satisfied
+ * by `MutationCtx`, so both `checkRegistration` (a query) and
+ * `finishRegistration` (a mutation) run the exact same code.
+ *
+ * Failures that the user can correct come back as a `userError`. For a
+ * protocol violation, the function throws an error (see
+ * `finishRegistration`).
+ */
+async function verifyRegistration(
+  ctx: QueryCtx,
+  args: RegistrationCheckArgs,
+): Promise<RegistrationVerification> {
+  const clientData = parseClientDataJSON(new Uint8Array(args.clientDataJSON));
+  if (clientData.type !== ClientDataType.Create) {
+    throw new Error("Unexpected client data type.");
+  }
+  if (clientData.origin !== args.expectedOrigin) {
+    // We could allow this verification to be less strict in the future
+    // (see the comment in `finishAuthentication`).
+    throw new Error("Unexpected WebAuthn origin.");
+  }
+  if (clientData.crossOrigin === true) {
+    // In the future, we could allow the user to explicitly opt out to this.
+    throw new Error("Cross-origin WebAuthn ceremonies are not allowed.");
+  }
+  const challengeRow = await findChallenge(
+    ctx,
+    "registration",
+    clientData.challenge,
+  );
+  if (challengeRow === null || isChallengeExpired(challengeRow)) {
+    return { userError: { error: "CHALLENGE_EXPIRED" }, challengeRow };
+  }
+
+  const attestationObject = parseAttestationObject(
+    new Uint8Array(args.attestationObject),
+  );
+  const authenticatorData = attestationObject.authenticatorData;
+  if (!authenticatorData.verifyRelyingPartyIdHash(args.expectedRpId)) {
+    throw new Error("Relying party ID hash mismatch.");
+  }
+  if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
+    return { userError: { error: "VERIFICATION_FAILED" }, challengeRow };
+  }
+  const credential = authenticatorData.credential;
+  if (credential === null) {
+    throw new Error("Missing attested credential data.");
+  }
+
+  const cosePublicKey = credential.publicKey;
+  let algorithm: "ES256" | "RS256";
+  let publicKey: Uint8Array;
+  if (cosePublicKey.algorithm() === coseAlgorithmES256) {
+    const ec2 = cosePublicKey.ec2();
+    if (ec2.curve !== coseEllipticCurveP256) {
+      throw new Error("Unsupported elliptic curve (expected P-256).");
+    }
+    publicKey = new ECDSAPublicKey(p256, ec2.x, ec2.y).encodeSEC1Uncompressed();
+    algorithm = "ES256";
+  } else if (cosePublicKey.algorithm() === coseAlgorithmRS256) {
+    const rsa = cosePublicKey.rsa();
+    publicKey = new RSAPublicKey(rsa.n, rsa.e).encodePKCS1();
+    algorithm = "RS256";
+  } else {
+    throw new Error("Unsupported public key algorithm.");
+  }
+
+  const credentialId = toArrayBuffer(credential.id);
+  const existing = await ctx.db
+    .query("passkeys")
+    .withIndex("by_credentialId", (q) => q.eq("credentialId", credentialId))
+    .first();
+  if (existing !== null) {
+    // A compliant client cannot cause this: authenticators make a fresh
+    // random credential ID for each ceremony, and `excludeCredentials`
+    // makes the authenticator refuse a duplicate for this RP. A duplicate
+    // here shows a replayed or tampered registration.
+    throw new Error("The credential is already registered.");
+  }
+
+  return {
+    userError: null,
+    challengeRow,
+    credentialId,
+    algorithm,
+    publicKey: toArrayBuffer(publicKey),
+    counter: authenticatorData.signatureCounter,
+  };
+}
+
+const checkRegistrationResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({
+    success: v.literal(false),
+    userError: finishRegistrationUserError,
+  }),
+);
+type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
+
+/**
+ * Run the verifications of `finishRegistration`, without any write.
+ *
+ * A transactional sign-up flow calls this query first, before it creates
+ * the user. Because this is a query, the runtime enforces that nothing is
+ * stored: there is no way to store an unverified credential through it.
+ *
+ * Guarantee: when `checkRegistration` returns `success: true` inside a
+ * mutation, a `finishRegistration` call with the same arguments in the
+ * same mutation does not return a `userError`. The two calls run in one
+ * transaction, so they see the same rows, and Convex fixes the transaction
+ * timestamp, so the challenge TTL check cannot flip between the two calls.
+ *
+ * The guarantee does not cover throws. This function cannot see the
+ * handle-linking invariants of `finishRegistration` (they depend on
+ * `verifiedUserId`), so `finishRegistration` can still throw after a
+ * successful check, and a throw aborts the transaction. The function throws
+ * on the same protocol violations that make `finishRegistration` throw, so
+ * a caller transaction aborts identically for those.
+ */
+export const checkRegistration = query({
+  args: registrationCheckArgs,
+  returns: checkRegistrationResult,
+  handler: async (ctx, args): Promise<CheckRegistrationResult> => {
+    const verification = await verifyRegistration(ctx, args);
+    if (verification.userError !== null) {
+      return { success: false, userError: verification.userError };
+    }
+    return { success: true };
+  },
+});
+
 /**
  * Finish a registration ceremony.
  *
@@ -139,92 +311,32 @@ type FinishRegistrationResult = Infer<typeof finishRegistrationResult>;
  * Failures that the user can correct come back as a `userError`. For a
  * protocol violation, the function throws an error. The error aborts the
  * transaction around the call, so a new user row rolls back with it.
+ *
+ * A caller that must be sure that this call succeeds before it creates
+ * data runs `checkRegistration` first, in the same mutation.
  */
 export const finishRegistration = mutation({
   args: {
-    expectedRpId: v.string(),
-    expectedOrigin: v.string(),
+    ...registrationCheckArgs,
     verifiedUserId: v.string(),
     name: v.optional(v.string()),
-    attestationObject: v.bytes(),
-    clientDataJSON: v.bytes(),
   },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
-    const clientData = parseClientDataJSON(new Uint8Array(args.clientDataJSON));
-    if (clientData.type !== ClientDataType.Create) {
-      throw new Error("Unexpected client data type.");
-    }
-    if (clientData.origin !== args.expectedOrigin) {
-      // We could allow this verification to be less strict in the future
-      // (see the comment in `finishAuthentication`).
-      throw new Error("Unexpected WebAuthn origin.");
-    }
-    if (clientData.crossOrigin === true) {
-      // In the future, we could allow the user to explicitly opt out to this.
-      throw new Error("Cross-origin WebAuthn ceremonies are not allowed.");
-    }
-    const challengeRow = await consumeChallenge(
-      ctx,
-      "registration",
-      clientData.challenge,
-    );
-    if (challengeRow === null) {
-      return { success: false, userError: { error: "CHALLENGE_EXPIRED" } };
-    }
+    const verification = await verifyRegistration(ctx, args);
 
-    const attestationObject = parseAttestationObject(
-      new Uint8Array(args.attestationObject),
-    );
-    const authenticatorData = attestationObject.authenticatorData;
-    if (!authenticatorData.verifyRelyingPartyIdHash(args.expectedRpId)) {
-      throw new Error("Relying party ID hash mismatch.");
-    }
-    if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
-      // The challenge is consumed, so the cleanup loop cannot find the
-      // handle later. Remove it here when no user owns it.
-      await deleteUnlinkedHandle(ctx, challengeRow.handleId);
-      return { success: false, userError: { error: "VERIFICATION_FAILED" } };
-    }
-    const credential = authenticatorData.credential;
-    if (credential === null) {
-      throw new Error("Missing attested credential data.");
-    }
-
-    const cosePublicKey = credential.publicKey;
-    let algorithm: "ES256" | "RS256";
-    let publicKey: Uint8Array;
-    if (cosePublicKey.algorithm() === coseAlgorithmES256) {
-      const ec2 = cosePublicKey.ec2();
-      if (ec2.curve !== coseEllipticCurveP256) {
-        throw new Error("Unsupported elliptic curve (expected P-256).");
+    if (verification.userError !== null) {
+      // The challenge burns on each finish attempt, also when the
+      // verification fails. The ceremony can never complete: the unlinked
+      // handle of the ceremony goes away with the challenge.
+      if (verification.challengeRow !== null) {
+        await deleteDeadChallenge(ctx, verification.challengeRow);
       }
-      publicKey = new ECDSAPublicKey(
-        p256,
-        ec2.x,
-        ec2.y,
-      ).encodeSEC1Uncompressed();
-      algorithm = "ES256";
-    } else if (cosePublicKey.algorithm() === coseAlgorithmRS256) {
-      const rsa = cosePublicKey.rsa();
-      publicKey = new RSAPublicKey(rsa.n, rsa.e).encodePKCS1();
-      algorithm = "RS256";
-    } else {
-      throw new Error("Unsupported public key algorithm.");
+      return { success: false, userError: verification.userError };
     }
-
-    const credentialId = toArrayBuffer(credential.id);
-    const existing = await ctx.db
-      .query("passkeys")
-      .withIndex("by_credentialId", (q) => q.eq("credentialId", credentialId))
-      .first();
-    if (existing !== null) {
-      // A compliant client cannot cause this: authenticators make a fresh
-      // random credential ID for each ceremony, and `excludeCredentials`
-      // makes the authenticator refuse a duplicate for this RP. A duplicate
-      // here shows a replayed or tampered registration.
-      throw new Error("The credential is already registered.");
-    }
+    const challengeRow = verification.challengeRow;
+    // One use only: the consumed challenge is deleted.
+    await ctx.db.delete("challenges", challengeRow._id);
 
     // Link the handle of the ceremony to the verified user.
     const handle = await ctx.db.get("handles", challengeRow.handleId);
@@ -256,10 +368,10 @@ export const finishRegistration = mutation({
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.verifiedUserId,
       name: args.name,
-      credentialId,
-      algorithm,
-      publicKey: toArrayBuffer(publicKey),
-      counter: authenticatorData.signatureCounter,
+      credentialId: verification.credentialId,
+      algorithm: verification.algorithm,
+      publicKey: verification.publicKey,
+      counter: verification.counter,
     });
     return { success: true, passkeyId };
   },


### PR DESCRIPTION
This PR adds a `checkRegistration` function to the passkey component. This new function performs the exact same checks that `finishRegistration` does, but unlike `finishRegistration` it doesn’t write anything.

This new function is useful when implementing transactional passkey registration flows (e.g. the upcoming UsernamePasskey provider). Without this function, the account creation mutation would need to create the user, register the username, and then register the passkey. If the passkey registration fails, it would need to rollback the other operations, which is hard to do:
- either the provider throws an error to roll the transaction back, but then it’s not easy to catch errors in a typesafe way from the client;
- or the provider needs to manually cancel the account creation and the username registration — but this is hard to do, and the user creation itself is done by the user code.

`checkRegistration` makes sure the passkey registration won’t fail when we do it, because we already performed all the necessary verifications in the transaction.

Side note for the long term: I wonder if we’ll need for more auth components to follow the same pattern