### PR TITLE
Bring back setup functions

### DIFF
--- a/examples/nextjs/convex/auth.ts
+++ b/examples/nextjs/convex/auth.ts
@@ -1,31 +1,26 @@
 import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup";
-import { Anonymous } from "@convex-dev/auth/providers/anonymous/setup";
-import { UsernamePassword } from "@convex-dev/auth/providers/password/setup";
+import { setupCore } from "@convex-dev/auth/core/setup";
+import { setupAnonymous } from "@convex-dev/auth/providers/anonymous/setup";
+import { setupUsernamePassword } from "@convex-dev/auth/providers/password/setup";
 
-// The core owns sessions, accounts, and JWT minting. It calls back into our
-// `createOrUpdateUser` on every sign-in. Each provider exposes the functions its
-// client hooks call: `signInAnonymous` for the anonymous provider,
-// `signUpWithPassword` / `signInWithPassword` for the password one. Under SSR
-// those calls go through the auth proxy, which needs each one listed in `signIn`
-// in src/lib/serverAuth.ts.
-export const {
-  signOut,
-  refreshSession,
-  isAuthenticated,
-  providers: {
-    anonymous: { signInAnonymous },
-    password: { signUpWithPassword, signInWithPassword },
+// The core owns sessions, accounts, and JWT minting. Each provider is wired to
+// it with its own setup function, and only hands back its functions once the
+// app attaches the callback that creates its user rows. Each provider exposes
+// the functions its client hooks call: `signInAnonymous` for the anonymous
+// provider, `signUpWithPassword` / `signInWithPassword` for the password one.
+// Under SSR those calls get proxied to Convex via the SSR host. The sign-in
+// functions exposed here are wired up to be proxied in src/lib/serverAuth.ts.
+const core = setupCore({ component: components.auth });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+export const { signInAnonymous } = setupAnonymous(core, {
+  component: components.authAnonymous,
+}).attachUserCallback(internal.users.createOrUpdateUserAnonymous);
+
+export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
+  core,
+  {
+    component: components.authPasswordProvider,
+    usernameComponent: components.authUsername,
   },
-} = setupCore({
-  component: components.auth,
-  providers: [
-    provider(Anonymous, {
-      component: components.authAnonymous,
-    }),
-    provider(UsernamePassword, {
-      component: components.authPasswordProvider,
-      usernameComponent: components.authUsername,
-    }),
-  ],
-}).attachUserCallback(internal.users.createOrUpdateUser);
+).attachUserCallback(internal.users.createOrUpdateUserPassword);

--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -1,37 +1,69 @@
+/**
+ * Each provider configured in `convex/auth.ts` has an app-owned callback defined here.
+ *
+ * The callback is inovked whenever a user signs in. Each callback has a signature that
+ * matches the associated provider and the data that it supplies.
+ *
+ * In this example, the username and password provider includes the `username` in the
+ * profile data that it provides, while the anonymous provider doesn't. In the app's
+ * data model, the `username` is thus optional.
+ *
+ * @module
+ */
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
-import { internalMutation, query } from "./_generated/server";
+import { internalMutation, MutationCtx, query } from "./_generated/server";
 
