### PR TITLE
authEmail component: verified email storage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,6 +95,14 @@
       "types": "./dist/components/passkey/*.d.ts",
       "default": "./dist/components/passkey/*.js"
     },
+    "./email/*.js": {
+      "types": "./dist/components/email/*.d.ts",
+      "default": "./dist/components/email/*.js"
+    },
+    "./email/*": {
+      "types": "./dist/components/email/*.d.ts",
+      "default": "./dist/components/email/*.js"
+    },
     "./providers/testing/*": "./src/components/testing/*.ts",
     "./browser": {
       "types": "./dist/browser/index.d.ts",

--- a/packages/core/src/components/email/_generated/api.ts
+++ b/packages/core/src/components/email/_generated/api.ts
@@ -1,0 +1,52 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as public_ from "../public.js";
+import type * as validation from "../validation.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import { anyApi, componentsGeneric } from "convex/server";
+
+const fullApi: ApiFromModules<{
+  public: typeof public_;
+  validation: typeof validation;
+}> = anyApi as any;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+> = anyApi as any;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+> = anyApi as any;
+
+export const components = componentsGeneric() as unknown as {};

--- a/packages/core/src/components/email/_generated/component.ts
+++ b/packages/core/src/components/email/_generated/component.ts
@@ -1,0 +1,49 @@
+/* eslint-disable */
+/**
+ * Generated `ComponentApi` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type { FunctionReference } from "convex/server";
+
+/**
+ * A utility for referencing a Convex component's exposed API.
+ *
+ * Useful when expecting a parameter like `components.myComponent`.
+ * Usage:
+ * ```ts
+ * async function myFunction(ctx: QueryCtx, component: ComponentApi) {
+ *   return ctx.runQuery(component.someFile.someQuery, { ...args });
+ * }
+ * ```
+ */
+export type ComponentApi<Name extends string | undefined = string | undefined> =
+  {
+    public: {
+      deleteUser: FunctionReference<
+        "mutation",
+        "internal",
+        { userId: string },
+        null,
+        Name
+      >;
+      getEmails: FunctionReference<
+        "query",
+        "internal",
+        { userId: string },
+        Array<{ email: string; isPrimary: boolean }>,
+        Name
+      >;
+      getUserIdByEmail: FunctionReference<
+        "query",
+        "internal",
+        { email: string },
+        { email: string; userId: string } | null,
+        Name
+      >;
+    };
+  };

--- a/packages/core/src/components/email/_generated/dataModel.ts
+++ b/packages/core/src/components/email/_generated/dataModel.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/packages/core/src/components/email/_generated/server.ts
+++ b/packages/core/src/components/email/_generated/server.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query: QueryBuilder<DataModel, "public"> = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery: QueryBuilder<DataModel, "internal"> =
+  internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation: MutationBuilder<DataModel, "public"> = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation: MutationBuilder<DataModel, "internal"> =
+  internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action: ActionBuilder<DataModel, "public"> = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction: ActionBuilder<DataModel, "internal"> =
+  internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction: HttpActionBuilder = httpActionGeneric;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * If you're using code generation, use the `QueryCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ *
+ * If you're using code generation, use the `MutationCtx` type in `convex/_generated/server.d.ts` instead.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/packages/core/src/components/email/convex.config.ts
+++ b/packages/core/src/components/email/convex.config.ts
@@ -1,0 +1,13 @@
+import { defineComponent } from "convex/server";
+
+/**
+ * The email component.
+ *
+ * Tracks the verified email addresses of users, keyed only by an opaque
+ * `userId`. An email address goes into this component only after the user
+ * proves ownership of it. The app owns the users table and maps its own
+ * identifiers onto the `userId` it passes in.
+ */
+const component = defineComponent("authEmail");
+
+export default component;

--- a/packages/core/src/components/email/email.test.ts
+++ b/packages/core/src/components/email/email.test.ts
@@ -1,0 +1,198 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api.ts";
+import schema from "./schema.ts";
+import { normalizeEmail, validateEmailFormat } from "./validation.ts";
+
+const modules = import.meta.glob("./**/*.ts");
+
+function setup() {
+  return convexTest(schema, modules);
+}
+
+/** Seed a verified email row directly; the validation flow arrives later. */
+async function seedEmail(
+  t: ReturnType<typeof setup>,
+  userId: string,
+  email: string,
+  isPrimary: boolean,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("verifiedEmails", {
+      email,
+      normalizedEmail: normalizeEmail(email),
+      userId,
+      isPrimary,
+    });
+  });
+}
+
+describe("getEmails", () => {
+  test("returns an empty array for a user with no emails", async () => {
+    const t = setup();
+    expect(await t.query(api.public.getEmails, { userId: "user1" })).toEqual(
+      [],
+    );
+  });
+
+  test("returns the user's emails", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "alice@example.com", true);
+    await seedEmail(t, "user1", "alice@work.example", false);
+    await seedEmail(t, "user2", "bob@example.com", true);
+
+    const emails = await t.query(api.public.getEmails, { userId: "user1" });
+    expect(emails).toHaveLength(2);
+    expect(emails).toContainEqual({
+      email: "alice@example.com",
+      isPrimary: true,
+    });
+    expect(emails).toContainEqual({
+      email: "alice@work.example",
+      isPrimary: false,
+    });
+  });
+});
+
+describe("getUserIdByEmail", () => {
+  test("returns null for an unknown email", async () => {
+    const t = setup();
+    expect(
+      await t.query(api.public.getUserIdByEmail, {
+        email: "nobody@example.com",
+      }),
+    ).toBeNull();
+  });
+
+  test("finds the user with the same case as the stored address", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "Alice@Example.com", true);
+
+    expect(
+      await t.query(api.public.getUserIdByEmail, {
+        email: "Alice@Example.com",
+      }),
+    ).toEqual({ userId: "user1", email: "Alice@Example.com" });
+  });
+
+  test("finds the user with a different case, and returns the stored address", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "Alice@Example.com", true);
+
+    for (const email of [
+      "alice@example.com",
+      "ALICE@EXAMPLE.COM",
+      "aLiCe@eXaMpLe.CoM",
+    ]) {
+      expect(await t.query(api.public.getUserIdByEmail, { email })).toEqual({
+        userId: "user1",
+        email: "Alice@Example.com",
+      });
+    }
+  });
+
+  test("finds the user with a different Unicode normalization form", async () => {
+    const t = setup();
+    // The stored address uses the composed form ("é" as U+00E9).
+    await seedEmail(t, "user1", "H\u00e9l\u00e8ne@example.com", true);
+
+    // The argument uses the decomposed form ("e" + a combining accent).
+    expect(
+      await t.query(api.public.getUserIdByEmail, {
+        email: "he\u0301le\u0300ne@example.com",
+      }),
+    ).toEqual({ userId: "user1", email: "H\u00e9l\u00e8ne@example.com" });
+  });
+
+  test("does not match a different address that normalizes differently", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "Alice@Example.com", true);
+
+    expect(
+      await t.query(api.public.getUserIdByEmail, {
+        email: "alice@example.org",
+      }),
+    ).toBeNull();
+    expect(
+      await t.query(api.public.getUserIdByEmail, { email: "alic@example.com" }),
+    ).toBeNull();
+  });
+});
+
+describe("the stored email address", () => {
+  test("keeps the case that the user gave", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "Alice@Example.com", true);
+
+    expect(await t.query(api.public.getEmails, { userId: "user1" })).toEqual([
+      { email: "Alice@Example.com", isPrimary: true },
+    ]);
+  });
+
+  test("keeps both forms of the address in the row", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "Alice@Example.com", true);
+
+    const rows = await t.run((ctx) => ctx.db.query("verifiedEmails").collect());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe("Alice@Example.com");
+    expect(rows[0].normalizedEmail).toBe("alice@example.com");
+  });
+});
+
+describe("deleteUser", () => {
+  test("removes all the user's emails and leaves other users alone", async () => {
+    const t = setup();
+    await seedEmail(t, "user1", "alice@example.com", true);
+    await seedEmail(t, "user1", "alice@work.example", false);
+    await seedEmail(t, "user2", "bob@example.com", true);
+
+    await t.mutation(api.public.deleteUser, { userId: "user1" });
+
+    expect(await t.query(api.public.getEmails, { userId: "user1" })).toEqual(
+      [],
+    );
+    expect(
+      await t.query(api.public.getUserIdByEmail, {
+        email: "alice@example.com",
+      }),
+    ).toBeNull();
+    expect(await t.query(api.public.getEmails, { userId: "user2" })).toEqual([
+      { email: "bob@example.com", isPrimary: true },
+    ]);
+  });
+
+  test("is idempotent for a user with no data", async () => {
+    const t = setup();
+    await expect(
+      t.mutation(api.public.deleteUser, { userId: "user1" }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("validateEmailFormat", () => {
+  test("accepts a plain address", () => {
+    expect(validateEmailFormat("alice@example.com")).toBeNull();
+  });
+
+  test.each([
+    ["no at sign", "alice.example.com"],
+    ["empty local part", "@example.com"],
+    ["no domain dot", "alice@example"],
+    ["whitespace", "alice @example.com"],
+    ["two at signs", "a@b@example.com"],
+    ["too long", "a".repeat(250) + "@example.com"],
+  ])("rejects %s", (_name, email) => {
+    expect(validateEmailFormat(email)).toEqual({ error: "INVALID_EMAIL" });
+  });
+});
+
+describe("normalizeEmail", () => {
+  test("lowercases and applies NFC", () => {
+    expect(normalizeEmail("Alice@Example.COM")).toBe("alice@example.com");
+    // "e" + combining acute accent (U+0301) normalizes to the composed form.
+    expect(normalizeEmail("he\u0301lene@example.com")).toBe(
+      "h\u00e9lene@example.com",
+    );
+  });
+});

--- a/packages/core/src/components/email/public.ts
+++ b/packages/core/src/components/email/public.ts
@@ -1,0 +1,83 @@
+import { mutation, query, QueryCtx } from "./_generated/server.ts";
+import { Doc } from "./_generated/dataModel.ts";
+import { v } from "convex/values";
+import { normalizeEmail } from "./validation.ts";
+
+/**
+ * Get the verified email addresses of a user.
+ *
+ * The function returns an empty array when the user has no verified email.
+ */
+export const getEmails = query({
+  args: { userId: v.string() },
+  returns: v.array(v.object({ email: v.string(), isPrimary: v.boolean() })),
+  handler: async (
+    ctx,
+    { userId },
+  ): Promise<{ email: string; isPrimary: boolean }[]> => {
+    const rows = await emailsByUserId(ctx, userId);
+    return rows.map((row) => ({ email: row.email, isPrimary: row.isPrimary }));
+  },
+});
+
+/**
+ * Find the user that a verified email address identifies.
+ *
+ * The lookup ignores the case and the Unicode normalization form of the
+ * `email` argument. The `email` field of the result is the stored address,
+ * with the case that the user gave, which can be different from the argument.
+ * The function returns `null` when no user has verified this address.
+ */
+export const getUserIdByEmail = query({
+  args: { email: v.string() },
+  returns: v.union(
+    v.object({ userId: v.string(), email: v.string() }),
+    v.null(),
+  ),
+  handler: async (
+    ctx,
+    { email },
+  ): Promise<{ userId: string; email: string } | null> => {
+    const row = await emailByNormalizedEmail(ctx, normalizeEmail(email));
+    return row === null ? null : { userId: row.userId, email: row.email };
+  },
+});
+
+/**
+ * Delete all data the component holds for a user.
+ *
+ * Call this when the app deletes the user. The function is idempotent.
+ */
+export const deleteUser = mutation({
+  args: { userId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { userId }): Promise<null> => {
+    const rows = await emailsByUserId(ctx, userId);
+    for (const row of rows) {
+      await ctx.db.delete("verifiedEmails", row._id);
+    }
+    return null;
+  },
+});
+
+function emailsByUserId(
+  ctx: QueryCtx,
+  userId: string,
+): Promise<Doc<"verifiedEmails">[]> {
+  return ctx.db
+    .query("verifiedEmails")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+}
+
+function emailByNormalizedEmail(
+  ctx: QueryCtx,
+  normalizedEmail: string,
+): Promise<Doc<"verifiedEmails"> | null> {
+  return ctx.db
+    .query("verifiedEmails")
+    .withIndex("by_normalizedEmail", (q) =>
+      q.eq("normalizedEmail", normalizedEmail),
+    )
+    .unique();
+}

--- a/packages/core/src/components/email/schema.ts
+++ b/packages/core/src/components/email/schema.ts
@@ -1,0 +1,26 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  // One row for each verified email address.
+  //
+  // Invariants the component keeps true:
+  // - An email address belongs to at most one user.
+  // - A user with at least one email has exactly one primary email.
+  verifiedEmails: defineTable({
+    // The address with the case that the user gave. The app shows this value
+    // to the end user.
+    email: v.string(),
+    // The same address after normalization (see `normalizeEmail`). Lookups and
+    // uniqueness checks use this field, not `email`.
+    normalizedEmail: v.string(),
+    userId: v.string(),
+    // `true` for the user's primary address.
+    // The primary address can be used by the app when it needs to email
+    // a particular user (e.g. for security notifications).
+    isPrimary: v.boolean(),
+  })
+    .index("by_normalizedEmail", ["normalizedEmail"])
+    .index("by_userId", ["userId"])
+    .index("by_userId_isPrimary", ["userId", "isPrimary"]),
+});

--- a/packages/core/src/components/email/validation.ts
+++ b/packages/core/src/components/email/validation.ts
@@ -1,0 +1,65 @@
+import { Infer, v } from "convex/values";
+
+// The component applies only loose format rules: it rejects strings that can
+// not be a deliverable address, and nothing more. Real ownership of the
+// address is proven by the validation flow, not by format checks.
+
+// The longest address SMTP can deliver to (RFC 5321: 256 octets for the path,
+// minus the angle brackets).
+export const MAX_EMAIL_LENGTH = 254;
+
+// One "@" with a non-empty local part, and a domain with at least one dot
+// and no whitespace. Intentionally permissive: stricter patterns reject
+// addresses that exist.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+
+/**
+ * The user-facing error for a malformed email address. An application can
+ * show this error to the end user. The `error` field is a machine-readable
+ * code and the discriminant of the union.
+ */
+export const emailFormatUserError = v.object({
+  error: v.literal("INVALID_EMAIL"),
+});
+export type EmailFormatUserError = Infer<typeof emailFormatUserError>;
+
+/**
+ * Examine an email address against the format rules. Return an
+ * `INVALID_EMAIL` user error for a malformed address, or `null` when the
+ * address is acceptable.
+ */
+export function validateEmailFormat(
+  email: string,
+): EmailFormatUserError | null {
+  if (email.length > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.test(email)) {
+    return { error: "INVALID_EMAIL" };
+  }
+  return null;
+}
+
+/**
+ * Normalize an email address for storage and comparisons.
+ *
+ * The function first makes the address lowercase, so that lookups are not
+ * case-sensitive. Then it applies NFC normalization, so that two inputs that
+ * a user sees as the same but that use different Unicode normalization forms
+ * compare as equal. The order is important: the lowercase operation can make
+ * a string that is not in the NFC form.
+ */
+export function normalizeEmail(email: string): string {
+  return email.toLowerCase().normalize("NFC");
+
+  // Note that in theory, email addresses are case-sensitive (https://stackoverflow.com/a/9808332/4652564).
+  // In this project we always store the canonical email representation using the
+  // case that the user used, but use a normalized lowercase version to check for existing accounts.
+  //
+  // This means that if Jane.Doe@example.com creates an account, we will store her email
+  // as Jane.Doe@example.com (and the app will display her email using that case).
+  // She will also be able to log in with jane.doe@example.com.
+  // This is what we expect the correct behavior to be in practice.
+  //
+  // The only downside is that if jane.doe@example.com is a separate person,
+  // she won’t be able to also create an account.
+  // (But she won’t be able to perform account recovery to the original account,
+  // as account recovery emails will be sent to Jane.Doe@example.com).
+}

--- a/packages/core/src/components/testing/email.ts
+++ b/packages/core/src/components/testing/email.ts
@@ -1,0 +1,17 @@
+import type { TestConvex } from "convex-test";
+import type { GenericSchema, SchemaDefinition } from "convex/server";
+import schema from "../email/schema.ts";
+const modules = import.meta.glob("../email/**/*.ts");
+
+/**
+ * Register the email component with the test convex instance.
+ * @param t - The test convex instance, e.g. from calling `convexTest`.
+ * @param name - The name of the component, as registered in convex.config.ts.
+ */
+export function registerEmail(
+  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
+  name: string = "authEmail",
+) {
+  t.registerComponent(name, schema, modules);
+}
+export default { registerEmail, schema, modules };


### PR DESCRIPTION
This PR implements the first part of the `authEmail` component: storing verified emails.

It adds a `verifiedEmails` table with the following constraints:
- An email address can only be verified for at most one user. This is necessary because we'll use this table to implement login flows: if an email address could be verified for multiple users, it would be ambiguous what to do. If the user needs email verification for an unrelated purpose (e.g. sending invoices), they should consider using their own implementation of email verification.
- Emails are stored in the form the user provided. This means that if the user registers as `Jane.Doe@example.com`, we store it as such. We don't want to automatically lowercase email addresses (as this behavior [could be wrong](https://stackoverflow.com/a/9808332/4652564) in rare cases), and we also don’t want to refuse non-lowercase email addresses because that can be a bad user experience.
- Email lookups are done in a case-insensitive way. This means that if `Jane.Doe@example.com` has an account, `jane.doe@example.com` can’t have one. This is a tradeoff we’re willing to accept.

For now there is no way to verify new email addresses. This will be added by upcoming PRs.