### PR TITLE
Fix lifecycle issue on React Native

### DIFF
--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -11,6 +11,19 @@ const NAMESPACE = "https://happy-animal-123.convex.cloud";
 // Matches NamespacedStorage's `replace(/[^a-zA-Z0-9]/g, "")`.
 const SUFFIX = "httpshappyanimal123convexcloud";
 
+// Tests below swap in a stub `window` to simulate other runtimes. The
+// edge-runtime environment these tests run in supplies its own (`window ===
+// globalThis`, with working DOM event APIs), so we put that back afterwards.
+const ORIGINAL_WINDOW = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+function restoreWindow(): void {
+  if (ORIGINAL_WINDOW === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    Object.defineProperty(globalThis, "window", ORIGINAL_WINDOW);
+  }
+}
+
 function bundle(n: number): TokenBundle {
   return {
     accessToken: `access-${n}`,
@@ -58,9 +71,7 @@ function makeSsrClient(
 }
 
 describe("AuthClient", () => {
-  afterEach(() => {
-    delete (globalThis as { window?: unknown }).window;
-  });
+  afterEach(restoreWindow);
 
   test("starts unauthenticated with an empty store", async () => {
     const { client } = makeClient();
@@ -213,6 +224,29 @@ describe("AuthClient", () => {
     });
   });
 
+  test("works where `window` exists without DOM event APIs (React Native)", async () => {
+    // React Native's global object *is* `window`, but it has no
+    // addEventListener/removeEventListener. Cross-tab sync is skipped rather
+    // than throwing when the provider mounts.
+    (globalThis as { window?: unknown }).window = { navigator: {} };
+
+    const { client } = makeClient();
+    await expect(client.init()).resolves.toBeUndefined();
+    await client.setSession(bundle(1));
+    expect(client.getSnapshot().isAuthenticated).toBe(true);
+    expect(() => client.dispose()).not.toThrow();
+  });
+
+  test("works where there is no `window` at all (server runtime)", async () => {
+    delete (globalThis as { window?: unknown }).window;
+
+    const { client } = makeClient();
+    await expect(client.init()).resolves.toBeUndefined();
+    await client.setSession(bundle(1));
+    expect(client.getSnapshot().isAuthenticated).toBe(true);
+    expect(() => client.dispose()).not.toThrow();
+  });
+
   test("re-attaches the storage listener when init runs after dispose", async () => {
     const listeners = new Set<(event: StorageEvent) => void>();
     const storage = new InMemoryStorage();
@@ -264,9 +298,7 @@ function ssrAuthResult(n: number): SlimTokenBundle {
 }
 
 describe("AuthClient (SSR)", () => {
-  afterEach(() => {
-    delete (globalThis as { window?: unknown }).window;
-  });
+  afterEach(restoreWindow);
 
   test("setSession adopts an access-only session, storing no refresh token", async () => {
     const { client, storage } = makeSsrClient();

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -101,6 +101,26 @@ function hasRefreshToken(
   return "refreshToken" in session;
 }
 
+/**
+ * Returns the global `window` object when it supports DOM event listeners,
+ * otherwise `null`.
+ *
+ * It will be `null` on platforms like React Native.
+ */
+function domEventTarget(): Pick<
+  Window,
+  "addEventListener" | "removeEventListener"
+> | null {
+  if (typeof window === "undefined") return null;
+  if (
+    typeof window.addEventListener !== "function" ||
+    typeof window.removeEventListener !== "function"
+  ) {
+    return null;
+  }
+  return window;
+}
+
 function isNetworkError(error: unknown): boolean {
   return (
     error instanceof TypeError &&
@@ -207,7 +227,7 @@ export class AuthClient {
 
   /**
    * Load any persisted session from storage and start listening for cross-tab
-   * changes. Until this resolves, the client reports `isLoading`.
+   * changes (if applicable). Until this resolves, the client reports `isLoading`.
    *
    * Symmetric and repeatable with {@link dispose}: loading the session happens
    * once, but the cross-tab listener is (re)attached on every call, so an
@@ -238,16 +258,18 @@ export class AuthClient {
   }
 
   /**
-   * Detach the cross-tab storage listener. Call on teardown. Store subscribers
-   * are intentionally left in place — each is removed via the unsubscribe
-   * returned by {@link subscribe} — so a later {@link init} restores the client
-   * without losing its subscribers.
+   * Detach a registered cross-tab storage listener, if applicable.
+   *
+   * Call on teardown. Store subscribers are intentionally left in place — each
+   * is removed via the unsubscribe returned by {@link subscribe} — so a later
+   * {@link init} restores the client without losing its subscribers.
    */
   dispose(): void {
-    if (this.#storageListener !== null && typeof window !== "undefined") {
-      window.removeEventListener("storage", this.#storageListener);
-      this.#storageListener = null;
+    const target = domEventTarget();
+    if (this.#storageListener !== null && target !== null) {
+      target.removeEventListener("storage", this.#storageListener);
     }
+    this.#storageListener = null;
   }
 
   // --- Public actions ------------------------------------------------------
@@ -411,7 +433,9 @@ export class AuthClient {
   }
 
   #attachStorageListener(): void {
-    if (typeof window === "undefined") return;
+    const target = domEventTarget();
+    // This null check guards React Native, where cross-tab storage isn't a thing.
+    if (target === null) return;
     if (this.#storageListener !== null) return;
     const jwtKey = this.#storage.key(JWT_STORAGE_KEY);
     const refreshKey = this.#storage.key(REFRESH_TOKEN_STORAGE_KEY);
@@ -430,7 +454,7 @@ export class AuthClient {
         this.#refreshToken = event.newValue;
       }
     };
-    window.addEventListener("storage", listener);
+    target.addEventListener("storage", listener);
     this.#storageListener = listener;
   }
 


### PR DESCRIPTION
There's no cross-tab storage to synchronize on RN, so if there aren't DOM APIs on the global `window`, skip the storage listener setup/teardown.