### PR TITLE
Rename the auth core component to “auth”

### DIFF
--- a/examples/nextjs/convex/_generated/api.d.ts
+++ b/examples/nextjs/convex/_generated/api.d.ts
@@ -49,7 +49,7 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  auth: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"auth">;
   authAnonymous: import("@convex-dev/auth/providers/anonymous/_generated/component.js").ComponentApi<"authAnonymous">;
   authPasswordProvider: import("@convex-dev/auth/providers/password/_generated/component.js").ComponentApi<"authPasswordProvider">;
   authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;

--- a/examples/nextjs/convex/auth.ts
+++ b/examples/nextjs/convex/auth.ts
@@ -18,7 +18,7 @@ export const {
     password: { signUpWithPassword, signInWithPassword },
   },
 } = setupCore({
-  component: components.core,
+  component: components.auth,
   providers: [
     provider(Anonymous, {
       component: components.authAnonymous,

--- a/examples/nextjs/convex/convex.config.ts
+++ b/examples/nextjs/convex/convex.config.ts
@@ -1,6 +1,6 @@
 import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
+import auth from "@convex-dev/auth/core/convex.config.js";
 import anonymous from "@convex-dev/auth/providers/anonymous/convex.config.js";
 import passwordProvider from "@convex-dev/auth/providers/password/convex.config.js";
 import authUsername from "@convex-dev/auth/username/convex.config.js";
@@ -12,7 +12,7 @@ const app = defineApp({
   },
 });
 
-app.use(core, {
+app.use(auth, {
   httpPrefix: "/auth",
   env: {
     AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,

--- a/examples/react-minimal/convex/_generated/api.d.ts
+++ b/examples/react-minimal/convex/_generated/api.d.ts
@@ -51,6 +51,6 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  auth: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"auth">;
   authAnonymous: import("@convex-dev/auth/providers/anonymous/_generated/component.js").ComponentApi<"authAnonymous">;
 };

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -9,7 +9,7 @@ export const {
     anonymous: { signInAnonymous },
   },
 } = setupCore({
-  component: components.core,
+  component: components.auth,
   providers: [
     provider(Anonymous, {
       component: components.authAnonymous,

--- a/examples/react-minimal/convex/convex.config.ts
+++ b/examples/react-minimal/convex/convex.config.ts
@@ -1,6 +1,6 @@
 import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
+import auth from "@convex-dev/auth/core/convex.config.js";
 import anonymous from "@convex-dev/auth/providers/anonymous/convex.config.js";
 
 const app = defineApp({
@@ -10,7 +10,7 @@ const app = defineApp({
   },
 });
 
-app.use(core, {
+app.use(auth, {
   httpPrefix: "/auth",
   env: {
     AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,

--- a/examples/react-password/convex/_generated/api.d.ts
+++ b/examples/react-password/convex/_generated/api.d.ts
@@ -51,7 +51,7 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  core: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"core">;
+  auth: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"auth">;
   authPasswordProvider: import("@convex-dev/auth/providers/password/_generated/component.js").ComponentApi<"authPasswordProvider">;
   authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;
 };

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -9,7 +9,7 @@ export const {
     password: { signUpWithPassword, signInWithPassword },
   },
 } = setupCore({
-  component: components.core,
+  component: components.auth,
   providers: [
     provider(UsernamePassword, {
       component: components.authPasswordProvider,

--- a/examples/react-password/convex/convex.config.ts
+++ b/examples/react-password/convex/convex.config.ts
@@ -1,6 +1,6 @@
 import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
+import auth from "@convex-dev/auth/core/convex.config.js";
 import passwordProvider from "@convex-dev/auth/providers/password/convex.config.js";
 import username from "@convex-dev/auth/username/convex.config.js";
 
@@ -11,7 +11,7 @@ const app = defineApp({
   },
 });
 
-app.use(core, {
+app.use(auth, {
   httpPrefix: "/auth",
   env: {
     AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -53,7 +53,7 @@ export default {
 `,
   "convex.config.ts": `import { defineApp } from "convex/server";
 import { v } from "convex/values";
-import core from "@convex-dev/auth/core/convex.config.js";
+import auth from "@convex-dev/auth/core/convex.config.js";
 
 const app = defineApp({
   env: {
@@ -62,7 +62,7 @@ const app = defineApp({
   },
 });
 
-app.use(core, {
+app.use(auth, {
   httpPrefix: "/auth",
   env: {
     AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
@@ -83,7 +83,7 @@ export const {
     // TODO
   },
 } = setupCore({
-  component: components.core,
+  component: components.auth,
   providers: [
     // TODO
   ],

--- a/packages/core/src/components/core/convex.config.ts
+++ b/packages/core/src/components/core/convex.config.ts
@@ -12,6 +12,10 @@ import { v } from "convex/values";
  *
  * It does NOT know about any specific provider. Providers hand it identity
  * claims (see ../../lib/types) and the core turns that into a session + JWT.
+ *
+ * TODO Consider removing `/core/` from the import paths: apps import this
+ * component from `@convex-dev/auth/core/...`, which no longer matches the
+ * component name (`auth`).
  */
 const component = defineComponent("auth", {
   env: {

--- a/packages/core/src/components/core/convex.config.ts
+++ b/packages/core/src/components/core/convex.config.ts
@@ -13,7 +13,7 @@ import { v } from "convex/values";
  * It does NOT know about any specific provider. Providers hand it identity
  * claims (see ../../lib/types) and the core turns that into a session + JWT.
  */
-const component = defineComponent("core", {
+const component = defineComponent("auth", {
   env: {
     AUTH_PRIVATE_KEY: v.string(),
     AUTH_JWKS: v.string(),

--- a/packages/core/src/components/core/http.ts
+++ b/packages/core/src/components/core/http.ts
@@ -4,7 +4,7 @@ import { httpAction, env } from "./_generated/server";
 // The core serves its own JWKS. AUTH_JWKS is a static env var set by running
 // `npx @convex-dev/auth` and is served verbatim here. Convex mounts these
 // routes under the prefix the app declares in convex.config.ts
-// (`app.use(core, { httpPrefix: "/auth" })`), so the served path is
+// (`app.use(auth, { httpPrefix: "/auth" })`), so the served path is
 // <prefix>/.well-known/jwks.json — point auth.config.ts's `jwks` URL there.
 const http = httpRouter();
 

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -76,7 +76,7 @@ export type SignUpResult = Infer<typeof signUpResult>;
  *
  * ```ts
  * setupCore({
- *   component: components.core,
+ *   component: components.auth,
  *   providers: [
  *     provider(UsernamePassword, {
  *       component: components.authPasswordProvider,

--- a/packages/core/src/components/testing/core.ts
+++ b/packages/core/src/components/testing/core.ts
@@ -10,7 +10,7 @@ const modules = import.meta.glob("../core/**/*.ts");
  */
 export function registerCore(
   t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
-  name: string = "core",
+  name: string = "auth",
 ) {
   t.registerComponent(name, schema, modules);
 }


### PR DESCRIPTION
https://convexdev.slack.com/archives/C04U4LQ9WDD/p1786670004251699

This PR renames the core component from `core` to `auth` for consistency with the other auth components (e.g. `authPassword`, `authUsername`, `authPasskey`).

The import paths still include `core` (`@convex-dev/auth/core/*`). We might consider renaming them in the future.