-/**
- * The app's create-or-update-user callback (see `attachUserCallback`). The core
- * invokes it on every sign-in — without a `userId` the first time an identity is
- * seen, and with the resolved `userId` thereafter. On the first sign-in we mint
- * a users row (with the username from the password provider's profile, when
- * there is one); on later sign-ins we echo the id.
- */
-export const createOrUpdateUser = internalMutation({
+export const createOrUpdateUserAnonymous = internalMutation({
   args: {
-    provider: v.union(v.literal("anonymous"), v.literal("password")),
+    provider: v.literal("anonymous"),
     providerAccountId: v.string(),
-    profile: v.any(),
+    profile: v.object({}),
     userId: v.union(v.string(), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
-    if (args.userId !== null) {
-      const existing = ctx.db.normalizeId("users", args.userId);
-      if (existing === null) {
-        throw new Error(`Unknown user id: ${args.userId}`);
-      }
-      return existing;
-    }
-    const username =
-      typeof args.profile?.username === "string"
-        ? args.profile.username
-        : undefined;
-    return await ctx.db.insert("users", { username });
+    return await createOrUpdateUser(ctx, { userId: args.userId });
   },
 });
+
+export const createOrUpdateUserPassword = internalMutation({
+  args: {
+    provider: v.literal("password"),
+    providerAccountId: v.string(),
+    profile: v.object({ username: v.string() }),
+    userId: v.union(v.string(), v.null()),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    return await createOrUpdateUser(ctx, {
+      userId: args.userId,
+      username: args.profile.username,
+    });
+  },
+});
+
+/**
+ * The shared body of this app's create-or-update-user callbacks.
+ *
+ * The core invokes one of them on every sign-in — without a `userId` the first
+ * time an identity is seen, and with the resolved `userId` thereafter. On the
+ * first sign-in we mint a users row (with the username, when the provider
+ * supplies one); on later sign-ins we echo the id.
+ */
+async function createOrUpdateUser(
+  ctx: MutationCtx,
+  args: { userId: string | null; username?: string },
+): Promise<Id<"users">> {
+  if (args.userId !== null) {
+    const existing = ctx.db.normalizeId("users", args.userId);
+    if (existing === null) {
+      throw new Error(`Unknown user id: ${args.userId}`);
+    }
+    return existing;
+  }
+  return await ctx.db.insert("users", { username: args.username });
+}
 
 /**
  * The currently signed-in user, or null. Demonstrates an authenticated query

--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -19,7 +19,7 @@ export const createOrUpdateUserAnonymous = internalMutation({
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),
     profile: v.object({}),
-    userId: v.union(v.string(), v.null()),
+    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
@@ -32,7 +32,7 @@ export const createOrUpdateUserPassword = internalMutation({
     provider: v.literal("password"),
     providerAccountId: v.string(),
     profile: v.object({ username: v.string() }),
-    userId: v.union(v.string(), v.null()),
+    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
@@ -53,14 +53,10 @@ export const createOrUpdateUserPassword = internalMutation({
  */
 async function createOrUpdateUser(
   ctx: MutationCtx,
-  args: { userId: string | null; username?: string },
+  args: { userId: Id<"users"> | null; username?: string },
 ): Promise<Id<"users">> {
   if (args.userId !== null) {
-    const existing = ctx.db.normalizeId("users", args.userId);
-    if (existing === null) {
-      throw new Error(`Unknown user id: ${args.userId}`);
-    }
-    return existing;
+    return args.userId;
   }
   return await ctx.db.insert("users", { username: args.username });
 }

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -1,18 +1,10 @@
 import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup";
-import { Anonymous } from "@convex-dev/auth/providers/anonymous/setup";
+import { setupCore } from "@convex-dev/auth/core/setup";
+import { setupAnonymous } from "@convex-dev/auth/providers/anonymous/setup";
 
-export const {
-  signOut,
-  refreshSession,
-  providers: {
-    anonymous: { signInAnonymous },
-  },
-} = setupCore({
-  component: components.auth,
-  providers: [
-    provider(Anonymous, {
-      component: components.authAnonymous,
-    }),
-  ],
-}).attachUserCallback(internal.users.upsertFromAuth);
+const core = setupCore({ component: components.auth });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+export const { signInAnonymous } = setupAnonymous(core, {
+  component: components.authAnonymous,
+}).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -1,23 +1,22 @@
 import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
-export const upsertFromAuth = internalMutation({
+export const createOrUpdateUser = internalMutation({
   args: {
-    provider: v.union(v.literal("anonymous")),
+    provider: v.literal("anonymous"),
     providerAccountId: v.string(),
-    profile: v.any(),
+    profile: v.object({}),
     userId: v.union(v.string(), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
-    switch (args.provider) {
-      case "anonymous": {
-        return ctx.db.insert("users", {});
+    if (args.userId !== null) {
+      const existing = ctx.db.normalizeId("users", args.userId);
+      if (existing === null) {
+        throw new Error(`Unknown user id: ${args.userId}`);
       }
-      default: {
-        const _exhaustive: never = args.provider;
-        return _exhaustive;
-      }
+      return existing;
     }
+    return ctx.db.insert("users", {});
   },
 });

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -6,16 +6,12 @@ export const createOrUpdateUser = internalMutation({
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),
     profile: v.object({}),
-    userId: v.union(v.string(), v.null()),
+    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
     if (args.userId !== null) {
-      const existing = ctx.db.normalizeId("users", args.userId);
-      if (existing === null) {
-        throw new Error(`Unknown user id: ${args.userId}`);
-      }
-      return existing;
+      return args.userId;
     }
     return ctx.db.insert("users", {});
   },

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -1,19 +1,14 @@
 import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup";
-import { UsernamePassword } from "@convex-dev/auth/providers/password/setup";
+import { setupCore } from "@convex-dev/auth/core/setup";
+import { setupUsernamePassword } from "@convex-dev/auth/providers/password/setup";
 
-export const {
-  signOut,
-  refreshSession,
-  providers: {
-    password: { signUpWithPassword, signInWithPassword },
+const core = setupCore({ component: components.auth });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
+  core,
+  {
+    component: components.authPasswordProvider,
+    usernameComponent: components.authUsername,
   },
-} = setupCore({
-  component: components.auth,
-  providers: [
-    provider(UsernamePassword, {
-      component: components.authPasswordProvider,
-      usernameComponent: components.authUsername,
-    }),
-  ],
-}).attachUserCallback(internal.users.createOrUpdateUser);
+).attachUserCallback(internal.users.createOrUpdateUser);

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -6,16 +6,12 @@ export const createOrUpdateUser = internalMutation({
     provider: v.literal("password"),
     providerAccountId: v.string(),
     profile: v.object({ username: v.string() }),
-    userId: v.union(v.string(), v.null()),
+    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
     if (args.userId !== null) {
-      const existing = ctx.db.normalizeId("users", args.userId);
-      if (existing === null) {
-        throw new Error(`Unknown user id: ${args.userId}`);
-      }
-      return existing;
+      return args.userId;
     }
     return await ctx.db.insert("users", { username: args.profile.username });
   },

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -5,7 +5,7 @@ export const createOrUpdateUser = internalMutation({
   args: {
     provider: v.literal("password"),
     providerAccountId: v.string(),
-    profile: v.any(),
+    profile: v.object({ username: v.string() }),
     userId: v.union(v.string(), v.null()),
   },
   returns: v.id("users"),
@@ -17,10 +17,6 @@ export const createOrUpdateUser = internalMutation({
       }
       return existing;
     }
-    const username =
-      typeof args.profile?.username === "string"
-        ? args.profile.username
-        : undefined;
-    return await ctx.db.insert("users", { username });
+    return await ctx.db.insert("users", { username: args.profile.username });
   },
 });

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -74,23 +74,9 @@ app.use(auth, {
 export default app;
 `,
   "auth.ts": `import { components } from "./_generated/api";
-import { setupCore } from "@convex-dev/auth/core/setup.js";
+import { setupCore } from "@convex-dev/auth/core/setup";
 
-<<<<<<< HEAD
-export const {
-  signOut,
-  refreshSession,
-  providers: {
-    // TODO
-  },
-} = setupCore({
-  component: components.auth,
-  providers: [
-    // TODO
-  ],
-}).attachUserCallback(internal.users.createOrUpdateUser);
-=======
-const core = setupCore({ component: components.core });
+const core = setupCore({ component: components.auth });
 export const { signOut, refreshSession, isAuthenticated } = core;
 
 // TODO Set up a login provider. For example:
@@ -99,7 +85,6 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 //     component: components.authPasswordProvider,
 //     usernameComponent: components.authUsername,
 //   }).attachUserCallback(internal.users.createOrUpdateUser);
->>>>>>> 0e178cb (Bring back setup functions)
 `,
 };
 

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -73,9 +73,10 @@ app.use(auth, {
 
 export default app;
 `,
-  "auth.ts": `import { components, internal } from "./_generated/api";
-import { provider, setupCore } from "@convex-dev/auth/core/setup.js";
+  "auth.ts": `import { components } from "./_generated/api";
+import { setupCore } from "@convex-dev/auth/core/setup.js";
 
+<<<<<<< HEAD
 export const {
   signOut,
   refreshSession,
@@ -88,6 +89,17 @@ export const {
     // TODO
   ],
 }).attachUserCallback(internal.users.createOrUpdateUser);
+=======
+const core = setupCore({ component: components.core });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+// TODO Set up a login provider. For example:
+// export const { signUpWithPassword, signInWithPassword } =
+//   setupUsernamePassword(core, {
+//     component: components.authPasswordProvider,
+//     usernameComponent: components.authUsername,
+//   }).attachUserCallback(internal.users.createOrUpdateUser);
+>>>>>>> 0e178cb (Bring back setup functions)
 `,
 };
 

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -1,10 +1,13 @@
-import { mutationGeneric } from "convex/server";
 import {
-  defineProvider,
   vSignInSuccess,
+  type CreateOrUpdateUserFn,
   type SignInSuccess,
 } from "../../lib/types";
+import type { AuthCore } from "../core/setup";
 import { ComponentApi } from "./_generated/component";
+
+// TODO: derive this from the component mount path rather than hardcoding it.
+const PROVIDER_NAME = "anonymous";
 
 /**
  * An anonymous accounts provider.
@@ -14,33 +17,65 @@ import { ComponentApi } from "./_generated/component";
  *
  * There is no support for allowing a user to return with a previously issued
  * anonymous account.
+ *
+ * ```ts
+ * const core = setupCore({ component: components.core });
+ * export const { signOut, refreshSession, isAuthenticated } = core;
+ *
+ * export const { signInAnonymous } = setupAnonymous(core, {
+ *   component: components.authAnonymous,
+ * }).attachUserCallback(internal.users.createOrUpdateUser);
+ * ```
  */
-export const Anonymous = defineProvider({
-  name: "anonymous",
-  setup: ({ completeSignIn }, options: { component: ComponentApi }) => {
-    const { component } = options;
-    return {
-      // Anonymous sign-in cannot fail per-user, so this only ever produces the
-      // success arm. It still returns the shared envelope rather than a bare
-      // bundle: that is the shape the SSR auth proxy recognizes (and validates
-      // before moving the refresh token into its cookie), and it leaves room for
-      // a `userError` arm later without another breaking change.
-      signInAnonymous: mutationGeneric({
-        args: {},
-        returns: vSignInSuccess,
-        handler: async (ctx): Promise<SignInSuccess> => {
-          const anonymousId = await ctx.runMutation(
-            component.provider.createAnonymousAccount,
-            {},
-          );
-          const tokens = await completeSignIn(ctx, {
-            provider: "anonymous",
-            providerAccountId: anonymousId,
-            profile: {},
-          });
-          return { success: true, tokens };
-        },
-      }),
-    };
+export function setupAnonymous(
+  core: AuthCore,
+  options: {
+    /** The mounted anonymous component (`components.authAnonymous`). */
+    component: ComponentApi;
   },
-});
+) {
+  const { component } = options;
+
+  return {
+    /**
+     * Supply the app's create-or-update-user mutation (see
+     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
+     * get this provider's functions to export.
+     */
+    attachUserCallback(
+      createOrUpdateUser: CreateOrUpdateUserFn<
+        "anonymous",
+        Record<string, never>
+      >,
+    ) {
+      const { authMutation } = core.bindProvider({
+        name: PROVIDER_NAME,
+        createOrUpdateUser,
+      });
+
+      return {
+        // Anonymous sign-in cannot fail per-user, so this only ever produces
+        // the success arm. It still returns the shared envelope rather than a
+        // bare bundle: that is the shape the SSR auth proxy recognizes (and
+        // validates before moving the refresh token into its cookie), and it
+        // leaves room for a `userError` arm later without another breaking
+        // change.
+        signInAnonymous: authMutation({
+          args: {},
+          returns: vSignInSuccess,
+          handler: async (ctx): Promise<SignInSuccess> => {
+            const anonymousId = await ctx.runMutation(
+              component.provider.createAnonymousAccount,
+              {},
+            );
+            const tokens = await ctx.convexAuth.completeSignIn({
+              providerAccountId: anonymousId,
+              profile: {},
+            });
+            return { success: true, tokens };
+          },
+        }),
+      };
+    },
+  };
+}

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -27,8 +27,8 @@ const PROVIDER_NAME = "anonymous";
  * }).attachUserCallback(internal.users.createOrUpdateUser);
  * ```
  */
-export function setupAnonymous(
-  core: AuthCore,
+export function setupAnonymous<UsersTable extends string>(
+  core: AuthCore<UsersTable>,
   options: {
     /** The mounted anonymous component (`components.authAnonymous`). */
     component: ComponentApi;
@@ -45,7 +45,8 @@ export function setupAnonymous(
     attachUserCallback(
       createOrUpdateUser: CreateOrUpdateUserFn<
         "anonymous",
-        Record<string, never>
+        Record<string, never>,
+        UsersTable
       >,
     ) {
       const { authMutation } = core.bindProvider({

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -14,12 +14,7 @@ import {
   getCreateOrUpdateUserCalls,
   resetCreateOrUpdateUserCalls,
 } from "./testApp";
-import { provider } from "./setup";
-import {
-  defineProvider,
-  type AuthClaims,
-  type TokenBundle,
-} from "../../lib/types";
+import { type AuthClaims, type TokenBundle } from "../../lib/types";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -346,23 +341,5 @@ describe("getUserIdByAccount", () => {
       providerAccountId: "alice",
     });
     expect(other).toBeNull();
-  });
-});
-
-describe("provider()", () => {
-  /** A minimal config whose options type the pairing must enforce. */
-  const Dummy = defineProvider({
-    name: "dummy",
-    setup: (_helpers, options: { limit: number }) => ({ options }),
-  });
-
-  test("pairs a config with its options and rejects unknown options", () => {
-    const paired = provider(Dummy, { limit: 1 });
-    expect(paired).toEqual([Dummy, { limit: 1 }]);
-    provider(Dummy, {
-      limit: 1,
-      // @ts-expect-error — unknown options must error, not be silently ignored
-      unknownOption: true,
-    });
   });
 });

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -6,7 +6,7 @@ import {
   env,
 } from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
-import { v } from "convex/values";
+import { GenericId, v } from "convex/values";
 import { FunctionHandle } from "convex/server";
 import {
   vAuthClaims,
@@ -152,6 +152,18 @@ type CreateOrUpdateUserFunctionHandle = FunctionHandle<
 >;
 
 /**
+ * Type the given userId string as a {@link GenericId}.
+ *
+ * The core stores app user ids as opaque strings and has no access to the
+ * app's data model. The type for user-supplied callbacks types them as
+ * `Id<usersTable>` for the app's benefit, so re-brand on the way back out. The
+ * value is the same string either way.
+ */
+function asUserId(userId: string): GenericId<string> {
+  return userId as GenericId<string>;
+}
+
+/**
  * Resolve a provider identity to its account, creating one (and the app user
  * behind it) the first time the identity is seen. The app's user callback runs
  * on *every* sign-in: with no `userId` the first time (it mints/returns the
@@ -185,7 +197,7 @@ async function resolveAccount(
           provider: claims.provider,
           providerAccountId: claims.providerAccountId,
           profile: claims.profile,
-          userId: account.userId,
+          userId: asUserId(account.userId),
         }))
       ) {
         throw new Error(

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -146,9 +146,9 @@ async function issueSession(
 }
 
 type CreateOrUpdateUserFunctionHandle = FunctionHandle<
-  CreateOrUpdateUserFn<string>["_type"],
-  CreateOrUpdateUserFn<string>["_args"],
-  CreateOrUpdateUserFn<string>["_returnType"]
+  CreateOrUpdateUserFn<string, unknown>["_type"],
+  CreateOrUpdateUserFn<string, unknown>["_args"],
+  CreateOrUpdateUserFn<string, unknown>["_returnType"]
 >;
 
 /**

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -1,48 +1,84 @@
 import {
+  actionGeneric,
+  createFunctionHandle,
+  GenericActionCtx,
+  GenericDataModel,
+  GenericMutationCtx,
   mutationGeneric,
   queryGeneric,
-  createFunctionHandle,
+  RegisteredAction,
   RegisteredMutation,
   RegisteredQuery,
+  ReturnValueForOptionalValidator,
 } from "convex/server";
-import { v } from "convex/values";
+import { ObjectType, PropertyValidators, v, Validator } from "convex/values";
 import type { ComponentApi } from "./_generated/component";
 import {
   vTokenBundle,
   type TokenBundle,
-  ProviderConfig,
-  CompleteSignInFunc,
-  ResolveUserIdFunc,
-  CreateOrUpdateUserFn,
+  type ConvexAuthCtx,
+  type CreateOrUpdateUserFn,
 } from "../../lib/types";
 
-// Helper: pairs a `ProviderConfig` with its options, preserving `Name`, `Options` and `Api` individually.
-// TODO: dowski - consider whether this function should exist, or whether defineProvider
-// should return a function that's callable with the options.
-export function provider<Name extends string, Options, Api>(
-  config: ProviderConfig<Name, Options, Api>,
-  // `NoInfer` means we type error on extra properties as long as options are defined inline.
-  options: NoInfer<Options>,
-): readonly [ProviderConfig<Name, Options, Api>, Options] {
-  return [config, options] as const;
-}
+/**
+ * A type for a factory that returns a `RegisteredMutation` with a handler that
+ * has access to provider-bound auth helpers on `ctx.convexAuth`.
+ *
+ * The signature mirrors convex's own `MutationBuilder` inference, simplified
+ * where providers never need the generality: `args` is required (dropping the
+ * zero-arg/function shorthand machinery) and there is no app data model
+ * (providers are app-agnostic; their storage lives behind their own
+ * component's functions). `returns` keeps convex's exact optional-validator
+ * scheme: with a validator, the handler's return is constrained to (a promise
+ * of) its type; without one, it falls back to whatever the handler declares.
+ */
+export type AuthMutationBuilder<Profile> = <
+  ArgsValidator extends PropertyValidators,
+  ReturnsValidator extends
+    PropertyValidators | Validator<unknown, "required", string> | void,
+  ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> =
+    ReturnValueForOptionalValidator<ReturnsValidator>,
+>(fn: {
+  args: ArgsValidator;
+  returns?: ReturnsValidator;
+  handler: (
+    ctx: GenericMutationCtx<GenericDataModel> & ConvexAuthCtx<Profile>,
+    args: ObjectType<ArgsValidator>,
+  ) => ReturnValue;
+}) => RegisteredMutation<"public", ObjectType<ArgsValidator>, ReturnValue>;
 
-// An explicitly loosely typed tuple of [ProviderConfig, Options]. The `any`s are
-// intentional: this is a constraint that concrete provider tuples must extend, and
-// `unknown` would break assignability via contravariance in `ProviderConfig.setup`.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ProviderWithOptions = readonly [ProviderConfig<any, any, any>, any];
+/** The action flavor of {@link AuthMutationBuilder}. */
+export type AuthActionBuilder<Profile> = <
+  ArgsValidator extends PropertyValidators,
+  ReturnsValidator extends
+    PropertyValidators | Validator<unknown, "required", string> | void,
+  ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> =
+    ReturnValueForOptionalValidator<ReturnsValidator>,
+>(fn: {
+  args: ArgsValidator;
+  returns?: ReturnsValidator;
+  handler: (
+    ctx: GenericActionCtx<GenericDataModel> & ConvexAuthCtx<Profile>,
+    args: ObjectType<ArgsValidator>,
+  ) => ReturnValue;
+}) => RegisteredAction<"public", ObjectType<ArgsValidator>, ReturnValue>;
 
-// Maps a tuple of entries to
-// { [ProviderConfig.name]: ReturnType<ProviderConfig.setup> } by distributing
-// over the tuple's union.
-type ProviderApis<T extends readonly ProviderWithOptions[]> = {
-  [K in T[number] as K[0]["name"]]: ReturnType<K[0]["setup"]>;
+/**
+ * The function builders a provider gets from {@link AuthCore.bindProvider}.
+ *
+ * Each builds a public Convex function whose handler receives the
+ * provider-bound helpers on `ctx.convexAuth` alongside the standard ctx.
+ */
+export type ProviderBuilders<Profile> = {
+  authMutation: AuthMutationBuilder<Profile>;
+  authAction: AuthActionBuilder<Profile>;
 };
 
-// The app-facing handlers that `attachUserCallback` produces once the
-// create-or-update-user callback is supplied.
-type AuthApi<T extends readonly ProviderWithOptions[]> = {
+/**
+ * The core auth API returned by {@link setupCore}: the session handlers the
+ * app re-exports, plus {@link AuthCore.bindProvider} for wiring up providers.
+ */
+export type AuthCore = {
   /**
    * Signs out of the current session.
    *
@@ -82,65 +118,51 @@ type AuthApi<T extends readonly ProviderWithOptions[]> = {
     Promise<boolean>
   >;
   /**
-   * The auth APIs that each provider exposes.
+   * Register a provider with the core and get the function builders its
+   * implementation uses.
    *
-   * Each provider is accessible on this object by its name.
+   * `name` identifies the provider in the core's `accounts` table: accounts
+   * are keyed by `(name, providerAccountId)`, so it must be unique among the
+   * providers bound to this core — a duplicate throws immediately (two
+   * providers sharing a name would silently share accounts).
+   *
+   * `createOrUpdateUser` is the app's user callback for this provider (see
+   * {@link CreateOrUpdateUserFn}); the core invokes it on every sign-in the
+   * returned builders complete.
+   *
+   * Provider setup functions call this from inside their `attachUserCallback`,
+   * once the app has supplied the callback — so the builders can simply close
+   * over it, and a provider with no callback cannot exist. It is not meant to
+   * be called by application code directly.
    */
-  // TODO: dowski - rather than a nested object of providers, see about
-  // folding their APIs in as peers to `signOut` and `refreshSession` for
-  // a cleaner developer experience.
-  providers: ProviderApis<T>;
-};
-
-// Intermediate builder returned by `setupCore` before the app's user callback
-// is known. Its sole method, `attachUserCallback`, is deliberately
-// *non-generic* in the provider tuple `T`: `T` is already fixed by the time
-// `attachUserCallback` is called, so its return type `AuthApi<T>` is fully
-// determined without typing the `createOrUpdateUser` argument. See the note
-// on `setupCore` for why that decoupling is required.
-type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
-  /**
-   * The `createOrUpdateUser` function passed in here represents the core
-   * entrypoint for an application to integrate its user model with Convex Auth.
-   *
-   * It will be called in two scenarios, both associated with a user signing in:
-   *
-   *  1. The first time a user signs in with an account from a provider.
-   *    * The `userId` argument will not be present in this case.
-   *    * The application should do one of:
-   *      a. Create a new user record and return its `_id`
-   *      b. Use trusted information in the `profile` (e.g. a verified email)
-   *         to associate the account with an existing user, and return its
-   *         `_id`
-   *  2. Subsequent sign ins from a provider
-   *    * The `userId` argument will be present.
-   *    * The application may use the data in `profile` to update or otherwise
-   *      modify the stored user record.
-   *    * The existing `userId` must be the return value.
-   *
-   * The application keeps ownership of its users table — the core only holds a
-   * reference to this one mutation.
-   *
-   * If an application wants to reject a sign in, it can throw a `ConvexError`
-   * and the entire sign in attempt will be blocked.
-   */
-  attachUserCallback(
-    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
-  ): AuthApi<T>;
+  bindProvider<Provider extends string, Profile>(options: {
+    name: Provider;
+    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>;
+  }): ProviderBuilders<Profile>;
 };
 
 /**
  * Build the app-facing auth-core handlers from the mounted `core` component
- * reference and the auth providers that the app will use. Returns
- * ready-to-export `signOut`/`refreshSession` mutations plus a typesafe
- * `providers` object keyed by provider name and containing its API.
+ * reference. Returns ready-to-export `signOut`/`refreshSession`/
+ * `isAuthenticated` handlers plus `bindProvider`, which provider setup
+ * functions use to wire themselves to the core:
+ *
+ * ```ts
+ * const core = setupCore({ component: components.core });
+ * export const { signOut, refreshSession, isAuthenticated } = core;
+ *
+ * export const { signUpWithPassword, signInWithPassword } =
+ *   setupUsernamePassword(core, {
+ *     component: components.authPasswordProvider,
+ *     usernameComponent: components.authUsername,
+ *   }).attachUserCallback(internal.users.createOrUpdateUser);
+ * ```
  *
  * The core never triggers a sign-in itself: it has no idea how any given
- * provider authenticates a user. *Triggering `signIn` is each provider's
- * responsibility* and should be part of its returned API. A provider verifies
- * the user its own way (checking a password, say), produces the standard
- * claims, and then calls a `completeSignIn` function that the core makes
- * available to each provider to allow them to exchange claims for a session.
+ * provider authenticates a user. *Triggering sign-in is each provider's
+ * responsibility.* A provider verifies the user its own way (checking a
+ * password, say) and then calls the `completeSignIn` helper the core injects
+ * on `ctx.convexAuth` to exchange the verified identity for a session.
  *
  * Token lifetimes are configurable here and default to 1m (access) and 30d
  * (refresh). The access-token TTL must be shorter than the refresh-token TTL,
@@ -149,36 +171,8 @@ type CoreBuilder<T extends readonly ProviderWithOptions[]> = {
  *
  * Changes to token TTLs impact newly minted tokens, not ones that have
  * already been issued.
- *
- * @returns a builder object with an `attachUserCallback` function that
- *          completes the configuration of Convex Auth.
  */
-// Why this is a two-step (`setupCore(...).attachUserCallback(...)`) API
-//
-// The app's `createOrUpdateUser` is a reference into the app's *own* `internal`
-// API. But the module that calls `setupCore` also exports the handlers this
-// returns (`signOut` etc.), so those exports are part of that same `internal`
-// API. If the `internal.*` reference were passed straight into this generic
-// call, TS would have to type it while inferring the provider tuple `T` — and
-// typing it forces resolving the module's own API type, which depends on these
-// exports, which depend on this call: a cycle, reported as
-// `TS7022: '…' implicitly has type 'any' because it … is referenced … in its
-// own initializer`.
-//
-// Splitting the call sidesteps that. `setupCore` is generic in `T` but never
-// sees the `internal.*` reference, so inferring `T` touches nothing circular.
-// `attachUserCallback` *does* take the reference, but by then `T` is fixed,
-// so it is a non-generic call whose return type `AuthApi<T>` is fully
-// determined by the signature alone. TS resolves the exported bindings' types
-// from that return type without eagerly typing the `internal.*` argument, so
-// the cycle never forms. (Inside the *single generic* call it did, because
-// inferring `T` required typing every argument, `internal.*` included.)
-export function setupCore<T extends readonly ProviderWithOptions[]>({
-  component,
-  accessTokenTtlSeconds,
-  refreshTokenTtlSeconds,
-  providers,
-}: {
+export function setupCore(options: {
   component: ComponentApi;
   /**
    * Access-token lifetime in seconds. Defaults to 60 (1 minute).
@@ -194,99 +188,131 @@ export function setupCore<T extends readonly ProviderWithOptions[]>({
    * already been issued.
    */
   refreshTokenTtlSeconds?: number;
-  /**
-   * A list of providers with options to configure them.
-   *
-   * Each one will be wired up to the core and produce an API that will be
-   * accessible on {@link AuthApi.providers} which is returned from
-   * {@link CoreBuilder.attachUserCallback}.
-   *
-   * Adding a provider and exporting the Convex API it defines will allow
-   * signing in via that provider. The core will create sessions
-   * when sign ins happen via the provider. Removing a provider does not
-   * revoke those sessions, but will prevent future sign ins.
-   */
-  providers: T;
-}): CoreBuilder<T> {
+}): AuthCore {
+  const { component, accessTokenTtlSeconds, refreshTokenTtlSeconds } = options;
+
   const issuer = (): string => {
     const url = process.env.CONVEX_SITE_URL;
     if (!url) throw new Error("CONVEX_SITE_URL is not available");
     return url;
   };
 
-  // Takes the `createOrUpdateUser` callback, wires it to sign in and returns the
-  // full auth API.
-  const buildFullApi = (
-    createOrUpdateUser: CreateOrUpdateUserFn<T[number][0]["name"]>,
-  ): AuthApi<T> => {
-    const completeSignIn: CompleteSignInFunc = async (ctx, claims) => {
-      const createOrUpdateUserHandle =
-        await createFunctionHandle(createOrUpdateUser);
-      return await ctx.runMutation(component.public.signIn, {
-        claims,
-        createOrUpdateUserHandle,
+  const refreshSession = mutationGeneric({
+    args: { refreshToken: v.string() },
+    returns: v.union(vTokenBundle, v.null()),
+    handler: async (ctx, args): Promise<TokenBundle | null> => {
+      return await ctx.runMutation(component.public.refresh, {
+        refreshToken: args.refreshToken,
         issuer: issuer(),
         accessTokenTtlSeconds,
         refreshTokenTtlSeconds,
       });
-    };
+    },
+  });
 
-    const result: Record<string, unknown> = {};
-    for (const [config, options] of providers) {
-      const resolveUserId: ResolveUserIdFunc = (ctx, providerAccountId) =>
-        ctx.runQuery(component.public.getUserIdByAccount, {
-          provider: config.name,
-          providerAccountId,
-        });
-      result[config.name] = config.setup(
-        { completeSignIn, resolveUserId },
-        options,
+  const signOut = mutationGeneric({
+    args: { refreshToken: v.string() },
+    returns: v.null(),
+    handler: async (ctx, args) => {
+      await ctx.runMutation(component.public.signOut, {
+        refreshToken: args.refreshToken,
+      });
+      return null;
+    },
+  });
+
+  // Runs at the app deployment level (not inside the component) because only
+  // there does `ctx.auth` reflect the caller's verified identity: Convex
+  // checks the access token's signature against the deployment JWKS before
+  // the handler runs, so a forged/unsigned token yields no identity here.
+  const isAuthenticated = queryGeneric({
+    args: {},
+    returns: v.boolean(),
+    handler: async (ctx): Promise<boolean> => {
+      return (await ctx.auth.getUserIdentity()) !== null;
+    },
+  });
+
+  // Names of providers bound to this core, for duplicate detection. Scoped to
+  // this `setupCore` call (not module-global): the collision that matters is
+  // two providers on the same core, whose accounts would silently share rows.
+  const boundProviderNames = new Set<string>();
+
+  const bindProvider = <Provider extends string, Profile>({
+    name,
+    createOrUpdateUser,
+  }: {
+    name: Provider;
+    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>;
+  }): ProviderBuilders<Profile> => {
+    if (boundProviderNames.has(name)) {
+      throw new Error(
+        `A provider named "${name}" is already bound to this auth core. ` +
+          `Provider names key the accounts table, so each provider must ` +
+          `have a unique name.`,
       );
     }
+    boundProviderNames.add(name);
 
-    const refreshSession = mutationGeneric({
-      args: { refreshToken: v.string() },
-      returns: v.union(vTokenBundle, v.null()),
-      handler: async (ctx, args): Promise<TokenBundle | null> => {
-        return await ctx.runMutation(component.public.refresh, {
-          refreshToken: args.refreshToken,
+    // The helpers close over the live ctx; both mutation and action ctxs
+    // expose the compatible `runMutation`/`runQuery` these need.
+    const makeHelpers = (
+      ctx:
+        | GenericActionCtx<GenericDataModel>
+        | GenericMutationCtx<GenericDataModel>,
+    ) => ({
+      completeSignIn: async (args: {
+        providerAccountId: string;
+        profile: Profile;
+      }): Promise<TokenBundle> => {
+        const createOrUpdateUserHandle =
+          await createFunctionHandle(createOrUpdateUser);
+        return await ctx.runMutation(component.public.signIn, {
+          claims: {
+            provider: name,
+            providerAccountId: args.providerAccountId,
+            profile: args.profile,
+          },
+          createOrUpdateUserHandle,
           issuer: issuer(),
           accessTokenTtlSeconds,
           refreshTokenTtlSeconds,
         });
       },
-    });
-
-    const signOut = mutationGeneric({
-      args: { refreshToken: v.string() },
-      returns: v.null(),
-      handler: async (ctx, args) => {
-        await ctx.runMutation(component.public.signOut, {
-          refreshToken: args.refreshToken,
+      resolveUserId: async (
+        providerAccountId: string,
+      ): Promise<string | null> => {
+        return await ctx.runQuery(component.public.getUserIdByAccount, {
+          provider: name,
+          providerAccountId,
         });
-        return null;
       },
     });
 
-    // Runs at the app deployment level (not inside the component) because only
-    // there does `ctx.auth` reflect the caller's verified identity: Convex
-    // checks the access token's signature against the deployment JWKS before
-    // the handler runs, so a forged/unsigned token yields no identity here.
-    const isAuthenticated = queryGeneric({
-      args: {},
-      returns: v.boolean(),
-      handler: async (ctx): Promise<boolean> => {
-        return (await ctx.auth.getUserIdentity()) !== null;
-      },
-    });
+    const authMutation: AuthMutationBuilder<Profile> = (fn) =>
+      mutationGeneric({
+        args: fn.args as PropertyValidators,
+        returns: fn.returns,
+        handler: (ctx, args) =>
+          fn.handler(
+            { ...ctx, convexAuth: makeHelpers(ctx) },
+            args as Parameters<typeof fn.handler>[1],
+          ),
+      });
 
-    return {
-      refreshSession,
-      signOut,
-      isAuthenticated,
-      providers: result as ProviderApis<T>,
-    };
+    const authAction: AuthActionBuilder<Profile> = (fn) =>
+      actionGeneric({
+        args: fn.args as PropertyValidators,
+        returns: fn.returns,
+        handler: (ctx, args) =>
+          fn.handler(
+            { ...ctx, convexAuth: makeHelpers(ctx) },
+            args as Parameters<typeof fn.handler>[1],
+          ),
+      });
+
+    return { authMutation, authAction };
   };
 
-  return { attachUserCallback: buildFullApi };
+  return { signOut, refreshSession, isAuthenticated, bindProvider };
 }

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -78,7 +78,15 @@ export type ProviderBuilders<Profile> = {
  * The core auth API returned by {@link setupCore}: the session handlers the
  * app re-exports, plus {@link AuthCore.bindProvider} for wiring up providers.
  */
-export type AuthCore = {
+export type AuthCore<UsersTable extends string = string> = {
+  /**
+   * The name of the app's users table, as configured on {@link setupCore}.
+   *
+   * Carried on the value (not just in the type) so provider setup functions
+   * can infer `UsersTable` from the `core` they are handed, and so the name is
+   * available for error messages.
+   */
+  usersTable: UsersTable;
   /**
    * Signs out of the current session.
    *
@@ -137,7 +145,7 @@ export type AuthCore = {
    */
   bindProvider<Provider extends string, Profile>(options: {
     name: Provider;
-    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>;
+    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>;
   }): ProviderBuilders<Profile>;
 };
 
@@ -172,8 +180,25 @@ export type AuthCore = {
  * Changes to token TTLs impact newly minted tokens, not ones that have
  * already been issued.
  */
-export function setupCore(options: {
+export function setupCore<UsersTable extends string = "users">(options: {
   component: ComponentApi;
+  /**
+   * The name of the app's users table. Defaults to `"users"`.
+   *
+   * The core never reads or writes the table — it only stores the id the app's
+   * create-or-update-user callback returns. The name is a *type-level* contract:
+   * it makes every provider's `attachUserCallback` demand a mutation whose
+   * `userId` argument and return type are `Id<usersTable>`, so an app cannot
+   * accidentally hand back an id from some other table (and, because the app
+   * then declares `v.id(usersTable)`, Convex enforces the same thing at runtime).
+   *
+   * Set this if the app's users live in a table with a different name:
+   *
+   * ```ts
+   * const core = setupCore({ component: components.auth, usersTable: "members" });
+   * ```
+   */
+  usersTable?: UsersTable;
   /**
    * Access-token lifetime in seconds. Defaults to 60 (1 minute).
    *
@@ -188,8 +213,11 @@ export function setupCore(options: {
    * already been issued.
    */
   refreshTokenTtlSeconds?: number;
-}): AuthCore {
+}): AuthCore<UsersTable> {
   const { component, accessTokenTtlSeconds, refreshTokenTtlSeconds } = options;
+  // The default only matters to the type system (the core never touches the
+  // table), but keep the value in sync with the `= "users"` default above.
+  const usersTable = options.usersTable ?? ("users" as UsersTable);
 
   const issuer = (): string => {
     const url = process.env.CONVEX_SITE_URL;
@@ -243,7 +271,7 @@ export function setupCore(options: {
     createOrUpdateUser,
   }: {
     name: Provider;
-    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>;
+    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>;
   }): ProviderBuilders<Profile> => {
     if (boundProviderNames.has(name)) {
       throw new Error(
@@ -314,5 +342,5 @@ export function setupCore(options: {
     return { authMutation, authAction };
   };
 
-  return { signOut, refreshSession, isAuthenticated, bindProvider };
+  return { usersTable, signOut, refreshSession, isAuthenticated, bindProvider };
 }

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -93,8 +93,8 @@ export type SignUpResult = Infer<typeof signUpResult>;
  * user id back from it at sign-in. The password component itself stores only
  * `{ userId, passwordHash }` and knows nothing about usernames.
  */
-export function setupUsernamePassword(
-  core: AuthCore,
+export function setupUsernamePassword<UsersTable extends string>(
+  core: AuthCore<UsersTable>,
   options: UsernamePasswordOptions,
 ) {
   const { component, usernameComponent } = options;
@@ -108,7 +108,8 @@ export function setupUsernamePassword(
     attachUserCallback(
       createOrUpdateUser: CreateOrUpdateUserFn<
         "password",
-        { username: string }
+        { username: string },
+        UsersTable
       >,
     ) {
       const { authMutation } = core.bindProvider({

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -1,10 +1,10 @@
-import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import {
-  defineProvider,
   vSignInSuccess,
   USE_USER_ID_AS_ACCOUNT_ID,
+  type CreateOrUpdateUserFn,
 } from "../../lib/types";
+import type { AuthCore } from "../core/setup";
 import type { ComponentApi } from "./_generated/component.js";
 import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.js";
 import {
@@ -17,8 +17,11 @@ import {
   verifyPasswordUserError,
 } from "./validation";
 
+// TODO: derive this from the component mount path rather than hardcoding it.
+const PROVIDER_NAME = "password";
+
 /**
- * Options for {@link UsernamePassword}.
+ * Options for {@link setupUsernamePassword}.
  */
 export type UsernamePasswordOptions = {
   /**
@@ -33,9 +36,6 @@ export type UsernamePasswordOptions = {
    */
   usernameComponent: UsernameComponentApi;
 };
-
-// TODO: derive this from the component mount path rather than hardcoding it.
-const PROVIDER_NAME = "password";
 
 const signInResult = v.union(
   vSignInSuccess,
@@ -72,18 +72,17 @@ export type SignUpResult = Infer<typeof signUpResult>;
 
 /**
  * The simplest password recipe: every account is a `(username, password)` pair,
- * with no email or email verification. Wire it into `setupCore`:
+ * with no email or email verification. Wire it up in `convex/auth.ts`:
  *
  * ```ts
- * setupCore({
- *   component: components.auth,
- *   providers: [
- *     provider(UsernamePassword, {
- *       component: components.authPasswordProvider,
- *       usernameComponent: components.authUsername,
- *     }),
- *   ],
- * }).attachUserCallback(internal.users.upsertFromAuth);
+ * const core = setupCore({ component: components.auth });
+ * export const { signOut, refreshSession, isAuthenticated } = core;
+ *
+ * export const { signUpWithPassword, signInWithPassword } =
+ *   setupUsernamePassword(core, {
+ *     component: components.authPasswordProvider,
+ *     usernameComponent: components.authUsername,
+ *   }).attachUserCallback(internal.users.createOrUpdateUser);
  * ```
  *
  * The app re-exports the returned `signUpWithPassword` / `signInWithPassword`
@@ -94,137 +93,160 @@ export type SignUpResult = Infer<typeof signUpResult>;
  * user id back from it at sign-in. The password component itself stores only
  * `{ userId, passwordHash }` and knows nothing about usernames.
  */
-export const UsernamePassword = defineProvider({
-  name: PROVIDER_NAME,
-  setup: ({ completeSignIn }, options: UsernamePasswordOptions) => {
-    const { component, usernameComponent } = options;
+export function setupUsernamePassword(
+  core: AuthCore,
+  options: UsernamePasswordOptions,
+) {
+  const { component, usernameComponent } = options;
 
-    return {
-      /**
-       * Create a new account: reject a taken username or an invalid password,
-       * otherwise create the user + session and store the username and the
-       * password.
-       */
-      signUpWithPassword: mutationGeneric({
-        args: { username: v.string(), password: v.string() },
-        returns: signUpResult,
-        handler: async (ctx, { username, password }): Promise<SignUpResult> => {
-          // Validate the username and the password *before* creating
-          // anything, so invalid input never mints a session.
-          // (`setUsername` and `setPassword` do the same checks again, but by
-          // then the account would already exist.)
-          // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
-          const usernameError = validateUsernameFormat(username);
-          if (usernameError !== null) {
-            return { success: false, userError: usernameError };
-          }
-          const userError = validatePasswordInputFormat(password);
-          if (userError !== null) {
-            return { success: false, userError };
-          }
+  return {
+    /**
+     * Supply the app's create-or-update-user mutation (see
+     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
+     * get this provider's functions to export.
+     */
+    attachUserCallback(
+      createOrUpdateUser: CreateOrUpdateUserFn<
+        "password",
+        { username: string }
+      >,
+    ) {
+      const { authMutation } = core.bindProvider({
+        name: PROVIDER_NAME,
+        createOrUpdateUser,
+      });
 
-          const existing = await ctx.runQuery(
-            usernameComponent.public.getUserIdByUsername,
-            { username },
-          );
-          if (existing !== null) {
-            return { success: false, userError: { error: "USERNAME_TAKEN" } };
-          }
+      return {
+        /**
+         * Create a new account: reject a taken username or an invalid password,
+         * otherwise create the user + session and store the username and the
+         * password.
+         */
+        signUpWithPassword: authMutation({
+          args: { username: v.string(), password: v.string() },
+          returns: signUpResult,
+          handler: async (
+            ctx,
+            { username, password },
+          ): Promise<SignUpResult> => {
+            // Validate the username and the password *before* creating
+            // anything, so invalid input never mints a session.
+            // (`setUsername` and `setPassword` do the same checks again, but by
+            // then the account would already exist.)
+            // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
+            const usernameError = validateUsernameFormat(username);
+            if (usernameError !== null) {
+              return { success: false, userError: usernameError };
+            }
+            const userError = validatePasswordInputFormat(password);
+            if (userError !== null) {
+              return { success: false, userError };
+            }
 
-          // Create the account + app user (via the app's createOrUpdateUser)
-          // and mint the session. Password accounts are keyed by the app user
-          // id, which does not exist before this call mints it, hence the
-          // placeholder; sign-in passes the user id itself. `profile.username`
-          // keeps the original casing for display.
-          //
-          // TODO(nicolas) The app's `createOrUpdateUser` callback should not
-          // receive a provider account ID for the password provider at all:
-          // the value is an internal key ("" at sign-up, the user id
-          // afterwards) with no meaning to the app. We will probably improve
-          // this when providers support typesafe profiles.
-          const tokens = await completeSignIn(ctx, {
-            provider: PROVIDER_NAME,
-            providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
-            profile: { username },
-          });
-
-          const setUsernameResult = await ctx.runMutation(
-            usernameComponent.public.setUsername,
-            { userId: tokens.userId, username },
-          );
-          if (!setUsernameResult.success) {
-            // Unexpected: we validated the username above, and this handler
-            // is a mutation, thus the check for a conflict above and this
-            // call are in the same transaction.
-            // Throwing so that the transaction doesn’t commit.
-            throw new Error(
-              "Unexpected error when setting the username: " +
-                setUsernameResult.userError.error,
-              { cause: setUsernameResult.userError },
+            const existing = await ctx.runQuery(
+              usernameComponent.public.getUserIdByUsername,
+              { username },
             );
-          }
+            if (existing !== null) {
+              return { success: false, userError: { error: "USERNAME_TAKEN" } };
+            }
 
-          const setResult = await ctx.runMutation(
-            component.public.setPassword,
-            {
-              userId: tokens.userId,
-              password,
-            },
-          );
-          if (!setResult.success) {
-            // Unexpected: we pre-validated the password above,
-            // so this call should not fail.
-            // Throwing so that the transaction doesn’t commit.
+            // Create the account + app user (via the app's createOrUpdateUser)
+            // and mint the session. Password accounts are keyed by the app user
+            // id, which does not exist before this call mints it, hence the
+            // placeholder; sign-in passes the user id itself. `profile.username`
+            // keeps the original casing for display.
             //
-            // TODO(nicolas) can we improve this?
-            throw new Error(
-              "Unexpected error when setting the password: " + userError,
-              { cause: userError },
+            // TODO(nicolas) The app's `createOrUpdateUser` callback should not
+            // receive a provider account ID for the password provider at all:
+            // the value is an internal key ("" at sign-up, the user id
+            // afterwards) with no meaning to the app. We will probably improve
+            // this when providers support typesafe profiles.
+            const tokens = await ctx.convexAuth.completeSignIn({
+              providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
+              profile: { username },
+            });
+
+            const setUsernameResult = await ctx.runMutation(
+              usernameComponent.public.setUsername,
+              { userId: tokens.userId, username },
             );
-          }
+            if (!setUsernameResult.success) {
+              // Unexpected: we validated the username above, and this handler
+              // is a mutation, thus the check for a conflict above and this
+              // call are in the same transaction.
+              // Throwing so that the transaction doesn’t commit.
+              throw new Error(
+                "Unexpected error when setting the username: " +
+                  setUsernameResult.userError.error,
+                { cause: setUsernameResult.userError },
+              );
+            }
 
-          return { success: true, tokens };
-        },
-      }),
+            const setResult = await ctx.runMutation(
+              component.public.setPassword,
+              {
+                userId: tokens.userId,
+                password,
+              },
+            );
+            if (!setResult.success) {
+              // Unexpected: we pre-validated the password above,
+              // so this call should not fail.
+              // Throwing so that the transaction doesn’t commit.
+              //
+              // TODO(nicolas) can we improve this?
+              throw new Error(
+                "Unexpected error when setting the password: " + userError,
+                { cause: userError },
+              );
+            }
 
-      /**
-       * Verify an existing account's password and, on success, mint a session.
-       * Returns `USER_NOT_FOUND` when the username has no account and
-       * `INVALID_CREDENTIALS` when the password is wrong, so callers can tell
-       * the two apart. (Account existence is already observable via sign-up's
-       * `USERNAME_TAKEN`, so distinguishing them here leaks nothing new.)
-       */
-      signInWithPassword: mutationGeneric({
-        args: { username: v.string(), password: v.string() },
-        returns: signInResult,
-        handler: async (ctx, { username, password }): Promise<SignInResult> => {
-          const userId = await ctx.runQuery(
-            usernameComponent.public.getUserIdByUsername,
-            { username },
-          );
-          if (userId === null) {
-            return {
-              success: false,
-              userError: { error: "USER_NOT_FOUND" },
-            };
-          }
+            return { success: true, tokens };
+          },
+        }),
 
-          const verifyResult = await ctx.runMutation(
-            component.public.verifyPassword,
-            { userId, password },
-          );
-          if (!verifyResult.success) {
-            return { success: false, userError: verifyResult.userError };
-          }
+        /**
+         * Verify an existing account's password and, on success, mint a session.
+         * Returns `USER_NOT_FOUND` when the username has no account and
+         * `INVALID_CREDENTIALS` when the password is wrong, so callers can tell
+         * the two apart. (Account existence is already observable via sign-up's
+         * `USERNAME_TAKEN`, so distinguishing them here leaks nothing new.)
+         */
+        signInWithPassword: authMutation({
+          args: { username: v.string(), password: v.string() },
+          returns: signInResult,
+          handler: async (
+            ctx,
+            { username, password },
+          ): Promise<SignInResult> => {
+            const userId = await ctx.runQuery(
+              usernameComponent.public.getUserIdByUsername,
+              { username },
+            );
+            if (userId === null) {
+              return {
+                success: false,
+                userError: { error: "USER_NOT_FOUND" },
+              };
+            }
 
-          const tokens = await completeSignIn(ctx, {
-            provider: PROVIDER_NAME,
-            providerAccountId: userId,
-            profile: { username },
-          });
-          return { success: true, tokens };
-        },
-      }),
-    };
-  },
-});
+            const verifyResult = await ctx.runMutation(
+              component.public.verifyPassword,
+              { userId, password },
+            );
+            if (!verifyResult.success) {
+              return { success: false, userError: verifyResult.userError };
+            }
+
+            const tokens = await ctx.convexAuth.completeSignIn({
+              providerAccountId: userId,
+              profile: { username },
+            });
+            return { success: true, tokens };
+          },
+        }),
+      };
+    },
+  };
+}

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,10 +1,6 @@
-import {
-  FunctionReference,
-  GenericActionCtx,
-  GenericDataModel,
-} from "convex/server";
+import { FunctionReference } from "convex/server";
 
-import { GenericId, Infer, v } from "convex/values";
+import { Infer, v } from "convex/values";
 
 /**
  * Shared contracts that cross a module boundary within Convex Auth. That includes
@@ -135,7 +131,7 @@ export type IsAuthenticatedFn = FunctionReference<
 >;
 
 /**
- * The auth mutations the app exports from `setupCore(...).attachUserCallback`.
+ * The auth mutations the app exports from `setupCore`.
  * Passed as references (not names) because an app may re-export them under any
  * names. Consumed by both SPA and SSR implementations.
  */
@@ -182,120 +178,90 @@ export const vCreateOrUpdateUser = v.object({
   userId: v.union(v.string(), v.null()),
 });
 
-export type CreateOrUpdateUserFn<Provider extends string> = FunctionReference<
+/**
+ * The type of an app defined create-or-update-user mutation.
+ *
+ * This is the core entrypoint for an application to integrate its user model
+ * with Convex Auth. Apps install one per provider, via that provider's
+ * `attachUserCallback`, typed with that provider's exact name and profile
+ * shape.
+ *
+ * It will be called in two scenarios, both associated with a user signing in:
+ *
+ *  1. The first time a user signs in with an account from a provider.
+ *    * The `userId` argument will be `null` in this case.
+ *    * The application should create a new user record and return its `_id`
+ *  2. Subsequent sign ins from a provider
+ *    * The `userId` argument will be present.
+ *    * The application may use the data in `profile` to update or otherwise
+ *      modify the stored user record.
+ *    * The existing `userId` must be the return value.
+ *
+ * The application keeps ownership of its users table — the core only holds a
+ * reference to this one mutation, and treats the returned user id as an
+ * opaque string (so the table can have any name).
+ *
+ * If an application wants to reject a sign in, it can throw a `ConvexError`
+ * and the entire sign in attempt will be blocked.
+ *
+ * The mutation's args must be declared with the provider's *exact* literal
+ * types (e.g. `provider: v.literal("password")`, `profile: v.object({ username:
+ * v.string() })`).
+ *
+ * One mutation shared across providers, declaring a union of provider names,
+ * is runtime-safe but does not typecheck, because `FunctionReference` args
+ * compare covariantly. For shared logic, define one thin mutation per provider
+ * that delegates to a plain shared function.
+ */
+export type CreateOrUpdateUserFn<
+  Provider extends string,
+  Profile,
+> = FunctionReference<
   "mutation",
   "internal",
   {
     provider: Provider;
     providerAccountId: string;
-    // TODO: dowski - investigate type safety for provider profile data.
-    profile: unknown;
+    profile: Profile;
     userId: string | null;
   },
-  GenericId<"users">
+  string
 >;
 
 /**
- * The subset of a Convex `ctx` that {@link CompleteSignInFunc} needs. It only
- * calls `runMutation`, so accepting this structural type lets a provider
- * complete sign in from either a mutation or an action.
- */
-type RunMutationCtx = Pick<GenericActionCtx<GenericDataModel>, "runMutation">;
-
-/**
- * The subset of a Convex `ctx` that {@link ResolveUserIdFunc} needs. It only
- * calls `runQuery`, so accepting this structural type lets a provider resolve
- * a user id from either a mutation or an action.
- */
-type RunQueryCtx = Pick<GenericActionCtx<GenericDataModel>, "runQuery">;
-
-/**
- * Exchanges verified auth claims for a bundle.
- */
-export type CompleteSignInFunc = (
-  ctx: RunMutationCtx,
-  claims: AuthClaims,
-) => Promise<TokenBundle>;
-
-/**
- * A function that finds the user ID a provider account ID is associated with
- * (bound to a particular provider).
+ * The helpers that `authMutation`/`authAction` inject onto `ctx` for a
+ * provider's handlers.
  *
- * This does not mint a session or edit any data.
+ * This API is used for building auth providers.
  */
-export type ResolveUserIdFunc = (
-  ctx: RunQueryCtx,
-  providerAccountId: string,
-) => Promise<string | null>;
-
-export type ProviderHelpers = {
-  completeSignIn: CompleteSignInFunc;
-  resolveUserId: ResolveUserIdFunc;
-};
-
-type ProviderSetupFunc<O, P> = (helpers: ProviderHelpers, options: O) => P;
-
-export type ProviderConfig<N extends string, O, P> = {
+export type BoundAuthHelpers<Profile> = {
   /**
-   * The name of this provider.
+   * Exchange a verified account identity for a session.
    *
-   * This value will be persisted the `accounts` table and passed to
-   * the {@link CreateOrUpdateUserFn}.
+   * Call this once the provider has authenticated an account its own way
+   * (checking a password, say). It resolves (or creates) the account and its
+   * app user via an app-provided create-or-update-user callback, mints a
+   * session, and returns the tokens a client needs to make authenticated
+   * calls.
    */
-  // TODO: consider making the component more first-class in the API and using its name.
-  name: N;
+  completeSignIn(args: {
+    providerAccountId: string;
+    profile: Profile;
+  }): Promise<TokenBundle>;
   /**
-   * Convex Auth will call this function to setup this provider.
+   * Look up the app user id for a given `providerAccountId`.
    *
-   * It should return an object of names to Convex functions that will
-   * make up the public API surface of the provider. The provider APIs
-   * should be exported by application code so they are callable by
-   * client code. The API is responsible for authenticating a user and
-   * triggering the completion of sign in.
-   *
-   * It will be passed a {@link ProviderHelpers} bundle, provided by Convex
-   * Auth. `completeSignIn` accepts claims from a provider, establishes a
-   * session and returns the tokens required for a client application to make
-   * authenticated calls to Convex functions; the provider function that
-   * completes an authentication flow should call it once it has authenticated
-   * an account and return the result. `resolveUserId` looks up the app user id
-   * behind one of this provider's account identifiers without minting a session
-   * (e.g. to find the user a password should be verified against).
-   *
-   * It will also receive any `options` that the provider defined.
+   * Returns `null` when no user id is found for the account.
    */
-  setup: ProviderSetupFunc<O, P>;
+  resolveUserId(providerAccountId: string): Promise<string | null>;
 };
 
 /**
- * A convenience function for defining a `ProviderConfig`.
+ * The ctx additions that `authMutation`/`authAction` provide to provider
+ * handlers.
  *
- * Call it like:
- *
- * ```typescript
- * const FooProvider = defineProvider(
- *   {
- *     name: "foo",
- *     setup: ({ completeSignIn, resolveUserId }, options: {limit: number}) => {
- *       return {
- *         login: actionGeneric({
- *           args: {},
- *           handler: async (ctx, args) => {
- *             // Do your login magic here.
- *             const claims = await authenticateFoo(args, options.limit);
- *             return completeSignIn(ctx, claims);
- *           }
- *         })
- *       }
- *     },
- *   }
- * );
- * ```
- *
- * All of the generic types are inferred from the passed in object.
+ * The {@link BoundAuthHelpers} are available under `ctx.convexAuth`.
  */
-export function defineProvider<const N extends string, O, P>(
-  config: ProviderConfig<N, O, P>,
-): ProviderConfig<N, O, P> {
-  return config;
-}
+export type ConvexAuthCtx<Profile> = {
+  convexAuth: BoundAuthHelpers<Profile>;
+};

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,6 +1,6 @@
 import { FunctionReference } from "convex/server";
 
-import { Infer, v } from "convex/values";
+import { GenericId, Infer, v } from "convex/values";
 
 /**
  * Shared contracts that cross a module boundary within Convex Auth. That includes
@@ -198,8 +198,11 @@ export const vCreateOrUpdateUser = v.object({
  *    * The existing `userId` must be the return value.
  *
  * The application keeps ownership of its users table — the core only holds a
- * reference to this one mutation, and treats the returned user id as an
- * opaque string (so the table can have any name).
+ * reference to this one mutation, and treats the returned user id as an opaque
+ * string at runtime. At the type level the table is named by the `usersTable`
+ * option on `setupCore` (defaulting to `"users"`), which is what makes the
+ * callback's `userId` argument and return type `Id<usersTable>` rather than a
+ * bare string.
  *
  * If an application wants to reject a sign in, it can throw a `ConvexError`
  * and the entire sign in attempt will be blocked.
@@ -216,6 +219,7 @@ export const vCreateOrUpdateUser = v.object({
 export type CreateOrUpdateUserFn<
   Provider extends string,
   Profile,
+  UsersTable extends string = string,
 > = FunctionReference<
   "mutation",
   "internal",
@@ -223,9 +227,9 @@ export type CreateOrUpdateUserFn<
     provider: Provider;
     providerAccountId: string;
     profile: Profile;
-    userId: string | null;
+    userId: GenericId<UsersTable> | null;
   },
-  string
+  GenericId<UsersTable>
 >;
 
 /**

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -1,5 +1,6 @@
 import { Infer, v } from "convex/values";
-import { defineProvider } from "../../lib/types";
+import type { CreateOrUpdateUserFn } from "../../lib/types";
+import type { AuthCore } from "../../components/core/setup";
 import {
   setupOauth,
   type OauthCatalog,
@@ -49,10 +50,10 @@ type GithubUser = {
 type GithubUserInfo = { user: GithubUser; emails: GithubEmail[] };
 
 /** Map GitHub's userinfo responses to {@link GithubProfile}. */
-export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
-  _claims,
-  userInfoResponses,
-) => {
+export const normalizeGithubProfile: OauthProfile<
+  GithubProfile,
+  GithubUserInfo
+> = (_claims, userInfoResponses) => {
   const user = userInfoResponses?.user;
   if (user === undefined) {
     throw new Error("GitHub userinfo response is missing the `user` entry");
@@ -78,7 +79,7 @@ export const normalizeGithubProfile: OauthProfile<GithubUserInfo> = (
 };
 
 /** GitHub's endpoints, scopes, and profile mapping. */
-const githubCatalog: OauthCatalog<GithubUserInfo> = {
+const githubCatalog: OauthCatalog<GithubProfile, GithubUserInfo> = {
   authorizationEndpoint: "https://github.com/login/oauth/authorize",
   tokenEndpoint: "https://github.com/login/oauth/access_token",
   scopes: ["read:user", "user:email"],
@@ -91,14 +92,14 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
 };
 
 /**
- * Built-in GitHub OAuth provider. Register it with its own oauth component
+ * Built-in GitHub OAuth provider. Wire it up with its own oauth component
  * instance:
  *
  * ```ts
- * provider(OauthGithub, {
+ * export const { startSignInGithub, completeSignInGithub } = setupGithub(core, {
  *   component: components.oauthGithub,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * })
+ * }).attachUserCallback(internal.users.createOrUpdateGithubUser);
  * ```
  *
  * Setup:
@@ -111,18 +112,27 @@ const githubCatalog: OauthCatalog<GithubUserInfo> = {
  *
  * The `httpPrefix` alone determines the callback URL.
  */
-export const OauthGithub = defineProvider({
-  name: "github",
-  setup: (helpers, options: OauthProviderOptions) => {
-    const { startSignIn, completeSignIn } = setupOauth(
-      "github",
-      githubCatalog,
-      helpers,
-      options,
-    );
-    return {
-      startSignInGithub: startSignIn,
-      completeSignInGithub: completeSignIn,
-    };
-  },
-});
+export function setupGithub(core: AuthCore, options: OauthProviderOptions) {
+  return {
+    /**
+     * Supply the app's create-or-update-user mutation (see
+     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
+     * get this provider's functions to export.
+     */
+    attachUserCallback(
+      createOrUpdateUser: CreateOrUpdateUserFn<"github", GithubProfile>,
+    ) {
+      const { startSignIn, completeSignIn } = setupOauth(
+        core,
+        "github",
+        githubCatalog,
+        createOrUpdateUser,
+        options,
+      );
+      return {
+        startSignInGithub: startSignIn,
+        completeSignInGithub: completeSignIn,
+      };
+    },
+  };
+}

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -112,7 +112,10 @@ const githubCatalog: OauthCatalog<GithubProfile, GithubUserInfo> = {
  *
  * The `httpPrefix` alone determines the callback URL.
  */
-export function setupGithub(core: AuthCore, options: OauthProviderOptions) {
+export function setupGithub<UsersTable extends string>(
+  core: AuthCore<UsersTable>,
+  options: OauthProviderOptions,
+) {
   return {
     /**
      * Supply the app's create-or-update-user mutation (see
@@ -120,7 +123,11 @@ export function setupGithub(core: AuthCore, options: OauthProviderOptions) {
      * get this provider's functions to export.
      */
     attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<"github", GithubProfile>,
+      createOrUpdateUser: CreateOrUpdateUserFn<
+        "github",
+        GithubProfile,
+        UsersTable
+      >,
     ) {
       const { startSignIn, completeSignIn } = setupOauth(
         core,

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -1,5 +1,6 @@
 import { Infer, v } from "convex/values";
-import { defineProvider } from "../../lib/types";
+import type { CreateOrUpdateUserFn } from "../../lib/types";
+import type { AuthCore } from "../../components/core/setup";
 import {
   setupOauth,
   type OauthCatalog,
@@ -33,7 +34,7 @@ export type GoogleProfile = Infer<typeof vGoogleProfile>;
  * returns an id_token, so `claims` is always present here. A missing one is
  * a bug.
  */
-export const normalizeGoogleProfile: OauthProfile = (claims) => {
+export const normalizeGoogleProfile: OauthProfile<GoogleProfile> = (claims) => {
   if (claims === undefined) {
     throw new Error("Google returned no id_token to build a profile from");
   }
@@ -47,7 +48,7 @@ export const normalizeGoogleProfile: OauthProfile = (claims) => {
 };
 
 /** Google's endpoints, scopes, and profile mapping. */
-const googleCatalog: OauthCatalog = {
+const googleCatalog: OauthCatalog<GoogleProfile> = {
   authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenEndpoint: "https://oauth2.googleapis.com/token",
   // Google documents both forms, with or without the https prefix.
@@ -58,14 +59,14 @@ const googleCatalog: OauthCatalog = {
 };
 
 /**
- * Built-in Google OAuth provider. Register it with its own oauth component
+ * Built-in Google OAuth provider. Wire it up with its own oauth component
  * instance:
  *
  * ```ts
- * provider(OauthGoogle, {
+ * export const { startSignInGoogle, completeSignInGoogle } = setupGoogle(core, {
  *   component: components.oauthGoogle,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * })
+ * }).attachUserCallback(internal.users.createOrUpdateGoogleUser);
  * ```
  *
  * Setup:
@@ -78,18 +79,27 @@ const googleCatalog: OauthCatalog = {
  *
  * The `httpPrefix` alone determines the callback URL.
  */
-export const OauthGoogle = defineProvider({
-  name: "google",
-  setup: (helpers, options: OauthProviderOptions) => {
-    const { startSignIn, completeSignIn } = setupOauth(
-      "google",
-      googleCatalog,
-      helpers,
-      options,
-    );
-    return {
-      startSignInGoogle: startSignIn,
-      completeSignInGoogle: completeSignIn,
-    };
-  },
-});
+export function setupGoogle(core: AuthCore, options: OauthProviderOptions) {
+  return {
+    /**
+     * Supply the app's create-or-update-user mutation (see
+     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
+     * get this provider's functions to export.
+     */
+    attachUserCallback(
+      createOrUpdateUser: CreateOrUpdateUserFn<"google", GoogleProfile>,
+    ) {
+      const { startSignIn, completeSignIn } = setupOauth(
+        core,
+        "google",
+        googleCatalog,
+        createOrUpdateUser,
+        options,
+      );
+      return {
+        startSignInGoogle: startSignIn,
+        completeSignInGoogle: completeSignIn,
+      };
+    },
+  };
+}

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -79,7 +79,10 @@ const googleCatalog: OauthCatalog<GoogleProfile> = {
  *
  * The `httpPrefix` alone determines the callback URL.
  */
-export function setupGoogle(core: AuthCore, options: OauthProviderOptions) {
+export function setupGoogle<UsersTable extends string>(
+  core: AuthCore<UsersTable>,
+  options: OauthProviderOptions,
+) {
   return {
     /**
      * Supply the app's create-or-update-user mutation (see
@@ -87,7 +90,11 @@ export function setupGoogle(core: AuthCore, options: OauthProviderOptions) {
      * get this provider's functions to export.
      */
     attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<"google", GoogleProfile>,
+      createOrUpdateUser: CreateOrUpdateUserFn<
+        "google",
+        GoogleProfile,
+        UsersTable
+      >,
     ) {
       const { startSignIn, completeSignIn } = setupOauth(
         core,

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -1,30 +1,41 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { makeFunctionReference } from "convex/server";
+import { makeFunctionReference, mutationGeneric } from "convex/server";
+import type { PropertyValidators } from "convex/values";
 import { api, internal } from "./_generated/api.js";
 import type { ComponentApi } from "./_generated/component.js";
 import schema from "./schema.js";
 import { setupOauth, type OauthProfile } from "./setup";
 import { encryptTicketPayload, generateRandomToken } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
-import type { AuthClaims, ProviderHelpers, TokenBundle } from "../../lib/types";
+import type {
+  AuthClaims,
+  BoundAuthHelpers,
+  TokenBundle,
+} from "../../lib/types";
+import type {
+  AuthActionBuilder,
+  AuthCore,
+  AuthMutationBuilder,
+  ProviderBuilders,
+} from "../../components/core/setup";
 
 /**
  * Tests for the app-side `completeSignIn` mutation that `setupOauth`
  * produces, run against the real component (real `claimTicket`, real ticket
- * crypto). The helpers that turn verified claims into a session
- * (`helpers.completeSignIn`) are faked and spied here. The real helpers are
+ * crypto). The core helper that turns verified claims into a session
+ * (`ctx.convexAuth.completeSignIn`) is faked and spied here. The real one is
  * covered by the core's own suite (components/core/core.test.ts).
  */
 
 /**
- * Claims recorded by the fake `helpers.completeSignIn`. The suite runs in
- * one process, so tests read and reset this directly.
+ * Claims recorded by the fake `ctx.convexAuth.completeSignIn`. The suite runs
+ * in one process, so tests read and reset this directly.
  */
 const completeSignInCalls: AuthClaims[] = [];
 
 /**
- * When set, the fake `helpers.completeSignIn` throws this instead of
+ * When set, the fake `ctx.convexAuth.completeSignIn` throws this instead of
  * returning a bundle, modeling the app rejecting the sign-in from its
  * `createOrUpdateUser` callback.
  */
@@ -40,19 +51,50 @@ const FAKE_BUNDLE: TokenBundle = {
 };
 
 /**
- * Fake {@link ProviderHelpers}. `resolveUserId` is never reached by
- * redemption.
+ * A fake core whose builders inject fake {@link BoundAuthHelpers}.
+ * `resolveUserId` is never reached by redemption.
  */
-const fakeHelpers: ProviderHelpers = {
-  completeSignIn: async (_ctx, claims) => {
-    completeSignInCalls.push({ ...claims });
-    if (helperFailure.error !== undefined) {
-      throw helperFailure.error;
-    }
-    return FAKE_BUNDLE;
+const FAKE_CORE = {
+  bindProvider: <Provider extends string, Profile>({
+    name,
+  }: {
+    name: Provider;
+  }): ProviderBuilders<Profile> => {
+    const convexAuth: BoundAuthHelpers<Profile> = {
+      completeSignIn: async ({ providerAccountId, profile }) => {
+        completeSignInCalls.push({
+          provider: name,
+          providerAccountId,
+          profile,
+        });
+        if (helperFailure.error !== undefined) {
+          throw helperFailure.error;
+        }
+        return FAKE_BUNDLE;
+      },
+      resolveUserId: async () => null,
+    };
+    const authMutation: AuthMutationBuilder<Profile> = (fn) =>
+      mutationGeneric({
+        args: fn.args as PropertyValidators,
+        returns: fn.returns,
+        handler: (ctx, args) =>
+          fn.handler(
+            { ...ctx, convexAuth },
+            args as Parameters<typeof fn.handler>[1],
+          ),
+      });
+    const authAction: AuthActionBuilder<Profile> = () => {
+      throw new Error("redemption does not build actions");
+    };
+    return { authMutation, authAction };
   },
-  resolveUserId: async () => null,
-};
+} as unknown as AuthCore;
+
+/**
+ * A create-or-update-user callback reference. The fake core never invokes it.
+ */
+const FAKE_CALLBACK = {} as never;
 
 /**
  * Provider options for every instance under test. The component's own
@@ -94,7 +136,10 @@ const USERINFO_CATALOG = {
   profile: ((_claims, userInfoResponses) => ({
     id: String(userInfoResponses!.user.id),
     login: userInfoResponses!.user.login,
-  })) satisfies OauthProfile<{ user: { id: number; login: string } }>,
+  })) satisfies OauthProfile<
+    { id: string; login: string },
+    { user: { id: number; login: string } }
+  >,
 };
 
 /** A catalog whose profile mapping returns an empty id. */
@@ -123,24 +168,32 @@ const MISSING_ID_CATALOG = {
  * public mutations into the component's generated API.
  */
 const testApp = {
-  completeSignInAcme: setupOauth("acme", CLAIMS_CATALOG, fakeHelpers, OPTIONS)
-    .completeSignIn,
+  completeSignInAcme: setupOauth(
+    FAKE_CORE,
+    "acme",
+    CLAIMS_CATALOG,
+    FAKE_CALLBACK,
+    OPTIONS,
+  ).completeSignIn,
   completeSignInAcmeInfo: setupOauth(
+    FAKE_CORE,
     "acmeInfo",
     USERINFO_CATALOG,
-    fakeHelpers,
+    FAKE_CALLBACK,
     OPTIONS,
   ).completeSignIn,
   completeSignInEmptyId: setupOauth(
+    FAKE_CORE,
     "emptyId",
     EMPTY_ID_CATALOG,
-    fakeHelpers,
+    FAKE_CALLBACK,
     OPTIONS,
   ).completeSignIn,
   completeSignInMissingId: setupOauth(
+    FAKE_CORE,
     "missingId",
     MISSING_ID_CATALOG,
-    fakeHelpers,
+    FAKE_CALLBACK,
     OPTIONS,
   ).completeSignIn,
 };

--- a/packages/core/src/oauth/component/setup.test.ts
+++ b/packages/core/src/oauth/component/setup.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import type { ProviderHelpers } from "../../lib/types";
+import { actionGeneric, mutationGeneric } from "convex/server";
+import type { AuthCore } from "../../components/core/setup";
 import type { ComponentApi } from "./_generated/component.js";
 import {
   setupOauth,
@@ -20,15 +21,26 @@ const CATALOG: OauthCatalog = {
 };
 
 /**
+ * A core that hands back plain function builders. Nothing here calls the
+ * built functions, so the injected `ctx.convexAuth` is never needed.
+ */
+const CORE = {
+  bindProvider: () => ({
+    authMutation: mutationGeneric,
+    authAction: actionGeneric,
+  }),
+} as unknown as AuthCore;
+
+/**
  * Run the provider's setup with the given options merged over a valid base.
- * Validation runs before the helpers or the component are touched, so
+ * Validation runs before the core or the component are touched, so
  * fakes suffice.
  */
 function setup(
   options: Partial<OauthProviderOptions> = {},
   catalog: OauthCatalog = CATALOG,
 ) {
-  return setupOauth("acme", catalog, {} as ProviderHelpers, {
+  return setupOauth(CORE, "acme", catalog, {} as never, {
     component: {} as ComponentApi,
     allowedRedirectOrigins: ["https://app.example.com"],
     ...options,

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -146,12 +146,13 @@ function parseUrl(value: string): URL | null {
 export function setupOauth<
   Provider extends string,
   Profile extends { id: string },
+  UsersTable extends string,
   UserInfo extends Record<string, unknown> = Record<string, unknown>,
 >(
-  core: AuthCore,
+  core: AuthCore<UsersTable>,
   providerName: Provider,
   catalog: OauthCatalog<Profile, UserInfo>,
-  createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>,
+  createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>,
   options: OauthProviderOptions,
 ) {
   // Validate the app-supplied options up front so mistakes fail at deploy

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -2,9 +2,10 @@ import { mutationGeneric } from "convex/server";
 import { v } from "convex/values";
 import {
   vTokenBundle,
-  type ProviderHelpers,
+  type CreateOrUpdateUserFn,
   type TokenBundle,
 } from "../../lib/types";
+import type { AuthCore } from "../../components/core/setup";
 import type { ComponentApi } from "./_generated/component.js";
 import {
   decryptTicketPayload,
@@ -34,17 +35,21 @@ export type OidcClaims = {
  * `userInfoEndpoints`). `id` becomes the provider account id. Supplied by
  * each provider's catalog (see `google.ts`, `github.ts`).
  *
+ * `Profile` is the exact shape the mapping emits, which is what the app's
+ * create-or-update-user callback receives.
+ *
  * `UserInfo` is the catalog's declared shape for the userinfo responses,
  * keyed like `userInfoEndpoints`. It types what the provider is trusted to
  * return. The responses are provider-attested JSON and are not validated
  * against it at runtime.
  */
 export type OauthProfile<
+  Profile extends { id: string } = { id: string } & Record<string, unknown>,
   UserInfo extends Record<string, unknown> = Record<string, unknown>,
 > = (
   claims: OidcClaims | undefined,
   userInfoResponses: UserInfo | undefined,
-) => { id: string; [key: string]: unknown };
+) => Profile;
 
 /**
  * Provider-defined config for interacting with an individual OAuth provider.
@@ -54,6 +59,7 @@ export type OauthProfile<
  * {@link OauthProfile}).
  */
 export type OauthCatalog<
+  Profile extends { id: string } = { id: string } & Record<string, unknown>,
   UserInfo extends Record<string, unknown> = Record<string, unknown>,
 > = {
   /**
@@ -89,7 +95,7 @@ export type OauthCatalog<
    */
   pkce: boolean;
   /** Map the provider's attested identity to the account profile. */
-  profile: OauthProfile<UserInfo>;
+  profile: OauthProfile<Profile, UserInfo>;
 };
 
 /**
@@ -138,11 +144,14 @@ function parseUrl(value: string): URL | null {
  * TODO: support response_mode=form_post (Apple) before launch.
  */
 export function setupOauth<
+  Provider extends string,
+  Profile extends { id: string },
   UserInfo extends Record<string, unknown> = Record<string, unknown>,
 >(
-  providerName: string,
-  catalog: OauthCatalog<UserInfo>,
-  helpers: ProviderHelpers,
+  core: AuthCore,
+  providerName: Provider,
+  catalog: OauthCatalog<Profile, UserInfo>,
+  createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile>,
   options: OauthProviderOptions,
 ) {
   // Validate the app-supplied options up front so mistakes fail at deploy
@@ -182,6 +191,11 @@ export function setupOauth<
       `Provider "${providerName}" requests the "openid" scope, so the provider will return an id_token, but its catalog sets no issuer to validate it against`,
     );
   }
+
+  const { authMutation } = core.bindProvider({
+    name: providerName,
+    createOrUpdateUser,
+  });
 
   /**
    * Start an OAuth sign-in. The server mints `state` and returns it;
@@ -258,7 +272,9 @@ export function setupOauth<
    * `createOrUpdateUser`) rolls back the ticket claim. Only a
    * successful redemption consumes the ticket.
    */
-  const completeSignIn = mutationGeneric({
+  // TODO: dowski - return the shared `vSignInSuccess` envelope like the other
+  // providers do, instead of a bare bundle or null.
+  const completeSignIn = authMutation({
     args: {
       code: v.string(),
       state: v.string(),
@@ -294,8 +310,7 @@ export function setupOauth<
         );
       }
 
-      return await helpers.completeSignIn(ctx, {
-        provider: providerName,
+      return await ctx.convexAuth.completeSignIn({
         providerAccountId: profile.id,
         profile,
       });

--- a/packages/docs/content/docs/login-providers/anonymous.mdx
+++ b/packages/docs/content/docs/login-providers/anonymous.mdx
@@ -52,6 +52,14 @@ Add an empty `users` table to your schema in `convex/schema.ts`.
 
 Convex Auth will create a row for each account. You can also add application-specific fields to this table if necessary.
 
+The table does not have to be called `users` — if yours has another name, pass
+it to `setupCore`, and every provider's `attachUserCallback` will then require
+a callback typed with that table's ids:
+
+```ts title="convex/auth.ts"
+const core = setupCore({ component: components.auth, usersTable: "members" });
+```
+
 <include
   lang="ts"
   meta='title="convex/schema.ts" highlight="users: defineTable({}),"'

--- a/packages/docs/content/docs/login-providers/anonymous.mdx
+++ b/packages/docs/content/docs/login-providers/anonymous.mdx
@@ -75,12 +75,13 @@ Convex Auth will create a row for each account. You can also add application-spe
 
 ### Set up the public backend functions
 
-Add the `Anonymous` provider to `setupCore` and export its sign-in action in
-`convex/auth.ts`:
+Set up the anonymous provider with `setupAnonymous` and export the sign-in
+mutation it hands back once you attach the callback that creates your user
+rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { Anonymous }" highlight="providers: {...}," highlight="providers: [...],"'
+  meta='title="convex/auth.ts" highlight="import { setupAnonymous }" highlight="export const { signInAnonymous } = setupAnonymous(core, {...}).attachUserCallback(internal.users.createOrUpdateUser);"'
 >
   ../../../../../examples/react-minimal/convex/auth.ts
 </include>

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -52,6 +52,14 @@ Add a `users` table to your schema in `convex/schema.ts` with a `username` strin
 
 Convex Auth will create a row for each account. You can also add application-specific fields to this table if necessary.
 
+The table does not have to be called `users` — if yours has another name, pass
+it to `setupCore`, and every provider's `attachUserCallback` will then require
+a callback typed with that table's ids:
+
+```ts title="convex/auth.ts"
+const core = setupCore({ component: components.auth, usersTable: "members" });
+```
+
 <include
   lang="ts"
   meta='title="convex/schema.ts" highlight="users: defineTable({...}),"'

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -75,12 +75,13 @@ Convex Auth will create a row for each account. You can also add application-spe
 
 ### Set up the public backend functions
 
-Add the `UsernamePassword` provider to `setupCore` and export its sign-up and
-sign-in mutations in `convex/auth.ts`:
+Set up the password provider with `setupUsernamePassword` and export the
+sign-up and sign-in mutations it hands back once you attach the callback that
+creates your user rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { UsernamePassword }" highlight="providers: {...}," highlight="providers: [...],"'
+  meta='title="convex/auth.ts" highlight="import { setupUsernamePassword }" highlight="export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(...).attachUserCallback(internal.users.createOrUpdateUser);"'
 >
   ../../../../../examples/react-password/convex/auth.ts
 </include>


### PR DESCRIPTION
Bring back setup functions

This allows each provider to have its own callback for handling sign-in/sign-up.

It also makes provider creation somewhat less "magical". Providers are functions that take result of calling `setupCore` which includes custom helpers (`authMutation`, `authAction`) that have access on `ctx` to functions for completing sign in, looking up users, etc. The pattern is inspired by `convex-helpers` and its custom functions pattern.

Two nice benefits:

1. It's easy to scope behavior to providers
2. The callbacks can now be typed directly to the provider's profile type