### PR TITLE
Add oauth provider client

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -25,8 +25,8 @@ No action item, just here for awareness.
 
 ## One pending OAuth flow per storage
 
-The client keeps a single pending-flow key (`__convexAuthOauthFlow` in
-`packages/core/src/oauth/client.ts`). Two sign-ins running concurrently in
+The client keeps a single pending-flow key (`flow` in the oauth setup's
+scoped storage, `packages/core/src/oauth/client.ts`). Two sign-ins running concurrently in
 different tabs overwrite each other, and both fail recoverably (`expired` /
 `invalid_flow`); retrying works.
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -23,6 +23,17 @@ sign-in with an explicit error naming this requirement.
 
 No action item, just here for awareness.
 
+## One pending OAuth flow per storage
+
+The client keeps a single pending-flow key (`__convexAuthOauthFlow` in
+`packages/core/src/oauth/client.ts`). Two sign-ins running concurrently in
+different tabs overwrite each other, and both fail recoverably (`expired` /
+`invalid_flow`); retrying works.
+
+Fix direction: keyed pending flows selected by a non-secret flow id carried
+in the redirect URL. The state itself must still never be read from the URL,
+preserving the login-CSRF property.
+
 ## Support for custom url schemes (eg., React Native)
 
 `allowedRedirectOrigins` entries must be http(s) origins - custom schemes

--- a/packages/core/src/browser/ambientSignInClient.ts
+++ b/packages/core/src/browser/ambientSignInClient.ts
@@ -26,6 +26,14 @@
  *    around a sign-in completion, so the auth state reports loading rather
  *    than briefly signed out.
  *
+ * Bindings may register setups the app didn't explicitly opt into (the React
+ * binding registers `oauth()` by default), so `onInit` work must be
+ * self-gating. It may only do expensive work (a storage read, a network
+ * call) when it finds local evidence that a flow it owns is actually in
+ * progress, such as a namespaced URL param or a storage key the setup itself
+ * wrote. Absent that evidence it must return cheaply, so an app that never
+ * uses the provider pays nothing at startup.
+ *
  * The Convex imports are type-only. Like `SpaAuthApi`, this contract keeps
  * ambient sign-in logic free of any particular Convex client class, so
  * non-React bindings can drive the same setups.

--- a/packages/core/src/browser/ambientSignInClient.ts
+++ b/packages/core/src/browser/ambientSignInClient.ts
@@ -26,13 +26,9 @@
  *    around a sign-in completion, so the auth state reports loading rather
  *    than briefly signed out.
  *
- * Bindings may register setups the app didn't explicitly opt into (the React
- * binding registers `oauth()` by default), so `onInit` work must be
- * self-gating. It may only do expensive work (a storage read, a network
- * call) when it finds local evidence that a flow it owns is actually in
- * progress, such as a namespaced URL param or a storage key the setup itself
- * wrote. Absent that evidence it must return cheaply, so an app that never
- * uses the provider pays nothing at startup.
+ * `onInit` must gate its own work. A binding can register a setup the app
+ * never asked for, so `onInit` should return right away unless it finds a
+ * sign of its own flow, like a URL param or a storage key it wrote itself.
  *
  * The Convex imports are type-only. Like `SpaAuthApi`, this contract keeps
  * ambient sign-in logic free of any particular Convex client class, so

--- a/packages/core/src/lib/oauthParams.ts
+++ b/packages/core/src/lib/oauthParams.ts
@@ -20,5 +20,5 @@
 /** Carries the one-time code the client redeems for a session. */
 export const OAUTH_CODE_PARAM = "convexAuthCode";
 
-/** Carries a normalized {@link OAuthFlowError} code when the flow failed. */
+/** Carries a normalized {@link OauthFlowError} code when the flow failed. */
 export const OAUTH_ERROR_PARAM = "convexAuthError";

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getFunctionName, makeFunctionReference } from "convex/server";
+import { scopedKey } from "../browser/keyedStore";
+import {
+  registerProviderClientSetups,
+  type AuthSignInApi,
+} from "../browser/providerSetup";
+import { AuthClient } from "../browser/sessionManager";
+import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
+import type { TokenBundle } from "../lib/types";
+import {
+  OAUTH_ACTIONS_KEY,
+  OAUTH_FLOW_ERROR_KEY,
+  OAUTH_SETUP_ID,
+  oauth,
+  type OauthActions,
+  type OauthFlowError,
+  type OauthProviderRefs,
+} from "./client";
+
+const NAMESPACE = "https://happy-animal-123.convex.cloud";
+
+const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 0,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 0,
+  userId: "user-1",
+};
+
+// Real function references (they carry their path), the way an app picks them
+// off its generated `api.auth`. The start leg passes `startSignIn` through by
+// identity; the completion leg rebuilds `completeSignIn` from the persisted
+// path, so completion assertions compare paths via `getFunctionName`.
+const googleStart = makeFunctionReference<"mutation">("auth:startSignInGoogle");
+const googleComplete = makeFunctionReference<"mutation">(
+  "auth:completeSignInGoogle",
+);
+const GOOGLE_REFS: OauthProviderRefs = {
+  providerName: "google",
+  startSignIn: googleStart,
+  completeSignIn: googleComplete,
+};
+
+/** The oauth setup's scoped storage view over `storage`. */
+function flowStorage(storage: InMemoryStorage) {
+  return new NamespacedStorage(storage, NAMESPACE).scoped(OAUTH_SETUP_ID);
+}
+
+/** Store a pending flow the way `signIn` would before navigating away. */
+function seedPendingFlow(
+  storage: InMemoryStorage,
+  {
+    providerName = "google",
+    state = "state-1",
+    completeSignIn = "auth:completeSignInGoogle",
+  } = {},
+) {
+  void flowStorage(storage).set(
+    "flow",
+    JSON.stringify({ providerName, state, completeSignIn }),
+  );
+}
+
+/**
+ * Run the oauth setup against a real AuthClient and a fake sign-in api,
+ * the way `ConvexAuthProvider` would at client construction.
+ */
+function setupOAuth({ storage = new InMemoryStorage() } = {}) {
+  const client = new AuthClient({
+    mode: "spa",
+    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    storage,
+    storageNamespace: NAMESPACE,
+  });
+  const mutation = vi.fn();
+  const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
+  const onStarts = registerProviderClientSetups({
+    client,
+    signInApi,
+    setups: [oauth()],
+  });
+  const actions = client.store.get<OauthActions>(
+    scopedKey(OAUTH_SETUP_ID, OAUTH_ACTIONS_KEY),
+  )!;
+  const flowError = () =>
+    client.store.get<OauthFlowError | null>(
+      scopedKey(OAUTH_SETUP_ID, OAUTH_FLOW_ERROR_KEY),
+    );
+  return {
+    client,
+    mutation,
+    onStart: onStarts[0]!.onStart,
+    actions,
+    flowError,
+    storage,
+  };
+}
+
+/** The function path the fake `mutation` was called with. */
+function calledPath(mutation: ReturnType<typeof vi.fn>, call = 0): string {
+  return getFunctionName(mutation.mock.calls[call]![0] as never);
+}
+
+describe("OAuth client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
+    // Restore the prototype getter shadowed by the React Native stub.
+    delete (window.navigator as { product?: string }).product;
+  });
+
+  test("registers actions and a null flow error at setup", () => {
+    const { actions, flowError } = setupOAuth();
+    expect(actions.signIn).toBeTypeOf("function");
+    expect(flowError()).toBeNull();
+  });
+
+  test("registering oauth() twice on one provider throws", () => {
+    const { client } = setupOAuth();
+    const signInApi = {
+      mutation: vi.fn(),
+      action: vi.fn(),
+    } as unknown as AuthSignInApi;
+    expect(() =>
+      registerProviderClientSetups({
+        client,
+        signInApi,
+        setups: [oauth(), oauth()],
+      }),
+    ).toThrow(/registered twice/);
+  });
+
+  test("onStart redeems a callback code and adopts the session", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(bundle);
+
+    onStart();
+
+    await vi.waitFor(() =>
+      expect(client.getSnapshot().isAuthenticated).toBe(true),
+    );
+    expect(mutation).toHaveBeenCalledOnce();
+    // The reference is rebuilt from the persisted function path.
+    expect(calledPath(mutation)).toBe("auth:completeSignInGoogle");
+    expect(mutation.mock.calls[0]![1]).toEqual({
+      code: "code-1",
+      state: "state-1",
+    });
+    expect(client.getSnapshot().token).toBe("access-1");
+    expect(flowError()).toBeNull();
+    // The one-time code is stripped from the URL.
+    expect(window.location.search).toBe("");
+  });
+
+  test("stripping the callback params keeps the history state", async () => {
+    // Routers (React Router) keep their own entry state in `history.state`.
+    window.history.replaceState({ idx: 3 }, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(bundle);
+
+    onStart();
+
+    await vi.waitFor(() =>
+      expect(client.getSnapshot().isAuthenticated).toBe(true),
+    );
+    expect(window.location.search).toBe("");
+    expect(window.history.state).toEqual({ idx: 3 });
+  });
+
+  test("reports loading while a code is redeemed, through init resolving", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart } = setupOAuth({ storage });
+    const { promise, resolve } = Promise.withResolvers<TokenBundle>();
+    mutation.mockReturnValueOnce(promise);
+
+    // The real startup ordering: onStart latches synchronously, then init runs.
+    onStart();
+    expect(client.getSnapshot().isLoading).toBe(true);
+    await client.init();
+    expect(client.getSnapshot().isLoading).toBe(true);
+
+    resolve(bundle);
+    await vi.waitFor(() =>
+      expect(client.getSnapshot().isAuthenticated).toBe(true),
+    );
+    expect(client.getSnapshot().isLoading).toBe(false);
+  });
+
+  test("a second onStart run finds a clean URL and no-ops", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(bundle);
+
+    onStart();
+    onStart();
+
+    await vi.waitFor(() =>
+      expect(client.getSnapshot().isAuthenticated).toBe(true),
+    );
+    expect(mutation).toHaveBeenCalledTimes(1);
+  });
+
+  test("a callback error param sets the flow error and strips the URL", () => {
+    window.history.replaceState(null, "", "/?convexAuthError=access_denied");
+    const { mutation, onStart, flowError } = setupOAuth();
+
+    onStart();
+
+    // The library owns default copy for each code; apps rebrand by switching
+    // on `code` and ignoring `message`.
+    expect(flowError()).toEqual({
+      code: "access_denied",
+      message: "Sign-in was cancelled.",
+    });
+    expect(mutation).not.toHaveBeenCalled();
+    expect(window.location.search).toBe("");
+  });
+
+  test("a callback error consumes the pending flow", async () => {
+    window.history.replaceState(null, "", "/?convexAuthError=access_denied");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { onStart, flowError } = setupOAuth({ storage });
+
+    onStart();
+
+    expect(flowError()?.code).toBe("access_denied");
+    // The flow ended in an error, so the stored state can never complete.
+    await vi.waitFor(() => expect(flowStorage(storage).get("flow")).toBeNull());
+  });
+
+  test("an unknown error param normalizes to oauth_error", () => {
+    window.history.replaceState(null, "", "/?convexAuthError=server_exploded");
+    const { onStart, flowError } = setupOAuth();
+
+    onStart();
+
+    expect(flowError()?.code).toBe("oauth_error");
+  });
+
+  test("a code without a pending flow sets invalid_flow", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const { client, mutation, onStart, flowError } = setupOAuth();
+
+    onStart();
+    await client.init();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
+    expect(mutation).not.toHaveBeenCalled();
+    expect(client.getSnapshot().isLoading).toBe(false);
+    expect(client.getSnapshot().isAuthenticated).toBe(false);
+  });
+
+  test("a pending flow without a completeSignIn path is invalid", async () => {
+    // A record persisted by an older client (or tampered with) that lacks the
+    // function path can't be completed — it must not crash or half-redeem.
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    void flowStorage(storage).set(
+      "flow",
+      JSON.stringify({ providerName: "google", state: "state-1" }),
+    );
+    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+
+    onStart();
+    await client.init();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("a null bundle sets expired", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(null);
+
+    onStart();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("expired"));
+    expect(client.getSnapshot().isAuthenticated).toBe(false);
+  });
+
+  test("a failed redemption sets oauth_error", async () => {
+    // Also the dangling-path case: a persisted function path whose export was
+    // renamed mid-flight fails the call the same way.
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    mutation.mockRejectedValueOnce(new Error("boom"));
+
+    onStart();
+    await client.init();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("oauth_error"));
+    expect(client.getSnapshot().isLoading).toBe(false);
+  });
+
+  test("signIn starts a flow, persists it, and returns the redirect", async () => {
+    // The React Native branch returns the URL instead of navigating, which
+    // also keeps jsdom (no navigation support) happy.
+    Object.defineProperty(window.navigator, "product", {
+      value: "ReactNative",
+      configurable: true,
+    });
+    const { mutation, actions, storage } = setupOAuth();
+    mutation.mockResolvedValueOnce({
+      redirect: "https://provider.example/auth?client_id=x",
+      state: "state-1",
+    });
+
+    const outcome = await actions.signIn(GOOGLE_REFS, {
+      redirectTo: "http://localhost/app",
+    });
+
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(googleStart, {
+      redirectTo: "http://localhost/app",
+    });
+    expect(outcome).toEqual({
+      redirect: new URL("https://provider.example/auth?client_id=x"),
+    });
+    // The persisted flow carries the completeSignIn function path, so
+    // completion can run on a page that never held the references.
+    expect(flowStorage(storage).get("flow")).toBe(
+      JSON.stringify({
+        providerName: "google",
+        state: "state-1",
+        completeSignIn: "auth:completeSignInGoogle",
+      }),
+    );
+  });
+
+  test("signIn with a code completes the pending flow", async () => {
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, actions } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(bundle);
+
+    const outcome = await actions.signIn(GOOGLE_REFS, { code: "code-1" });
+
+    expect(outcome).toEqual({ signedIn: true });
+    expect(mutation).toHaveBeenCalledOnce();
+    expect(calledPath(mutation)).toBe("auth:completeSignInGoogle");
+    expect(mutation.mock.calls[0]![1]).toEqual({
+      code: "code-1",
+      state: "state-1",
+    });
+    expect(client.getSnapshot().isAuthenticated).toBe(true);
+  });
+
+  test("signIn clears a previous flow error", async () => {
+    window.history.replaceState(null, "", "/?convexAuthError=access_denied");
+    Object.defineProperty(window.navigator, "product", {
+      value: "ReactNative",
+      configurable: true,
+    });
+    const { mutation, onStart, actions, flowError } = setupOAuth();
+    onStart();
+    expect(flowError()?.code).toBe("access_denied");
+
+    mutation.mockResolvedValueOnce({
+      redirect: "https://provider.example/auth",
+      state: "state-2",
+    });
+    await actions.signIn(GOOGLE_REFS);
+
+    expect(flowError()).toBeNull();
+  });
+
+  test("a foreign code/error param is ignored and left in the URL", () => {
+    window.history.replaceState(null, "", "/?code=foreign&error=foreign");
+    const { mutation, onStart, flowError } = setupOAuth();
+
+    onStart();
+
+    // Only namespaced params are ours; a plain code/error belongs to the app.
+    expect(mutation).not.toHaveBeenCalled();
+    expect(flowError()).toBeNull();
+    expect(window.location.search).toBe("?code=foreign&error=foreign");
+  });
+});

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { getFunctionName, makeFunctionReference } from "convex/server";
-import type { AuthSignInApi } from "../browser/providerSetup";
+import type { AuthSignInApi } from "../browser/ambientSignInClient";
 import { AuthClient, type AuthState } from "../browser/sessionManager";
 import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
 import type { TokenBundle } from "../lib/types";
