### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Convex Auth",
+  "install": "bash .cursor/setup.sh"
+}

--- a/.cursor/setup.sh
+++ b/.cursor/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for @convex-dev/auth.
+# Mirrors the install steps used by CI (.github/workflows/{lint,test}.yml).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Install dependencies for the library and its example/test apps.
+npm ci
+(cd test && npm ci)
+(cd test-nextjs && npm ci)
+(cd test-router && npm ci)
+
+# Build the library. The example apps link it via `file:..`, and the CLI
+# bundle produced here is exercised by the tooling.
+npm run build
+
+# `just` drives the local Convex backend used by the Next.js e2e harness.
+if ! command -v just >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+    | sudo bash -s -- --to /usr/local/bin
+fi
+
+# Playwright browsers (+ OS deps) for the Next.js end-to-end tests.
+# Idempotent: skips already-installed browsers.
+(cd test-nextjs && npx playwright install --with-deps)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for `@convex-dev/auth` so future agents boot ready to build, lint, and run both the unit and end-to-end test suites.

## Changes

- `.cursor/environment.json` — names the environment and points `install` at the setup script (default base image, no custom Dockerfile needed).
- `.cursor/setup.sh` — idempotent setup that mirrors CI:
  - `npm ci` in the root and the `test`, `test-nextjs`, `test-router` apps
  - `npm run build` (the example apps link the library via `file:..`)
  - installs `just` (drives the local Convex backend for the Next.js e2e harness) if missing
  - `npx playwright install --with-deps` for the browser e2e tests

No user secrets are required: the Next.js e2e harness downloads a local Convex backend binary, generates its own admin key, and uses hardcoded test JWT keys.

## Validation

Local VM (Node 22.14):

| Check | Result |
| --- | --- |
| `npm run build` | Passed |
| `npm run lint` | Passed |
| `npm run test:once` (unit) | 42 passed, 1 todo |
| Next.js Playwright e2e | 15 passed (chromium, firefox, webkit) |
| `setup.sh` idempotence | Passed twice (exit 0) |
| `setup.sh` from scratch (`just` + Playwright) | Passed (exit 0) |

Draft environment builds:

| Build | Config | Result |
| --- | --- | --- |
| `bld-...cff85866` | Committed config (default image, install from scratch) | SUCCEEDED |
| `bld-...3801bd86` | With prebuilt snapshot | SUCCEEDED |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be65f86b-af9d-4e0b-aa9a-60b3e821bc7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be65f86b-af9d-4e0b-aa9a-60b3e821bc7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

