### PR TITLE
Do not sign the user out when a token refresh fails transiently

### DIFF
--- a/src/nextjs/server/proxy.ts
+++ b/src/nextjs/server/proxy.ts
@@ -76,11 +76,12 @@ export async function proxyAuthActionToConvex(
     } catch (error) {
       console.error(`Hit error while running \`auth:signIn\`:`);
       console.error(error);
-      logVerbose(`Clearing auth cookies`, verbose);
+      logVerbose(`Leaving auth cookies unchanged`, verbose);
+      // A failed `auth:signIn` never minted tokens, so there is nothing to
+      // clear. Clearing here would sign out a session that is still valid,
+      // for example when the call failed because the network did.
       // Send raw error message to client, just like Convex Action would
-      const response = jsonResponse({ error: (error as Error).message }, 400);
-      await setAuthCookies(response, null, cookieConfig);
-      return response;
+      return jsonResponse({ error: (error as Error).message }, 400);
     }
     if (result.redirect !== undefined) {
       const { redirect } = result;

--- a/src/nextjs/server/request.ts
+++ b/src/nextjs/server/request.ts
@@ -129,27 +129,41 @@ async function getRefreshedTokens(options: ConvexAuthNextjsMiddlewareOptions) {
     );
     return undefined;
   }
+  let result: SignInAction["_returnType"];
   try {
-    const result = await fetchAction(
+    result = await fetchAction(
       "auth:signIn" as unknown as SignInAction,
       {
         refreshToken,
       },
       getConvexNextjsOptions(options),
     );
-    if (result.tokens === undefined) {
-      throw new Error("Invalid `signIn` action result for token refresh");
-    }
+  } catch (error) {
+    // A thrown error means the request did not complete, so we learned nothing
+    // about the session. An invalid, expired or already used refresh token does
+    // not throw, it resolves with `tokens: null` and is handled below.
+    // Return `undefined` to leave the existing cookies in place and retry on
+    // the next request, instead of signing a valid session out.
+    console.error(error);
     logVerbose(
-      `Successfully refreshed tokens: is null? ${result.tokens === null}`,
+      `Failed to refresh tokens, returning undefined to leave the existing cookies in place`,
       verbose,
     );
-    return result.tokens;
-  } catch (error) {
-    console.error(error);
-    logVerbose(`Failed to refresh tokens, returning null`, verbose);
+    return undefined;
+  }
+  if (result.tokens === undefined) {
+    // The server responded, but with a result this version does not understand.
+    // That is a protocol mismatch rather than a transient failure, so keep
+    // clearing the session.
+    console.error("Invalid `signIn` action result for token refresh");
+    logVerbose(`Invalid token refresh result, returning null`, verbose);
     return null;
   }
+  logVerbose(
+    `Successfully refreshed tokens: is null? ${result.tokens === null}`,
+    verbose,
+  );
+  return result.tokens;
 }
 
 function decodeToken(token: string) {

--- a/test/nextjsTokenRefresh.test.ts
+++ b/test/nextjsTokenRefresh.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment edge-runtime
+import { NextRequest } from "next/server";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const fetchAction = vi.fn();
+
+vi.mock("convex/nextjs", () => ({
+  fetchAction: (...args: any[]) => fetchAction(...args),
+}));
+
+let requestCookies: Record<string, string> = {};
+
+vi.mock("next/headers", () => ({
+  headers: () => new Headers({ Host: "localhost:3000" }),
+  cookies: () => ({
+    get: (name: string) =>
+      name in requestCookies
+        ? { name, value: requestCookies[name] }
+        : undefined,
+    set: () => {},
+    delete: () => {},
+  }),
+}));
+
+const { handleAuthenticationInRequest } = await import(
+  "../src/nextjs/server/request"
+);
+
+/**
+ * A token that is close enough to expiry that the middleware refreshes it.
+ */
+function expiringToken() {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const payload = { iat: nowSeconds - 3600, exp: nowSeconds + 5 };
+  const encode = (value: object) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "RS256" })}.${encode(payload)}.signature`;
+}
+
+beforeEach(() => {
+  fetchAction.mockReset();
+  requestCookies = {
+    __convexAuthJWT: expiringToken(),
+    __convexAuthRefreshToken: "refresh-token",
+  };
+});
+
+function request() {
+  return new NextRequest("http://localhost:3000/");
+}
+
+test("a failed token refresh request leaves the session alone", async () => {
+  fetchAction.mockRejectedValue(new Error("fetch failed"));
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const result = await handleAuthenticationInRequest(request(), {});
+
+  // `undefined` means "nothing to do this request", so the caller leaves the
+  // cookies untouched and the next request retries. `null` would delete them.
+  expect(result).toEqual({ kind: "refreshTokens", refreshTokens: undefined });
+});
+
+test("a refresh token the server rejects still clears the session", async () => {
+  fetchAction.mockResolvedValue({ tokens: null });
+
+  const result = await handleAuthenticationInRequest(request(), {});
+
+  expect(result).toEqual({ kind: "refreshTokens", refreshTokens: null });
+});
+
+test("a successful token refresh returns the new tokens", async () => {
+  const tokens = { token: "new-token", refreshToken: "new-refresh-token" };
+  fetchAction.mockResolvedValue({ tokens });
+
+  const result = await handleAuthenticationInRequest(request(), {});
+
+  expect(result).toEqual({ kind: "refreshTokens", refreshTokens: tokens });
+});


### PR DESCRIPTION
## Symptom

A signed-in user is silently signed out and sent back through a full login, without touching sign-out and without their session having expired. We hit this in production behind a serverless platform, at a low but steady rate, concentrated on the first request after an idle period.

## Root cause

`getRefreshedTokens` in `src/nextjs/server/request.ts` returned `null` from its catch block, for any error at all. `null` is not "we do not know yet", it is "clear the session": both call sites in `src/nextjs/server/index.tsx` pass it to `setAuthCookies` / `setAuthCookiesInMiddleware`, which delete the JWT and refresh-token cookies.

So one failed request between the Next.js server and Convex destroys a healthy session.

## Why a throw is not a revocation

A refresh token that is genuinely invalid, expired, or already used does not throw. The backend resolves the action with `{ tokens: null }`, and the success path returns `result.tokens` directly, so `null` flows through and clears the cookies exactly as it should. That behaviour is unchanged here.

A throw therefore only ever means the call did not complete: a network failure between the hosting platform and Convex, or a cold start. Nothing was learned about the session, so nothing should be done to it.

## The fix

The three-state contract already exists. The declared result type is `{ token, refreshToken } | null | undefined`, and both consumers already guard on `refreshTokens !== undefined`, which skips the cookie write entirely and leaves the cookies untouched. `undefined` is exactly "nothing to do this request". The catch now returns it, and the next request retries the refresh. No type change, no new state.

Two sites:

1. **`src/nextjs/server/request.ts`**: the `try` is narrowed to the `fetchAction` call so only a genuine transport failure is treated as transient. The `result.tokens === undefined` protocol-violation check moves just below it and still returns `null`, deliberately: a response the client cannot parse is a version mismatch, not a blip, and retrying it forever would be worse than clearing. Keeping its behaviour identical also keeps this diff strictly about the transient case.

2. **`src/nextjs/server/proxy.ts`**: the `auth:signIn` catch built a 400 and then called `setAuthCookies(response, null, ...)`, wiping the cookie jar of an already-healthy session. A failed sign-in never minted tokens, so there is nothing that needs clearing. The `auth:signOut` catch below it is untouched and still clears cookies, which is correct.

The `logVerbose` strings are updated too, since the old ones ("returning null", "Clearing auth cookies") show up in user bug reports and would now describe something that no longer happens.

## Testing

Added `test/nextjsTokenRefresh.test.ts`, which drives `handleAuthenticationInRequest` with `convex/nextjs` and `next/headers` mocked, following the pattern `test/authProvider.test.tsx` already uses to test `src/` directly. Three cases:

- a rejected refresh call yields `refreshTokens: undefined`, so the cookies survive (fails on `main`, returns `null`)
- a server-rejected refresh token yields `refreshTokens: null`, so the session is still cleared (passes both before and after, which is the point)
- a successful refresh yields the new tokens

Verified on this branch:

- `npm run lint`: exit 0
- `npm run build`: exit 0
- `npm run test:once`: exit 0, 14 files, 45 passed

The same three commands are green on unmodified `main` (13 files, 42 passed), so the baseline is clean.

## Related

Possibly, but not provably, the cause behind #174, where five people report the refreshToken cookie vanishing from a deployed app after an idle period. The failure mode matches, and the error string in that issue title is printed by `proxy.ts` when the cookie is already gone, so something deleted it earlier and both paths above delete it. I have not reproduced their setup, and at least two comments there describe a different localhost/secure-cookie problem that this does not touch, so I am not using a closing keyword.

#363 reports a failed-network refresh being mishandled in the React client and core `AuthenticationManager`. That is a different layer and this change does not fix it, but it is the same underlying assumption that a failed refresh means an invalid session.