@@ -38,9 +38,9 @@ const ACME_REFS: OauthProviderRefs = {
   completeSignIn: acmeComplete,
 };
 
-/** The oauth setup's scoped storage view over `storage`. */
+/** The oauth sign-in's scoped storage view over `storage`. */
 function flowStorage(storage: InMemoryStorage) {
-  return new NamespacedStorage(storage, NAMESPACE).scoped(OAUTH_SETUP_ID);
+  return new NamespacedStorage(storage, NAMESPACE).forSignIn(OAUTH_SETUP_ID);
 }
 
 /** Store a pending flow the way `signIn` would before navigating away. */
@@ -67,12 +67,12 @@ function setupOAuth({ storage = new InMemoryStorage() } = {}) {
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage,
     storageNamespace: NAMESPACE,
-    providerClients: { setups: [oauth()], signInApi },
+    ambientSignIns: { signIns: [oauth()], signInApi },
   });
-  const oauthState = client.providerState(OAUTH_SETUP_ID);
-  const actions = oauthState.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
+  const oauthValues = client.ambientSignInValues(OAUTH_SETUP_ID);
+  const actions = oauthValues.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
   const flowError = () =>
-    oauthState.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
+    oauthValues.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
   return { client, mutation, actions, flowError, storage };
 }
 
@@ -110,7 +110,7 @@ describe("OAuth client", () => {
           },
           storage: new InMemoryStorage(),
           storageNamespace: NAMESPACE,
-          providerClients: { setups: [oauth(), oauth()], signInApi },
+          ambientSignIns: { signIns: [oauth(), oauth()], signInApi },
         }),
     ).toThrow(/registered twice/);
   });

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -25,10 +25,9 @@ const bundle: TokenBundle = {
   userId: "user-1",
 };
 
