### PR TITLE
Add core signUpWithoutSession: account + user without a session

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 node_modules
 dist
+# Local anonymous Convex deployment state (used for component codegen).
+.convex
 **/_generated/**
 .agents
 .context

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -24,6 +24,16 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     public: {
+      createAccount: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          claims: { profile: any; provider: string; providerAccountId: string };
+          createOrUpdateUserHandle: string;
+        },
+        { userId: string },
+        Name
+      >;
       getUserIdByAccount: FunctionReference<
         "query",
         "internal",

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -24,16 +24,6 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     public: {
-      createAccount: FunctionReference<
-        "mutation",
-        "internal",
-        {
-          claims: { profile: any; provider: string; providerAccountId: string };
-          createOrUpdateUserHandle: string;
-        },
-        { userId: string },
-        Name
-      >;
       getUserIdByAccount: FunctionReference<
         "query",
         "internal",
@@ -103,6 +93,16 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           refreshTokenExpiresAt: number;
           userId: string;
         },
+        Name
+      >;
+      signUpWithoutSession: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          claims: { profile: any; provider: string; providerAccountId: string };
+          createUserHandle: string;
+        },
+        { userId: string },
         Name
       >;
     };

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -261,21 +261,21 @@ describe("signIn", () => {
   });
 });
 
-describe("createAccount", () => {
+describe("signUpWithoutSession", () => {
   test("creates the user and the account, but no session", async () => {
     const t = setup();
-    resetCreateOrUpdateUserCalls();
+    resetUserCallbackCalls();
 
-    const { userId } = await t.mutation(api.public.createAccount, {
+    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
       claims: claims(),
-      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+      createUserHandle: CREATE_USER_HANDLE,
     });
 
-    // The app's createOrUpdateUser echoes the providerAccountId as the user id.
+    // The app's createUser echoes the providerAccountId as the user id.
     expect(userId).toBe("alice");
-    const calls = getCreateOrUpdateUserCalls();
-    expect(calls).toHaveLength(1);
-    expect(calls[0].userId).toBeNull();
+    expect(getCreateUserCalls()).toHaveLength(1);
+    // No sign-in happened, so onSignIn does not run.
+    expect(getOnSignInCalls()).toHaveLength(0);
 
     // The account exists, but no session was minted.
     const counts = await t.run(async (ctx) => ({
@@ -287,15 +287,15 @@ describe("createAccount", () => {
 
   test("a later signIn resolves the same user and mints a session", async () => {
     const t = setup();
-    const { userId } = await t.mutation(api.public.createAccount, {
+    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
       claims: claims(),
-      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+      createUserHandle: CREATE_USER_HANDLE,
     });
 
     const bundle = await signIn(t, claims());
     expect(bundle.userId).toBe(userId);
 
-    // The sign-in reused the account that createAccount made.
+    // The sign-in reused the account that signUpWithoutSession made.
     const counts = await t.run(async (ctx) => ({
       accounts: (await ctx.db.query("accounts").collect()).length,
       sessions: (await ctx.db.query("sessions").collect()).length,
@@ -305,12 +305,12 @@ describe("createAccount", () => {
 
   test("keys the account by the minted user id with USE_USER_ID_AS_ACCOUNT_ID", async () => {
     const t = setup();
-    const { userId } = await t.mutation(api.public.createAccount, {
+    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
       claims: claims({
         providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
         profile: { email: "alice@example.com" },
       }),
-      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+      createUserHandle: CREATE_USER_HANDLE,
     });
 
     // The account's identifier is the user id the app minted, so a later
@@ -323,6 +323,24 @@ describe("createAccount", () => {
     );
     expect(accounts).toHaveLength(1);
     expect(accounts[0].providerAccountId).toBe(userId);
+  });
+
+  test("refuses an identity that already has an account", async () => {
+    const t = setup();
+    await signUp(t, claims());
+
+    // Like signUp: a second app user for the same identity is never minted.
+    await expect(
+      t.mutation(api.public.signUpWithoutSession, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+      }),
+    ).rejects.toThrow(/already\s+exists/i);
+
+    const accounts = await t.run(
+      async (ctx) => (await ctx.db.query("accounts").collect()).length,
+    );
+    expect(accounts).toBe(1);
   });
 });
 

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -15,7 +15,11 @@ import {
   getOnSignInCalls,
   resetUserCallbackCalls,
 } from "./testApp";
-import { type AuthClaims, type TokenBundle } from "../../lib/types";
+import {
+  type AuthClaims,
+  type TokenBundle,
+  USE_USER_ID_AS_ACCOUNT_ID,
+} from "../../lib/types";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -254,6 +258,71 @@ describe("signIn", () => {
       async (ctx) => (await ctx.db.query("sessions").collect()).length,
     );
     expect(sessions).toBe(0);
+  });
+});
+
+describe("createAccount", () => {
+  test("creates the user and the account, but no session", async () => {
+    const t = setup();
+    resetCreateOrUpdateUserCalls();
+
+    const { userId } = await t.mutation(api.public.createAccount, {
+      claims: claims(),
+      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+    });
+
+    // The app's createOrUpdateUser echoes the providerAccountId as the user id.
+    expect(userId).toBe("alice");
+    const calls = getCreateOrUpdateUserCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].userId).toBeNull();
+
+    // The account exists, but no session was minted.
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+    }));
+    expect(counts).toEqual({ accounts: 1, sessions: 0 });
+  });
+
+  test("a later signIn resolves the same user and mints a session", async () => {
+    const t = setup();
+    const { userId } = await t.mutation(api.public.createAccount, {
+      claims: claims(),
+      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+    });
+
+    const bundle = await signIn(t, claims());
+    expect(bundle.userId).toBe(userId);
+
+    // The sign-in reused the account that createAccount made.
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+    }));
+    expect(counts).toEqual({ accounts: 1, sessions: 1 });
+  });
+
+  test("keys the account by the minted user id with USE_USER_ID_AS_ACCOUNT_ID", async () => {
+    const t = setup();
+    const { userId } = await t.mutation(api.public.createAccount, {
+      claims: claims({
+        providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
+        profile: { email: "alice@example.com" },
+      }),
+      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+    });
+
+    // The account's identifier is the user id the app minted, so a later
+    // sign-in that passes the user id resolves the same user.
+    const bundle = await signIn(t, claims({ providerAccountId: userId }));
+    expect(bundle.userId).toBe(userId);
+
+    const accounts = await t.run(
+      async (ctx) => await ctx.db.query("accounts").collect(),
+    );
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].providerAccountId).toBe(userId);
   });
 });
 

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -353,6 +353,36 @@ export const signIn = mutation({
 });
 
 /**
+ * Create the account and the app user for a provider's verified identity
+ * claims, without minting a session.
+ *
+ * Providers use this (via the `createAccount` helper the core hands them)
+ * when the user must complete a step before the first sign-in — for example,
+ * an email validation. Account and user resolution follows the same rules as
+ * `signIn` (the app's `createOrUpdateUser` mutation runs, and
+ * `USE_USER_ID_AS_ACCOUNT_ID` keys the account by the minted user id), but no
+ * refresh token or access token is issued: the user cannot make authenticated
+ * calls until a later `signIn` succeeds.
+ */
+export const createAccount = mutation({
+  args: {
+    claims: vAuthClaims,
+    createOrUpdateUserHandle: v.string(),
+  },
+  returns: v.object({ userId: v.string() }),
+  handler: async (ctx, args): Promise<{ userId: string }> => {
+    // TODO: This API is kind of awkward. We might want to reconsider it before the GA v2 release.
+
+    const { userId } = await resolveAccount(
+      ctx,
+      args.claims,
+      args.createOrUpdateUserHandle as CreateOrUpdateUserFunctionHandle,
+    );
+    return { userId };
+  },
+});
+
+/**
  * Resolve a provider identity to its app user id without minting a session.
  *
  * Providers use this (via the `resolveUserId` helper the core hands them) to look

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -176,6 +176,8 @@ function asUserId(userId: string): GenericId<string> {
  * records the provider-identity -> user mapping. Returns what minting a
  * session needs: the account id and its app user id. The claims are passed to
  * the `createUser` callback.
+ *
+ * Both `signUp` and the sessionless `signUpWithoutSession` build on this.
  */
 async function createAccount(
   ctx: MutationCtx,
@@ -194,10 +196,11 @@ async function createAccount(
       claims.providerAccountId,
     );
     if (account !== null) {
-      // Signing up an identity that already has an account would mint a second
-      // app user for someone who already has one. Fail before calling the app.
+      // Creating an account for an identity that already has one would mint a
+      // second app user for someone who already has one. Fail before calling
+      // the app.
       throw new Error(
-        `Cannot sign up: an account for provider = ${JSON.stringify(claims.provider)} ` +
+        `Cannot create an account: an account for provider = ${JSON.stringify(claims.provider)} ` +
           `and provider account ID = ${JSON.stringify(claims.providerAccountId)} already ` +
           `exists. Providers that cannot tell a first sign-in from a return visit must ` +
           `look the identity up (getUserIdByAccount) and call signIn instead.`,
@@ -356,27 +359,27 @@ export const signIn = mutation({
  * Create the account and the app user for a provider's verified identity
  * claims, without minting a session.
  *
- * Providers use this (via the `createAccount` helper the core hands them)
- * when the user must complete a step before the first sign-in — for example,
- * an email validation. Account and user resolution follows the same rules as
- * `signIn` (the app's `createOrUpdateUser` mutation runs, and
- * `USE_USER_ID_AS_ACCOUNT_ID` keys the account by the minted user id), but no
- * refresh token or access token is issued: the user cannot make authenticated
- * calls until a later `signIn` succeeds.
+ * Providers use this (via the `signUpWithoutSession` helper the core hands
+ * them) when the user must complete a step before the first sign-in — for
+ * example, an email validation. Account creation follows the same rules as
+ * `signUp` (the app's `createUser` mutation mints the user,
+ * `USE_USER_ID_AS_ACCOUNT_ID` keys the account by the minted user id, and an
+ * identity that already has an account is refused), but no session is minted
+ * and `onSignIn` does not run: the user cannot make authenticated calls until
+ * a later `signIn` succeeds.
  */
-export const createAccount = mutation({
+export const signUpWithoutSession = mutation({
   args: {
     claims: vAuthClaims,
-    createOrUpdateUserHandle: v.string(),
+    createUserHandle: v.string(),
   },
   returns: v.object({ userId: v.string() }),
   handler: async (ctx, args): Promise<{ userId: string }> => {
     // TODO: This API is kind of awkward. We might want to reconsider it before the GA v2 release.
-
-    const { userId } = await resolveAccount(
+    const { userId } = await createAccount(
       ctx,
       args.claims,
-      args.createOrUpdateUserHandle as CreateOrUpdateUserFunctionHandle,
+      args.createUserHandle as CreateUserFunctionHandle,
     );
     return { userId };
   },

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -336,19 +336,17 @@ export function setupCore<UsersTable extends string = "users">(options: {
       // Creates the app user + account without a session, for providers where
       // the user must complete a step (e.g. an email validation) before the
       // first sign-in.
-      createAccount: async (args: {
+      signUpWithoutSession: async (args: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<{ userId: string }> => {
-        const createOrUpdateUserHandle =
-          await createFunctionHandle(createOrUpdateUser);
-        return await ctx.runMutation(component.public.createAccount, {
+        return await ctx.runMutation(component.public.signUpWithoutSession, {
           claims: {
             provider: name,
             providerAccountId: args.providerAccountId,
             profile: args.profile,
           },
-          createOrUpdateUserHandle,
+          createUserHandle: await createFunctionHandle(createUser),
         });
       },
       resolveUserId: async (

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -333,6 +333,24 @@ export function setupCore<UsersTable extends string = "users">(options: {
           refreshTokenTtlSeconds,
         });
       },
+      // Creates the app user + account without a session, for providers where
+      // the user must complete a step (e.g. an email validation) before the
+      // first sign-in.
+      createAccount: async (args: {
+        providerAccountId: string;
+        profile: Profile;
+      }): Promise<{ userId: string }> => {
+        const createOrUpdateUserHandle =
+          await createFunctionHandle(createOrUpdateUser);
+        return await ctx.runMutation(component.public.createAccount, {
+          claims: {
+            provider: name,
+            providerAccountId: args.providerAccountId,
+            profile: args.profile,
+          },
+          createOrUpdateUserHandle,
+        });
+      },
       resolveUserId: async (
         providerAccountId: string,
       ): Promise<string | null> => {

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -42,13 +42,10 @@ export const createUser = internalMutation({
   returns: v.string(),
   handler: async (_ctx, args) => {
     createUserCalls.push({ ...args });
-    if (args.userId !== null) {
-      return args.userId;
-    }
     // With `USE_USER_ID_AS_ACCOUNT_ID` the provider sends an empty account id,
     // so mint a fresh user id — like a real app's insert would.
     if (args.providerAccountId === "") {
-      return `user-${createOrUpdateUserCalls.length}`;
+      return `user-${createUserCalls.length}`;
     }
     return args.providerAccountId;
   },

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -42,6 +42,14 @@ export const createUser = internalMutation({
   returns: v.string(),
   handler: async (_ctx, args) => {
     createUserCalls.push({ ...args });
+    if (args.userId !== null) {
+      return args.userId;
+    }
+    // With `USE_USER_ID_AS_ACCOUNT_ID` the provider sends an empty account id,
+    // so mint a fresh user id — like a real app's insert would.
+    if (args.providerAccountId === "") {
+      return `user-${createOrUpdateUserCalls.length}`;
+    }
     return args.providerAccountId;
   },
 });

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -42,11 +42,6 @@ export const createUser = internalMutation({
   returns: v.string(),
   handler: async (_ctx, args) => {
     createUserCalls.push({ ...args });
-    // With `USE_USER_ID_AS_ACCOUNT_ID` the provider sends an empty account id,
-    // so mint a fresh user id — like a real app's insert would.
-    if (args.providerAccountId === "") {
-      return `user-${createUserCalls.length}`;
-    }
     return args.providerAccountId;
   },
 });

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -313,6 +313,19 @@ export type BoundAuthHelpers<Profile> = {
     profile: Profile;
   }): Promise<TokenBundle>;
   /**
+   * Create the account and the app user for a verified identity, but do not
+   * mint a session.
+   *
+   * Call this when the user must complete a step (for example, an email
+   * validation) before the first sign-in. Account and user resolution follows
+   * the same rules as `completeSignIn`. The provider signs the user in later
+   * with `completeSignIn`.
+   */
+  createAccount(args: {
+    providerAccountId: string;
+    profile: Profile;
+  }): Promise<{ userId: string }>;
+  /**
    * Look up the app user id for a given `providerAccountId`.
    *
    * Returns `null` when no user id is found for the account.

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -317,11 +317,12 @@ export type BoundAuthHelpers<Profile> = {
    * mint a session.
    *
    * Call this when the user must complete a step (for example, an email
-   * validation) before the first sign-in. Account and user resolution follows
-   * the same rules as `completeSignIn`. The provider signs the user in later
-   * with `completeSignIn`.
+   * validation) before the first sign-in. Account creation follows the same
+   * rules as `completeSignUp`: the app's `createUser` mints the user, and an
+   * identity that already has an account is refused. `onSignIn` does not run.
+   * The provider signs the user in later with `completeSignIn`.
    */
-  createAccount(args: {
+  signUpWithoutSession(args: {
     providerAccountId: string;
     profile: Profile;
   }): Promise<{ userId: string }>;

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -60,7 +60,7 @@ const FAKE_BUNDLE: TokenBundle = {
 
 /**
  * A fake core whose builders inject fake {@link BoundAuthHelpers}.
- * `createAccount` is never reached by redemption.
+ * `signUpWithoutSession` is never reached by redemption.
  */
 const FAKE_CORE = {
   bindProvider: <Provider extends string, Profile>({
@@ -90,8 +90,8 @@ const FAKE_CORE = {
       completeSignUp: record("signUp"),
       completeSignIn: record("signIn"),
       resolveUserId: async () => resolvedUserId.value,
-      createAccount: async () => {
-        throw new Error("createAccount is not used by redemption");
+      signUpWithoutSession: async () => {
+        throw new Error("signUpWithoutSession is not used by redemption");
       },
     };
     const authMutation: AuthMutationBuilder<Profile> = (fn) =>

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -58,7 +58,10 @@ const FAKE_BUNDLE: TokenBundle = {
   userId: "user-1",
 };
 
-/** A fake core whose builders inject fake {@link BoundAuthHelpers}. */
+/**
+ * A fake core whose builders inject fake {@link BoundAuthHelpers}.
+ * `createAccount` is never reached by redemption.
+ */
 const FAKE_CORE = {
   bindProvider: <Provider extends string, Profile>({
     name,
@@ -87,6 +90,9 @@ const FAKE_CORE = {
       completeSignUp: record("signUp"),
       completeSignIn: record("signIn"),
       resolveUserId: async () => resolvedUserId.value,
+      createAccount: async () => {
+        throw new Error("createAccount is not used by redemption");
+      },
     };
     const authMutation: AuthMutationBuilder<Profile> = (fn) =>
       mutationGeneric({


### PR DESCRIPTION
This PR adds a new `createAccount` function to the core component: it is similar to `signIn` as it also resolves the account and create it if necessary, but unlike `signIn` it does not mint a session.

This is useful for the email validation flow, because in this flow we create the `users` row before the email is validated.

I'm not sure whether this is a good API: we'll likely want to revisit the core API boundaries before the GA v2 release (I added a TODO comment).