### PR TITLE
Add the usePasskey React hook for the passkey provider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "./providers/password/react": "./src/components/password/react.tsx",
     "./providers/password/*": "./src/components/password/*.ts",
     "./providers/passkey/convex.config.js": "./src/components/passkey/convex.config.ts",
+    "./providers/passkey/react": "./src/components/passkey/react.tsx",
     "./providers/passkey/*": "./src/components/passkey/*.ts",
     "./providers/testing/*": "./src/components/testing/*.ts",
     "./browser": "./src/browser/index.ts",

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -11,6 +11,7 @@
 import type * as authentication from "../authentication.js";
 import type * as cleanup from "../cleanup.js";
 import type * as helpers from "../helpers.js";
+import type * as react from "../react.js";
 import type * as registration from "../registration.js";
 import type * as setup from "../setup.js";
 import type * as testAuthenticator from "../testAuthenticator.js";
@@ -27,6 +28,7 @@ const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   cleanup: typeof cleanup;
   helpers: typeof helpers;
+  react: typeof react;
   registration: typeof registration;
   setup: typeof setup;
   testAuthenticator: typeof testAuthenticator;

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -1,0 +1,496 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthClient } from "../../browser/sessionManager";
+import { InMemoryStorage } from "../../browser/storage";
+import type { TokenBundle } from "../../lib/types";
+import type { AuthSignInApi } from "../../react/client";
+import { AuthProvider, useAuth } from "../../react/client";
+import { useAuthToken } from "../../react";
+import { PasskeyApi, PasskeySignInResult, usePasskey } from "./react";
+
+// The hook runs its mutations through the injected `AuthSignInApi`, so
+// the tests substitute a signInApi rather than mocking `convex/react`. The
+// passkey hook calls several different mutations, so this signInApi
+// dispatches on the reference (a string sentinel here) to one mock per
+// mutation.
+const mutations = {
+  startSignIn: vi.fn(),
+  finishSignIn: vi.fn(),
+  finishSignUp: vi.fn(),
+  startAutofillSignIn: vi.fn(),
+};
+const signInApi = {
+  mutation: (fn: unknown, args: unknown) =>
+    mutations[fn as keyof typeof mutations](args),
+} as unknown as AuthSignInApi;
+
+const passkeyApi = {
+  startSignIn: "startSignIn",
+  startAutofillSignIn: "startAutofillSignIn",
+  finishSignIn: "finishSignIn",
+  finishSignUp: "finishSignUp",
+} as unknown as PasskeyApi;
+
+// The browser WebAuthn surface. jsdom has none, so the tests install a
+// fake `PublicKeyCredential` and `navigator.credentials`.
+const credentialsCreate = vi.fn();
+const credentialsGet = vi.fn();
+
+class FakePublicKeyCredential {
+  static isConditionalMediationAvailable = async () => true;
+}
+
+const NAMESPACE = "https://happy-animal-123.convex.cloud";
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 0,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 0,
+  userId: "user-1",
+};
+
+const registerStart = {
+  success: true,
+  step: "register",
+  challenge: new ArrayBuffer(16),
+  userHandle: new ArrayBuffer(16),
+  excludeCredentials: [],
+  rpId: "localhost",
+  rpName: "Test app",
+};
+
+const authenticateStart = {
+  success: true,
+  step: "authenticate",
+  challenge: new ArrayBuffer(16),
+  allowCredentials: [new ArrayBuffer(8)],
+  rpId: "localhost",
+};
+
+// A stand-in for the credential `navigator.credentials.create()` returns.
+const attestationCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    attestationObject: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+  },
+};
+
+// A stand-in for the credential `navigator.credentials.get()` returns.
+const assertionCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    authenticatorData: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    signature: new ArrayBuffer(3),
+  },
+};
+
+// A conditional-mediation request that stays pending, like a real browser
+// request until the user picks a passkey. It respects the abort signal, so
+// the hook's abort protocol (STOP/PAUSE/REFRESH) works against it.
+function pendingUntilAborted({ signal }: { signal?: AbortSignal }) {
+  return new Promise((_, reject) => {
+    signal?.addEventListener("abort", () => reject(signal.reason), {
+      once: true,
+    });
+  });
+}
+
+// `vi.unstubAllGlobals()` does not undo `Object.defineProperty`, so the
+// tests restore the original `navigator.credentials` own property (or its
+// absence) themselves.
+const originalCredentials = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "credentials",
+);
+
+beforeEach(() => {
+  vi.stubGlobal("PublicKeyCredential", FakePublicKeyCredential);
+  vi.stubGlobal("isSecureContext", true);
+  Object.defineProperty(window.navigator, "credentials", {
+    value: { create: credentialsCreate, get: credentialsGet },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  if (originalCredentials === undefined) {
+    delete (window.navigator as { credentials?: unknown }).credentials;
+  } else {
+    Object.defineProperty(window.navigator, "credentials", originalCredentials);
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  for (const mock of Object.values(mutations)) {
+    mock.mockReset();
+  }
+  credentialsCreate.mockReset();
+  credentialsGet.mockReset();
+});
+
+function makeWrapper() {
+  const client = new AuthClient({
+    mode: "spa",
+    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    storage: new InMemoryStorage(),
+    storageNamespace: NAMESPACE,
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <AuthProvider authClient={client} signInApi={signInApi}>
+      {children}
+    </AuthProvider>
+  );
+}
+
+function renderPasskey(
+  initialProps: { autofill: boolean } = { autofill: false },
+) {
+  return renderHook(
+    ({ autofill }: { autofill: boolean }) => ({
+      auth: useAuth(),
+      token: useAuthToken(),
+      // A new api object on every render, like Convex's generated `api`
+      // proxy, whose property accesses never compare equal.
+      passkey: usePasskey({ ...passkeyApi }, { autofill }),
+    }),
+    { wrapper: makeWrapper(), initialProps },
+  );
+}
+
+describe("usePasskey signIn", () => {
+  test("sign-up success runs the registration ceremony and adopts the session", async () => {
+    mutations.startSignIn.mockResolvedValue(registerStart);
+    credentialsCreate.mockResolvedValue(attestationCredential);
+    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "alice" });
+    });
+
+    expect(mutations.startSignIn).toHaveBeenCalledWith({ username: "alice" });
+    expect(mutations.finishSignUp).toHaveBeenCalledWith({
+      username: "alice",
+      attestationObject: attestationCredential.response.attestationObject,
+      clientDataJSON: attestationCredential.response.clientDataJSON,
+    });
+    expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
+    expect(result.current.auth.isAuthenticated).toBe(true);
+    expect(result.current.token).toBe("access-1");
+  });
+
+  test("sign-in success runs the authentication ceremony and adopts the session", async () => {
+    mutations.startSignIn.mockResolvedValue(authenticateStart);
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.finishSignIn.mockResolvedValue({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+    });
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "alice" });
+    });
+
+    // `rawId` carries the credential ID bytes, not the base64url `id`.
+    expect(mutations.finishSignIn).toHaveBeenCalledWith({
+      credentialId: assertionCredential.rawId,
+      authenticatorData: assertionCredential.response.authenticatorData,
+      clientDataJSON: assertionCredential.response.clientDataJSON,
+      signature: assertionCredential.response.signature,
+    });
+    expect(returned).toEqual({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+      flow: "signIn",
+    });
+    expect(result.current.auth.isAuthenticated).toBe(true);
+  });
+
+  test("a server userError passes through without a ceremony", async () => {
+    const failure = {
+      success: false,
+      userError: { error: "USERNAME_INVALID" },
+    };
+    mutations.startSignIn.mockResolvedValue(failure);
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "no" });
+    });
+
+    expect(returned).toEqual(failure);
+    expect(credentialsCreate).not.toHaveBeenCalled();
+    expect(credentialsGet).not.toHaveBeenCalled();
+    expect(result.current.auth.isAuthenticated).toBe(false);
+  });
+
+  test("NotAllowedError folds into CEREMONY_ABORTED", async () => {
+    mutations.startSignIn.mockResolvedValue(authenticateStart);
+    credentialsGet.mockRejectedValue(
+      new DOMException("The operation was cancelled.", "NotAllowedError"),
+    );
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "alice" });
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    expect(result.current.auth.isAuthenticated).toBe(false);
+    expect(result.current.passkey.pending).toBe(false);
+  });
+
+  test("a second signIn while one runs fails fast and the first completes", async () => {
+    mutations.startSignIn.mockResolvedValue(authenticateStart);
+    let resolveCeremony!: (value: unknown) => void;
+    credentialsGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCeremony = resolve;
+      }),
+    );
+    mutations.finishSignIn.mockResolvedValue({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+    });
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let first!: Promise<PasskeySignInResult>;
+    act(() => {
+      first = result.current.passkey.signIn({ username: "alice" });
+    });
+    await waitFor(() => expect(result.current.passkey.pending).toBe(true));
+
+    // The second call must not start another ceremony or deadlock; it
+    // returns a folded failure immediately.
+    let second!: PasskeySignInResult;
+    await act(async () => {
+      second = await result.current.passkey.signIn({ username: "alice" });
+    });
+    expect(second).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    expect(mutations.startSignIn).toHaveBeenCalledTimes(1);
+
+    // The first call still completes normally.
+    let firstResult!: PasskeySignInResult;
+    await act(async () => {
+      resolveCeremony(assertionCredential);
+      firstResult = await first;
+    });
+    expect(firstResult).toEqual({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+      flow: "signIn",
+    });
+    expect(result.current.passkey.pending).toBe(false);
+    expect(result.current.auth.isAuthenticated).toBe(true);
+  });
+
+  test("signIn keeps one identity across re-renders", async () => {
+    const { result, rerender } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    const firstIdentity = result.current.passkey.signIn;
+    rerender({ autofill: false });
+    expect(result.current.passkey.signIn).toBe(firstIdentity);
+  });
+});
+
+describe("usePasskey autofill", () => {
+  test("autofill: false reports status 'idle' and available: false", async () => {
+    const { result, rerender } = renderPasskey({ autofill: false });
+    expect(result.current.passkey.autofill.status).toBe("idle");
+    expect(result.current.passkey.autofill.available).toBe(false);
+    rerender({ autofill: false });
+    expect(result.current.passkey.autofill.status).toBe("idle");
+    expect(result.current.passkey.autofill.available).toBe(false);
+    expect(mutations.startAutofillSignIn).not.toHaveBeenCalled();
+  });
+
+  test("a rejecting availability check reports available: false and status 'stopped'", async () => {
+    const spy = vi
+      .spyOn(FakePublicKeyCredential, "isConditionalMediationAvailable")
+      .mockRejectedValue(new Error("detection failed"));
+    const { result, unmount } = renderPasskey({ autofill: true });
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("stopped"),
+    );
+    expect(result.current.passkey.autofill.available).toBe(false);
+    expect(mutations.startAutofillSignIn).not.toHaveBeenCalled();
+    spy.mockRestore();
+
+    unmount();
+    await act(async () => {});
+  });
+
+  test("flipping autofill to false moves status from 'waiting' back to 'idle'", async () => {
+    mutations.startAutofillSignIn.mockResolvedValue({
+      challenge: new ArrayBuffer(16),
+      rpId: "localhost",
+    });
+    credentialsGet.mockImplementation(pendingUntilAborted);
+    const { result, rerender, unmount } = renderPasskey({ autofill: true });
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("waiting"),
+    );
+    expect(result.current.passkey.autofill.available).toBe(true);
+
+    rerender({ autofill: false });
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("idle"),
+    );
+
+    // Let the aborted loop settle before the next test runs.
+    unmount();
+    await act(async () => {});
+  });
+
+  test("a picked passkey signs the user in: waiting → signedIn", async () => {
+    mutations.startAutofillSignIn.mockResolvedValue({
+      challenge: new ArrayBuffer(16),
+      rpId: "localhost",
+    });
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.finishSignIn.mockResolvedValue({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+    });
+    const { result, unmount } = renderPasskey({ autofill: true });
+
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("signedIn"),
+    );
+    expect(mutations.finishSignIn).toHaveBeenCalledWith({
+      credentialId: assertionCredential.rawId,
+      authenticatorData: assertionCredential.response.authenticatorData,
+      clientDataJSON: assertionCredential.response.clientDataJSON,
+      signature: assertionCredential.response.signature,
+    });
+    expect(result.current.auth.isAuthenticated).toBe(true);
+    expect(result.current.passkey.autofill.lastError).toBe(null);
+
+    unmount();
+    await act(async () => {});
+  });
+
+  test("a success after a failed assertion clears lastError", async () => {
+    mutations.startAutofillSignIn.mockResolvedValue({
+      challenge: new ArrayBuffer(16),
+      rpId: "localhost",
+    });
+    credentialsGet.mockResolvedValue(assertionCredential);
+    // The first assertion fails on the server; the loop retries with a
+    // fresh challenge and the second one succeeds.
+    mutations.finishSignIn
+      .mockResolvedValueOnce({
+        success: false,
+        userError: { error: "VERIFICATION_FAILED" },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        tokens: bundle,
+        username: "alice",
+      });
+    const { result, unmount } = renderPasskey({ autofill: true });
+
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("signedIn"),
+    );
+    expect(result.current.auth.isAuthenticated).toBe(true);
+    // The failure of the first attempt must not stay visible after the
+    // user is signed in.
+    expect(result.current.passkey.autofill.lastError).toBe(null);
+
+    unmount();
+    await act(async () => {});
+  });
+
+  test("signIn pauses the pending autofill request and resumes it after", async () => {
+    mutations.startAutofillSignIn.mockResolvedValue({
+      challenge: new ArrayBuffer(16),
+      rpId: "localhost",
+    });
+    // The conditional (autofill) request stays pending until aborted; the
+    // modal ceremony resolves. Record every abort of a conditional
+    // request, so the test can see the PAUSE.
+    const conditionalAborts: unknown[] = [];
+    credentialsGet.mockImplementation(
+      (options: { mediation?: string; signal?: AbortSignal }) => {
+        if (options.mediation !== "conditional") {
+          // The modal ceremony must never run while a conditional request
+          // is pending; a real browser rejects it.
+          expect(conditionalAborts.length).toBeGreaterThan(0);
+          return Promise.resolve(assertionCredential);
+        }
+        return new Promise((_, reject) => {
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              conditionalAborts.push(options.signal!.reason);
+              reject(options.signal!.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    mutations.startSignIn.mockResolvedValue(authenticateStart);
+    mutations.finishSignIn.mockResolvedValue({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+    });
+    const { result, unmount } = renderPasskey({ autofill: true });
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("waiting"),
+    );
+    expect(mutations.startAutofillSignIn).toHaveBeenCalledTimes(1);
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "alice" });
+    });
+
+    // The modal flow paused the autofill request before its ceremony...
+    expect(conditionalAborts).toEqual(["PAUSE"]);
+    expect(returned).toEqual({
+      success: true,
+      tokens: bundle,
+      username: "alice",
+      flow: "signIn",
+    });
+    // ...and resumed it afterwards: the loop asks for a fresh challenge
+    // and a new conditional request starts.
+    await waitFor(() =>
+      expect(mutations.startAutofillSignIn).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(result.current.passkey.autofill.status).toBe("waiting"),
+    );
+
+    unmount();
+    await act(async () => {});
+  });
+});

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -393,9 +393,13 @@ export function usePasskey(
   const pendingRef = useRef(false);
 
   // The autofill flow's state.
-  const [available, setAvailable] = useState<boolean | null>(null);
-  const [status, setStatus] = useState<PasskeyAutofillStatus>("idle");
-  const [lastError, setLastError] = useState<PasskeyAutofillError | null>(null);
+  const [autofillAvailable, setAutofillAvailable] = useState<boolean | null>(
+    null,
+  );
+  const [autofillStatus, setAutofillStatus] =
+    useState<PasskeyAutofillStatus>("idle");
+  const [autofillLastError, setAutofillLastError] =
+    useState<PasskeyAutofillError | null>(null);
   const cancelAutofillRef = useRef<() => void>(() => {});
 
   // The pause/resume handle of the pending autofill request; `null` while
@@ -493,11 +497,11 @@ export function usePasskey(
     if (!autofillEnabled) {
       // Report the off state, so `status` does not stay stuck on the last
       // value of a previous enabled run.
-      setStatus("idle");
+      setAutofillStatus("idle");
       // No detection runs and the autocompletion list will not offer
       // passkeys. Report `false`, so `available` does not stay on `null`
       // ("detection runs") forever.
-      setAvailable(false);
+      setAutofillAvailable(false);
       return;
     }
     // The outer controller lives for the whole effect. The cleanup aborts
@@ -584,9 +588,9 @@ export function usePasskey(
       if (outer.signal.aborted) {
         return;
       }
-      setAvailable(supported);
+      setAutofillAvailable(supported);
       if (!supported) {
-        setStatus("stopped");
+        setAutofillStatus("stopped");
         return;
       }
 
@@ -615,14 +619,14 @@ export function usePasskey(
           continue;
         }
 
-        setStatus("waiting");
+        setAutofillStatus("waiting");
         let start;
         try {
           const { passkeyApi, signInApi } = currentRef.current;
           start = await signInApi.mutation(passkeyApi.startAutofillSignIn, {});
         } catch (cause) {
-          setLastError(foldClientError(cause));
-          setStatus("stopped");
+          setAutofillLastError(foldClientError(cause));
+          setAutofillStatus("stopped");
           return;
         }
         if (pauseCount > 0 || outer.signal.aborted) {
@@ -657,11 +661,11 @@ export function usePasskey(
             },
           })) as PublicKeyCredential | null;
           if (credential === null) {
-            setStatus("stopped");
+            setAutofillStatus("stopped");
             return;
           }
 
-          setStatus("signingIn");
+          setAutofillStatus("signingIn");
           const { passkeyApi, signInApi, setSession } = currentRef.current;
           const result = await signInApi.mutation(
             passkeyApi.finishSignIn,
@@ -676,14 +680,14 @@ export function usePasskey(
             await setSession(result.tokens);
             // A failed attempt earlier in this loop can have set
             // `lastError`. The sign-in succeeded, so clear it.
-            setLastError(null);
-            setStatus("signedIn");
+            setAutofillLastError(null);
+            setAutofillStatus("signedIn");
             return;
           }
-          setLastError(result.userError);
+          setAutofillLastError(result.userError);
           failures += 1;
           if (failures >= MAX_AUTOFILL_FAILURES) {
-            setStatus("stopped");
+            setAutofillStatus("stopped");
             return;
           }
           // Try again with a fresh challenge.
@@ -704,8 +708,8 @@ export function usePasskey(
           // another pending request, e.g. from a second `usePasskey`
           // instance): retrying would spin, so stop for good.
           // `foldClientError` maps it to `CEREMONY_ABORTED`.
-          setLastError(foldClientError(error));
-          setStatus("stopped");
+          setAutofillLastError(foldClientError(error));
+          setAutofillStatus("stopped");
           return;
         } finally {
           clearTimeout(refreshTimer);
@@ -736,7 +740,7 @@ export function usePasskey(
 
   const cancelAutofill = useCallback(() => {
     cancelAutofillRef.current();
-    setStatus("stopped");
+    setAutofillStatus("stopped");
   }, []);
 
   return {
@@ -763,11 +767,11 @@ export function usePasskey(
        * Whether the browser can offer passkeys in the autocompletion
        * list. `null` while detection runs; `false` when autofill is off.
        */
-      available,
+      available: autofillAvailable,
       /** The state of the request; see {@link PasskeyAutofillStatus}. */
-      status,
+      status: autofillStatus,
       /** The most recent failure, for display or logging. */
-      lastError,
+      lastError: autofillLastError,
       /** Stop the pending autofill request for good. */
       cancel: cancelAutofill,
     },

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -1,0 +1,770 @@
+/**
+ * React client for the passkey provider, exported at
+ * `@convex-dev/auth/providers/passkey/react`.
+ *
+ * The React client wraps the browser-side WebAuthentication code
+ * (`navigator.credentials`). It exports a `usePasskey` hook that is used
+ * on the passkey login form, which handles both:
+ * - Manually logging in by providing an identifier (e.g. username)
+ *   then registering a new passkey or logging in
+ * - Passkey autofill (conditional mediation) where the user selects an account
+ *   directly in the autocompletion list.
+ *
+ * @module
+ */
+"use client";
+
+import type { FunctionReference } from "convex/server";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ClientView } from "../../lib/types";
+import { useAuthActions, useAuthSignInApi } from "../../react";
+import type {
+  FinishSignInResult,
+  FinishSignUpResult,
+  StartAutofillSignInResult,
+  StartSignInResult,
+} from "./setup";
+import { CHALLENGE_TTL_MS } from "./validation";
+
+/**
+ * The `startSignIn` mutation the app re-exports from its `setupCore`.
+ */
+type StartSignInMutation = FunctionReference<
+  "mutation",
+  "public",
+  { username: string },
+  StartSignInResult
+>;
+
+/**
+ * The `startAutofillSignIn` mutation the app re-exports from its
+ * `setupCore`.
+ */
+type StartAutofillSignInMutation = FunctionReference<
+  "mutation",
+  "public",
+  Record<string, never>,
+  StartAutofillSignInResult
+>;
+
+/**
+ * The `finishSignUp` mutation the app re-exports from its `setupCore`.
+ *
+ * Its return value is the access-only {@link ClientView}, which is what both
+ * session models have in common. Hand it to `setSession`, the only supported
+ * consumer.
+ */
+type FinishSignUpMutation = FunctionReference<
+  "mutation",
+  "public",
+  {
+    username: string;
+    attestationObject: ArrayBuffer;
+    clientDataJSON: ArrayBuffer;
+  },
+  ClientView<FinishSignUpResult>
+>;
+
+/**
+ * The `finishSignIn` mutation the app re-exports from its `setupCore`.
+ */
+type FinishSignInMutation = FunctionReference<
+  "mutation",
+  "public",
+  {
+    credentialId: ArrayBuffer;
+    authenticatorData: ArrayBuffer;
+    clientDataJSON: ArrayBuffer;
+    signature: ArrayBuffer;
+  },
+  ClientView<FinishSignInResult>
+>;
+
+/** The mutation references {@link usePasskey} drives. */
+export type PasskeyApi = {
+  startSignIn: StartSignInMutation;
+  startAutofillSignIn: StartAutofillSignInMutation;
+  finishSignIn: FinishSignInMutation;
+  finishSignUp: FinishSignUpMutation;
+};
+
+/**
+ * Failures the client produces that the server never returns. The hook
+ * folds them into the result so callers handle *every* failure through the
+ * one `userError` switch and never need their own `try`/`catch`:
+ *
+ * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
+ *   refused the ceremony (`NotAllowedError`), or a second `signIn` call
+ *   came in while one was already running (the browser would refuse the
+ *   second modal ceremony anyway). This is the most common failure; show a
+ *   calm "sign-in was cancelled" message.
+ * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
+ *   page is not a secure context.
+ * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
+ *   unexpected server error). The thrown value is preserved on `cause` for
+ *   callers that want to inspect or log it.
+ */
+type ClientFailure = {
+  success: false;
+  userError:
+    | { error: "CEREMONY_ABORTED" }
+    | { error: "WEBAUTHN_UNSUPPORTED" }
+    | { error: "OTHER_ERROR"; cause: unknown };
+};
+
+/**
+ * The result of the `signIn` callback from {@link usePasskey}.
+ *
+ * A success carries a `flow` discriminant: `"signUp"` when the ceremony
+ * created a new account, `"signIn"` when it authenticated an existing one.
+ */
+export type PasskeySignInResult =
+  | (Extract<ClientView<FinishSignUpResult>, { success: true }> & {
+      flow: "signUp";
+    })
+  | (Extract<ClientView<FinishSignInResult>, { success: true }> & {
+      flow: "signIn";
+    })
+  | Extract<ClientView<FinishSignUpResult>, { success: false }>
+  | Extract<ClientView<FinishSignInResult>, { success: false }>
+  | Extract<StartSignInResult, { success: false }>
+  | ClientFailure;
+
+/**
+ * The failures the `autofill` flow of {@link usePasskey} reports through
+ * `lastError`: the server's `finishSignIn` errors plus the client-side
+ * {@link ClientFailure} errors. Every thrown value is folded into this
+ * shape, so callers handle every failure through the one `error` switch.
+ */
+export type PasskeyAutofillError =
+  | Extract<FinishSignInResult, { success: false }>["userError"]
+  | ClientFailure["userError"];
+
+/**
+ * The states of the `autofill` flow of {@link usePasskey}:
+ *
+ * - `"idle"`: the flow has not started yet, or autofill is off.
+ * - `"waiting"`: the autofill request is pending in the browser.
+ * - `"signingIn"`: an assertion is being verified on the server.
+ * - `"signedIn"`: the sign-in succeeded and the session is set.
+ * - `"stopped"`: the flow is done without a sign-in (cancellation,
+ *   failure, or no browser support).
+ */
+export type PasskeyAutofillStatus =
+  "idle" | "waiting" | "signingIn" | "signedIn" | "stopped";
+
+// A pending autofill request refreshes its challenge before the server's
+// challenge TTL expires. The two-minute margin makes sure the challenge
+// that the user finally redeems is never expired.
+const AUTOFILL_REFRESH_MS = CHALLENGE_TTL_MS - 2 * 60 * 1000;
+
+// After this many autofill assertions in a row come back as a `userError`,
+// the autofill flow stops instead of asking the browser again.
+const MAX_AUTOFILL_FAILURES = 3;
+
+// The values a pending autofill `credentials.get()` is aborted with. The
+// promise rejects with the abort reason, so the loop can tell why it woke.
+type AutofillAbortReason = "STOP" | "REFRESH" | "PAUSE";
+
+/**
+ * The pause/resume gates of a running autofill loop. `pause()` aborts the
+ * in-flight browser request and resolves when the loop is parked;
+ * `resume()` lets the loop start a fresh request.
+ */
+type AutofillHandle = {
+  pause: () => Promise<void>;
+  resume: () => void;
+};
+
+function supportsWebAuthn(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof PublicKeyCredential !== "undefined" &&
+    window.isSecureContext
+  );
+}
+
+function isCeremonyAborted(cause: unknown): boolean {
+  // `NotAllowedError` is what the browser throws when the user dismisses
+  // the dialog, when the ceremony times out, and when the page is not
+  // allowed to run one. A `null` credential is handled separately.
+  return cause instanceof DOMException && cause.name === "NotAllowedError";
+}
+
+/**
+ * Fold a thrown value into the {@link ClientFailure} `userError` shape, so
+ * callers handle every failure through the one `userError` switch.
+ */
+function foldClientError(cause: unknown): ClientFailure["userError"] {
+  if (isCeremonyAborted(cause)) {
+    return { error: "CEREMONY_ABORTED" };
+  }
+  return { error: "OTHER_ERROR", cause };
+}
+
+/**
+ * When the thrown value is the abort of the given signal, return the abort
+ * reason. Return `null` for every other error, even when the signal aborted
+ * afterwards: a real failure can race a `PAUSE`/`REFRESH` abort, and the
+ * signal alone would misattribute it.
+ */
+function autofillAbortReason(
+  error: unknown,
+  signal: AbortSignal,
+): AutofillAbortReason | null {
+  if (error === "STOP" || error === "REFRESH" || error === "PAUSE") {
+    // The browser rejected with the abort reason itself.
+    return error;
+  }
+  if (
+    error instanceof DOMException &&
+    error.name === "AbortError" &&
+    signal.aborted
+  ) {
+    // The browser rejected with a generic `AbortError`: the reason is on
+    // the signal.
+    const reason = signal.reason as unknown;
+    if (reason === "REFRESH" || reason === "PAUSE") {
+      return reason;
+    }
+    return "STOP";
+  }
+  return null;
+}
+
+/** The `finishSignIn` arguments derived from a WebAuthn assertion. */
+type AssertionArgs = {
+  credentialId: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  signature: ArrayBuffer;
+};
+
+/**
+ * Turn an assertion credential into the `finishSignIn` arguments. Shared
+ * between the modal authenticate path and the autofill path.
+ */
+function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    // `rawId` carries the credential ID bytes; `credential.id` is the
+    // base64url form and must not be sent.
+    credentialId: credential.rawId,
+    authenticatorData: response.authenticatorData,
+    clientDataJSON: response.clientDataJSON,
+    signature: response.signature,
+  };
+}
+
+/**
+ * Run the modal registration ceremony and return the `finishSignUp`
+ * arguments, or `null` when the browser returns no credential.
+ */
+async function runRegistrationCeremony(
+  username: string,
+  start: Extract<StartSignInResult, { step: "register" }>,
+): Promise<{
+  username: string;
+  attestationObject: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+} | null> {
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      challenge: start.challenge,
+      rp: { id: start.rpId, name: start.rpName },
+      // The handle comes from the server: the app user id cannot be used,
+      // because the user row does not exist yet.
+      user: {
+        id: start.userHandle,
+        name: username,
+        displayName: username,
+      },
+      // Exactly the algorithms the server accepts (ES256 and RS256; see
+      // the verification in `registration.ts`).
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 }, // ES256
+        { type: "public-key", alg: -257 }, // RS256
+      ],
+      // A discoverable credential is required for autofill, and the
+      // server hard-requires user verification.
+      authenticatorSelection: {
+        residentKey: "required",
+        requireResidentKey: true,
+        userVerification: "required",
+      },
+      attestation: "none",
+      excludeCredentials: start.excludeCredentials.map((id) => ({
+        type: "public-key",
+        id,
+      })),
+    },
+  })) as PublicKeyCredential | null;
+  if (credential === null) {
+    return null;
+  }
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    username,
+    attestationObject: response.attestationObject,
+    clientDataJSON: response.clientDataJSON,
+  };
+}
+
+/**
+ * Run the modal authentication ceremony and return the `finishSignIn`
+ * arguments, or `null` when the browser returns no credential.
+ */
+async function runAuthenticationCeremony(
+  start: Extract<StartSignInResult, { step: "authenticate" }>,
+): Promise<AssertionArgs | null> {
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge: start.challenge,
+      rpId: start.rpId,
+      allowCredentials: start.allowCredentials.map((id) => ({
+        type: "public-key",
+        id,
+      })),
+      userVerification: "required",
+    },
+  })) as PublicKeyCredential | null;
+  if (credential === null) {
+    return null;
+  }
+  return assertionArgs(credential);
+}
+
+/**
+ * Client for the passkey provider.
+ *
+ * This client handles both:
+ * - Manually logging in by providing an identifier (e.g. username)
+ *   then registering a new passkey or logging in
+ * - Passkey autofill (conditional mediation) where the user selects an account
+ *   directly in the autocompletion list.
+ *
+ * ```tsx
+ * import { usePasskey } from "@convex-dev/auth/providers/passkey/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * function LogIn() {
+ *   const { signIn, pending, autofill } = usePasskey({
+ *     startSignIn: api.auth.startSignIn,
+ *     startAutofillSignIn: api.auth.startAutofillSignIn,
+ *     finishSignIn: api.auth.finishSignIn,
+ *     finishSignUp: api.auth.finishSignUp,
+ *   });
+ *   return (
+ *     <form
+ *       onSubmit={async (e) => {
+ *         e.preventDefault();
+ *         const result = await signIn({ username });
+ *         if (!result.success) {
+ *           // map result.userError to a message
+ *         }
+ *       }}
+ *     >
+ *       <input autoComplete="username webauthn" ... />
+ *       <button disabled={pending}>Continue</button>
+ *     </form>
+ *   );
+ * }
+ * ```
+ *
+ * @param api The app's re-exported passkey mutation references.
+ * @param options Set `autofill: false` to keep the autofill request off.
+ */
+export function usePasskey(
+  api: PasskeyApi,
+  options: { autofill?: boolean } = {},
+) {
+  // TODO(nicolas) Refactor this hook, potentially allow more extensibility
+
+  const { autofill: autofillEnabled = true } = options;
+  const { setSession } = useAuthActions();
+  // Running through the signInApi rather than `useMutation` is what lets
+  // this hook serve both session models (SPA + SSR).
+  const signInApi = useAuthSignInApi();
+
+  // The identifier-first (modal) flow's state.
+  const [pending, setPending] = useState(false);
+  // The re-entry guard reads through a ref: `pending` from `useState`
+  // would be stale inside the callback.
+  const pendingRef = useRef(false);
+
+  // The autofill flow's state.
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [status, setStatus] = useState<PasskeyAutofillStatus>("idle");
+  const [lastError, setLastError] = useState<PasskeyAutofillError | null>(null);
+  const cancelAutofillRef = useRef<() => void>(() => {});
+
+  // The pause/resume handle of the pending autofill request; `null` while
+  // no autofill loop runs. Browsers reject a modal `credentials.create()`
+  // /`get()` while a conditional (autofill) request is pending on the same
+  // page, so the modal flow must pause the autofill request first and
+  // resume it when the modal ceremony is over. Both flows live in this
+  // hook, so the handle is instance state — a ref — and no cross-component
+  // coordination exists.
+  const autofillHandleRef = useRef<AutofillHandle | null>(null);
+
+  // The flows read the mutation references, the sign-in API and
+  // `setSession` through a ref: their identities are not stable across
+  // renders (Convex's generated `api` object creates a new reference on
+  // every property access), and neither `signIn`'s identity nor the
+  // pending browser request must change on a render.
+  const currentRef = useRef({ api, signInApi, setSession });
+  currentRef.current = { api, signInApi, setSession };
+
+  const signIn = useCallback(
+    async ({
+      username,
+    }: {
+      username: string;
+    }): Promise<PasskeySignInResult> => {
+      // Refuse a second call while one is running: it would deadlock the
+      // autofill pause/resume protocol, and the browser rejects a second
+      // modal ceremony anyway.
+      if (pendingRef.current) {
+        return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+      }
+      pendingRef.current = true;
+      setPending(true);
+      // Pause the pending autofill request before the modal ceremony, and
+      // resume it whatever the outcome. Capture the handle once, so pause
+      // and resume act on the same loop even when the autofill effect
+      // restarts mid-ceremony.
+      const autofillHandle = autofillHandleRef.current;
+      await autofillHandle?.pause();
+      try {
+        if (!supportsWebAuthn()) {
+          return {
+            success: false,
+            userError: { error: "WEBAUTHN_UNSUPPORTED" },
+          };
+        }
+        const { api, signInApi, setSession } = currentRef.current;
+
+        const start = await signInApi.mutation(api.startSignIn, { username });
+        if (!start.success) {
+          return start;
+        }
+
+        if (start.step === "register") {
+          const args = await runRegistrationCeremony(username, start);
+          if (args === null) {
+            return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+          }
+          const result = await signInApi.mutation(api.finishSignUp, args);
+          if (!result.success) {
+            return result;
+          }
+          await setSession(result.tokens);
+          return { ...result, flow: "signUp" };
+        }
+
+        const args = await runAuthenticationCeremony(start);
+        if (args === null) {
+          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        }
+        const result = await signInApi.mutation(api.finishSignIn, args);
+        if (!result.success) {
+          return result;
+        }
+        await setSession(result.tokens);
+        return { ...result, flow: "signIn" };
+      } catch (cause) {
+        return { success: false, userError: foldClientError(cause) };
+      } finally {
+        autofillHandle?.resume();
+        // Reset even when something throws.
+        pendingRef.current = false;
+        setPending(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!autofillEnabled) {
+      // Report the off state, so `status` does not stay stuck on the last
+      // value of a previous enabled run.
+      setStatus("idle");
+      // No detection runs and the autocompletion list will not offer
+      // passkeys. Report `false`, so `available` does not stay on `null`
+      // ("detection runs") forever.
+      setAvailable(false);
+      return;
+    }
+    // The outer controller lives for the whole effect. The cleanup aborts
+    // it with `STOP`, which makes the autofill flow StrictMode-safe by
+    // construction: the throwaway first mount's loop sees its own
+    // controller aborted and exits, while the second mount runs its own
+    // loop with its own controller.
+    const outer = new AbortController();
+    cancelAutofillRef.current = () =>
+      outer.abort("STOP" satisfies AutofillAbortReason);
+
+    // The pause/resume gates behind the {@link AutofillHandle} this effect
+    // publishes on `autofillHandleRef`. The pauses are reference-counted,
+    // so nested pause/resume pairs compose (the modal flow and the
+    // tab-visibility pause can overlap).
+    let pauseCount = 0;
+    let parked = false;
+    let inner: AbortController | null = null;
+    let onParked: (() => void) | null = null;
+    let onResumed: (() => void) | null = null;
+    const handle: AutofillHandle = {
+      pause: () => {
+        pauseCount += 1;
+        if (parked) {
+          // The loop is already parked: there is nothing to wait for.
+          return Promise.resolve();
+        }
+        // Chain onto an earlier waiter, so two concurrent `pause()` calls
+        // both resolve when the loop parks.
+        const previous = onParked;
+        const parkedPromise = new Promise<void>((resolve) => {
+          onParked = () => {
+            previous?.();
+            resolve();
+          };
+        });
+        inner?.abort("PAUSE" satisfies AutofillAbortReason);
+        return parkedPromise;
+      },
+      resume: () => {
+        pauseCount = Math.max(0, pauseCount - 1);
+        if (pauseCount === 0) {
+          onResumed?.();
+          onResumed = null;
+        }
+      },
+    };
+
+    // Pause the loop while the tab is hidden: a background tab must not
+    // keep minting fresh challenges. On return to a visible tab, the loop
+    // resumes with a fresh challenge.
+    let pausedForVisibility = false;
+    const onVisibilityChange = () => {
+      if (document.hidden && !pausedForVisibility) {
+        pausedForVisibility = true;
+        void handle.pause();
+      } else if (!document.hidden && pausedForVisibility) {
+        pausedForVisibility = false;
+        handle.resume();
+      }
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+      // The tab can already be hidden when the effect runs.
+      onVisibilityChange();
+    }
+
+    const run = async () => {
+      // Feature-detect conditional mediation. The method is a static one,
+      // and it is absent in older browsers: guard before calling it. Count
+      // a rejection as "not available": if it escaped, the promise chain
+      // below would reject unhandled and the hook would stay on
+      // `available: null` and `status: "idle"` forever.
+      let supported = false;
+      try {
+        supported =
+          supportsWebAuthn() &&
+          typeof PublicKeyCredential.isConditionalMediationAvailable ===
+            "function" &&
+          (await PublicKeyCredential.isConditionalMediationAvailable());
+      } catch {
+        // Keep `supported` as `false`.
+      }
+      if (outer.signal.aborted) {
+        return;
+      }
+      setAvailable(supported);
+      if (!supported) {
+        setStatus("stopped");
+        return;
+      }
+
+      // Publish the handle for the modal flow. A StrictMode remount
+      // cannot get here twice: the first mount's loop sees its aborted
+      // controller at the check above and returns first.
+      autofillHandleRef.current = handle;
+      let failures = 0;
+      while (!outer.signal.aborted) {
+        if (pauseCount > 0) {
+          // Park until the modal flow resumes us (or the hook stops).
+          parked = true;
+          onParked?.();
+          onParked = null;
+          let release!: () => void;
+          const parkWait = new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          onResumed = release;
+          outer.signal.addEventListener("abort", release, { once: true });
+          await parkWait;
+          // Remove the listener: repeated park cycles must not accumulate
+          // listeners on the outer signal.
+          outer.signal.removeEventListener("abort", release);
+          parked = false;
+          continue;
+        }
+
+        setStatus("waiting");
+        let start;
+        try {
+          const { api, signInApi } = currentRef.current;
+          start = await signInApi.mutation(api.startAutofillSignIn, {});
+        } catch (cause) {
+          setLastError(foldClientError(cause));
+          setStatus("stopped");
+          return;
+        }
+        if (pauseCount > 0 || outer.signal.aborted) {
+          // The modal flow paused us while the challenge was being
+          // fetched: park (at the top of the loop) before a new browser
+          // request starts.
+          continue;
+        }
+
+        inner = new AbortController();
+        const innerController = inner;
+        const forwardAbort = () =>
+          innerController.abort(outer.signal.reason ?? "STOP");
+        outer.signal.addEventListener("abort", forwardAbort, { once: true });
+        // Refresh before the server's challenge TTL, so the challenge
+        // that the user finally redeems is never expired.
+        const refreshTimer = setTimeout(
+          () => innerController.abort("REFRESH" satisfies AutofillAbortReason),
+          AUTOFILL_REFRESH_MS,
+        );
+        try {
+          const credential = (await navigator.credentials.get({
+            mediation: "conditional",
+            signal: innerController.signal,
+            publicKey: {
+              challenge: start.challenge,
+              rpId: start.rpId,
+              userVerification: "required",
+              // No allow-list: the passkey the user picks identifies the
+              // account.
+              allowCredentials: [],
+            },
+          })) as PublicKeyCredential | null;
+          if (credential === null) {
+            setStatus("stopped");
+            return;
+          }
+
+          setStatus("signingIn");
+          const { api, signInApi, setSession } = currentRef.current;
+          const result = await signInApi.mutation(
+            api.finishSignIn,
+            assertionArgs(credential),
+          );
+          if (result.success) {
+            // Residual race with the modal flow: when the user resolves
+            // the autofill assertion just before the modal flow pauses us,
+            // and the modal ceremony also completes, `setSession` runs
+            // twice and the last write wins. Both sessions are valid, so
+            // this is harmless.
+            await setSession(result.tokens);
+            // A failed attempt earlier in this loop can have set
+            // `lastError`. The sign-in succeeded, so clear it.
+            setLastError(null);
+            setStatus("signedIn");
+            return;
+          }
+          setLastError(result.userError);
+          failures += 1;
+          if (failures >= MAX_AUTOFILL_FAILURES) {
+            setStatus("stopped");
+            return;
+          }
+          // Try again with a fresh challenge.
+        } catch (error) {
+          // Look at the thrown value before the signal: a real failure
+          // can race a `PAUSE`/`REFRESH` abort, and the signal alone
+          // would misattribute it.
+          const reason = autofillAbortReason(error, innerController.signal);
+          if (reason === "REFRESH" || reason === "PAUSE") {
+            // The top of the loop starts a fresh request, or parks until
+            // `resume()`.
+            continue;
+          }
+          if (reason === "STOP") {
+            return; // The hook unmounted or `cancel()` ran.
+          }
+          // Includes `NotAllowedError` (a permissions-policy refusal or
+          // another pending request, e.g. from a second `usePasskey`
+          // instance): retrying would spin, so stop for good.
+          // `foldClientError` maps it to `CEREMONY_ABORTED`.
+          setLastError(foldClientError(error));
+          setStatus("stopped");
+          return;
+        } finally {
+          clearTimeout(refreshTimer);
+          outer.signal.removeEventListener("abort", forwardAbort);
+          inner = null;
+        }
+      }
+    };
+
+    void run().finally(() => {
+      // Never leave a `pause()` caller hanging, whatever path exited the
+      // loop.
+      onParked?.();
+      onParked = null;
+      // Retract the handle, unless a newer effect run published its own.
+      if (autofillHandleRef.current === handle) {
+        autofillHandleRef.current = null;
+      }
+    });
+
+    return () => {
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      }
+      outer.abort("STOP" satisfies AutofillAbortReason);
+    };
+  }, [autofillEnabled]);
+
+  const cancelAutofill = useCallback(() => {
+    cancelAutofillRef.current();
+    setStatus("stopped");
+  }, []);
+
+  return {
+    /**
+     * Runs the identifier-first passkey flow for the given username.
+     *
+     * Returns an object with a `success` boolean flag.
+     *
+     * If it is `true` the sign-in (or the account creation) was successful
+     * and the client will establish an authenticated session with the
+     * Convex backend server. The `flow` field tells which one it was:
+     * `"signUp"` created a new account, `"signIn"` authenticated an
+     * existing one.
+     *
+     * If it is `false` the returned object will have a `userError` field
+     * with additional details about why sign-in failed.
+     */
+    signIn,
+    /** `true` while a `signIn` attempt is running. */
+    pending,
+    /** The autofill flow's state. */
+    autofill: {
+      /**
+       * Whether the browser can offer passkeys in the autocompletion
+       * list. `null` while detection runs; `false` when autofill is off.
+       */
+      available,
+      /** The state of the request; see {@link PasskeyAutofillStatus}. */
+      status,
+      /** The most recent failure, for display or logging. */
+      lastError,
+      /** Stop the pending autofill request for good. */
+      cancel: cancelAutofill,
+    },
+  };
+}

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -371,11 +371,11 @@ async function runAuthenticationCeremony(
  * }
  * ```
  *
- * @param api The app's re-exported passkey mutation references.
+ * @param passkeyApi The app's re-exported passkey mutation references.
  * @param options Set `autofill: false` to keep the autofill request off.
  */
 export function usePasskey(
-  api: PasskeyApi,
+  passkeyApi: PasskeyApi,
   options: { autofill?: boolean } = {},
 ) {
   // TODO(nicolas) Refactor this hook, potentially allow more extensibility
@@ -412,8 +412,8 @@ export function usePasskey(
   // renders (Convex's generated `api` object creates a new reference on
   // every property access), and neither `signIn`'s identity nor the
   // pending browser request must change on a render.
-  const currentRef = useRef({ api, signInApi, setSession });
-  currentRef.current = { api, signInApi, setSession };
+  const currentRef = useRef({ passkeyApi, signInApi, setSession });
+  currentRef.current = { passkeyApi, signInApi, setSession };
 
   const signIn = useCallback(
     async ({
@@ -442,9 +442,11 @@ export function usePasskey(
             userError: { error: "WEBAUTHN_UNSUPPORTED" },
           };
         }
-        const { api, signInApi, setSession } = currentRef.current;
+        const { passkeyApi, signInApi, setSession } = currentRef.current;
 
-        const start = await signInApi.mutation(api.startSignIn, { username });
+        const start = await signInApi.mutation(passkeyApi.startSignIn, {
+          username,
+        });
         if (!start.success) {
           return start;
         }
@@ -454,7 +456,10 @@ export function usePasskey(
           if (args === null) {
             return { success: false, userError: { error: "CEREMONY_ABORTED" } };
           }
-          const result = await signInApi.mutation(api.finishSignUp, args);
+          const result = await signInApi.mutation(
+            passkeyApi.finishSignUp,
+            args,
+          );
           if (!result.success) {
             return result;
           }
@@ -466,7 +471,7 @@ export function usePasskey(
         if (args === null) {
           return { success: false, userError: { error: "CEREMONY_ABORTED" } };
         }
-        const result = await signInApi.mutation(api.finishSignIn, args);
+        const result = await signInApi.mutation(passkeyApi.finishSignIn, args);
         if (!result.success) {
           return result;
         }
@@ -613,8 +618,8 @@ export function usePasskey(
         setStatus("waiting");
         let start;
         try {
-          const { api, signInApi } = currentRef.current;
-          start = await signInApi.mutation(api.startAutofillSignIn, {});
+          const { passkeyApi, signInApi } = currentRef.current;
+          start = await signInApi.mutation(passkeyApi.startAutofillSignIn, {});
         } catch (cause) {
           setLastError(foldClientError(cause));
           setStatus("stopped");
@@ -657,9 +662,9 @@ export function usePasskey(
           }
 
           setStatus("signingIn");
-          const { api, signInApi, setSession } = currentRef.current;
+          const { passkeyApi, signInApi, setSession } = currentRef.current;
           const result = await signInApi.mutation(
-            api.finishSignIn,
+            passkeyApi.finishSignIn,
             assertionArgs(credential),
           );
           if (result.success) {


### PR DESCRIPTION
Adds the React client for the passkey provider.

This is a first draft: I probably will want to have a closer look at the implementation of `usePasskey` to:
- make sure the implementation is resilient
- potentially split the hook into smaller pieces so that it can be reused in custom passkey-based auth flows
- potentially restructure the hook around SimpleWebAuthn