### PR TITLE
Passkey component: throw for a duplicate credential ID

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -84,9 +84,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              | { error: "CHALLENGE_EXPIRED" }
-              | { error: "VERIFICATION_FAILED" }
-              | { error: "CREDENTIAL_ALREADY_REGISTERED" };
+              { error: "CHALLENGE_EXPIRED" } | { error: "VERIFICATION_FAILED" };
           },
         Name
       >;

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { ping, vBatchResult } from "@convex-dev/batch-worker";
+import { ping } from "@convex-dev/batch-worker";
 import { components, internal } from "./_generated/api";
 import { internalMutation, internalQuery } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -565,7 +565,7 @@ describe("finishRegistration", () => {
     // A compliant client cannot cause this, so the mutation throws instead
     // of returning a user error.
     const { args } = await registrationArgs(t, "user2", {
-      startUserId: null,
+      isNewAccountFlow: true,
       credential,
     });
     await expect(
@@ -605,27 +605,6 @@ describe("finishRegistration", () => {
       ctx.db.query("challenges").collect(),
     );
     expect(challenges).toEqual([]);
-  });
-
-  test("deletes the unlinked handle for a duplicate credential in the new-account flow", async () => {
-    const t = setup();
-    const { credential } = await register(t, "user1");
-    const { challenge } = await t.mutation(api.registration.startRegistration, {
-      userId: null,
-    });
-    const { args } = await registrationArgs(t, "user2", {
-      challenge,
-      credential,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "CREDENTIAL_ALREADY_REGISTERED" },
-    });
-    // Only the linked handle of user1 stays.
-    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
-    expect(handles).toHaveLength(1);
-    expect(handles[0].userId).toBe("user1");
   });
 
   test("keeps the linked handle when verification fails for an existing user", async () => {

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -557,20 +557,30 @@ describe("finishRegistration", () => {
     ).rejects.toThrow("Unsupported elliptic curve (expected P-256).");
   });
 
-  test("returns CREDENTIAL_ALREADY_REGISTERED for a duplicate credential ID", async () => {
+  test("throws for a duplicate credential ID", async () => {
     const t = setup();
+    await register(t, "user1");
     const { credential } = await register(t, "user1");
-    const { args } = await registrationArgs(t, "user2", { credential });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "CREDENTIAL_ALREADY_REGISTERED" },
+    // A second ceremony for a new account, with a credential that exists.
+    // A compliant client cannot cause this, so the mutation throws instead
+    // of returning a user error.
+    const { args } = await registrationArgs(t, "user2", {
+      startUserId: null,
+      credential,
     });
-    // The failed attempt still burned its challenge.
+    await expect(
+      t.mutation(api.registration.finishRegistration, args),
+    ).rejects.toThrow("The credential is already registered.");
+    // The throw rolls back the mutation: the challenge and its unlinked
+    // handle stay, and the cleanup loop erases them after the TTL.
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
     );
-    expect(challenges).toEqual([]);
+    expect(challenges).toHaveLength(1);
+    expect((await handleRows(t)).map((row) => row.userId)).toEqual([
+      "user1",
+      null,
+    ]);
   });
 
   test("deletes the unlinked handle when verification fails in the new-account flow", async () => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -219,13 +219,11 @@ export const finishRegistration = mutation({
       .withIndex("by_credentialId", (q) => q.eq("credentialId", credentialId))
       .first();
     if (existing !== null) {
-      // Same as VERIFICATION_FAILED above: the ceremony is burned, so
-      // remove the handle when no user owns it.
-      await deleteUnlinkedHandle(ctx, challengeRow.handleId);
-      return {
-        success: false,
-        userError: { error: "CREDENTIAL_ALREADY_REGISTERED" },
-      };
+      // A compliant client cannot cause this: authenticators make a fresh
+      // random credential ID for each ceremony, and `excludeCredentials`
+      // makes the authenticator refuse a duplicate for this RP. A duplicate
+      // here shows a replayed or tampered registration.
+      throw new Error("The credential is already registered.");
     }
 
     // Link the handle of the ceremony to the verified user.

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -24,8 +24,6 @@ export const finishRegistrationUserError = v.union(
   v.object({ error: v.literal("CHALLENGE_EXPIRED") }),
   // The authenticator did not report user presence and user verification.
   v.object({ error: v.literal("VERIFICATION_FAILED") }),
-  // The credential is already registered, for this user or a different user.
-  v.object({ error: v.literal("CREDENTIAL_ALREADY_REGISTERED") }),
 );
 export type FinishRegistrationUserError = Infer<
   typeof finishRegistrationUserError


### PR DESCRIPTION
A compliant client should never cause `CREDENTIAL_ALREADY_REGISTERED` to be thrown. I’m moving to an internal error for consistency.

This is also convenient for the #461 refactor