### PR TITLE
Add a warning that will let React Native apps know they need to configure token storage

### DIFF
--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { SlimTokenBundle, TokenBundle } from "../lib/types";
-import { AuthClient, SpaAuthApi, SsrAuthApi } from "./sessionManager";
+import {
+  AuthClient,
+  INITIAL_AUTH_STATE,
+  SpaAuthApi,
+  SsrAuthApi,
+} from "./sessionManager";
 import {
   InMemoryStorage,
   JWT_STORAGE_KEY,
   REFRESH_TOKEN_STORAGE_KEY,
+  type TokenStorage,
 } from "./storage";
 
 const NAMESPACE = "https://happy-animal-123.convex.cloud";
@@ -34,9 +40,11 @@ function bundle(n: number): TokenBundle {
   };
 }
 
+// `storage` is typed as the interface rather than the concrete default so the
+// async-store tests below can pass their own implementation.
 function makeClient(
   authApi: Partial<SpaAuthApi> = {},
-  storage = new InMemoryStorage(),
+  storage: TokenStorage = new InMemoryStorage(),
 ) {
   const client = new AuthClient({
     mode: "spa",
@@ -404,5 +412,91 @@ describe("AuthClient (SSR)", () => {
     expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
       null,
     );
+  });
+});
+
+/**
+ * A {@link TokenStorage} whose every method returns a promise, like in React
+ * Native.
+ */
+class AsyncTokenStorage implements TokenStorage {
+  readonly entries = new Map<string, string>();
+
+  async getItem(key: string): Promise<string | null> {
+    await Promise.resolve();
+    return this.entries.get(key) ?? null;
+  }
+  async setItem(key: string, value: string): Promise<void> {
+    await Promise.resolve();
+    this.entries.set(key, value);
+  }
+  async removeItem(key: string): Promise<void> {
+    await Promise.resolve();
+    this.entries.delete(key);
+  }
+}
+
+describe("AuthClient (async storage)", () => {
+  afterEach(restoreWindow);
+
+  test("hydrates a persisted session on init", async () => {
+    // The case that matters on React Native: a session survives an app
+    // restart, rather than the user landing on the sign-in screen every launch.
+    const storage = new AsyncTokenStorage();
+    storage.entries.set(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
+    storage.entries.set(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`, "refresh-1");
+
+    const { client } = makeClient({}, storage);
+    await client.init();
+
+    expect(client.getSnapshot()).toEqual({
+      isLoading: false,
+      isAuthenticated: true,
+      token: "access-1",
+    });
+  });
+
+  test("reports loading until the store resolves", async () => {
+    const storage = new AsyncTokenStorage();
+    storage.entries.set(`${JWT_STORAGE_KEY}_${SUFFIX}`, "access-1");
+
+    const { client } = makeClient({}, storage);
+    const initialized = client.init();
+    // A store that answers asynchronously must not be reported as "signed out"
+    // in the meantime — that flash would bounce the user to a sign-in screen.
+    expect(client.getSnapshot()).toEqual(INITIAL_AUTH_STATE);
+
+    await initialized;
+    expect(client.getSnapshot()).toMatchObject({ isAuthenticated: true });
+  });
+
+  test("persists, rotates and clears through the async store", async () => {
+    const refreshSession = vi.fn(async (rt: string) => {
+      // The rotated token must be read back out of the async store, not just
+      // held in memory.
+      expect(rt).toBe("refresh-1");
+      return bundle(2);
+    });
+    const storage = new AsyncTokenStorage();
+    const { client } = makeClient({ refreshSession }, storage);
+    await client.init();
+
+    await client.setSession(bundle(1));
+    expect(storage.entries.get(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "access-1",
+    );
+    expect(storage.entries.get(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-1",
+    );
+
+    expect(await client.fetchAccessToken({ forceRefreshToken: true })).toBe(
+      "access-2",
+    );
+    expect(storage.entries.get(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-2",
+    );
+
+    await client.signOut();
+    expect(storage.entries.size).toBe(0);
   });
 });

--- a/packages/core/src/browser/storage.test.ts
+++ b/packages/core/src/browser/storage.test.ts
@@ -1,0 +1,71 @@
+/**
+ * These tests cover the behavior of the `defaultStorage` function under
+ * different environments. The default is what is used when no distinct
+ * `storage` is passed in when configuring client-side Convex Auth.
+ *
+ * @module
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  InMemoryStorage,
+  defaultStorage,
+  resetInMemoryFallbackWarning,
+} from "./storage";
+
+// The edge-runtime environment supplies its own `window` (=== globalThis), and
+// we keep a reference to it here to restore it after each test (some of which
+// set a new value for `window`).
+const ORIGINAL_WINDOW = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+function setWindow(value: unknown): void {
+  (globalThis as { window?: unknown }).window = value;
+}
+
+describe("defaultStorage", () => {
+  beforeEach(() => {
+    resetInMemoryFallbackWarning();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_WINDOW === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      Object.defineProperty(globalThis, "window", ORIGINAL_WINDOW);
+    }
+    vi.restoreAllMocks();
+  });
+
+  test("uses localStorage in a browser", () => {
+    const localStorage = new InMemoryStorage();
+    setWindow({ localStorage });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(defaultStorage()).toBe(localStorage);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("falls back to memory silently on a server", () => {
+    delete (globalThis as { window?: unknown }).window;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // In-memory is the right answer for a single server render, so this path
+    // must stay quiet — otherwise every SSR request logs a warning.
+    expect(defaultStorage()).toBeInstanceOf(InMemoryStorage);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("warns once when a runtime has `window` but no localStorage", () => {
+    // React Native's shape: sessions would silently vanish on app restart.
+    setWindow({ navigator: {} });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(defaultStorage()).toBeInstanceOf(InMemoryStorage);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/storage/);
+
+    // A provider remount must not turn the hint into a repeating log.
+    defaultStorage();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -50,14 +50,34 @@ export class InMemoryStorage implements TokenStorage {
   }
 }
 
+let warnedAboutInMemoryFallback = false;
+
+/** Exposed for tests; the warning is otherwise once per process. */
+export function resetInMemoryFallbackWarning(): void {
+  warnedAboutInMemoryFallback = false;
+}
+
 /**
  * The default storage: the browser's `localStorage` when available, otherwise
  * an {@link InMemoryStorage}. Callers that need cross-tab sessions, React
  * Native, or per-tab sessions should pass their own storage instead.
  */
 export function defaultStorage(): TokenStorage {
-  if (typeof window !== "undefined" && window.localStorage) {
-    return window.localStorage;
+  if (typeof window !== "undefined") {
+    if (window.localStorage) return window.localStorage;
+    // React Native has a window with no `localStorage`. Warn once here that
+    // in-memory storage will be used until another storage implementation is
+    // supplied.
+    if (!warnedAboutInMemoryFallback) {
+      warnedAboutInMemoryFallback = true;
+      console.warn(
+        "[convex-auth] This runtime has no `localStorage`, so the session is " +
+          "being kept in memory and will not survive an app restart. Pass a " +
+          "`storage` implementation to your auth provider to persist it." +
+          "For React Native, that would be one backed by `expo-secure-store` " +
+          "or `AsyncStorage`.",
+      );
+    }
   }
   return new InMemoryStorage();
 }

--- a/packages/core/src/browser/storage.ts
+++ b/packages/core/src/browser/storage.ts
@@ -73,9 +73,9 @@ export function defaultStorage(): TokenStorage {
       console.warn(
         "[convex-auth] This runtime has no `localStorage`, so the session is " +
           "being kept in memory and will not survive an app restart. Pass a " +
-          "`storage` implementation to your auth provider to persist it." +
-          "For React Native, that would be one backed by `expo-secure-store` " +
-          "or `AsyncStorage`.",
+          "`storage` implementation to your auth provider to persist it. " +
+          "For React Native, that would be one backed by something like " +
+          "`expo-secure-store`.",
       );
     }
   }

--- a/packages/core/src/react/index.tsx
+++ b/packages/core/src/react/index.tsx
@@ -70,9 +70,27 @@ export function ConvexAuthProvider({
   /** The app's `refreshSession` and `signOut` mutation references. */
   api: ConvexAuthApi;
   /**
-   * A custom {@link TokenStorage}. Defaults to `localStorage` in the browser
-   * (in-memory under SSR). Set this for React Native, or to `sessionStorage`
-   * for per-tab sessions.
+   * A custom {@link TokenStorage} implementation.
+   *
+   * If none is supplied, the system defaults to `localStorage` in the browser
+   * and in-memory where there is no `localStorage` (SSR).
+   *
+   * Client runtimes with no `localStorage` like React Native are strongly
+   * advised to provide an implementation, because the in-memory default will
+   * cause users to get logged out each time the app closes.
+   *
+   * Here's an example of an implementation for Expo that could be passed in
+   * here:
+   *
+   * ```ts
+   * import * as SecureStore from "expo-secure-store";
+   *
+   * const secureStorage = {
+   *   getItem: SecureStore.getItemAsync,
+   *   setItem: SecureStore.setItemAsync,
+   *   removeItem: SecureStore.deleteItemAsync,
+   * };
+   * ```
    */
   storage?: TokenStorage;
   /**


### PR DESCRIPTION
Also includes some tests that cover using promise based storage in the app.