-// Real function references (they carry their path), the way an app picks them
-// off its generated `api.auth`. The start leg passes `startSignIn` through by
-// identity; the completion leg rebuilds `completeSignIn` from the persisted
-// path, so completion assertions compare paths via `getFunctionName`.
+// Real function references, so they carry a path. Completion rebuilds its
+// reference from the saved path, so those assertions compare paths with
+// `getFunctionName` rather than comparing the references themselves.
 const googleStart = makeFunctionReference<"mutation">("auth:startSignInGoogle");
 const googleComplete = makeFunctionReference<"mutation">(
   "auth:completeSignInGoogle",
@@ -60,10 +59,10 @@ function seedPendingFlow(
 }
 
 /**
- * Run the oauth setup against a real AuthClient and a fake sign-in api. The
- * setup runs during client construction through a wrapper that keeps the
- * returned onInit away from the client and hands it to the test instead, so
- * tests drive the startup work by hand and `client.init()` won't also run it.
+ * Run the oauth setup against a real AuthClient and a fake sign-in api. A
+ * wrapper hands the returned onInit to the test instead of the client, so
+ * tests can run the startup work themselves and `client.init()` won't also
+ * run it.
  */
 function setupOAuth({ storage = new InMemoryStorage() } = {}) {
   const mutation = vi.fn();
@@ -251,7 +250,7 @@ describe("OAuth client", () => {
 
     onInit();
 
-    // The library owns default copy for each code; apps rebrand by switching
+    // The library owns default copy for each code. Apps rebrand by switching
     // on `code` and ignoring `message`.
     expect(flowError()).toEqual({
       code: "access_denied",
@@ -297,8 +296,8 @@ describe("OAuth client", () => {
   });
 
   test("a pending flow without a completeSignIn path is invalid", async () => {
-    // A record persisted by an older client (or tampered with) that lacks the
-    // function path can't be completed — it must not crash or half-redeem.
+    // A record saved by an older client, or tampered with, that has no
+    // function path. It must not crash or half-redeem.
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     void flowStorage(storage).set(
@@ -420,7 +419,7 @@ describe("OAuth client", () => {
 
     onInit();
 
-    // Only namespaced params are ours; a plain code/error belongs to the app.
+    // Only namespaced params are ours. A plain code or error is the app's.
     expect(mutation).not.toHaveBeenCalled();
     expect(flowError()).toBeNull();
     expect(window.location.search).toBe("?code=foreign&error=foreign");

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { getFunctionName, makeFunctionReference } from "convex/server";
 import type { AuthSignInApi } from "../browser/providerSetup";
-import { AuthClient } from "../browser/sessionManager";
+import { AuthClient, type AuthState } from "../browser/sessionManager";
 import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
 import type { TokenBundle } from "../lib/types";
 import {
@@ -25,17 +25,17 @@ const bundle: TokenBundle = {
   userId: "user-1",
 };
 
-// Real function references, so they carry a path. Completion rebuilds its
-// reference from the saved path, so those assertions compare paths with
-// `getFunctionName` rather than comparing the references themselves.
-const googleStart = makeFunctionReference<"mutation">("auth:startSignInGoogle");
-const googleComplete = makeFunctionReference<"mutation">(
-  "auth:completeSignInGoogle",
+// A stand-in provider. The refs carry real paths because `signIn` saves the
+// completeSignIn path and completion rebuilds the reference from it, so
+// assertions compare paths with `getFunctionName`, not references.
+const acmeStart = makeFunctionReference<"mutation">("auth:startSignInAcme");
+const acmeComplete = makeFunctionReference<"mutation">(
+  "auth:completeSignInAcme",
 );
-const GOOGLE_REFS: OauthProviderRefs = {
-  providerName: "google",
-  startSignIn: googleStart,
-  completeSignIn: googleComplete,
+const ACME_REFS: OauthProviderRefs = {
+  providerName: "acme",
+  startSignIn: acmeStart,
+  completeSignIn: acmeComplete,
 };
 
 /** The oauth setup's scoped storage view over `storage`. */
@@ -47,9 +47,9 @@ function flowStorage(storage: InMemoryStorage) {
 function seedPendingFlow(
   storage: InMemoryStorage,
   {
-    providerName = "google",
+    providerName = "acme",
     state = "state-1",
-    completeSignIn = "auth:completeSignInGoogle",
+    completeSignIn = "auth:completeSignInAcme",
   } = {},
 ) {
   void flowStorage(storage).set(
@@ -58,46 +58,22 @@ function seedPendingFlow(
   );
 }
 
-/**
- * Run the oauth setup against a real AuthClient and a fake sign-in api. A
- * wrapper hands the returned onInit to the test instead of the client, so
- * tests can run the startup work themselves and `client.init()` won't also
- * run it.
- */
+/** Run the real oauth setup against an AuthClient with a fake sign-in api. */
 function setupOAuth({ storage = new InMemoryStorage() } = {}) {
   const mutation = vi.fn();
   const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
-  const captured: { onInit?: () => void } = {};
-  const oauthSetup = oauth();
   const client = new AuthClient({
     mode: "spa",
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage,
     storageNamespace: NAMESPACE,
-    providerClients: {
-      setups: [
-        {
-          id: oauthSetup.id,
-          setup: (ctx) => {
-            captured.onInit = oauthSetup.setup(ctx)?.onInit;
-          },
-        },
-      ],
-      signInApi,
-    },
+    providerClients: { setups: [oauth()], signInApi },
   });
   const oauthState = client.providerState(OAUTH_SETUP_ID);
   const actions = oauthState.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
   const flowError = () =>
     oauthState.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
-  return {
-    client,
-    mutation,
-    onInit: captured.onInit!,
-    actions,
-    flowError,
-    storage,
-  };
+  return { client, mutation, actions, flowError, storage };
 }
 
 /** The function path the fake `mutation` was called with. */
@@ -139,21 +115,12 @@ describe("OAuth client", () => {
     ).toThrow(/registered twice/);
   });
 
-  test("client.init runs the setup's onInit and completes a pending flow", async () => {
-    // The real wiring, no capture wrapper: oauth() registered the way
-    // `ConvexAuthProvider` does it, with init driving the startup work.
+  test("init redeems a callback code and adopts the session", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const mutation = vi.fn().mockResolvedValueOnce(bundle);
-    const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
-    const client = new AuthClient({
-      mode: "spa",
-      authApi: { refreshSession: async () => null, signOut: async () => {} },
-      storage,
-      storageNamespace: NAMESPACE,
-      providerClients: { setups: [oauth()], signInApi },
-    });
+    const { client, mutation, flowError } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce(bundle);
 
     await client.init();
 
@@ -161,24 +128,8 @@ describe("OAuth client", () => {
       expect(client.getSnapshot().isAuthenticated).toBe(true),
     );
     expect(mutation).toHaveBeenCalledOnce();
-    expect(window.location.search).toBe("");
-  });
-
-  test("onInit redeems a callback code and adopts the session", async () => {
-    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
-    const storage = new InMemoryStorage();
-    seedPendingFlow(storage);
-    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(bundle);
-
-    onInit();
-
-    await vi.waitFor(() =>
-      expect(client.getSnapshot().isAuthenticated).toBe(true),
-    );
-    expect(mutation).toHaveBeenCalledOnce();
     // The reference is rebuilt from the persisted function path.
-    expect(calledPath(mutation)).toBe("auth:completeSignInGoogle");
+    expect(calledPath(mutation)).toBe("auth:completeSignInAcme");
     expect(mutation.mock.calls[0]![1]).toEqual({
       code: "code-1",
       state: "state-1",
@@ -194,10 +145,10 @@ describe("OAuth client", () => {
     window.history.replaceState({ idx: 3 }, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onInit } = setupOAuth({ storage });
+    const { client, mutation } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(bundle);
 
-    onInit();
+    await client.init();
 
     await vi.waitFor(() =>
       expect(client.getSnapshot().isAuthenticated).toBe(true),
@@ -206,18 +157,25 @@ describe("OAuth client", () => {
     expect(window.history.state).toEqual({ idx: 3 });
   });
 
-  test("reports loading while a code is redeemed, through init resolving", async () => {
+  test("never reports signed out while a code is redeemed", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onInit } = setupOAuth({ storage });
+    const { client, mutation } = setupOAuth({ storage });
     const { promise, resolve } = Promise.withResolvers<TokenBundle>();
     mutation.mockReturnValueOnce(promise);
 
-    // Mirror init's real ordering by hand. onInit marks sign-in pending
-    // synchronously, then the session load runs.
-    onInit();
-    expect(client.getSnapshot().isLoading).toBe(true);
+    // The session load finishes long before the redemption does. Any snapshot
+    // in between that is done loading and not authenticated would bounce the
+    // user to a sign-in screen.
+    const signedOut: AuthState[] = [];
+    const unsubscribe = client.subscribe(() => {
+      const state = client.getSnapshot();
+      if (!state.isLoading && !state.isAuthenticated) {
+        signedOut.push(state);
+      }
+    });
+
     await client.init();
     expect(client.getSnapshot().isLoading).toBe(true);
 
@@ -226,29 +184,44 @@ describe("OAuth client", () => {
       expect(client.getSnapshot().isAuthenticated).toBe(true),
     );
     expect(client.getSnapshot().isLoading).toBe(false);
+    expect(signedOut).toEqual([]);
+    unsubscribe();
   });
 
-  test("a second onInit run finds a clean URL and no-ops", async () => {
+  test("a second client on the same URL finds it clean and no-ops", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onInit } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(bundle);
+    const { client: first, mutation: firstMutation } = setupOAuth({ storage });
+    firstMutation.mockResolvedValueOnce(bundle);
 
-    onInit();
-    onInit();
-
+    await first.init();
     await vi.waitFor(() =>
-      expect(client.getSnapshot().isAuthenticated).toBe(true),
+      expect(first.getSnapshot().isAuthenticated).toBe(true),
     );
-    expect(mutation).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe("");
+
+    // The code is one-time, so a second client over the same page must not try
+    // to redeem it again. Each harness makes its own mutation spy, so a second
+    // redemption would show up on the second client's spy.
+    const {
+      client: second,
+      mutation: secondMutation,
+      flowError: secondFlowError,
+    } = setupOAuth({ storage });
+    await second.init();
+
+    expect(secondMutation).not.toHaveBeenCalled();
+    // A code still in the URL with the flow already consumed would land here
+    // as invalid_flow.
+    expect(secondFlowError()).toBeNull();
   });
 
-  test("a callback error param sets the flow error and strips the URL", () => {
+  test("a callback error param sets the flow error and strips the URL", async () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
-    const { mutation, onInit, flowError } = setupOAuth();
+    const { client, mutation, flowError } = setupOAuth();
 
-    onInit();
+    await client.init();
 
     // The library owns default copy for each code. Apps rebrand by switching
     // on `code` and ignoring `message`.
@@ -264,29 +237,28 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { onInit, flowError } = setupOAuth({ storage });
+    const { client, flowError } = setupOAuth({ storage });
 
-    onInit();
+    await client.init();
 
     expect(flowError()?.code).toBe("access_denied");
     // The flow ended in an error, so the stored state can never complete.
     await vi.waitFor(() => expect(flowStorage(storage).get("flow")).toBeNull());
   });
 
-  test("an unknown error param normalizes to oauth_error", () => {
+  test("an unknown error param normalizes to oauth_error", async () => {
     window.history.replaceState(null, "", "/?convexAuthError=server_exploded");
-    const { onInit, flowError } = setupOAuth();
+    const { client, flowError } = setupOAuth();
 
-    onInit();
+    await client.init();
 
     expect(flowError()?.code).toBe("oauth_error");
   });
 
   test("a code without a pending flow sets invalid_flow", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
-    const { client, mutation, onInit, flowError } = setupOAuth();
+    const { client, mutation, flowError } = setupOAuth();
 
-    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
@@ -302,11 +274,10 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     void flowStorage(storage).set(
       "flow",
-      JSON.stringify({ providerName: "google", state: "state-1" }),
+      JSON.stringify({ providerName: "acme", state: "state-1" }),
     );
-    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
+    const { client, mutation, flowError } = setupOAuth({ storage });
 
-    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
@@ -317,10 +288,10 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
+    const { client, mutation, flowError } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(null);
 
-    onInit();
+    await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("expired"));
     expect(client.getSnapshot().isAuthenticated).toBe(false);
@@ -332,10 +303,9 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
+    const { client, mutation, flowError } = setupOAuth({ storage });
     mutation.mockRejectedValueOnce(new Error("boom"));
 
-    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("oauth_error"));
@@ -355,11 +325,11 @@ describe("OAuth client", () => {
       state: "state-1",
     });
 
-    const outcome = await actions.signIn(GOOGLE_REFS, {
+    const outcome = await actions.signIn(ACME_REFS, {
       redirectTo: "http://localhost/app",
     });
 
-    expect(mutation).toHaveBeenCalledExactlyOnceWith(googleStart, {
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(acmeStart, {
       redirectTo: "http://localhost/app",
     });
     expect(outcome).toEqual({
@@ -369,9 +339,9 @@ describe("OAuth client", () => {
     // completion can run on a page that never held the references.
     expect(flowStorage(storage).get("flow")).toBe(
       JSON.stringify({
-        providerName: "google",
+        providerName: "acme",
         state: "state-1",
-        completeSignIn: "auth:completeSignInGoogle",
+        completeSignIn: "auth:completeSignInAcme",
       }),
     );
   });
@@ -382,11 +352,11 @@ describe("OAuth client", () => {
     const { client, mutation, actions } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(bundle);
 
-    const outcome = await actions.signIn(GOOGLE_REFS, { code: "code-1" });
+    const outcome = await actions.signIn(ACME_REFS, { code: "code-1" });
 
     expect(outcome).toEqual({ signedIn: true });
     expect(mutation).toHaveBeenCalledOnce();
-    expect(calledPath(mutation)).toBe("auth:completeSignInGoogle");
+    expect(calledPath(mutation)).toBe("auth:completeSignInAcme");
     expect(mutation.mock.calls[0]![1]).toEqual({
       code: "code-1",
       state: "state-1",
@@ -400,24 +370,24 @@ describe("OAuth client", () => {
       value: "ReactNative",
       configurable: true,
     });
-    const { mutation, onInit, actions, flowError } = setupOAuth();
-    onInit();
+    const { client, mutation, actions, flowError } = setupOAuth();
+    await client.init();
     expect(flowError()?.code).toBe("access_denied");
 
     mutation.mockResolvedValueOnce({
       redirect: "https://provider.example/auth",
       state: "state-2",
     });
-    await actions.signIn(GOOGLE_REFS);
+    await actions.signIn(ACME_REFS);
 
     expect(flowError()).toBeNull();
   });
 
-  test("a foreign code/error param is ignored and left in the URL", () => {
+  test("a foreign code/error param is ignored and left in the URL", async () => {
     window.history.replaceState(null, "", "/?code=foreign&error=foreign");
-    const { mutation, onInit, flowError } = setupOAuth();
+    const { client, mutation, flowError } = setupOAuth();
 
-    onInit();
+    await client.init();
 
     // Only namespaced params are ours. A plain code or error is the app's.
     expect(mutation).not.toHaveBeenCalled();

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -1,11 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { getFunctionName, makeFunctionReference } from "convex/server";
-import { scopedKey } from "../browser/keyedStore";
-import {
-  registerProviderClientSetups,
-  type AuthSignInApi,
-} from "../browser/providerSetup";
+import type { AuthSignInApi } from "../browser/providerSetup";
 import { AuthClient } from "../browser/sessionManager";
 import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
 import type { TokenBundle } from "../lib/types";
@@ -64,34 +60,41 @@ function seedPendingFlow(
 }
 
 /**
- * Run the oauth setup against a real AuthClient and a fake sign-in api,
- * the way `ConvexAuthProvider` would at client construction.
+ * Run the oauth setup against a real AuthClient and a fake sign-in api. The
+ * setup runs during client construction through a wrapper that keeps the
+ * returned onInit away from the client and hands it to the test instead, so
+ * tests drive the startup work by hand and `client.init()` won't also run it.
  */
 function setupOAuth({ storage = new InMemoryStorage() } = {}) {
+  const mutation = vi.fn();
+  const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
+  const captured: { onInit?: () => void } = {};
+  const oauthSetup = oauth();
   const client = new AuthClient({
     mode: "spa",
     authApi: { refreshSession: async () => null, signOut: async () => {} },
     storage,
     storageNamespace: NAMESPACE,
+    providerClients: {
+      setups: [
+        {
+          id: oauthSetup.id,
+          setup: (ctx) => {
+            captured.onInit = oauthSetup.setup(ctx)?.onInit;
+          },
+        },
+      ],
+      signInApi,
+    },
   });
-  const mutation = vi.fn();
-  const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
-  const onStarts = registerProviderClientSetups({
-    client,
-    signInApi,
-    setups: [oauth()],
-  });
-  const actions = client.store.get<OauthActions>(
-    scopedKey(OAUTH_SETUP_ID, OAUTH_ACTIONS_KEY),
-  )!;
+  const oauthState = client.providerState(OAUTH_SETUP_ID);
+  const actions = oauthState.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
   const flowError = () =>
-    client.store.get<OauthFlowError | null>(
-      scopedKey(OAUTH_SETUP_ID, OAUTH_FLOW_ERROR_KEY),
-    );
+    oauthState.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
   return {
     client,
     mutation,
-    onStart: onStarts[0]!.onStart,
+    onInit: captured.onInit!,
     actions,
     flowError,
     storage,
@@ -118,28 +121,58 @@ describe("OAuth client", () => {
   });
 
   test("registering oauth() twice on one provider throws", () => {
-    const { client } = setupOAuth();
     const signInApi = {
       mutation: vi.fn(),
       action: vi.fn(),
     } as unknown as AuthSignInApi;
-    expect(() =>
-      registerProviderClientSetups({
-        client,
-        signInApi,
-        setups: [oauth(), oauth()],
-      }),
+    expect(
+      () =>
+        new AuthClient({
+          mode: "spa",
+          authApi: {
+            refreshSession: async () => null,
+            signOut: async () => {},
+          },
+          storage: new InMemoryStorage(),
+          storageNamespace: NAMESPACE,
+          providerClients: { setups: [oauth(), oauth()], signInApi },
+        }),
     ).toThrow(/registered twice/);
   });
 
-  test("onStart redeems a callback code and adopts the session", async () => {
+  test("client.init runs the setup's onInit and completes a pending flow", async () => {
+    // The real wiring, no capture wrapper: oauth() registered the way
+    // `ConvexAuthProvider` does it, with init driving the startup work.
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    const mutation = vi.fn().mockResolvedValueOnce(bundle);
+    const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
+    const client = new AuthClient({
+      mode: "spa",
+      authApi: { refreshSession: async () => null, signOut: async () => {} },
+      storage,
+      storageNamespace: NAMESPACE,
+      providerClients: { setups: [oauth()], signInApi },
+    });
+
+    await client.init();
+
+    await vi.waitFor(() =>
+      expect(client.getSnapshot().isAuthenticated).toBe(true),
+    );
+    expect(mutation).toHaveBeenCalledOnce();
+    expect(window.location.search).toBe("");
+  });
+
+  test("onInit redeems a callback code and adopts the session", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(bundle);
 
-    onStart();
+    onInit();
 
     await vi.waitFor(() =>
       expect(client.getSnapshot().isAuthenticated).toBe(true),
@@ -162,10 +195,10 @@ describe("OAuth client", () => {
     window.history.replaceState({ idx: 3 }, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart } = setupOAuth({ storage });
+    const { client, mutation, onInit } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(bundle);
 
-    onStart();
+    onInit();
 
     await vi.waitFor(() =>
       expect(client.getSnapshot().isAuthenticated).toBe(true),
@@ -178,12 +211,13 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart } = setupOAuth({ storage });
+    const { client, mutation, onInit } = setupOAuth({ storage });
     const { promise, resolve } = Promise.withResolvers<TokenBundle>();
     mutation.mockReturnValueOnce(promise);
 
-    // The real startup ordering: onStart latches synchronously, then init runs.
-    onStart();
+    // Mirror init's real ordering by hand. onInit marks sign-in pending
+    // synchronously, then the session load runs.
+    onInit();
     expect(client.getSnapshot().isLoading).toBe(true);
     await client.init();
     expect(client.getSnapshot().isLoading).toBe(true);
@@ -195,15 +229,15 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isLoading).toBe(false);
   });
 
-  test("a second onStart run finds a clean URL and no-ops", async () => {
+  test("a second onInit run finds a clean URL and no-ops", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart } = setupOAuth({ storage });
+    const { client, mutation, onInit } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(bundle);
 
-    onStart();
-    onStart();
+    onInit();
+    onInit();
 
     await vi.waitFor(() =>
       expect(client.getSnapshot().isAuthenticated).toBe(true),
@@ -213,9 +247,9 @@ describe("OAuth client", () => {
 
   test("a callback error param sets the flow error and strips the URL", () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
-    const { mutation, onStart, flowError } = setupOAuth();
+    const { mutation, onInit, flowError } = setupOAuth();
 
-    onStart();
+    onInit();
 
     // The library owns default copy for each code; apps rebrand by switching
     // on `code` and ignoring `message`.
@@ -231,9 +265,9 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { onStart, flowError } = setupOAuth({ storage });
+    const { onInit, flowError } = setupOAuth({ storage });
 
-    onStart();
+    onInit();
 
     expect(flowError()?.code).toBe("access_denied");
     // The flow ended in an error, so the stored state can never complete.
@@ -242,18 +276,18 @@ describe("OAuth client", () => {
 
   test("an unknown error param normalizes to oauth_error", () => {
     window.history.replaceState(null, "", "/?convexAuthError=server_exploded");
-    const { onStart, flowError } = setupOAuth();
+    const { onInit, flowError } = setupOAuth();
 
-    onStart();
+    onInit();
 
     expect(flowError()?.code).toBe("oauth_error");
   });
 
   test("a code without a pending flow sets invalid_flow", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
-    const { client, mutation, onStart, flowError } = setupOAuth();
+    const { client, mutation, onInit, flowError } = setupOAuth();
 
-    onStart();
+    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
@@ -271,9 +305,9 @@ describe("OAuth client", () => {
       "flow",
       JSON.stringify({ providerName: "google", state: "state-1" }),
     );
-    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
 
-    onStart();
+    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("invalid_flow"));
@@ -284,10 +318,10 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
     mutation.mockResolvedValueOnce(null);
 
-    onStart();
+    onInit();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("expired"));
     expect(client.getSnapshot().isAuthenticated).toBe(false);
@@ -299,10 +333,10 @@ describe("OAuth client", () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
-    const { client, mutation, onStart, flowError } = setupOAuth({ storage });
+    const { client, mutation, onInit, flowError } = setupOAuth({ storage });
     mutation.mockRejectedValueOnce(new Error("boom"));
 
-    onStart();
+    onInit();
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("oauth_error"));
@@ -367,8 +401,8 @@ describe("OAuth client", () => {
       value: "ReactNative",
       configurable: true,
     });
-    const { mutation, onStart, actions, flowError } = setupOAuth();
-    onStart();
+    const { mutation, onInit, actions, flowError } = setupOAuth();
+    onInit();
     expect(flowError()?.code).toBe("access_denied");
 
     mutation.mockResolvedValueOnce({
@@ -382,9 +416,9 @@ describe("OAuth client", () => {
 
   test("a foreign code/error param is ignored and left in the URL", () => {
     window.history.replaceState(null, "", "/?code=foreign&error=foreign");
-    const { mutation, onStart, flowError } = setupOAuth();
+    const { mutation, onInit, flowError } = setupOAuth();
 
-    onStart();
+    onInit();
 
     // Only namespaced params are ours; a plain code/error belongs to the app.
     expect(mutation).not.toHaveBeenCalled();

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -76,6 +76,22 @@ function setupOAuth({ storage = new InMemoryStorage() } = {}) {
   return { client, mutation, actions, flowError, storage };
 }
 
+// Save original navigator.product value so it can be restored. Can't just mock
+// the window entirely as we do elsewhere because this test runs in jsdom env.
+const ORIGINAL_PRODUCT = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "product",
+);
+
+/** Undo the React Native stub's shadowing of `navigator.product`. */
+function restoreNavigatorProduct(): void {
+  if (ORIGINAL_PRODUCT === undefined) {
+    delete (window.navigator as { product?: string }).product;
+  } else {
+    Object.defineProperty(window.navigator, "product", ORIGINAL_PRODUCT);
+  }
+}
+
 /** The function path the fake `mutation` was called with. */
 function calledPath(mutation: ReturnType<typeof vi.fn>, call = 0): string {
   return getFunctionName(mutation.mock.calls[call]![0] as never);
@@ -85,8 +101,7 @@ describe("OAuth client", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     window.history.replaceState(null, "", "/");
-    // Restore the prototype getter shadowed by the React Native stub.
-    delete (window.navigator as { product?: string }).product;
+    restoreNavigatorProduct();
   });
 
   test("registers actions and a null flow error at setup", () => {
@@ -223,12 +238,7 @@ describe("OAuth client", () => {
 
     await client.init();
 
-    // The library owns default copy for each code. Apps rebrand by switching
-    // on `code` and ignoring `message`.
-    expect(flowError()).toEqual({
-      code: "access_denied",
-      message: "Sign-in was cancelled.",
-    });
+    expect(flowError()).toEqual({ code: "access_denied" });
     expect(mutation).not.toHaveBeenCalled();
     expect(window.location.search).toBe("");
   });

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -14,9 +14,9 @@ import {
   getFunctionName,
   makeFunctionReference,
 } from "convex/server";
-import type { AuthProviderClientSetup } from "../browser/providerSetup";
+import type { AmbientSignInClient } from "../browser/ambientSignInClient";
 import { retryOnNetworkError } from "../browser/retry";
-import type { ScopedStorage } from "../browser/storage";
+import type { SignInStorage } from "../browser/storage";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../lib/oauthParams";
 import type { TokenBundle } from "../lib/types";
 
@@ -99,7 +99,7 @@ export type SignInOptions = {
  */
 export type SignInOutcome = { redirect: URL } | { signedIn: boolean };
 
-/** The sign-in actions {@link oauth} registers in the auth client's store. */
+/** The sign-in actions {@link oauth} publishes for its hooks to read. */
 export type OauthActions = {
   /**
    * Start the given provider's OAuth flow, or finish a saved one when
@@ -114,12 +114,12 @@ export type OauthActions = {
 /** The id {@link oauth} registers under. */
 export const OAUTH_SETUP_ID = "oauth";
 
-/** Store key where {@link oauth} registers its {@link OauthActions}. */
+/** Key {@link oauth} publishes its {@link OauthActions} under. */
 export const OAUTH_ACTIONS_KEY = "actions";
 
 /**
- * Store key holding the current {@link OauthFlowError}, or `null` when the
- * last attempt was fine. It is set at registration, so `undefined` means
+ * Key holding the current {@link OauthFlowError}, or `null` when the last
+ * attempt was fine. It is set at registration, so `undefined` means
  * {@link oauth} was never registered.
  */
 export const OAUTH_FLOW_ERROR_KEY = "flowError";
@@ -157,7 +157,7 @@ type PendingFlow = {
  * be used again anyway.
  */
 async function takePendingFlow(
-  storage: ScopedStorage,
+  storage: SignInStorage,
 ): Promise<PendingFlow | null> {
   const raw = await storage.get(OAUTH_FLOW_STORAGE_KEY);
   await storage.remove(OAUTH_FLOW_STORAGE_KEY);
@@ -192,16 +192,16 @@ async function takePendingFlow(
  * startup work that finishes a flow. Provider mutations arrive with each
  * {@link OauthActions.signIn} call, so the setup takes no configuration.
  */
-export function oauth(): AuthProviderClientSetup {
-  const setup: AuthProviderClientSetup["setup"] = ({
+export function oauth(): AmbientSignInClient {
+  const setup: AmbientSignInClient["setup"] = ({
     client,
-    store,
+    values,
     storage,
     signInApi,
   }) => {
     /** Set or clear the flow error apps read for sign-in feedback. */
     const setFlowError = (code: OauthFlowErrorCode | null): void => {
-      store.set(
+      values.set(
         OAUTH_FLOW_ERROR_KEY,
         code === null ? null : { code, message: FLOW_ERROR_MESSAGES[code] },
       );
@@ -308,7 +308,7 @@ export function oauth(): AuthProviderClientSetup {
       return { redirect: url };
     };
 
-    store.set(OAUTH_ACTIONS_KEY, { signIn } satisfies OauthActions);
+    values.set(OAUTH_ACTIONS_KEY, { signIn } satisfies OauthActions);
     setFlowError(null);
     return { onInit: handleCallback };
   };

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -60,23 +60,10 @@ export type OauthProviderRefs = {
 export type OauthFlowErrorCode =
   "access_denied" | "expired" | "oauth_error" | "invalid_flow";
 
-/** Why a sign-in failed, with default copy an app can render as-is. */
+/** Why a sign-in failed. */
 export type OauthFlowError = {
   /** Why the sign-in failed. */
   code: OauthFlowErrorCode;
-  /**
-   * Default English copy for `code`. Not a stable string. To localize or
-   * rebrand, switch on `code` and ignore this.
-   */
-  message: string;
-};
-
-/** Default user-facing copy for each {@link OauthFlowErrorCode}. */
-const FLOW_ERROR_MESSAGES: Record<OauthFlowErrorCode, string> = {
-  access_denied: "Sign-in was cancelled.",
-  expired: "Sign-in took too long. Please try again.",
-  oauth_error: "Something went wrong during sign-in. Please try again.",
-  invalid_flow: "This sign-in can't be completed here. Please try again.",
 };
 
 /** Options accepted by {@link OauthActions.signIn}. */
@@ -201,10 +188,7 @@ export function oauth(): AmbientSignInClient {
   }) => {
     /** Set or clear the flow error apps read for sign-in feedback. */
     const setFlowError = (code: OauthFlowErrorCode | null): void => {
-      values.set(
-        OAUTH_FLOW_ERROR_KEY,
-        code === null ? null : { code, message: FLOW_ERROR_MESSAGES[code] },
-      );
+      values.set(OAUTH_FLOW_ERROR_KEY, code === null ? null : { code });
     };
 
     /**

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -1,0 +1,374 @@
+/**
+ * Framework-agnostic client for the OAuth providers.
+ *
+ * A provider's job on the client is to run its own sign-in flow and hand the
+ * resulting {@link TokenBundle} to the core client's `setSession`. OAuth's
+ * flow spans a full page round-trip (`signIn` navigates away to the identity
+ * provider, and the provider's callback redirects back with a one-time
+ * `code`), so the {@link oauth} setup registers startup work: when the app
+ * loads, it completes any pending flow.
+ *
+ * Flow: `signIn` asks the server for an authorization URL, keeps the minted
+ * `state` in storage, and navigates away. The callback redirects back with a
+ * one-time `code` (or a normalized `error`); at startup this client redeems
+ * `code` + `state` for a {@link TokenBundle} and adopts the session. The
+ * state is read from storage only, never from the URL: a client that accepts
+ * state from URL params can be handed an attacker's flow and complete
+ * sign-in into the attacker's account (login CSRF).
+ *
+ * Provider functions are passed as plain references: `signIn` takes the
+ * provider's `startSignIn`/`completeSignIn` pair (see
+ * {@link OauthProviderRefs}), typically picked off the app's `api.auth`
+ * module. Completion must work on whatever page the flow returns to, where
+ * the code that started the flow (and held the references) may not run, so
+ * the pending-flow record persists the `completeSignIn` *function path*
+ * (via `getFunctionName`) and startup completion rebuilds the reference
+ * from storage.
+ *
+ * Nothing here depends on React — the hooks live in `./react`.
+ *
+ * @module
+ */
+import {
+  FunctionReference,
+  getFunctionName,
+  makeFunctionReference,
+} from "convex/server";
+import type { AuthProviderClientSetup } from "../browser/providerSetup";
+import { retryOnNetworkError } from "../browser/retry";
+import type { ScopedStorage } from "../browser/storage";
+import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../lib/oauthParams";
+import type { TokenBundle } from "../lib/types";
+
+/**
+ * The client-callable mutations an OAuth provider adds to the app's API,
+ * passed as references (not names) because an app may re-export them under
+ * any names.
+ */
+export type OauthProviderApi = {
+  /** The provider's `startSignIn*` mutation. */
+  startSignIn: FunctionReference<
+    "mutation",
+    "public",
+    { redirectTo: string },
+    { redirect: string; state: string }
+  >;
+  /** The provider's `completeSignIn*` mutation. */
+  completeSignIn: FunctionReference<
+    "mutation",
+    "public",
+    { code: string; state: string },
+    TokenBundle | null
+  >;
+};
+
+/**
+ * Everything {@link OauthActions.signIn} needs to run one provider's flow:
+ * the provider's mutation pair plus its name. The name never resolves
+ * anything; it labels the pending flow for debugging and future
+ * provider-scoped error copy.
+ */
+export type OauthProviderRefs = {
+  /** The provider's name, e.g. `"google"`. A label, not a lookup key. */
+  providerName: string;
+} & OauthProviderApi;
+
+/**
+ * Why the last sign-in attempt failed, normalized so apps can map each code
+ * to their own user-facing copy:
+ *
+ * - `"access_denied"`: the user cancelled at the identity provider.
+ * - `"expired"`: the flow took too long, or the code was already redeemed.
+ * - `"oauth_error"`: something else went wrong during the provider handshake.
+ * - `"invalid_flow"`: the callback arrived without a matching pending flow —
+ *   this client never started the sign-in (or already completed it).
+ */
+export type OauthFlowErrorCode =
+  "access_denied" | "expired" | "oauth_error" | "invalid_flow";
+
+/**
+ * A sign-in flow error: the normalized {@link OauthFlowErrorCode} plus a
+ * default, English, user-facing `message`. The message is a convenience so
+ * apps can render something without writing their own copy — it is *not* a
+ * stable string. Localize or rebrand by switching on `code` and ignoring
+ * `message`.
+ */
+export type OauthFlowError = {
+  /** The normalized reason the sign-in failed. */
+  code: OauthFlowErrorCode;
+  /** Default English copy for `code`. Not stable — match on `code`. */
+  message: string;
+};
+
+/** Default user-facing copy for each {@link OauthFlowErrorCode}. */
+const FLOW_ERROR_MESSAGES: Record<OauthFlowErrorCode, string> = {
+  access_denied: "Sign-in was cancelled.",
+  expired: "Sign-in took too long. Please try again.",
+  oauth_error: "Something went wrong during sign-in. Please try again.",
+  invalid_flow: "This sign-in can't be completed here. Please try again.",
+};
+
+/** Options accepted by {@link OauthActions.signIn}. */
+export type SignInOptions = {
+  /**
+   * Where the flow returns to when it completes. Must be an http(s) URL on
+   * an allowed origin (see the provider's `allowedRedirectOrigins`); defaults
+   * to the current URL. Custom-scheme deep links (`myapp://`) can't be
+   * allowlisted yet, so React Native apps return via https universal links /
+   * app links.
+   */
+  redirectTo?: string;
+  /**
+   * A callback `code` obtained out-of-band (React Native's in-app
+   * browser). Completes the pending flow instead of starting one.
+   */
+  code?: string;
+};
+
+/**
+ * What a sign-in call resolves to: the identity provider URL to open (React
+ * Native, where the client doesn't navigate itself), or — for an out-of-band
+ * `code` completion — whether the session was signed in.
+ */
+export type SignInOutcome = { redirect: URL } | { signedIn: boolean };
+
+/**
+ * The sign-in actions {@link oauth} registers in the auth client's store.
+ * Per-provider conveniences (`useSignInWithGoogle`) live in `./react` and
+ * delegate here with their references statically picked.
+ */
+export type OauthActions = {
+  /**
+   * Start the given provider's OAuth flow (or, with `options.code`, complete
+   * one). Starting navigates away to the identity provider — except in React
+   * Native, where the returned `redirect` URL should be opened in an in-app
+   * browser and the `code` from its callback fed back via
+   * `signIn(refs, { code })`, with an https universal-link `redirectTo`
+   * (see {@link SignInOptions.redirectTo}).
+   */
+  signIn: (
+    refs: OauthProviderRefs,
+    options?: SignInOptions,
+  ) => Promise<SignInOutcome>;
+};
+
+/**
+ * The id {@link oauth} registers under. The setup's store and storage views
+ * are scoped by it.
+ */
+export const OAUTH_SETUP_ID = "oauth";
+
+/**
+ * Store key where {@link oauth} registers its {@link OauthActions}, within
+ * the setup's scoped store view.
+ */
+export const OAUTH_ACTIONS_KEY = "actions";
+
+/**
+ * Store key holding the current {@link OauthFlowError} object (or `null`),
+ * within the setup's scoped store view. Seeded at setup, so `undefined`
+ * means {@link oauth} was never registered.
+ */
+export const OAUTH_FLOW_ERROR_KEY = "flowError";
+
+/** The `error` values the server callback emits (see the component's `http.ts`). */
+const SERVER_ERRORS: ReadonlySet<string> = new Set([
+  "access_denied",
+  "expired",
+  "oauth_error",
+]);
+
+/** Storage key for the pending sign-in flow, within the setup's scoped storage. */
+const OAUTH_FLOW_STORAGE_KEY = "flow";
+
+/**
+ * The record `signIn` persists to storage before redirecting to the identity provider.
+ * The redirect can land on any page of the app, including one that never
+ * called a sign-in hook, so the record carries everything completion needs:
+ * the `state` to validate and the `completeSignIn` function path to invoke.
+ */
+type PendingFlow = {
+  /** Which provider the flow belongs to (a label; see {@link OauthProviderRefs}). */
+  providerName: string;
+  /** The state minted at sign-in: proof this client initiated the flow. */
+  state: string;
+  /**
+   * The function path of the provider's `completeSignIn` mutation (from
+   * `getFunctionName`), rebuilt into a reference at completion. A path that
+   * dangles by then (the app renamed the export and deployed mid-flight)
+   * fails the call and surfaces as `oauth_error`.
+   */
+  completeSignIn: string;
+};
+
+/**
+ * Take (read and remove) the pending sign-in flow stored at sign-in time.
+ * Consumed whether or not the redemption that follows succeeds: the flow is
+ * bound to a one-time code, so it can never be completed twice.
+ */
+async function takePendingFlow(
+  storage: ScopedStorage,
+): Promise<PendingFlow | null> {
+  const raw = await storage.get(OAUTH_FLOW_STORAGE_KEY);
+  await storage.remove(OAUTH_FLOW_STORAGE_KEY);
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as {
+      providerName?: unknown;
+      state?: unknown;
+      completeSignIn?: unknown;
+    };
+    if (
+      typeof parsed.providerName !== "string" ||
+      typeof parsed.state !== "string" ||
+      typeof parsed.completeSignIn !== "string"
+    ) {
+      return null;
+    }
+    return {
+      providerName: parsed.providerName,
+      state: parsed.state,
+      completeSignIn: parsed.completeSignIn,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Client setup for the OAuth providers. It owns the flow's storage and
+ * startup completion; the provider functions themselves arrive as
+ * references with each {@link OauthActions.signIn} call (the React hooks pick
+ * them off the app's `api.auth` statically), so the setup itself needs no
+ * configuration. Register it via `ConvexAuthProvider`'s `providerClients`
+ * prop.
+ *
+ * Completion runs on whatever page the flow returns to: sign-in persisted the
+ * `completeSignIn` function path with the flow, so no provider wiring needs
+ * to be mounted there.
+ *
+ * While a callback code is being redeemed the core auth state reports
+ * loading, so `<AuthLoading>`/`<Unauthenticated>` behave correctly with no
+ * extra gating in the app.
+ */
+export function oauth(): AuthProviderClientSetup {
+  const setup: AuthProviderClientSetup["setup"] = ({
+    client,
+    store,
+    storage,
+    signInApi,
+  }) => {
+    const setFlowError = (code: OauthFlowErrorCode | null): void => {
+      store.set(
+        OAUTH_FLOW_ERROR_KEY,
+        code === null ? null : { code, message: FLOW_ERROR_MESSAGES[code] },
+      );
+    };
+
+    /**
+     * Redeem a callback `code` against the pending flow and adopt the
+     * session. Wrapped in `withSignInPending` end to end — including
+     * `setSession` — so the auth state reports loading until the client is
+     * authenticated.
+     */
+    const completeFlow = async (code: string): Promise<boolean> =>
+      await client.withSignInPending(async () => {
+        const pending = await takePendingFlow(storage);
+        if (pending === null) {
+          setFlowError("invalid_flow");
+          return false;
+        }
+        const completeSignIn = makeFunctionReference<"mutation">(
+          pending.completeSignIn,
+        ) as OauthProviderApi["completeSignIn"];
+        try {
+          const bundle = await retryOnNetworkError(() =>
+            signInApi.mutation(completeSignIn, { code, state: pending.state }),
+          );
+          if (bundle === null) {
+            // Unknown, already redeemed, expired, or mismatched state — all
+            // indistinguishable server-side.
+            setFlowError("expired");
+            return false;
+          }
+          await client.setSession(bundle);
+          return true;
+        } catch {
+          setFlowError("oauth_error");
+          return false;
+        }
+      });
+
+    /**
+     * Complete any pending flow the callback redirected back to. Reads and
+     * strips the callback params synchronously, before any await, so a rerun
+     * finds a clean URL and no-ops — the one-time code is only redeemed once.
+     * Only the component's namespaced params are consumed, so an unrelated
+     * `?code=`/`?error=` the app uses itself is left untouched.
+     */
+    const handleCallback = (): void => {
+      if (typeof window === "undefined") {
+        return;
+      }
+      const url = new URL(window.location.href);
+      const code = url.searchParams.get(OAUTH_CODE_PARAM);
+      const errorParam = url.searchParams.get(OAUTH_ERROR_PARAM);
+      if (code === null && errorParam === null) {
+        return;
+      }
+      url.searchParams.delete(OAUTH_CODE_PARAM);
+      url.searchParams.delete(OAUTH_ERROR_PARAM);
+      // Keep the current history state: routers (React Router) store their
+      // own entry state there, and stripping our params must not discard it.
+      window.history.replaceState(window.history.state, "", url.toString());
+      if (errorParam !== null) {
+        // The server ended the flow with an error, so the stored state can
+        // never complete — drop it, keeping `invalid_flow` meaningful if a
+        // stray code arrives later.
+        void storage.remove(OAUTH_FLOW_STORAGE_KEY);
+        setFlowError(
+          SERVER_ERRORS.has(errorParam)
+            ? (errorParam as OauthFlowErrorCode)
+            : "oauth_error",
+        );
+        return;
+      }
+      if (code === null) {
+        return;
+      }
+      void completeFlow(code);
+    };
+
+    const signIn: OauthActions["signIn"] = async (refs, options) => {
+      setFlowError(null);
+      if (options?.code !== undefined) {
+        return { signedIn: await completeFlow(options.code) };
+      }
+      const { redirect, state } = await signInApi.mutation(refs.startSignIn, {
+        redirectTo: options?.redirectTo ?? window.location.href,
+      });
+      await storage.set(
+        OAUTH_FLOW_STORAGE_KEY,
+        JSON.stringify({
+          providerName: refs.providerName,
+          state,
+          completeSignIn: getFunctionName(refs.completeSignIn),
+        } satisfies PendingFlow),
+      );
+      const url = new URL(redirect);
+      // Don't navigate in React Native: the app opens the returned URL in an
+      // in-app browser and completes with `signIn(refs, { code })`.
+      if (navigator.product !== "ReactNative") {
+        window.location.href = url.toString();
+      }
+      return { redirect: url };
+    };
+
+    store.set(OAUTH_ACTIONS_KEY, { signIn } satisfies OauthActions);
+    setFlowError(null);
+    return { onStart: handleCallback };
+  };
+  return { id: OAUTH_SETUP_ID, setup };
+}

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -368,7 +368,7 @@ export function oauth(): AuthProviderClientSetup {
 
     store.set(OAUTH_ACTIONS_KEY, { signIn } satisfies OauthActions);
     setFlowError(null);
-    return { onStart: handleCallback };
+    return { onInit: handleCallback };
   };
   return { id: OAUTH_SETUP_ID, setup };
 }

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -1,31 +1,11 @@
 /**
  * Framework-agnostic client for the OAuth providers.
  *
- * A provider's job on the client is to run its own sign-in flow and hand the
- * resulting {@link TokenBundle} to the core client's `setSession`. OAuth's
- * flow spans a full page round-trip (`signIn` navigates away to the identity
- * provider, and the provider's callback redirects back with a one-time
- * `code`), so the {@link oauth} setup registers startup work: when the app
- * loads, it completes any pending flow.
- *
- * Flow: `signIn` asks the server for an authorization URL, keeps the minted
- * `state` in storage, and navigates away. The callback redirects back with a
- * one-time `code` (or a normalized `error`); at startup this client redeems
- * `code` + `state` for a {@link TokenBundle} and adopts the session. The
- * state is read from storage only, never from the URL: a client that accepts
- * state from URL params can be handed an attacker's flow and complete
- * sign-in into the attacker's account (login CSRF).
- *
- * Provider functions are passed as plain references: `signIn` takes the
- * provider's `startSignIn`/`completeSignIn` pair (see
- * {@link OauthProviderRefs}), typically picked off the app's `api.auth`
- * module. Completion must work on whatever page the flow returns to, where
- * the code that started the flow (and held the references) may not run, so
- * the pending-flow record persists the `completeSignIn` *function path*
- * (via `getFunctionName`) and startup completion rebuilds the reference
- * from storage.
- *
- * Nothing here depends on React — the hooks live in `./react`.
+ * Sign-in spans a full page round-trip, so this client saves what it needs
+ * before navigating away and finishes the flow at startup. The server hands
+ * back a `state` when a flow starts and this client keeps it locally, then
+ * sends it back with the code from the callback URL. That pairing is what
+ * proves this browser started the sign-in.
  *
  * @module
  */
@@ -41,9 +21,8 @@ import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../lib/oauthParams";
 import type { TokenBundle } from "../lib/types";
 
 /**
- * The client-callable mutations an OAuth provider adds to the app's API,
- * passed as references (not names) because an app may re-export them under
- * any names.
+ * The mutations an OAuth provider adds to the app's API. Passed as
+ * references, not names, because an app can re-export them under any name.
  */
 export type OauthProviderApi = {
   /** The provider's `startSignIn*` mutation. */
@@ -62,41 +41,33 @@ export type OauthProviderApi = {
   >;
 };
 
-/**
- * Everything {@link OauthActions.signIn} needs to run one provider's flow:
- * the provider's mutation pair plus its name. The name never resolves
- * anything; it labels the pending flow for debugging and future
- * provider-scoped error copy.
- */
+/** One provider's mutations plus its name. */
 export type OauthProviderRefs = {
-  /** The provider's name, e.g. `"google"`. A label, not a lookup key. */
+  /** The provider's name, e.g. `"google"`. Only a label, never a lookup key. */
   providerName: string;
 } & OauthProviderApi;
 
 /**
- * Why the last sign-in attempt failed, normalized so apps can map each code
- * to their own user-facing copy:
+ * Why the last sign-in attempt failed. Apps map each code to their own
+ * user-facing copy.
  *
  * - `"access_denied"`: the user cancelled at the identity provider.
  * - `"expired"`: the flow took too long, or the code was already redeemed.
  * - `"oauth_error"`: something else went wrong during the provider handshake.
- * - `"invalid_flow"`: the callback arrived without a matching pending flow —
- *   this client never started the sign-in (or already completed it).
+ * - `"invalid_flow"`: the callback arrived but this client has no saved flow,
+ *   so it never started this sign-in or already finished it.
  */
 export type OauthFlowErrorCode =
   "access_denied" | "expired" | "oauth_error" | "invalid_flow";
 
-/**
- * A sign-in flow error: the normalized {@link OauthFlowErrorCode} plus a
- * default, English, user-facing `message`. The message is a convenience so
- * apps can render something without writing their own copy — it is *not* a
- * stable string. Localize or rebrand by switching on `code` and ignoring
- * `message`.
- */
+/** Why a sign-in failed, with default copy an app can render as-is. */
 export type OauthFlowError = {
-  /** The normalized reason the sign-in failed. */
+  /** Why the sign-in failed. */
   code: OauthFlowErrorCode;
-  /** Default English copy for `code`. Not stable — match on `code`. */
+  /**
+   * Default English copy for `code`. Not a stable string. To localize or
+   * rebrand, switch on `code` and ignore this.
+   */
   message: string;
 };
 
@@ -111,40 +82,28 @@ const FLOW_ERROR_MESSAGES: Record<OauthFlowErrorCode, string> = {
 /** Options accepted by {@link OauthActions.signIn}. */
 export type SignInOptions = {
   /**
-   * Where the flow returns to when it completes. Must be an http(s) URL on
-   * an allowed origin (see the provider's `allowedRedirectOrigins`); defaults
-   * to the current URL. Custom-scheme deep links (`myapp://`) can't be
-   * allowlisted yet, so React Native apps return via https universal links /
-   * app links.
+   * Where the flow returns to when it finishes. Defaults to the current URL.
+   * Must be an http or https URL. Custom schemes like `myapp://` are not
+   * supported yet.
    */
   redirectTo?: string;
-  /**
-   * A callback `code` obtained out-of-band (React Native's in-app
-   * browser). Completes the pending flow instead of starting one.
-   */
+  /** A callback `code` to finish a saved flow instead of starting a new one. */
   code?: string;
 };
 
 /**
- * What a sign-in call resolves to: the identity provider URL to open (React
- * Native, where the client doesn't navigate itself), or — for an out-of-band
- * `code` completion — whether the session was signed in.
+ * What a sign-in call resolves to. Starting a flow gives back the identity
+ * provider URL, which React Native has to open itself because this client
+ * only navigates on the web. Finishing a flow with a `code` gives back
+ * whether the user is now signed in.
  */
 export type SignInOutcome = { redirect: URL } | { signedIn: boolean };
 
-/**
- * The sign-in actions {@link oauth} registers in the auth client's store.
- * Per-provider conveniences (`useSignInWithGoogle`) live in `./react` and
- * delegate here with their references statically picked.
- */
+/** The sign-in actions {@link oauth} registers in the auth client's store. */
 export type OauthActions = {
   /**
-   * Start the given provider's OAuth flow (or, with `options.code`, complete
-   * one). Starting navigates away to the identity provider — except in React
-   * Native, where the returned `redirect` URL should be opened in an in-app
-   * browser and the `code` from its callback fed back via
-   * `signIn(refs, { code })`, with an https universal-link `redirectTo`
-   * (see {@link SignInOptions.redirectTo}).
+   * Start the given provider's OAuth flow, or finish a saved one when
+   * `options.code` is set. Starting navigates away to the identity provider.
    */
   signIn: (
     refs: OauthProviderRefs,
@@ -152,59 +111,50 @@ export type OauthActions = {
   ) => Promise<SignInOutcome>;
 };
 
-/**
- * The id {@link oauth} registers under. The setup's store and storage views
- * are scoped by it.
- */
+/** The id {@link oauth} registers under. */
 export const OAUTH_SETUP_ID = "oauth";
 
-/**
- * Store key where {@link oauth} registers its {@link OauthActions}, within
- * the setup's scoped store view.
- */
+/** Store key where {@link oauth} registers its {@link OauthActions}. */
 export const OAUTH_ACTIONS_KEY = "actions";
 
 /**
- * Store key holding the current {@link OauthFlowError} object (or `null`),
- * within the setup's scoped store view. Seeded at setup, so `undefined`
- * means {@link oauth} was never registered.
+ * Store key holding the current {@link OauthFlowError}, or `null` when the
+ * last attempt was fine. It is set at registration, so `undefined` means
+ * {@link oauth} was never registered.
  */
 export const OAUTH_FLOW_ERROR_KEY = "flowError";
 
-/** The `error` values the server callback emits (see the component's `http.ts`). */
+/** The `error` values the server callback can put in the URL. */
 const SERVER_ERRORS: ReadonlySet<string> = new Set([
   "access_denied",
   "expired",
   "oauth_error",
 ]);
 
-/** Storage key for the pending sign-in flow, within the setup's scoped storage. */
+/** Storage key for the saved sign-in flow. */
 const OAUTH_FLOW_STORAGE_KEY = "flow";
 
-/**
- * The record `signIn` persists to storage before redirecting to the identity provider.
- * The redirect can land on any page of the app, including one that never
- * called a sign-in hook, so the record carries everything completion needs:
- * the `state` to validate and the `completeSignIn` function path to invoke.
- */
+/** What `signIn` saves before it navigates to the identity provider. */
 type PendingFlow = {
-  /** Which provider the flow belongs to (a label; see {@link OauthProviderRefs}). */
+  /** Which provider the flow belongs to. */
   providerName: string;
-  /** The state minted at sign-in: proof this client initiated the flow. */
+  /** The state minted at sign-in. Proof this client started the flow. */
   state: string;
   /**
-   * The function path of the provider's `completeSignIn` mutation (from
-   * `getFunctionName`), rebuilt into a reference at completion. A path that
-   * dangles by then (the app renamed the export and deployed mid-flight)
-   * fails the call and surfaces as `oauth_error`.
+   * The path of the provider's `completeSignIn` mutation, from
+   * `getFunctionName`. The flow can return to any page of the app, including
+   * one that never held the mutation reference, so the path is saved here and
+   * the reference is rebuilt from it. If the app renamed that export and
+   * redeployed mid-flight the path no longer resolves and the sign-in fails
+   * as `oauth_error`.
    */
   completeSignIn: string;
 };
 
 /**
- * Take (read and remove) the pending sign-in flow stored at sign-in time.
- * Consumed whether or not the redemption that follows succeeds: the flow is
- * bound to a one-time code, so it can never be completed twice.
+ * Read and remove the saved sign-in flow. It is removed even if the redeem
+ * that follows fails, because the code it pairs with is one-time and cannot
+ * be used again anyway.
  */
 async function takePendingFlow(
   storage: ScopedStorage,
@@ -238,20 +188,9 @@ async function takePendingFlow(
 }
 
 /**
- * Client setup for the OAuth providers. It owns the flow's storage and
- * startup completion; the provider functions themselves arrive as
- * references with each {@link OauthActions.signIn} call (the React hooks pick
- * them off the app's `api.auth` statically), so the setup itself needs no
- * configuration. Register it via `ConvexAuthProvider`'s `providerClients`
- * prop.
- *
- * Completion runs on whatever page the flow returns to: sign-in persisted the
- * `completeSignIn` function path with the flow, so no provider wiring needs
- * to be mounted there.
- *
- * While a callback code is being redeemed the core auth state reports
- * loading, so `<AuthLoading>`/`<Unauthenticated>` behave correctly with no
- * extra gating in the app.
+ * Client setup for the OAuth providers. It owns the flow's storage and the
+ * startup work that finishes a flow. Provider mutations arrive with each
+ * {@link OauthActions.signIn} call, so the setup takes no configuration.
  */
 export function oauth(): AuthProviderClientSetup {
   const setup: AuthProviderClientSetup["setup"] = ({
@@ -260,6 +199,7 @@ export function oauth(): AuthProviderClientSetup {
     storage,
     signInApi,
   }) => {
+    /** Set or clear the flow error apps read for sign-in feedback. */
     const setFlowError = (code: OauthFlowErrorCode | null): void => {
       store.set(
         OAUTH_FLOW_ERROR_KEY,
@@ -268,10 +208,10 @@ export function oauth(): AuthProviderClientSetup {
     };
 
     /**
-     * Redeem a callback `code` against the pending flow and adopt the
-     * session. Wrapped in `withSignInPending` end to end — including
-     * `setSession` — so the auth state reports loading until the client is
-     * authenticated.
+     * Redeem a callback `code` against the saved flow and adopt the session.
+     * The whole thing runs inside `withSignInPending`, including
+     * `setSession`, so the auth state stays on loading until the client is
+     * signed in rather than flickering through signed out.
      */
     const completeFlow = async (code: string): Promise<boolean> =>
       await client.withSignInPending(async () => {
@@ -288,8 +228,8 @@ export function oauth(): AuthProviderClientSetup {
             signInApi.mutation(completeSignIn, { code, state: pending.state }),
           );
           if (bundle === null) {
-            // Unknown, already redeemed, expired, or mismatched state — all
-            // indistinguishable server-side.
+            // The server can't tell unknown, already redeemed, expired, and
+            // mismatched state apart, so they all land here.
             setFlowError("expired");
             return false;
           }
@@ -302,11 +242,11 @@ export function oauth(): AuthProviderClientSetup {
       });
 
     /**
-     * Complete any pending flow the callback redirected back to. Reads and
-     * strips the callback params synchronously, before any await, so a rerun
-     * finds a clean URL and no-ops — the one-time code is only redeemed once.
-     * Only the component's namespaced params are consumed, so an unrelated
-     * `?code=`/`?error=` the app uses itself is left untouched.
+     * Finish a flow the callback redirected back to. The params are read and
+     * stripped from the URL before the first await, so if this runs twice the
+     * second run sees a clean URL and does nothing. Only the params this
+     * client owns are touched, so a `?code=` or `?error=` the app uses for its
+     * own purposes is left alone.
      */
     const handleCallback = (): void => {
       if (typeof window === "undefined") {
@@ -320,13 +260,14 @@ export function oauth(): AuthProviderClientSetup {
       }
       url.searchParams.delete(OAUTH_CODE_PARAM);
       url.searchParams.delete(OAUTH_ERROR_PARAM);
-      // Keep the current history state: routers (React Router) store their
-      // own entry state there, and stripping our params must not discard it.
+      // Pass the current history state back through. Routers like React
+      // Router keep their own entry state there and stripping our params must
+      // not drop it.
       window.history.replaceState(window.history.state, "", url.toString());
       if (errorParam !== null) {
-        // The server ended the flow with an error, so the stored state can
-        // never complete — drop it, keeping `invalid_flow` meaningful if a
-        // stray code arrives later.
+        // The server ended the flow with an error, so the saved state can
+        // never be used. Drop it now so a stray code arriving later still
+        // reports `invalid_flow`.
         void storage.remove(OAUTH_FLOW_STORAGE_KEY);
         setFlowError(
           SERVER_ERRORS.has(errorParam)
@@ -341,6 +282,7 @@ export function oauth(): AuthProviderClientSetup {
       void completeFlow(code);
     };
 
+    /** Start a provider's flow, or finish a saved one when `code` is given. */
     const signIn: OauthActions["signIn"] = async (refs, options) => {
       setFlowError(null);
       if (options?.code !== undefined) {
@@ -358,8 +300,8 @@ export function oauth(): AuthProviderClientSetup {
         } satisfies PendingFlow),
       );
       const url = new URL(redirect);
-      // Don't navigate in React Native: the app opens the returned URL in an
-      // in-app browser and completes with `signIn(refs, { code })`.
+      // Don't navigate in React Native. The app opens the returned URL in an
+      // in-app browser and finishes with `signIn(refs, { code })`.
       if (navigator.product !== "ReactNative") {
         window.location.href = url.toString();
       }


### PR DESCRIPTION
- Handles oauth flow from initialization to completion
- Stores server provided state in its scoped storage and includes it in ticket claim
- Handles code/error for url query params on load
- Basic error reporting with default messaging