### PR TITLE
Split the user callback to differentiate new and returning users

### DIFF
--- a/examples/nextjs/convex/auth.ts
+++ b/examples/nextjs/convex/auth.ts
@@ -5,7 +5,7 @@ import { setupUsernamePassword } from "@convex-dev/auth/providers/password/setup
 
 // The core owns sessions, accounts, and JWT minting. Each provider is wired to
 // it with its own setup function, and only hands back its functions once the
-// app attaches the callback that creates its user rows. Each provider exposes
+// app attaches the callbacks that create its user rows. Each provider exposes
 // the functions its client hooks call: `signInAnonymous` for the anonymous
 // provider, `signUpWithPassword` / `signInWithPassword` for the password one.
 // Under SSR those calls get proxied to Convex via the SSR host. The sign-in
@@ -15,12 +15,16 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 
 export const { signInAnonymous } = setupAnonymous(core, {
   component: components.authAnonymous,
-}).attachUserCallback(internal.users.createOrUpdateUserAnonymous);
+}).attachUserCallbacks({ onSignUp: internal.users.onSignUpAnonymous });
 
+// `onSignIn` is optional. This app uses it to stamp the user's last sign-in.
 export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
   core,
   {
     component: components.authPasswordProvider,
     usernameComponent: components.authUsername,
   },
-).attachUserCallback(internal.users.createOrUpdateUserPassword);
+).attachUserCallbacks({
+  onSignUp: internal.users.onSignUpPassword,
+  onSignIn: internal.users.onSignInPassword,
+});

--- a/examples/nextjs/convex/auth.ts
+++ b/examples/nextjs/convex/auth.ts
@@ -13,11 +13,15 @@ import { setupUsernamePassword } from "@convex-dev/auth/providers/password/setup
 const core = setupCore({ component: components.auth });
 export const { signOut, refreshSession, isAuthenticated } = core;
 
+// `onSignIn` is optional, and runs on every sign-in including the first. This
+// app uses it to stamp the user's last sign-in.
 export const { signInAnonymous } = setupAnonymous(core, {
   component: components.authAnonymous,
-}).attachUserCallbacks({ onSignUp: internal.users.onSignUpAnonymous });
+}).attachUserCallbacks({
+  createUser: internal.users.createUserAnonymous,
+  onSignIn: internal.users.onSignInAnonymous,
+});
 
-// `onSignIn` is optional. This app uses it to stamp the user's last sign-in.
 export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
   core,
   {
@@ -25,6 +29,6 @@ export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
     usernameComponent: components.authUsername,
   },
 ).attachUserCallbacks({
-  onSignUp: internal.users.onSignUpPassword,
+  createUser: internal.users.createUserPassword,
   onSignIn: internal.users.onSignInPassword,
 });

--- a/examples/nextjs/convex/schema.ts
+++ b/examples/nextjs/convex/schema.ts
@@ -2,9 +2,11 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 // Password sign-ups carry a username in the provider's profile; anonymous
-// sign-ins carry no profile, so the column is optional.
+// sign-ins carry no profile, so the column is optional. `lastSignedInAt` is
+// maintained by this app's own callbacks (see convex/users.ts).
 export default defineSchema({
   users: defineTable({
     username: v.optional(v.string()),
+    lastSignedInAt: v.optional(v.number()),
   }),
 });

--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -14,7 +14,7 @@
  */
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
-import { internalMutation, MutationCtx, query } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 
 export const createUserAnonymous = internalMutation({
   args: {
@@ -40,14 +40,9 @@ export const createUserPassword = internalMutation({
   },
 });
 
-/**
- * The per-sign-in hooks. Because `onSignIn` runs on a first sign-in too, right
- * after `createUser`, stamping `lastSignedInAt` here covers every sign-in and
- * the create callbacks don't have to repeat it.
- *
- * One mutation per provider, since each declares its provider's exact literal
- * types, both delegating to a plain shared function.
- */
+// Below is an exmple of using the per-sign-in hooks. Here the app is choosing to
+// record a `lastSignedInAt` timestamp for each user upon sign-in.
+
 export const onSignInAnonymous = internalMutation({
   args: {
     provider: v.literal("anonymous"),
@@ -57,7 +52,7 @@ export const onSignInAnonymous = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    return await touchLastSignedIn(ctx, args.userId);
+    await ctx.db.patch("users", args.userId, { lastSignedInAt: Date.now() });
   },
 });
 
@@ -70,17 +65,9 @@ export const onSignInPassword = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    return await touchLastSignedIn(ctx, args.userId);
+    await ctx.db.patch("users", args.userId, { lastSignedInAt: Date.now() });
   },
 });
-
-async function touchLastSignedIn(
-  ctx: MutationCtx,
-  userId: Id<"users">,
-): Promise<null> {
-  await ctx.db.patch("users", userId, { lastSignedInAt: Date.now() });
-  return null;
-}
 
 /**
  * The currently signed-in user, or null. Demonstrates an authenticated query

--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -1,10 +1,10 @@
 /**
  * Each provider configured in `convex/auth.ts` has app-owned callbacks defined here.
  *
- * A provider calls `onSignUp` the first time it sees an account, which creates the
- * app's user row and returns its id, and the optional `onSignIn` whenever a known
- * account signs back in. Each callback has a signature that matches the associated
- * provider and the data that it supplies.
+ * A provider calls `createUser` the first time it sees an account, which creates the
+ * app's user row and returns its id, and then calls the optional `onSignIn` on every
+ * sign-in, that first one included. Each callback has a signature that matches the
+ * associated provider and the data that it supplies.
  *
  * In this example, the username and password provider includes the `username` in the
  * profile data that it provides, while the anonymous provider doesn't. In the app's
@@ -16,7 +16,7 @@ import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
 import { internalMutation, MutationCtx, query } from "./_generated/server";
 
-export const onSignUpAnonymous = internalMutation({
+export const createUserAnonymous = internalMutation({
   args: {
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),
@@ -24,11 +24,11 @@ export const onSignUpAnonymous = internalMutation({
   },
   returns: v.id("users"),
   handler: async (ctx) => {
-    return await createUser(ctx, {});
+    return await ctx.db.insert("users", {});
   },
 });
 
-export const onSignUpPassword = internalMutation({
+export const createUserPassword = internalMutation({
   args: {
     provider: v.literal("password"),
     providerAccountId: v.string(),
@@ -36,17 +36,31 @@ export const onSignUpPassword = internalMutation({
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
-    return await createUser(ctx, { username: args.profile.username });
+    return await ctx.db.insert("users", { username: args.profile.username });
   },
 });
 
 /**
- * The return-visit hook for the password provider. The user already exists, so
- * there is nothing to return, just a chance to touch the app's own record.
+ * The per-sign-in hooks. Because `onSignIn` runs on a first sign-in too, right
+ * after `createUser`, stamping `lastSignedInAt` here covers every sign-in and
+ * the create callbacks don't have to repeat it.
  *
- * The anonymous provider has no equivalent: every anonymous sign-in establishes
- * a new account, so it only takes an `onSignUp`.
+ * One mutation per provider, since each declares its provider's exact literal
+ * types, both delegating to a plain shared function.
  */
+export const onSignInAnonymous = internalMutation({
+  args: {
+    provider: v.literal("anonymous"),
+    providerAccountId: v.string(),
+    profile: v.object({}),
+    userId: v.id("users"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    return await touchLastSignedIn(ctx, args.userId);
+  },
+});
+
 export const onSignInPassword = internalMutation({
   args: {
     provider: v.literal("password"),
@@ -56,23 +70,16 @@ export const onSignInPassword = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    await ctx.db.patch("users", args.userId, { lastSignedInAt: Date.now() });
-    return null;
+    return await touchLastSignedIn(ctx, args.userId);
   },
 });
 
-/**
- * The shared body of this app's sign-up callbacks. Providers that supply a
- * username pass it along; the anonymous one has none.
- */
-async function createUser(
+async function touchLastSignedIn(
   ctx: MutationCtx,
-  args: { username?: string },
-): Promise<Id<"users">> {
-  return await ctx.db.insert("users", {
-    username: args.username,
-    lastSignedInAt: Date.now(),
-  });
+  userId: Id<"users">,
+): Promise<null> {
+  await ctx.db.patch("users", userId, { lastSignedInAt: Date.now() });
+  return null;
 }
 
 /**

--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -1,8 +1,10 @@
 /**
- * Each provider configured in `convex/auth.ts` has an app-owned callback defined here.
+ * Each provider configured in `convex/auth.ts` has app-owned callbacks defined here.
  *
- * The callback is inovked whenever a user signs in. Each callback has a signature that
- * matches the associated provider and the data that it supplies.
+ * A provider calls `onSignUp` the first time it sees an account, which creates the
+ * app's user row and returns its id, and the optional `onSignIn` whenever a known
+ * account signs back in. Each callback has a signature that matches the associated
+ * provider and the data that it supplies.
  *
  * In this example, the username and password provider includes the `username` in the
  * profile data that it provides, while the anonymous provider doesn't. In the app's
@@ -14,51 +16,63 @@ import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
 import { internalMutation, MutationCtx, query } from "./_generated/server";
 
-export const createOrUpdateUserAnonymous = internalMutation({
+export const onSignUpAnonymous = internalMutation({
   args: {
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),
     profile: v.object({}),
-    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
-  handler: async (ctx, args) => {
-    return await createOrUpdateUser(ctx, { userId: args.userId });
+  handler: async (ctx) => {
+    return await createUser(ctx, {});
   },
 });
 
-export const createOrUpdateUserPassword = internalMutation({
+export const onSignUpPassword = internalMutation({
   args: {
     provider: v.literal("password"),
     providerAccountId: v.string(),
     profile: v.object({ username: v.string() }),
-    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
-    return await createOrUpdateUser(ctx, {
-      userId: args.userId,
-      username: args.profile.username,
-    });
+    return await createUser(ctx, { username: args.profile.username });
   },
 });
 
 /**
- * The shared body of this app's create-or-update-user callbacks.
+ * The return-visit hook for the password provider. The user already exists, so
+ * there is nothing to return, just a chance to touch the app's own record.
  *
- * The core invokes one of them on every sign-in — without a `userId` the first
- * time an identity is seen, and with the resolved `userId` thereafter. On the
- * first sign-in we mint a users row (with the username, when the provider
- * supplies one); on later sign-ins we echo the id.
+ * The anonymous provider has no equivalent: every anonymous sign-in establishes
+ * a new account, so it only takes an `onSignUp`.
  */
-async function createOrUpdateUser(
+export const onSignInPassword = internalMutation({
+  args: {
+    provider: v.literal("password"),
+    providerAccountId: v.string(),
+    profile: v.object({ username: v.string() }),
+    userId: v.id("users"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.patch("users", args.userId, { lastSignedInAt: Date.now() });
+    return null;
+  },
+});
+
+/**
+ * The shared body of this app's sign-up callbacks. Providers that supply a
+ * username pass it along; the anonymous one has none.
+ */
+async function createUser(
   ctx: MutationCtx,
-  args: { userId: Id<"users"> | null; username?: string },
+  args: { username?: string },
 ): Promise<Id<"users">> {
-  if (args.userId !== null) {
-    return args.userId;
-  }
-  return await ctx.db.insert("users", { username: args.username });
+  return await ctx.db.insert("users", {
+    username: args.username,
+    lastSignedInAt: Date.now(),
+  });
 }
 
 /**

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -7,4 +7,4 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 
 export const { signInAnonymous } = setupAnonymous(core, {
   component: components.authAnonymous,
-}).attachUserCallback(internal.users.createOrUpdateUser);
+}).attachUserCallbacks({ onSignUp: internal.users.onSignUp });

--- a/examples/react-minimal/convex/auth.ts
+++ b/examples/react-minimal/convex/auth.ts
@@ -7,4 +7,4 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 
 export const { signInAnonymous } = setupAnonymous(core, {
   component: components.authAnonymous,
-}).attachUserCallbacks({ onSignUp: internal.users.onSignUp });
+}).attachUserCallbacks({ createUser: internal.users.createUser });

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -2,10 +2,12 @@ import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Every anonymous sign-in establishes a new account, so this app only needs a
- * sign-up callback: create the user row and return its id.
+ * Create the user row for a new anonymous account and return its id.
+ *
+ * Every anonymous sign-in establishes a new account, so this runs on every
+ * anonymous sign-in.
  */
-export const onSignUp = internalMutation({
+export const createUser = internalMutation({
   args: {
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),

--- a/examples/react-minimal/convex/users.ts
+++ b/examples/react-minimal/convex/users.ts
@@ -1,18 +1,18 @@
 import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
-export const createOrUpdateUser = internalMutation({
+/**
+ * Every anonymous sign-in establishes a new account, so this app only needs a
+ * sign-up callback: create the user row and return its id.
+ */
+export const onSignUp = internalMutation({
   args: {
     provider: v.literal("anonymous"),
     providerAccountId: v.string(),
     profile: v.object({}),
-    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
-  handler: async (ctx, args) => {
-    if (args.userId !== null) {
-      return args.userId;
-    }
-    return ctx.db.insert("users", {});
+  handler: async (ctx) => {
+    return await ctx.db.insert("users", {});
   },
 });

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -11,4 +11,4 @@ export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
     component: components.authPasswordProvider,
     usernameComponent: components.authUsername,
   },
-).attachUserCallback(internal.users.createOrUpdateUser);
+).attachUserCallbacks({ onSignUp: internal.users.onSignUp });

--- a/examples/react-password/convex/auth.ts
+++ b/examples/react-password/convex/auth.ts
@@ -11,4 +11,4 @@ export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(
     component: components.authPasswordProvider,
     usernameComponent: components.authUsername,
   },
-).attachUserCallbacks({ onSignUp: internal.users.onSignUp });
+).attachUserCallbacks({ createUser: internal.users.createUser });

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -1,18 +1,21 @@
 import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
-export const createOrUpdateUser = internalMutation({
+/**
+ * Create the user row for a new password account and return its id. The
+ * provider supplies the username it just registered in `profile`.
+ *
+ * An `onSignIn` callback is optional, and this app has nothing to do when
+ * someone signs back in, so it attaches only this one.
+ */
+export const onSignUp = internalMutation({
   args: {
     provider: v.literal("password"),
     providerAccountId: v.string(),
     profile: v.object({ username: v.string() }),
-    userId: v.union(v.id("users"), v.null()),
   },
   returns: v.id("users"),
   handler: async (ctx, args) => {
-    if (args.userId !== null) {
-      return args.userId;
-    }
     return await ctx.db.insert("users", { username: args.profile.username });
   },
 });

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -4,11 +4,8 @@ import { v } from "convex/values";
 /**
  * Create the user row for a new password account and return its id. The
  * provider supplies the username it just registered in `profile`.
- *
- * An `onSignIn` callback is optional, and this app has nothing to do when
- * someone signs back in, so it attaches only this one.
  */
-export const onSignUp = internalMutation({
+export const createUser = internalMutation({
   args: {
     provider: v.literal("password"),
     providerAccountId: v.string(),

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -84,7 +84,7 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 //   setupUsernamePassword(core, {
 //     component: components.authPasswordProvider,
 //     usernameComponent: components.authUsername,
-//   }).attachUserCallbacks({ onSignUp: internal.users.onSignUp });
+//   }).attachUserCallbacks({ createUser: internal.users.createUser });
 `,
 };
 

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -84,7 +84,7 @@ export const { signOut, refreshSession, isAuthenticated } = core;
 //   setupUsernamePassword(core, {
 //     component: components.authPasswordProvider,
 //     usernameComponent: components.authUsername,
-//   }).attachUserCallback(internal.users.createOrUpdateUser);
+//   }).attachUserCallbacks({ onSignUp: internal.users.onSignUp });
 `,
 };
 

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -1,6 +1,6 @@
 import {
   vSignInSuccess,
-  type CreateOrUpdateUserFn,
+  type OnSignUpFn,
   type SignInSuccess,
 } from "../../lib/types";
 import type { AuthCore } from "../core/setup";
@@ -24,7 +24,7 @@ const PROVIDER_NAME = "anonymous";
  *
  * export const { signInAnonymous } = setupAnonymous(core, {
  *   component: components.authAnonymous,
- * }).attachUserCallback(internal.users.createOrUpdateUser);
+ * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpAnonymous });
  * ```
  */
 export function setupAnonymous<UsersTable extends string>(
@@ -38,20 +38,20 @@ export function setupAnonymous<UsersTable extends string>(
 
   return {
     /**
-     * Supply the app's create-or-update-user mutation (see
-     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
-     * get this provider's functions to export.
+     * Supply the app's sign-up mutation (see {@link OnSignUpFn} for how its
+     * args must be declared) and get this provider's functions to export.
+     *
+     * There is no `onSignIn`: every anonymous sign-in establishes a new
+     * account, so a return-visit callback could never fire.
      */
-    attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<
-        "anonymous",
-        Record<string, never>,
-        UsersTable
-      >,
-    ) {
+    attachUserCallbacks({
+      onSignUp,
+    }: {
+      onSignUp: OnSignUpFn<"anonymous", Record<string, never>, UsersTable>;
+    }) {
       const { authMutation } = core.bindProvider({
         name: PROVIDER_NAME,
-        createOrUpdateUser,
+        onSignUp,
       });
 
       return {
@@ -69,7 +69,7 @@ export function setupAnonymous<UsersTable extends string>(
               component.provider.createAnonymousAccount,
               {},
             );
-            const tokens = await ctx.convexAuth.completeSignIn({
+            const tokens = await ctx.convexAuth.completeSignUp({
               providerAccountId: anonymousId,
               profile: {},
             });

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -1,7 +1,7 @@
 import {
   vSignInSuccess,
-  type OnSignUpFn,
   type SignInSuccess,
+  type UserCallbacks,
 } from "../../lib/types";
 import type { AuthCore } from "../core/setup";
 import { ComponentApi } from "./_generated/component";
@@ -24,7 +24,7 @@ const PROVIDER_NAME = "anonymous";
  *
  * export const { signInAnonymous } = setupAnonymous(core, {
  *   component: components.authAnonymous,
- * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpAnonymous });
+ * }).attachUserCallbacks({ createUser: internal.users.createUserAnonymous });
  * ```
  */
 export function setupAnonymous<UsersTable extends string>(
@@ -38,20 +38,21 @@ export function setupAnonymous<UsersTable extends string>(
 
   return {
     /**
-     * Supply the app's sign-up mutation (see {@link OnSignUpFn} for how its
+     * Supply the app's user callbacks (see {@link UserCallbacks} for how their
      * args must be declared) and get this provider's functions to export.
      *
-     * There is no `onSignIn`: every anonymous sign-in establishes a new
-     * account, so a return-visit callback could never fire.
+     * Every anonymous sign-in establishes a new account, so `createUser` runs
+     * every time. An `onSignIn` is still worth attaching for work an app does
+     * on every sign-in whatever the provider, since it runs right afterwards.
      */
     attachUserCallbacks({
-      onSignUp,
-    }: {
-      onSignUp: OnSignUpFn<"anonymous", Record<string, never>, UsersTable>;
-    }) {
+      createUser,
+      onSignIn,
+    }: UserCallbacks<"anonymous", Record<string, never>, UsersTable>) {
       const { authMutation } = core.bindProvider({
         name: PROVIDER_NAME,
-        onSignUp,
+        createUser,
+        onSignIn,
       });
 
       return {

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -81,8 +81,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           accessTokenTtlSeconds?: number;
           claims: { profile: any; provider: string; providerAccountId: string };
+          createUserHandle: string;
           issuer: string;
-          onSignUpHandle: string;
+          onSignInHandle?: string;
           refreshTokenTtlSeconds?: number;
         },
         {

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -55,8 +55,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           accessTokenTtlSeconds?: number;
           claims: { profile: any; provider: string; providerAccountId: string };
-          createOrUpdateUserHandle: string;
           issuer: string;
+          onSignInHandle?: string;
           refreshTokenTtlSeconds?: number;
         },
         {
@@ -73,6 +73,25 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { refreshToken: string },
         null,
+        Name
+      >;
+      signUp: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          accessTokenTtlSeconds?: number;
+          claims: { profile: any; provider: string; providerAccountId: string };
+          issuer: string;
+          onSignUpHandle: string;
+          refreshTokenTtlSeconds?: number;
+        },
+        {
+          accessToken: string;
+          accessTokenExpiresAt: number;
+          refreshToken: string;
+          refreshTokenExpiresAt: number;
+          userId: string;
+        },
         Name
       >;
     };

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -11,8 +11,8 @@ import {
 import { api } from "./_generated/api";
 import schema from "./schema";
 import {
+  getCreateUserCalls,
   getOnSignInCalls,
-  getOnSignUpCalls,
   resetUserCallbackCalls,
 } from "./testApp";
 import { type AuthClaims, type TokenBundle } from "../../lib/types";
@@ -24,8 +24,9 @@ const modules = import.meta.glob("./**/*.ts");
 // vars so the suite exercises genuine JWT signing/verification.
 const ISSUER = "https://example.convex.site";
 const AUDIENCE = "convex";
-const ON_SIGN_UP_HANDLE = "testApp:onSignUp";
+const CREATE_USER_HANDLE = "testApp:createUser";
 const ON_SIGN_IN_HANDLE = "testApp:onSignIn";
+const THROWING_ON_SIGN_IN_HANDLE = "testApp:onSignInThatThrows";
 let publicJwk: JWK;
 
 beforeAll(async () => {
@@ -58,7 +59,8 @@ function setup() {
 async function signUp(t: ReturnType<typeof setup>, c: AuthClaims) {
   return await t.mutation(api.public.signUp, {
     claims: c,
-    onSignUpHandle: ON_SIGN_UP_HANDLE,
+    createUserHandle: CREATE_USER_HANDLE,
+    onSignInHandle: ON_SIGN_IN_HANDLE,
     issuer: ISSUER,
   });
 }
@@ -83,7 +85,7 @@ describe("signUp", () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
-    // The app's onSignUp echoes the providerAccountId as the user id.
+    // The app's createUser echoes the providerAccountId as the user id.
     expect(bundle.userId).toBe("alice");
     expect(bundle.refreshToken).toBeTruthy();
     expect(bundle.accessTokenExpiresAt).toBeGreaterThan(Date.now());
@@ -107,21 +109,66 @@ describe("signUp", () => {
     expect(counts).toEqual({ accounts: 1, sessions: 1 });
   });
 
-  test("invokes the app's onSignUp with the claims", async () => {
+  test("invokes the app's createUser with the claims, then onSignIn", async () => {
     const t = setup();
     resetUserCallbackCalls();
 
     await signUp(t, claims({ profile: { name: "Alice" } }));
 
-    expect(getOnSignUpCalls()).toEqual([
+    expect(getCreateUserCalls()).toEqual([
       {
         provider: "password",
         providerAccountId: "alice",
         profile: { name: "Alice" },
       },
     ]);
-    // Sign-up does not call the user supplied onSignIn function
+    // A first sign-in is still a sign-in, so onSignIn runs too, with the id
+    // createUser just returned. Per-sign-in work has one home.
+    expect(getOnSignInCalls()).toEqual([
+      {
+        provider: "password",
+        providerAccountId: "alice",
+        profile: { name: "Alice" },
+        userId: "alice",
+      },
+    ]);
+  });
+
+  test("creates the user without an onSignIn attached", async () => {
+    const t = setup();
+    resetUserCallbackCalls();
+
+    const bundle = await t.mutation(api.public.signUp, {
+      claims: claims(),
+      createUserHandle: CREATE_USER_HANDLE,
+      issuer: ISSUER,
+    });
+
+    expect(bundle.userId).toBe("alice");
+    expect(getCreateUserCalls()).toHaveLength(1);
     expect(getOnSignInCalls()).toHaveLength(0);
+  });
+
+  test("an onSignIn that throws rolls back the user it just created", async () => {
+    const t = setup();
+
+    await expect(
+      t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        onSignInHandle: THROWING_ON_SIGN_IN_HANDLE,
+        issuer: ISSUER,
+      }),
+    ).rejects.toThrow(/no sign-ins for you/);
+
+    // The account insert is a write of the same mutation, so it rolls back with
+    // it, and the app's own users row rolls back the same way. The session was
+    // never reached, since onSignIn runs before it is minted.
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+    }));
+    expect(counts).toEqual({ accounts: 0, sessions: 0 });
   });
 
   test("refuses to sign up an identity that already has an account", async () => {
@@ -167,16 +214,16 @@ describe("signIn", () => {
     await signUp(t, claims({ profile: { name: "Alice" } }));
     await signIn(t, claims({ profile: { name: "Alice 2.0" } }));
 
-    // The app gets the known id and the fresh profile to sync from.
-    expect(getOnSignUpCalls()).toHaveLength(1);
-    expect(getOnSignInCalls()).toEqual([
-      {
-        provider: "password",
-        providerAccountId: "alice",
-        profile: { name: "Alice 2.0" },
-        userId: "alice",
-      },
-    ]);
+    // The app gets the known id and the fresh profile to sync from. createUser
+    // ran once, for the sign-up; onSignIn ran for both.
+    expect(getCreateUserCalls()).toHaveLength(1);
+    expect(getOnSignInCalls()).toHaveLength(2);
+    expect(getOnSignInCalls()[1]).toEqual({
+      provider: "password",
+      providerAccountId: "alice",
+      profile: { name: "Alice 2.0" },
+      userId: "alice",
+    });
   });
 
   test("mints the session without notifying an app that attached no onSignIn", async () => {
@@ -328,7 +375,7 @@ describe("token lifetime configuration", () => {
     const before = Date.now();
     const bundle = await t.mutation(api.public.signUp, {
       claims: claims(),
-      onSignUpHandle: ON_SIGN_UP_HANDLE,
+      createUserHandle: CREATE_USER_HANDLE,
       issuer: ISSUER,
       accessTokenTtlSeconds: 300, // 5 minutes
     });
@@ -349,7 +396,7 @@ describe("token lifetime configuration", () => {
     const before = Date.now();
     const bundle = await t.mutation(api.public.signUp, {
       claims: claims(),
-      onSignUpHandle: ON_SIGN_UP_HANDLE,
+      createUserHandle: CREATE_USER_HANDLE,
       issuer: ISSUER,
       refreshTokenTtlSeconds: oneHourSeconds,
     });
@@ -378,7 +425,7 @@ describe("token lifetime configuration", () => {
     await expect(
       t.mutation(api.public.signUp, {
         claims: claims(),
-        onSignUpHandle: ON_SIGN_UP_HANDLE,
+        createUserHandle: CREATE_USER_HANDLE,
         issuer: ISSUER,
         accessTokenTtlSeconds: 100,
         refreshTokenTtlSeconds: 1, // 1s — shorter than the 100s access token

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -11,8 +11,9 @@ import {
 import { api } from "./_generated/api";
 import schema from "./schema";
 import {
-  getCreateOrUpdateUserCalls,
-  resetCreateOrUpdateUserCalls,
+  getOnSignInCalls,
+  getOnSignUpCalls,
+  resetUserCallbackCalls,
 } from "./testApp";
 import { type AuthClaims, type TokenBundle } from "../../lib/types";
 
@@ -23,7 +24,8 @@ const modules = import.meta.glob("./**/*.ts");
 // vars so the suite exercises genuine JWT signing/verification.
 const ISSUER = "https://example.convex.site";
 const AUDIENCE = "convex";
-const CREATE_OR_UPDATE_USER_HANDLE = "testApp:createOrUpdateUser";
+const ON_SIGN_UP_HANDLE = "testApp:onSignUp";
+const ON_SIGN_IN_HANDLE = "testApp:onSignIn";
 let publicJwk: JWK;
 
 beforeAll(async () => {
@@ -52,10 +54,20 @@ function setup() {
   return convexTest(schema, modules);
 }
 
+/** Establish a brand new identity: the account, its app user, and a session. */
+async function signUp(t: ReturnType<typeof setup>, c: AuthClaims) {
+  return await t.mutation(api.public.signUp, {
+    claims: c,
+    onSignUpHandle: ON_SIGN_UP_HANDLE,
+    issuer: ISSUER,
+  });
+}
+
+/** Sign a known identity back in, as an app that attached an `onSignIn` does. */
 async function signIn(t: ReturnType<typeof setup>, c: AuthClaims) {
   return await t.mutation(api.public.signIn, {
     claims: c,
-    createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+    onSignInHandle: ON_SIGN_IN_HANDLE,
     issuer: ISSUER,
   });
 }
@@ -66,12 +78,12 @@ function expectBundle(bundle: TokenBundle | null): TokenBundle {
   return bundle as TokenBundle;
 }
 
-describe("signIn", () => {
+describe("signUp", () => {
   test("creates an account + session and mints a verifiable JWT", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
-    // The app's createOrUpdateUser echoes the providerAccountId as the user id.
+    // The app's onSignUp echoes the providerAccountId as the user id.
     expect(bundle.userId).toBe("alice");
     expect(bundle.refreshToken).toBeTruthy();
     expect(bundle.accessTokenExpiresAt).toBeGreaterThan(Date.now());
@@ -95,9 +107,42 @@ describe("signIn", () => {
     expect(counts).toEqual({ accounts: 1, sessions: 1 });
   });
 
-  test("resolves an existing account instead of creating a duplicate", async () => {
+  test("invokes the app's onSignUp with the claims", async () => {
     const t = setup();
-    const first = await signIn(t, claims({ profile: { name: "Alice" } }));
+    resetUserCallbackCalls();
+
+    await signUp(t, claims({ profile: { name: "Alice" } }));
+
+    expect(getOnSignUpCalls()).toEqual([
+      {
+        provider: "password",
+        providerAccountId: "alice",
+        profile: { name: "Alice" },
+      },
+    ]);
+    // Sign-up does not call the user supplied onSignIn function
+    expect(getOnSignInCalls()).toHaveLength(0);
+  });
+
+  test("refuses to sign up an identity that already has an account", async () => {
+    const t = setup();
+    await signUp(t, claims());
+
+    // Rather than minting a second app user for someone who already has one.
+    await expect(signUp(t, claims())).rejects.toThrow(/already\s+exists/i);
+
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+    }));
+    expect(counts).toEqual({ accounts: 1, sessions: 1 });
+  });
+});
+
+describe("signIn", () => {
+  test("reuses the existing account and mints a fresh session", async () => {
+    const t = setup();
+    const first = await signUp(t, claims({ profile: { name: "Alice" } }));
     const second = await signIn(t, claims({ profile: { name: "Alice 2.0" } }));
 
     expect(second.userId).toBe(first.userId);
@@ -110,33 +155,65 @@ describe("signIn", () => {
         sessions: sessionDocs.length,
       };
     });
-    // One account reused, profile refreshed; a fresh session per sign-in.
+    // One account reused; a fresh session per sign-in.
     expect(accounts).toBe(1);
     expect(sessions).toBe(2);
   });
 
-  test("invokes the app's user callback on every sign-in", async () => {
+  test("invokes the app's onSignIn with the resolved user id and latest claims", async () => {
     const t = setup();
-    resetCreateOrUpdateUserCalls();
+    resetUserCallbackCalls();
 
-    await signIn(t, claims({ profile: { name: "Alice" } }));
+    await signUp(t, claims({ profile: { name: "Alice" } }));
     await signIn(t, claims({ profile: { name: "Alice 2.0" } }));
 
-    const calls = getCreateOrUpdateUserCalls();
-    // Called both times. First sign-in mints the user (no `userId`); the return
-    // carries the known `userId` so the app can update its own user record.
-    expect(calls).toHaveLength(2);
-    expect(calls[0].userId).toBeNull();
-    expect(calls[0].profile).toEqual({ name: "Alice" });
-    expect(calls[1].userId).toBe("alice");
-    expect(calls[1].profile).toEqual({ name: "Alice 2.0" });
+    // The app gets the known id and the fresh profile to sync from.
+    expect(getOnSignUpCalls()).toHaveLength(1);
+    expect(getOnSignInCalls()).toEqual([
+      {
+        provider: "password",
+        providerAccountId: "alice",
+        profile: { name: "Alice 2.0" },
+        userId: "alice",
+      },
+    ]);
+  });
+
+  test("mints the session without notifying an app that attached no onSignIn", async () => {
+    const t = setup();
+    await signUp(t, claims());
+    resetUserCallbackCalls();
+
+    // No `onSignInHandle` is what an app that left `onSignIn` out sends.
+    const bundle = await t.mutation(api.public.signIn, {
+      claims: claims(),
+      issuer: ISSUER,
+    });
+
+    expect(bundle.userId).toBe("alice");
+    expect(getOnSignInCalls()).toHaveLength(0);
+  });
+
+  test("refuses to sign in an identity with no account", async () => {
+    const t = setup();
+
+    // A miss means the provider's records and the core's have diverged, and
+    // creating a user here would paper over that.
+    await expect(signIn(t, claims())).rejects.toThrow(
+      /must go through signUp/i,
+    );
+
+    const sessions = await t.run(
+      async (ctx) => (await ctx.db.query("sessions").collect()).length,
+    );
+    expect(sessions).toBe(0);
   });
 });
 
 describe("refresh", () => {
   test("rotates the refresh token and mints a fresh access token", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
     const rotated = expectBundle(
       await t.mutation(api.public.refresh, {
@@ -159,7 +236,7 @@ describe("refresh", () => {
 
   test("honors the grace window for a just-rotated token (concurrent refresh)", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
     await t.mutation(api.public.refresh, {
       refreshToken: bundle.refreshToken,
@@ -180,7 +257,7 @@ describe("refresh", () => {
 
   test("returns null and clears the session once the refresh token has expired", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
     // Force the session past its refresh-token expiry.
     await t.run(async (ctx) => {
@@ -216,7 +293,7 @@ describe("refresh", () => {
 describe("signOut", () => {
   test("revokes the session so it can no longer be refreshed", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
     await t.mutation(api.public.signOut, {
       refreshToken: bundle.refreshToken,
@@ -236,7 +313,7 @@ describe("signOut", () => {
 
   test("is idempotent — signing out an already-revoked token does not throw", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
 
     await t.mutation(api.public.signOut, { refreshToken: bundle.refreshToken });
     await expect(
@@ -246,12 +323,12 @@ describe("signOut", () => {
 });
 
 describe("token lifetime configuration", () => {
-  test("honors a custom access-token TTL on sign-in", async () => {
+  test("honors a custom access-token TTL on sign-up", async () => {
     const t = setup();
     const before = Date.now();
-    const bundle = await t.mutation(api.public.signIn, {
+    const bundle = await t.mutation(api.public.signUp, {
       claims: claims(),
-      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+      onSignUpHandle: ON_SIGN_UP_HANDLE,
       issuer: ISSUER,
       accessTokenTtlSeconds: 300, // 5 minutes
     });
@@ -264,15 +341,15 @@ describe("token lifetime configuration", () => {
     );
   });
 
-  test("honors a custom refresh-token TTL on sign-in and on rotation", async () => {
+  test("honors a custom refresh-token TTL on sign-up and on rotation", async () => {
     const t = setup();
     const oneHourSeconds = 60 * 60;
     const oneHourMs = oneHourSeconds * 1000;
 
     const before = Date.now();
-    const bundle = await t.mutation(api.public.signIn, {
+    const bundle = await t.mutation(api.public.signUp, {
       claims: claims(),
-      createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+      onSignUpHandle: ON_SIGN_UP_HANDLE,
       issuer: ISSUER,
       refreshTokenTtlSeconds: oneHourSeconds,
     });
@@ -299,9 +376,9 @@ describe("token lifetime configuration", () => {
   test("rejects a configuration where the access TTL is not shorter than the refresh TTL", async () => {
     const t = setup();
     await expect(
-      t.mutation(api.public.signIn, {
+      t.mutation(api.public.signUp, {
         claims: claims(),
-        createOrUpdateUserHandle: CREATE_OR_UPDATE_USER_HANDLE,
+        onSignUpHandle: ON_SIGN_UP_HANDLE,
         issuer: ISSUER,
         accessTokenTtlSeconds: 100,
         refreshTokenTtlSeconds: 1, // 1s — shorter than the 100s access token
@@ -320,9 +397,9 @@ describe("getUserIdByAccount", () => {
     expect(userId).toBeNull();
   });
 
-  test("returns the user id after the account is created by signIn", async () => {
+  test("returns the user id after the account is created by signUp", async () => {
     const t = setup();
-    const bundle = await signIn(t, claims());
+    const bundle = await signUp(t, claims());
     const userId = await t.query(api.public.getUserIdByAccount, {
       provider: "password",
       providerAccountId: "alice",
@@ -332,7 +409,7 @@ describe("getUserIdByAccount", () => {
 
   test("does not confuse identities across providers", async () => {
     const t = setup();
-    await signIn(
+    await signUp(
       t,
       claims({ provider: "password", providerAccountId: "alice" }),
     );

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -17,7 +17,7 @@ import {
 } from "../../lib/types";
 import { signJwt, generateRefreshToken } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
-import { CreateOrUpdateUserFn } from "../../lib/types";
+import { OnSignInFn, OnSignUpFn } from "../../lib/types";
 
 // --- Configuration ---------------------------------------------------------
 
@@ -145,10 +145,16 @@ async function issueSession(
   };
 }
 
-type CreateOrUpdateUserFunctionHandle = FunctionHandle<
-  CreateOrUpdateUserFn<string, unknown>["_type"],
-  CreateOrUpdateUserFn<string, unknown>["_args"],
-  CreateOrUpdateUserFn<string, unknown>["_returnType"]
+type OnSignUpFunctionHandle = FunctionHandle<
+  OnSignUpFn<string, unknown>["_type"],
+  OnSignUpFn<string, unknown>["_args"],
+  OnSignUpFn<string, unknown>["_returnType"]
+>;
+
+type OnSignInFunctionHandle = FunctionHandle<
+  OnSignInFn<string, unknown>["_type"],
+  OnSignInFn<string, unknown>["_args"],
+  OnSignInFn<string, unknown>["_returnType"]
 >;
 
 /**
@@ -164,65 +170,53 @@ function asUserId(userId: string): GenericId<string> {
 }
 
 /**
- * Resolve a provider identity to its account, creating one (and the app user
- * behind it) the first time the identity is seen. The app's user callback runs
- * on *every* sign-in: with no `userId` the first time (it mints/returns the
- * user id), and with the known `userId` on every return (so it can sync the
- * user record from the latest claims — the core stores no profile itself, the
- * claims pass through and are otherwise discarded). Returns just what minting a
- * session needs: the account id and its app user id.
+ * Create the account and app-level user for an identity the core has not seen before.
+ *
+ * The app's `onSignUp` callback mints and returns the user id, and this
+ * records the provider-identity -> user mapping. Returns what minting a
+ * session needs: the account id and its app user id. The claims are passed to
+ * the `onSignUp` callback.
  */
-async function resolveAccount(
+async function createAccount(
   ctx: MutationCtx,
   claims: AuthClaims,
-  createOrUpdateUser: CreateOrUpdateUserFunctionHandle,
+  onSignUp: OnSignUpFunctionHandle,
 ): Promise<{ accountId: Id<"accounts">; userId: string }> {
-  // `USE_USER_ID_AS_ACCOUNT_ID` means the provider keys the account by the
-  // app user id, which does not exist before this sign-in mints it. Such
-  // claims can never match an existing account (accounts are never stored
-  // with an empty identifier): on later sign-ins the provider puts the user
-  // id in the claims itself.
+  // `USE_USER_ID_AS_ACCOUNT_ID` means the account is keyed by the app user id,
+  // which does not exist until the callback below mints it. Such claims can
+  // never match an existing account (accounts are never stored with an empty
+  // identifier), so there is nothing to check yet; the pre-insert check below
+  // covers that path once the key is known.
   if (claims.providerAccountId !== USE_USER_ID_AS_ACCOUNT_ID) {
     const account = await accountByIdentity(
       ctx,
       claims.provider,
       claims.providerAccountId,
     );
-    if (account) {
-      // Returning identity: hand the app the latest claims with the known user
-      // id so it can update its own user record.
-      if (
-        account.userId !==
-        (await ctx.runMutation(createOrUpdateUser, {
-          provider: claims.provider,
-          providerAccountId: claims.providerAccountId,
-          profile: claims.profile,
-          userId: asUserId(account.userId),
-        }))
-      ) {
-        throw new Error(
-          "createOrUpdateUser may not return a new userId for an existing user",
-        );
-      }
-      return { accountId: account._id, userId: account.userId };
+    if (account !== null) {
+      // Signing up an identity that already has an account would mint a second
+      // app user for someone who already has one. Fail before calling the app.
+      throw new Error(
+        `Cannot sign up: an account for provider = ${JSON.stringify(claims.provider)} ` +
+        `and provider account ID = ${JSON.stringify(claims.providerAccountId)} already ` +
+        `exists. Providers that cannot tell a first sign-in from a return visit must ` +
+        `look the identity up (getUserIdByAccount) and call signIn instead.`,
+      );
     }
   }
 
-  // First sign-in for this identity: ask the app to mint/return its user id,
-  // then record the provider-identity -> user mapping.
-  const userId = await ctx.runMutation(createOrUpdateUser, {
+  const userId = await ctx.runMutation(onSignUp, {
     provider: claims.provider,
-    // With `USE_USER_ID_AS_ACCOUNT_ID` the user id is not minted yet, so
-    // there is no meaningful value to hand the app here.
     providerAccountId: claims.providerAccountId,
     profile: claims.profile,
-    userId: null,
   });
   const { provider } = claims;
   const providerAccountId =
     claims.providerAccountId === USE_USER_ID_AS_ACCOUNT_ID
       ? userId
       : claims.providerAccountId;
+  // The last word on uniqueness, for the `USE_USER_ID_AS_ACCOUNT_ID` path,
+  // whose key is only known now. Redundant for every other path, and cheap.
   const existingAccount = await ctx.db
     .query("accounts")
     .withIndex("by_provider_account", (q) =>
@@ -242,24 +236,29 @@ async function resolveAccount(
   return { accountId, userId };
 }
 
-// --- Public API ------------------------------------------------------------
+// --- Component API ------------------------------------------------------------
 
 /**
- * Exchange a provider's verified identity claims for a session: resolve (or
- * create) the account and its app user, then mint a refresh token + access
- * token. This is the core's entry point for *logging a user in*; each provider
- * calls it (via the app's `completeSignIn`) once it has authenticated the user
- * and produced claims. `createOrUpdateUserHandle` is a handle to the app's
- * user create-or-update mutation, invoked on every sign-in (without a `userId`
- * the first time an identity is seen, with the resolved `userId` thereafter);
- * the JWT is issued with `issuer` as its `iss`. Token lifetimes default to 1m
- * (access) and 30d (refresh) unless `accessTokenTtlSeconds` /
- * `refreshTokenTtlSeconds` are supplied (the app sets these once via `setupCore`).
+ * Performs an app-integrated new user sign-up.
+ *
+ * Establishes a session and returns a token bundle upon success.
+ * 
+ * Providers don't typically call this API directly, but instead use the
+ * framework's `completeSignUp` helper. That function takes care of passing the
+ * `onSignUpHandle` app callback.
+ *
+ * The JWT accessToken in the return value is issued with `issuer` as its
+ * `iss`. Token lifetimes default to 1m (access) and 30d (refresh) unless
+ * `accessTokenTtlSeconds` / `refreshTokenTtlSeconds` are supplied (the app
+ * sets these once via `setupCore`).
+ *
+ * Throws when the identity already has an account. See {@link signIn} for the
+ * return-visit path.
  */
-export const signIn = mutation({
+export const signUp = mutation({
   args: {
     claims: vAuthClaims,
-    createOrUpdateUserHandle: v.string(),
+    onSignUpHandle: v.string(),
     issuer: v.string(),
     accessTokenTtlSeconds: v.optional(v.number()),
     refreshTokenTtlSeconds: v.optional(v.number()),
@@ -267,12 +266,70 @@ export const signIn = mutation({
   returns: vTokenBundle,
   handler: async (ctx, args): Promise<TokenBundle> => {
     const ttl = resolveTtlConfig(args);
-    const { accountId, userId } = await resolveAccount(
+    const { accountId, userId } = await createAccount(
       ctx,
       args.claims,
-      args.createOrUpdateUserHandle as CreateOrUpdateUserFunctionHandle,
+      args.onSignUpHandle as OnSignUpFunctionHandle,
     );
     return await issueSession(ctx, accountId, userId, args.issuer, ttl);
+  },
+});
+
+/**
+ * Performs an app-integrated user sign-in.
+ *
+ * Establishes a session and returns a token bundle upon success.
+ * 
+ * Providers don't typically call this API directly, but instead use the
+ * framework's `completeSignIn` helper. That function takes care of passing the
+ * `onSignInHandle` app callback.
+ *
+ * The JWT accessToken in the return value is issued with `issuer` as its
+ * `iss`. Token lifetimes default to 1m (access) and 30d (refresh) unless
+ * `accessTokenTtlSeconds` / `refreshTokenTtlSeconds` are supplied (the app
+ * sets these once via `setupCore`).
+ *
+ * Throws when the identity has no account.
+ */
+export const signIn = mutation({
+  args: {
+    claims: vAuthClaims,
+    onSignInHandle: v.optional(v.string()),
+    issuer: v.string(),
+    accessTokenTtlSeconds: v.optional(v.number()),
+    refreshTokenTtlSeconds: v.optional(v.number()),
+  },
+  returns: vTokenBundle,
+  handler: async (ctx, args): Promise<TokenBundle> => {
+    const ttl = resolveTtlConfig(args);
+    const { claims } = args;
+    const account = await accountByIdentity(
+      ctx,
+      claims.provider,
+      claims.providerAccountId,
+    );
+    if (account === null) {
+      throw new Error(
+        `Cannot sign in: no account for provider = ${JSON.stringify(claims.provider)} ` +
+        `and provider account ID = ${JSON.stringify(claims.providerAccountId)} exists. ` +
+        `A first sign-in for an identity must go through signUp.`,
+      );
+    }
+    if (args.onSignInHandle !== undefined) {
+      await ctx.runMutation(args.onSignInHandle as OnSignInFunctionHandle, {
+        provider: claims.provider,
+        providerAccountId: claims.providerAccountId,
+        profile: claims.profile,
+        userId: asUserId(account.userId),
+      });
+    }
+    return await issueSession(
+      ctx,
+      account._id,
+      account.userId,
+      args.issuer,
+      ttl,
+    );
   },
 });
 

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -17,7 +17,7 @@ import {
 } from "../../lib/types";
 import { signJwt, generateRefreshToken } from "./crypto";
 import { sha256Hex } from "../../lib/crypto";
-import { OnSignInFn, OnSignUpFn } from "../../lib/types";
+import { CreateUserFn, OnSignInFn } from "../../lib/types";
 
 // --- Configuration ---------------------------------------------------------
 
@@ -145,10 +145,10 @@ async function issueSession(
   };
 }
 
-type OnSignUpFunctionHandle = FunctionHandle<
-  OnSignUpFn<string, unknown>["_type"],
-  OnSignUpFn<string, unknown>["_args"],
-  OnSignUpFn<string, unknown>["_returnType"]
+type CreateUserFunctionHandle = FunctionHandle<
+  CreateUserFn<string, unknown>["_type"],
+  CreateUserFn<string, unknown>["_args"],
+  CreateUserFn<string, unknown>["_returnType"]
 >;
 
 type OnSignInFunctionHandle = FunctionHandle<
@@ -172,15 +172,15 @@ function asUserId(userId: string): GenericId<string> {
 /**
  * Create the account and app-level user for an identity the core has not seen before.
  *
- * The app's `onSignUp` callback mints and returns the user id, and this
+ * The app's `createUser` callback mints and returns the user id, and this
  * records the provider-identity -> user mapping. Returns what minting a
  * session needs: the account id and its app user id. The claims are passed to
- * the `onSignUp` callback.
+ * the `createUser` callback.
  */
 async function createAccount(
   ctx: MutationCtx,
   claims: AuthClaims,
-  onSignUp: OnSignUpFunctionHandle,
+  createUser: CreateUserFunctionHandle,
 ): Promise<{ accountId: Id<"accounts">; userId: string }> {
   // `USE_USER_ID_AS_ACCOUNT_ID` means the account is keyed by the app user id,
   // which does not exist until the callback below mints it. Such claims can
@@ -198,14 +198,14 @@ async function createAccount(
       // app user for someone who already has one. Fail before calling the app.
       throw new Error(
         `Cannot sign up: an account for provider = ${JSON.stringify(claims.provider)} ` +
-        `and provider account ID = ${JSON.stringify(claims.providerAccountId)} already ` +
-        `exists. Providers that cannot tell a first sign-in from a return visit must ` +
-        `look the identity up (getUserIdByAccount) and call signIn instead.`,
+          `and provider account ID = ${JSON.stringify(claims.providerAccountId)} already ` +
+          `exists. Providers that cannot tell a first sign-in from a return visit must ` +
+          `look the identity up (getUserIdByAccount) and call signIn instead.`,
       );
     }
   }
 
-  const userId = await ctx.runMutation(onSignUp, {
+  const userId = await ctx.runMutation(createUser, {
     provider: claims.provider,
     providerAccountId: claims.providerAccountId,
     profile: claims.profile,
@@ -236,16 +236,40 @@ async function createAccount(
   return { accountId, userId };
 }
 
+/**
+ * Run the app's sign-in callback, if it attached one. Every sign-in goes
+ * through here, a first one included, so per-sign-in work in the app has a
+ * single home.
+ */
+async function notifySignIn(
+  ctx: MutationCtx,
+  claims: AuthClaims,
+  userId: string,
+  onSignInHandle: string | undefined,
+): Promise<void> {
+  if (onSignInHandle === undefined) return;
+  await ctx.runMutation(onSignInHandle as OnSignInFunctionHandle, {
+    provider: claims.provider,
+    providerAccountId: claims.providerAccountId,
+    profile: claims.profile,
+    userId: asUserId(userId),
+  });
+}
+
 // --- Component API ------------------------------------------------------------
 
 /**
  * Performs an app-integrated new user sign-up.
  *
  * Establishes a session and returns a token bundle upon success.
- * 
+ *
  * Providers don't typically call this API directly, but instead use the
  * framework's `completeSignUp` helper. That function takes care of passing the
- * `onSignUpHandle` app callback.
+ * `createUserHandle` and `onSignInHandle` app callbacks.
+ *
+ * `createUser` mints the app user, then `onSignIn` runs like it does for any
+ * other sign-in. An `onSignIn` that throws therefore rolls back the user
+ * `createUser` just made, since both are subtransactions of this one.
  *
  * The JWT accessToken in the return value is issued with `issuer` as its
  * `iss`. Token lifetimes default to 1m (access) and 30d (refresh) unless
@@ -258,7 +282,8 @@ async function createAccount(
 export const signUp = mutation({
   args: {
     claims: vAuthClaims,
-    onSignUpHandle: v.string(),
+    createUserHandle: v.string(),
+    onSignInHandle: v.optional(v.string()),
     issuer: v.string(),
     accessTokenTtlSeconds: v.optional(v.number()),
     refreshTokenTtlSeconds: v.optional(v.number()),
@@ -269,8 +294,9 @@ export const signUp = mutation({
     const { accountId, userId } = await createAccount(
       ctx,
       args.claims,
-      args.onSignUpHandle as OnSignUpFunctionHandle,
+      args.createUserHandle as CreateUserFunctionHandle,
     );
+    await notifySignIn(ctx, args.claims, userId, args.onSignInHandle);
     return await issueSession(ctx, accountId, userId, args.issuer, ttl);
   },
 });
@@ -279,7 +305,7 @@ export const signUp = mutation({
  * Performs an app-integrated user sign-in.
  *
  * Establishes a session and returns a token bundle upon success.
- * 
+ *
  * Providers don't typically call this API directly, but instead use the
  * framework's `completeSignIn` helper. That function takes care of passing the
  * `onSignInHandle` app callback.
@@ -311,18 +337,11 @@ export const signIn = mutation({
     if (account === null) {
       throw new Error(
         `Cannot sign in: no account for provider = ${JSON.stringify(claims.provider)} ` +
-        `and provider account ID = ${JSON.stringify(claims.providerAccountId)} exists. ` +
-        `A first sign-in for an identity must go through signUp.`,
+          `and provider account ID = ${JSON.stringify(claims.providerAccountId)} exists. ` +
+          `A first sign-in for an identity must go through signUp.`,
       );
     }
-    if (args.onSignInHandle !== undefined) {
-      await ctx.runMutation(args.onSignInHandle as OnSignInFunctionHandle, {
-        provider: claims.provider,
-        providerAccountId: claims.providerAccountId,
-        profile: claims.profile,
-        userId: asUserId(account.userId),
-      });
-    }
+    await notifySignIn(ctx, claims, account.userId, args.onSignInHandle);
     return await issueSession(
       ctx,
       account._id,

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -134,8 +134,8 @@ export type AuthCore<UsersTable extends string = string> = {
    * providers bound to this core — a duplicate throws immediately (two
    * providers sharing a name would silently share accounts).
    *
-   * `onSignUp` is the app's user-creating callback for this provider and
-   * `onSignIn` is the optional return-visit hook (see {@link UserCallbacks}).
+   * `createUser` is the app's user-creating callback for this provider and
+   * `onSignIn` is its optional per-sign-in hook (see {@link UserCallbacks}).
    *
    * Provider setup functions call this from inside their `attachUserCallbacks`,
    * once the app has supplied the callbacks, so the builders can close over
@@ -163,7 +163,7 @@ export type AuthCore<UsersTable extends string = string> = {
  *   setupUsernamePassword(core, {
  *     component: components.authPasswordProvider,
  *     usernameComponent: components.authUsername,
- *   }).attachUserCallbacks({ onSignUp: internal.users.onSignUpPassword });
+ *   }).attachUserCallbacks({ createUser: internal.users.createUserPassword });
  * ```
  *
  * The core never triggers a sign-in itself: it has no idea how any given
@@ -188,11 +188,11 @@ export function setupCore<UsersTable extends string = "users">(options: {
    * The name of the app's users table. Defaults to `"users"`.
    *
    * The core never reads or writes the table — it only stores the id the app's
-   * `onSignUp` callback returns. The name is a *type-level* contract: it makes
-   * every provider's `attachUserCallbacks` demand mutations whose `userId`
-   * argument and return type are `Id<usersTable>`, so an app cannot
-   * accidentally hand back an id from some other table (and, because the app
-   * then declares `v.id(usersTable)`, Convex enforces the same thing at runtime).
+   * `createUser` callback returns. The name is a *type-level* contract: it makes
+   * every provider's `attachUserCallbacks` demand a `createUser` returning
+   * `Id<usersTable>` and an `onSignIn` taking one, so an app cannot accidentally
+   * hand back an id from some other table (and, because the app then declares
+   * `v.id(usersTable)`, Convex enforces the same thing at runtime).
    *
    * Set this if the app's users live in a table with a different name:
    *
@@ -270,7 +270,7 @@ export function setupCore<UsersTable extends string = "users">(options: {
 
   const bindProvider = <Provider extends string, Profile>({
     name,
-    onSignUp,
+    createUser,
     onSignIn,
   }: {
     name: Provider;
@@ -288,6 +288,11 @@ export function setupCore<UsersTable extends string = "users">(options: {
     }
     boundProviderNames.add(name);
 
+    // Undefined when the app attached no `onSignIn`, which tells the core to
+    // mint the session without notifying the app.
+    const onSignInHandle = async (): Promise<string | undefined> =>
+      onSignIn === undefined ? undefined : await createFunctionHandle(onSignIn);
+
     // The helpers close over the live ctx; both mutation and action ctxs
     // expose the compatible `runMutation`/`runQuery` these need.
     const makeHelpers = (
@@ -299,14 +304,14 @@ export function setupCore<UsersTable extends string = "users">(options: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<TokenBundle> => {
-        const onSignUpHandle = await createFunctionHandle(onSignUp);
         return await ctx.runMutation(component.public.signUp, {
           claims: {
             provider: name,
             providerAccountId: args.providerAccountId,
             profile: args.profile,
           },
-          onSignUpHandle,
+          createUserHandle: await createFunctionHandle(createUser),
+          onSignInHandle: await onSignInHandle(),
           issuer: issuer(),
           accessTokenTtlSeconds,
           refreshTokenTtlSeconds,
@@ -316,18 +321,13 @@ export function setupCore<UsersTable extends string = "users">(options: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<TokenBundle> => {
-        // With no handle the core mints the session without notifying the app.
-        const onSignInHandle =
-          onSignIn === undefined
-            ? undefined
-            : await createFunctionHandle(onSignIn);
         return await ctx.runMutation(component.public.signIn, {
           claims: {
             provider: name,
             providerAccountId: args.providerAccountId,
             profile: args.profile,
           },
-          onSignInHandle,
+          onSignInHandle: await onSignInHandle(),
           issuer: issuer(),
           accessTokenTtlSeconds,
           refreshTokenTtlSeconds,

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -17,7 +17,7 @@ import {
   vTokenBundle,
   type TokenBundle,
   type ConvexAuthCtx,
-  type CreateOrUpdateUserFn,
+  type UserCallbacks,
 } from "../../lib/types";
 
 /**
@@ -134,19 +134,19 @@ export type AuthCore<UsersTable extends string = string> = {
    * providers bound to this core — a duplicate throws immediately (two
    * providers sharing a name would silently share accounts).
    *
-   * `createOrUpdateUser` is the app's user callback for this provider (see
-   * {@link CreateOrUpdateUserFn}); the core invokes it on every sign-in the
-   * returned builders complete.
+   * `onSignUp` is the app's user-creating callback for this provider and
+   * `onSignIn` is the optional return-visit hook (see {@link UserCallbacks}).
    *
-   * Provider setup functions call this from inside their `attachUserCallback`,
-   * once the app has supplied the callback — so the builders can simply close
-   * over it, and a provider with no callback cannot exist. It is not meant to
-   * be called by application code directly.
+   * Provider setup functions call this from inside their `attachUserCallbacks`,
+   * once the app has supplied the callbacks, so the builders can close over
+   * them and a provider with no way to create users cannot exist. It is not
+   * meant to be called by application code directly.
    */
-  bindProvider<Provider extends string, Profile>(options: {
-    name: Provider;
-    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>;
-  }): ProviderBuilders<Profile>;
+  bindProvider<Provider extends string, Profile>(
+    options: {
+      name: Provider;
+    } & UserCallbacks<Provider, Profile, UsersTable>,
+  ): ProviderBuilders<Profile>;
 };
 
 /**
@@ -163,14 +163,16 @@ export type AuthCore<UsersTable extends string = string> = {
  *   setupUsernamePassword(core, {
  *     component: components.authPasswordProvider,
  *     usernameComponent: components.authUsername,
- *   }).attachUserCallback(internal.users.createOrUpdateUser);
+ *   }).attachUserCallbacks({ onSignUp: internal.users.onSignUpPassword });
  * ```
  *
  * The core never triggers a sign-in itself: it has no idea how any given
  * provider authenticates a user. *Triggering sign-in is each provider's
  * responsibility.* A provider verifies the user its own way (checking a
- * password, say) and then calls the `completeSignIn` helper the core injects
- * on `ctx.convexAuth` to exchange the verified identity for a session.
+ * password, say) and then calls one of the helpers the core injects on
+ * `ctx.convexAuth` to exchange the verified identity for a session:
+ * `completeSignUp` when it has just established the account, `completeSignIn`
+ * when the account already exists.
  *
  * Token lifetimes are configurable here and default to 1m (access) and 30d
  * (refresh). The access-token TTL must be shorter than the refresh-token TTL,
@@ -186,9 +188,9 @@ export function setupCore<UsersTable extends string = "users">(options: {
    * The name of the app's users table. Defaults to `"users"`.
    *
    * The core never reads or writes the table — it only stores the id the app's
-   * create-or-update-user callback returns. The name is a *type-level* contract:
-   * it makes every provider's `attachUserCallback` demand a mutation whose
-   * `userId` argument and return type are `Id<usersTable>`, so an app cannot
+   * `onSignUp` callback returns. The name is a *type-level* contract: it makes
+   * every provider's `attachUserCallbacks` demand mutations whose `userId`
+   * argument and return type are `Id<usersTable>`, so an app cannot
    * accidentally hand back an id from some other table (and, because the app
    * then declares `v.id(usersTable)`, Convex enforces the same thing at runtime).
    *
@@ -268,11 +270,15 @@ export function setupCore<UsersTable extends string = "users">(options: {
 
   const bindProvider = <Provider extends string, Profile>({
     name,
-    createOrUpdateUser,
+    onSignUp,
+    onSignIn,
   }: {
     name: Provider;
-    createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>;
-  }): ProviderBuilders<Profile> => {
+  } & UserCallbacks<
+    Provider,
+    Profile,
+    UsersTable
+  >): ProviderBuilders<Profile> => {
     if (boundProviderNames.has(name)) {
       throw new Error(
         `A provider named "${name}" is already bound to this auth core. ` +
@@ -289,19 +295,39 @@ export function setupCore<UsersTable extends string = "users">(options: {
         | GenericActionCtx<GenericDataModel>
         | GenericMutationCtx<GenericDataModel>,
     ) => ({
+      completeSignUp: async (args: {
+        providerAccountId: string;
+        profile: Profile;
+      }): Promise<TokenBundle> => {
+        const onSignUpHandle = await createFunctionHandle(onSignUp);
+        return await ctx.runMutation(component.public.signUp, {
+          claims: {
+            provider: name,
+            providerAccountId: args.providerAccountId,
+            profile: args.profile,
+          },
+          onSignUpHandle,
+          issuer: issuer(),
+          accessTokenTtlSeconds,
+          refreshTokenTtlSeconds,
+        });
+      },
       completeSignIn: async (args: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<TokenBundle> => {
-        const createOrUpdateUserHandle =
-          await createFunctionHandle(createOrUpdateUser);
+        // With no handle the core mints the session without notifying the app.
+        const onSignInHandle =
+          onSignIn === undefined
+            ? undefined
+            : await createFunctionHandle(onSignIn);
         return await ctx.runMutation(component.public.signIn, {
           claims: {
             provider: name,
             providerAccountId: args.providerAccountId,
             profile: args.profile,
           },
-          createOrUpdateUserHandle,
+          onSignInHandle,
           issuer: issuer(),
           accessTokenTtlSeconds,
           refreshTokenTtlSeconds,

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -1,43 +1,60 @@
-import { vCreateOrUpdateUser } from "../../lib/types";
+import { vOnSignIn, vOnSignUp } from "../../lib/types";
 import { internalMutation } from "./_generated/server";
 import { Infer, v } from "convex/values";
 
 /**
- * Test-only spy state. The core calls the app's user callback on every sign-in
- * (with `userId` set for returning identities, unset on first sign-in), and the
+ * Test-only spy state. The core calls the app's `onSignUp` when it first sees an
+ * identity and its (optional) `onSignIn` when a known account returns, and the
  * suite needs to assert that. convex-test runs the whole suite in one process,
- * so a module-level log is a stable spy; the reader and reset below are plain
- * functions the test imports directly, not Convex queries/mutations, since
- * there's no reason to round-trip through the test deployment to read in-process
- * state. This file is excluded from the published build, so the global state
- * never reaches production.
+ * so module-level logs are a stable spy; the readers and reset below are plain
+ * functions the test imports directly, since there's no reason to round-trip
+ * through the test deployment to read in-process state. This file is excluded
+ * from the published build, so the global state never reaches production.
  */
-type CreateOrUpdateUserCall = Infer<typeof vCreateOrUpdateUser>;
-const createOrUpdateUserCalls: CreateOrUpdateUserCall[] = [];
+type OnSignUpCall = Infer<typeof vOnSignUp>;
+type OnSignInCall = Infer<typeof vOnSignIn>;
+const onSignUpCalls: OnSignUpCall[] = [];
+const onSignInCalls: OnSignInCall[] = [];
 
-/** Read the recorded `createOrUpdateUser` calls (test-only). */
-export function getCreateOrUpdateUserCalls(): readonly CreateOrUpdateUserCall[] {
-  return createOrUpdateUserCalls;
+/** Read the recorded `onSignUp` calls (test-only). */
+export function getOnSignUpCalls(): readonly OnSignUpCall[] {
+  return onSignUpCalls;
+}
+
+/** Read the recorded `onSignIn` calls (test-only). */
+export function getOnSignInCalls(): readonly OnSignInCall[] {
+  return onSignInCalls;
 }
 
 /** Clear the recorded calls so a test can assert in isolation (test-only). */
-export function resetCreateOrUpdateUserCalls(): void {
-  createOrUpdateUserCalls.length = 0;
+export function resetUserCallbackCalls(): void {
+  onSignUpCalls.length = 0;
+  onSignInCalls.length = 0;
 }
 
 /**
- * Stand-in for the app's user create-or-update callback, used only by the
- * core's isolated test suite. The core invokes this (by function handle) on
- * every sign-in for an identity; like a minimal real app, it owns no users
- * table and just echoes the provider-scoped account id back as the app user id,
- * honoring an explicit `userId` when one is supplied (returning sign-in / link
- * path).
+ * Stand-in for the app's sign-up callback, used only by the core's isolated
+ * test suite. Like a minimal real app it owns no users table, and just echoes
+ * the provider-scoped account id back as the app user id.
  */
-export const createOrUpdateUser = internalMutation({
-  args: vCreateOrUpdateUser,
+export const onSignUp = internalMutation({
+  args: vOnSignUp,
   returns: v.string(),
   handler: async (_ctx, args) => {
-    createOrUpdateUserCalls.push({ ...args });
-    return args.userId ?? args.providerAccountId;
+    onSignUpCalls.push({ ...args });
+    return args.providerAccountId;
+  },
+});
+
+/**
+ * Stand-in for the app's sign-in callback: the core invokes it when a known
+ * account signs in again, and it returns nothing.
+ */
+export const onSignIn = internalMutation({
+  args: vOnSignIn,
+  returns: v.null(),
+  handler: async (_ctx, args) => {
+    onSignInCalls.push({ ...args });
+    return null;
   },
 });

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -1,24 +1,24 @@
-import { vOnSignIn, vOnSignUp } from "../../lib/types";
+import { vCreateUser, vOnSignIn } from "../../lib/types";
 import { internalMutation } from "./_generated/server";
 import { Infer, v } from "convex/values";
 
 /**
- * Test-only spy state. The core calls the app's `onSignUp` when it first sees an
- * identity and its (optional) `onSignIn` when a known account returns, and the
- * suite needs to assert that. convex-test runs the whole suite in one process,
+ * Test-only spy state. The core calls the app's `createUser` when it first sees
+ * an identity and its (optional) `onSignIn` on every sign-in, and the suite
+ * needs to assert that. convex-test runs the whole suite in one process,
  * so module-level logs are a stable spy; the readers and reset below are plain
  * functions the test imports directly, since there's no reason to round-trip
  * through the test deployment to read in-process state. This file is excluded
  * from the published build, so the global state never reaches production.
  */
-type OnSignUpCall = Infer<typeof vOnSignUp>;
+type CreateUserCall = Infer<typeof vCreateUser>;
 type OnSignInCall = Infer<typeof vOnSignIn>;
-const onSignUpCalls: OnSignUpCall[] = [];
+const createUserCalls: CreateUserCall[] = [];
 const onSignInCalls: OnSignInCall[] = [];
 
-/** Read the recorded `onSignUp` calls (test-only). */
-export function getOnSignUpCalls(): readonly OnSignUpCall[] {
-  return onSignUpCalls;
+/** Read the recorded `createUser` calls (test-only). */
+export function getCreateUserCalls(): readonly CreateUserCall[] {
+  return createUserCalls;
 }
 
 /** Read the recorded `onSignIn` calls (test-only). */
@@ -28,27 +28,27 @@ export function getOnSignInCalls(): readonly OnSignInCall[] {
 
 /** Clear the recorded calls so a test can assert in isolation (test-only). */
 export function resetUserCallbackCalls(): void {
-  onSignUpCalls.length = 0;
+  createUserCalls.length = 0;
   onSignInCalls.length = 0;
 }
 
 /**
- * Stand-in for the app's sign-up callback, used only by the core's isolated
- * test suite. Like a minimal real app it owns no users table, and just echoes
- * the provider-scoped account id back as the app user id.
+ * Stand-in for the app's user-creating callback, used only by the core's
+ * isolated test suite. Like a minimal real app it owns no users table, and just
+ * echoes the provider-scoped account id back as the app user id.
  */
-export const onSignUp = internalMutation({
-  args: vOnSignUp,
+export const createUser = internalMutation({
+  args: vCreateUser,
   returns: v.string(),
   handler: async (_ctx, args) => {
-    onSignUpCalls.push({ ...args });
+    createUserCalls.push({ ...args });
     return args.providerAccountId;
   },
 });
 
 /**
- * Stand-in for the app's sign-in callback: the core invokes it when a known
- * account signs in again, and it returns nothing.
+ * Stand-in for the app's sign-in callback: the core invokes it on every sign-in,
+ * and it returns nothing.
  */
 export const onSignIn = internalMutation({
   args: vOnSignIn,
@@ -56,5 +56,17 @@ export const onSignIn = internalMutation({
   handler: async (_ctx, args) => {
     onSignInCalls.push({ ...args });
     return null;
+  },
+});
+
+/**
+ * An `onSignIn` that always throws, for asserting that a rejected sign-in rolls
+ * back everything the same call created.
+ */
+export const onSignInThatThrows = internalMutation({
+  args: vOnSignIn,
+  returns: v.null(),
+  handler: async () => {
+    throw new Error("no sign-ins for you");
   },
 });

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -82,7 +82,7 @@ export type SignUpResult = Infer<typeof signUpResult>;
  *   setupUsernamePassword(core, {
  *     component: components.authPasswordProvider,
  *     usernameComponent: components.authUsername,
- *   }).attachUserCallbacks({ onSignUp: internal.users.onSignUpPassword });
+ *   }).attachUserCallbacks({ createUser: internal.users.createUserPassword });
  * ```
  *
  * The app re-exports the returned `signUpWithPassword` / `signInWithPassword`
@@ -105,12 +105,12 @@ export function setupUsernamePassword<UsersTable extends string>(
      * args must be declared) and get this provider's functions to export.
      */
     attachUserCallbacks({
-      onSignUp,
+      createUser,
       onSignIn,
     }: UserCallbacks<"password", { username: string }, UsersTable>) {
       const { authMutation } = core.bindProvider({
         name: PROVIDER_NAME,
-        onSignUp,
+        createUser,
         onSignIn,
       });
 
@@ -149,8 +149,8 @@ export function setupUsernamePassword<UsersTable extends string>(
               return { success: false, userError: { error: "USERNAME_TAKEN" } };
             }
 
-            // Create the account + app user (via the app's onSignUp) and mint
-            // the session. Password accounts are keyed by the app user id,
+            // Create the account + app user (via the app's createUser) and
+            // mint the session. Password accounts are keyed by the app user id,
             // which does not exist before this call mints it, hence the
             // placeholder; sign-in passes the user id itself. `profile.username`
             // keeps the original casing for display.

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -2,7 +2,7 @@ import { Infer, v } from "convex/values";
 import {
   vSignInSuccess,
   USE_USER_ID_AS_ACCOUNT_ID,
-  type CreateOrUpdateUserFn,
+  type UserCallbacks,
 } from "../../lib/types";
 import type { AuthCore } from "../core/setup";
 import type { ComponentApi } from "./_generated/component.js";
@@ -82,7 +82,7 @@ export type SignUpResult = Infer<typeof signUpResult>;
  *   setupUsernamePassword(core, {
  *     component: components.authPasswordProvider,
  *     usernameComponent: components.authUsername,
- *   }).attachUserCallback(internal.users.createOrUpdateUser);
+ *   }).attachUserCallbacks({ onSignUp: internal.users.onSignUpPassword });
  * ```
  *
  * The app re-exports the returned `signUpWithPassword` / `signInWithPassword`
@@ -101,20 +101,17 @@ export function setupUsernamePassword<UsersTable extends string>(
 
   return {
     /**
-     * Supply the app's create-or-update-user mutation (see
-     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
-     * get this provider's functions to export.
+     * Supply the app's user callbacks (see {@link UserCallbacks} for how their
+     * args must be declared) and get this provider's functions to export.
      */
-    attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<
-        "password",
-        { username: string },
-        UsersTable
-      >,
-    ) {
+    attachUserCallbacks({
+      onSignUp,
+      onSignIn,
+    }: UserCallbacks<"password", { username: string }, UsersTable>) {
       const { authMutation } = core.bindProvider({
         name: PROVIDER_NAME,
-        createOrUpdateUser,
+        onSignUp,
+        onSignIn,
       });
 
       return {
@@ -152,18 +149,18 @@ export function setupUsernamePassword<UsersTable extends string>(
               return { success: false, userError: { error: "USERNAME_TAKEN" } };
             }
 
-            // Create the account + app user (via the app's createOrUpdateUser)
-            // and mint the session. Password accounts are keyed by the app user
-            // id, which does not exist before this call mints it, hence the
+            // Create the account + app user (via the app's onSignUp) and mint
+            // the session. Password accounts are keyed by the app user id,
+            // which does not exist before this call mints it, hence the
             // placeholder; sign-in passes the user id itself. `profile.username`
             // keeps the original casing for display.
             //
-            // TODO(nicolas) The app's `createOrUpdateUser` callback should not
-            // receive a provider account ID for the password provider at all:
-            // the value is an internal key ("" at sign-up, the user id
-            // afterwards) with no meaning to the app. We will probably improve
-            // this when providers support typesafe profiles.
-            const tokens = await ctx.convexAuth.completeSignIn({
+            // TODO(nicolas) The app's user callbacks should not receive a
+            // provider account ID for the password provider at all: the value
+            // is an internal key ("" at sign-up, the user id afterwards) with
+            // no meaning to the app. We will probably improve this when
+            // providers support typesafe profiles.
+            const tokens = await ctx.convexAuth.completeSignUp({
               providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
               profile: { username },
             });
@@ -240,6 +237,9 @@ export function setupUsernamePassword<UsersTable extends string>(
               return { success: false, userError: verifyResult.userError };
             }
 
+            // The username resolved to a user id and its password verified, so
+            // the account exists and `completeSignIn` (which throws otherwise)
+            // is the right helper.
             const tokens = await ctx.convexAuth.completeSignIn({
               providerAccountId: userId,
               profile: { username },

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -164,14 +164,14 @@ export type AuthClaims = Infer<typeof vAuthClaims>;
 /**
  * The `providerAccountId` a provider sends to `completeSignUp` when it has no
  * identifier of its own. The core then keys the new account by the app user id
- * `onSignUp` returns, and later sign-ins send that user id as the account
+ * `createUser` returns, and later sign-ins send that user id as the account
  * identifier.
  *
  * @TODO(nicolas) Consider replacing this mechanism
  */
 export const USE_USER_ID_AS_ACCOUNT_ID = "";
 
-export const vOnSignUp = v.object({
+export const vCreateUser = v.object({
   provider: v.string(),
   providerAccountId: v.string(),
   profile: v.any(),
@@ -185,9 +185,10 @@ export const vOnSignIn = v.object({
 });
 
 /**
- * The type of an app defined sign-up mutation: create the app's user record for
- * an identity the core has not seen before, and return its id. Returning
- * sign-ins go to {@link OnSignInFn} instead.
+ * The type of an app defined user-creating mutation: create the app's user
+ * record for an identity the core has not seen before, and return its id. It
+ * runs once per account, and {@link OnSignInFn} runs right after it, so this
+ * one is only responsible for what is true at creation time.
  *
  * This is the core entrypoint for an application to integrate its user model
  * with Convex Auth. Apps install one per provider, via that provider's
@@ -208,7 +209,7 @@ export const vOnSignIn = v.object({
  * compare covariantly. For shared logic, define one thin mutation per provider
  * that delegates to a plain shared function.
  */
-export type OnSignUpFn<
+export type CreateUserFn<
   Provider extends string,
   Profile,
   UsersTable extends string = string,
@@ -224,19 +225,23 @@ export type OnSignUpFn<
 >;
 
 /**
- * The type of an app defined sign-in mutation: an optional hook that runs when
- * a *known* account signs in again.
+ * The type of an app defined sign-in mutation: an optional hook that runs on
+ * *every* sign-in.
+ *
+ * That includes the first one, where it runs immediately after
+ * {@link CreateUserFn} has minted the user. So per-sign-in work (a last-seen
+ * timestamp, an audit row, syncing the user record from the latest `profile`,
+ * which the core does not store) belongs here and nowhere else.
  *
  * The core resolves the account to its app user first, so `userId` is always
- * present and there is nothing to return. Apps use it to sync their user record
- * from the latest `profile` (the core stores no profile itself), or to record a
- * last-seen timestamp. Declare `returns: v.null()` and return `null`, or leave
- * the callback out entirely if there is nothing to do on a return visit. Throw a
- * `ConvexError` to reject the sign in.
+ * present and there is nothing to return. Declare `returns: v.null()` and
+ * return `null`, or leave the callback out entirely. Throw a `ConvexError` to
+ * reject the sign in, which on a first sign-in rolls back the user the create
+ * callback just made.
  *
- * Like {@link OnSignUpFn}, the args must be declared with the provider's exact
- * literal types, and one mutation per provider (delegating to a plain shared
- * function) is how to share logic across providers.
+ * Like {@link CreateUserFn}, the args must be declared with the provider's
+ * exact literal types, and one mutation per provider (delegating to a plain
+ * shared function) is how to share logic across providers.
  */
 export type OnSignInFn<
   Provider extends string,
@@ -256,15 +261,15 @@ export type OnSignInFn<
 
 /**
  * The app's user callbacks for one provider, as its `attachUserCallbacks`
- * takes them: {@link OnSignUpFn} is required (something has to create the user
- * record), {@link OnSignInFn} is optional.
+ * takes them: {@link CreateUserFn} is required (something has to create the
+ * user record), {@link OnSignInFn} is optional.
  */
 export type UserCallbacks<
   Provider extends string,
   Profile,
   UsersTable extends string = string,
 > = {
-  onSignUp: OnSignUpFn<Provider, Profile, UsersTable>;
+  createUser: CreateUserFn<Provider, Profile, UsersTable>;
   onSignIn?: OnSignInFn<Provider, Profile, UsersTable>;
 };
 
@@ -279,8 +284,9 @@ export type BoundAuthHelpers<Profile> = {
    * Exchange a *newly established* account identity for a session.
    *
    * Call this when the provider has just created the account. The core records
-   * the account, calls the app's `onSignUp` to mint the app user, and returns
-   * the tokens a client needs to make authenticated calls.
+   * the account, calls the app's `createUser` to mint the app user, then its
+   * `onSignIn` like any other sign-in, and returns the tokens a client needs to
+   * make authenticated calls.
    *
    * Throws if the identity already has an account. A provider that cannot tell
    * a first sign-in from a return visit should call

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -162,50 +162,42 @@ export const vAuthClaims = v.object({
 export type AuthClaims = Infer<typeof vAuthClaims>;
 
 /**
- * Pass this as `providerAccountId` to `completeSignIn` when the provider has
- * no identifier of its own. The core then keys the new account by the app
- * user id it mints during sign-in. On later sign-ins, pass that user id as
- * the account identifier.
+ * The `providerAccountId` a provider sends to `completeSignUp` when it has no
+ * identifier of its own. The core then keys the new account by the app user id
+ * `onSignUp` returns, and later sign-ins send that user id as the account
+ * identifier.
  *
  * @TODO(nicolas) Consider replacing this mechanism
  */
 export const USE_USER_ID_AS_ACCOUNT_ID = "";
 
-export const vCreateOrUpdateUser = v.object({
+export const vOnSignUp = v.object({
   provider: v.string(),
   providerAccountId: v.string(),
   profile: v.any(),
-  userId: v.union(v.string(), v.null()),
+});
+
+export const vOnSignIn = v.object({
+  provider: v.string(),
+  providerAccountId: v.string(),
+  profile: v.any(),
+  userId: v.string(),
 });
 
 /**
- * The type of an app defined create-or-update-user mutation.
+ * The type of an app defined sign-up mutation: create the app's user record for
+ * an identity the core has not seen before, and return its id. Returning
+ * sign-ins go to {@link OnSignInFn} instead.
  *
  * This is the core entrypoint for an application to integrate its user model
  * with Convex Auth. Apps install one per provider, via that provider's
- * `attachUserCallback`, typed with that provider's exact name and profile
- * shape.
+ * `attachUserCallbacks`, typed with that provider's exact name and profile
+ * shape. Throw a `ConvexError` to reject the sign up.
  *
- * It will be called in two scenarios, both associated with a user signing in:
- *
- *  1. The first time a user signs in with an account from a provider.
- *    * The `userId` argument will be `null` in this case.
- *    * The application should create a new user record and return its `_id`
- *  2. Subsequent sign ins from a provider
- *    * The `userId` argument will be present.
- *    * The application may use the data in `profile` to update or otherwise
- *      modify the stored user record.
- *    * The existing `userId` must be the return value.
- *
- * The application keeps ownership of its users table — the core only holds a
- * reference to this one mutation, and treats the returned user id as an opaque
- * string at runtime. At the type level the table is named by the `usersTable`
- * option on `setupCore` (defaulting to `"users"`), which is what makes the
- * callback's `userId` argument and return type `Id<usersTable>` rather than a
- * bare string.
- *
- * If an application wants to reject a sign in, it can throw a `ConvexError`
- * and the entire sign in attempt will be blocked.
+ * The application keeps ownership of its users table. The core treats the
+ * returned id as an opaque string at runtime; at the type level the table is
+ * named by `setupCore`'s `usersTable` option, which is what makes the return
+ * type `Id<usersTable>` rather than a bare string.
  *
  * The mutation's args must be declared with the provider's *exact* literal
  * types (e.g. `provider: v.literal("password")`, `profile: v.object({ username:
@@ -216,7 +208,7 @@ export const vCreateOrUpdateUser = v.object({
  * compare covariantly. For shared logic, define one thin mutation per provider
  * that delegates to a plain shared function.
  */
-export type CreateOrUpdateUserFn<
+export type OnSignUpFn<
   Provider extends string,
   Profile,
   UsersTable extends string = string,
@@ -227,10 +219,54 @@ export type CreateOrUpdateUserFn<
     provider: Provider;
     providerAccountId: string;
     profile: Profile;
-    userId: GenericId<UsersTable> | null;
   },
   GenericId<UsersTable>
 >;
+
+/**
+ * The type of an app defined sign-in mutation: an optional hook that runs when
+ * a *known* account signs in again.
+ *
+ * The core resolves the account to its app user first, so `userId` is always
+ * present and there is nothing to return. Apps use it to sync their user record
+ * from the latest `profile` (the core stores no profile itself), or to record a
+ * last-seen timestamp. Declare `returns: v.null()` and return `null`, or leave
+ * the callback out entirely if there is nothing to do on a return visit. Throw a
+ * `ConvexError` to reject the sign in.
+ *
+ * Like {@link OnSignUpFn}, the args must be declared with the provider's exact
+ * literal types, and one mutation per provider (delegating to a plain shared
+ * function) is how to share logic across providers.
+ */
+export type OnSignInFn<
+  Provider extends string,
+  Profile,
+  UsersTable extends string = string,
+> = FunctionReference<
+  "mutation",
+  "internal",
+  {
+    provider: Provider;
+    providerAccountId: string;
+    profile: Profile;
+    userId: GenericId<UsersTable>;
+  },
+  null
+>;
+
+/**
+ * The app's user callbacks for one provider, as its `attachUserCallbacks`
+ * takes them: {@link OnSignUpFn} is required (something has to create the user
+ * record), {@link OnSignInFn} is optional.
+ */
+export type UserCallbacks<
+  Provider extends string,
+  Profile,
+  UsersTable extends string = string,
+> = {
+  onSignUp: OnSignUpFn<Provider, Profile, UsersTable>;
+  onSignIn?: OnSignInFn<Provider, Profile, UsersTable>;
+};
 
 /**
  * The helpers that `authMutation`/`authAction` inject onto `ctx` for a
@@ -240,13 +276,32 @@ export type CreateOrUpdateUserFn<
  */
 export type BoundAuthHelpers<Profile> = {
   /**
-   * Exchange a verified account identity for a session.
+   * Exchange a *newly established* account identity for a session.
    *
-   * Call this once the provider has authenticated an account its own way
-   * (checking a password, say). It resolves (or creates) the account and its
-   * app user via an app-provided create-or-update-user callback, mints a
-   * session, and returns the tokens a client needs to make authenticated
-   * calls.
+   * Call this when the provider has just created the account. The core records
+   * the account, calls the app's `onSignUp` to mint the app user, and returns
+   * the tokens a client needs to make authenticated calls.
+   *
+   * Throws if the identity already has an account. A provider that cannot tell
+   * a first sign-in from a return visit should call
+   * {@link BoundAuthHelpers.resolveUserId} first and pick the right helper;
+   * both run in one mutation transaction, so the check cannot go stale.
+   */
+  completeSignUp(args: {
+    providerAccountId: string;
+    profile: Profile;
+  }): Promise<TokenBundle>;
+  /**
+   * Exchange a verified *existing* account identity for a session.
+   *
+   * Call this once the provider has authenticated a known account its own way
+   * (checking a password, say). The core resolves the account to its app user,
+   * runs the app's `onSignIn` callback if one is attached, and returns the
+   * tokens a client needs to make authenticated calls.
+   *
+   * Throws if the identity has no account: reaching this helper is the
+   * provider's assertion that the account exists, so a miss is a bug rather
+   * than an authentication failure to report to the user.
    */
   completeSignIn(args: {
     providerAccountId: string;

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -290,8 +290,7 @@ export type BoundAuthHelpers<Profile> = {
    *
    * Throws if the identity already has an account. A provider that cannot tell
    * a first sign-in from a return visit should call
-   * {@link BoundAuthHelpers.resolveUserId} first and pick the right helper;
-   * both run in one mutation transaction, so the check cannot go stale.
+   * {@link BoundAuthHelpers.resolveUserId} first and pick the right helper.
    */
   completeSignUp(args: {
     providerAccountId: string;

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -99,7 +99,7 @@ const githubCatalog: OauthCatalog<GithubProfile, GithubUserInfo> = {
  * export const { startSignInGithub, completeSignInGithub } = setupGithub(core, {
  *   component: components.oauthGithub,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpGithub });
+ * }).attachUserCallbacks({ createUser: internal.users.createUserGithub });
  * ```
  *
  * Setup:

--- a/packages/core/src/oauth/component/github.ts
+++ b/packages/core/src/oauth/component/github.ts
@@ -1,5 +1,5 @@
 import { Infer, v } from "convex/values";
-import type { CreateOrUpdateUserFn } from "../../lib/types";
+import type { UserCallbacks } from "../../lib/types";
 import type { AuthCore } from "../../components/core/setup";
 import {
   setupOauth,
@@ -99,7 +99,7 @@ const githubCatalog: OauthCatalog<GithubProfile, GithubUserInfo> = {
  * export const { startSignInGithub, completeSignInGithub } = setupGithub(core, {
  *   component: components.oauthGithub,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * }).attachUserCallback(internal.users.createOrUpdateGithubUser);
+ * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpGithub });
  * ```
  *
  * Setup:
@@ -118,22 +118,17 @@ export function setupGithub<UsersTable extends string>(
 ) {
   return {
     /**
-     * Supply the app's create-or-update-user mutation (see
-     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
-     * get this provider's functions to export.
+     * Supply the app's user callbacks (see {@link UserCallbacks} for how their
+     * args must be declared) and get this provider's functions to export.
      */
-    attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<
-        "github",
-        GithubProfile,
-        UsersTable
-      >,
+    attachUserCallbacks(
+      callbacks: UserCallbacks<"github", GithubProfile, UsersTable>,
     ) {
       const { startSignIn, completeSignIn } = setupOauth(
         core,
         "github",
         githubCatalog,
-        createOrUpdateUser,
+        callbacks,
         options,
       );
       return {

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -66,7 +66,7 @@ const googleCatalog: OauthCatalog<GoogleProfile> = {
  * export const { startSignInGoogle, completeSignInGoogle } = setupGoogle(core, {
  *   component: components.oauthGoogle,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpGoogle });
+ * }).attachUserCallbacks({ createUser: internal.users.createUserGoogle });
  * ```
  *
  * Setup:

--- a/packages/core/src/oauth/component/google.ts
+++ b/packages/core/src/oauth/component/google.ts
@@ -1,5 +1,5 @@
 import { Infer, v } from "convex/values";
-import type { CreateOrUpdateUserFn } from "../../lib/types";
+import type { UserCallbacks } from "../../lib/types";
 import type { AuthCore } from "../../components/core/setup";
 import {
   setupOauth,
@@ -66,7 +66,7 @@ const googleCatalog: OauthCatalog<GoogleProfile> = {
  * export const { startSignInGoogle, completeSignInGoogle } = setupGoogle(core, {
  *   component: components.oauthGoogle,
  *   allowedRedirectOrigins: ["https://app.example.com", "http://localhost:5173"],
- * }).attachUserCallback(internal.users.createOrUpdateGoogleUser);
+ * }).attachUserCallbacks({ onSignUp: internal.users.onSignUpGoogle });
  * ```
  *
  * Setup:
@@ -85,22 +85,17 @@ export function setupGoogle<UsersTable extends string>(
 ) {
   return {
     /**
-     * Supply the app's create-or-update-user mutation (see
-     * {@link CreateOrUpdateUserFn} for how its args must be declared) and
-     * get this provider's functions to export.
+     * Supply the app's user callbacks (see {@link UserCallbacks} for how their
+     * args must be declared) and get this provider's functions to export.
      */
-    attachUserCallback(
-      createOrUpdateUser: CreateOrUpdateUserFn<
-        "google",
-        GoogleProfile,
-        UsersTable
-      >,
+    attachUserCallbacks(
+      callbacks: UserCallbacks<"google", GoogleProfile, UsersTable>,
     ) {
       const { startSignIn, completeSignIn } = setupOauth(
         core,
         "google",
         googleCatalog,
-        createOrUpdateUser,
+        callbacks,
         options,
       );
       return {

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -23,21 +23,29 @@ import type {
 /**
  * Tests for the app-side `completeSignIn` mutation that `setupOauth`
  * produces, run against the real component (real `claimTicket`, real ticket
- * crypto). The core helper that turns verified claims into a session
- * (`ctx.convexAuth.completeSignIn`) is faked and spied here. The real one is
- * covered by the core's own suite (components/core/core.test.ts).
+ * crypto). The core helpers it uses (`ctx.convexAuth.completeSignUp` /
+ * `completeSignIn`, plus the `resolveUserId` it picks between them with) are
+ * faked and spied here. The real ones are covered by the core's own suite
+ * (components/core/core.test.ts).
  */
 
 /**
- * Claims recorded by the fake `ctx.convexAuth.completeSignIn`. The suite runs
- * in one process, so tests read and reset this directly.
+ * Claims recorded by the fake `ctx.convexAuth.completeSignUp` /
+ * `completeSignIn`, tagged with which of the two redemption chose. The suite
+ * runs in one process, so tests read and reset this directly.
  */
-const completeSignInCalls: AuthClaims[] = [];
+type HelperCall = { kind: "signUp" | "signIn"; claims: AuthClaims };
+const helperCalls: HelperCall[] = [];
 
 /**
- * When set, the fake `ctx.convexAuth.completeSignIn` throws this instead of
- * returning a bundle, modeling the app rejecting the sign-in from its
- * `createOrUpdateUser` callback.
+ * What the fake `ctx.convexAuth.resolveUserId` reports. `null` (the default)
+ * models an identity the core has never seen; a user id models a return visit.
+ */
+const resolvedUserId = { value: null as string | null };
+
+/**
+ * When set, the fake helpers throw this instead of returning a bundle, modeling
+ * the app rejecting the sign-in from its `onSignUp` / `onSignIn` callback.
  */
 const helperFailure = { error: undefined as Error | undefined };
 
@@ -50,29 +58,35 @@ const FAKE_BUNDLE: TokenBundle = {
   userId: "user-1",
 };
 
-/**
- * A fake core whose builders inject fake {@link BoundAuthHelpers}.
- * `resolveUserId` is never reached by redemption.
- */
+/** A fake core whose builders inject fake {@link BoundAuthHelpers}. */
 const FAKE_CORE = {
   bindProvider: <Provider extends string, Profile>({
     name,
   }: {
     name: Provider;
   }): ProviderBuilders<Profile> => {
-    const convexAuth: BoundAuthHelpers<Profile> = {
-      completeSignIn: async ({ providerAccountId, profile }) => {
-        completeSignInCalls.push({
-          provider: name,
-          providerAccountId,
-          profile,
+    const record =
+      (kind: HelperCall["kind"]) =>
+      async ({
+        providerAccountId,
+        profile,
+      }: {
+        providerAccountId: string;
+        profile: Profile;
+      }) => {
+        helperCalls.push({
+          kind,
+          claims: { provider: name, providerAccountId, profile },
         });
         if (helperFailure.error !== undefined) {
           throw helperFailure.error;
         }
         return FAKE_BUNDLE;
-      },
-      resolveUserId: async () => null,
+      };
+    const convexAuth: BoundAuthHelpers<Profile> = {
+      completeSignUp: record("signUp"),
+      completeSignIn: record("signIn"),
+      resolveUserId: async () => resolvedUserId.value,
     };
     const authMutation: AuthMutationBuilder<Profile> = (fn) =>
       mutationGeneric({
@@ -92,9 +106,9 @@ const FAKE_CORE = {
 } as unknown as AuthCore;
 
 /**
- * A create-or-update-user callback reference. The fake core never invokes it.
+ * The app's user callbacks. The fake core never invokes them.
  */
-const FAKE_CALLBACK = {} as never;
+const FAKE_CALLBACKS = {} as never;
 
 /**
  * Provider options for every instance under test. The component's own
@@ -172,28 +186,28 @@ const testApp = {
     FAKE_CORE,
     "acme",
     CLAIMS_CATALOG,
-    FAKE_CALLBACK,
+    FAKE_CALLBACKS,
     OPTIONS,
   ).completeSignIn,
   completeSignInAcmeInfo: setupOauth(
     FAKE_CORE,
     "acmeInfo",
     USERINFO_CATALOG,
-    FAKE_CALLBACK,
+    FAKE_CALLBACKS,
     OPTIONS,
   ).completeSignIn,
   completeSignInEmptyId: setupOauth(
     FAKE_CORE,
     "emptyId",
     EMPTY_ID_CATALOG,
-    FAKE_CALLBACK,
+    FAKE_CALLBACKS,
     OPTIONS,
   ).completeSignIn,
   completeSignInMissingId: setupOauth(
     FAKE_CORE,
     "missingId",
     MISSING_ID_CATALOG,
-    FAKE_CALLBACK,
+    FAKE_CALLBACKS,
     OPTIONS,
   ).completeSignIn,
 };
@@ -255,7 +269,8 @@ async function mintTicket(
 
 afterEach(() => {
   vi.useRealTimers();
-  completeSignInCalls.length = 0;
+  helperCalls.length = 0;
+  resolvedUserId.value = null;
   helperFailure.error = undefined;
 });
 
@@ -271,12 +286,40 @@ describe("completeSignIn", () => {
 
     expect(bundle).toEqual(FAKE_BUNDLE);
     // The decrypted payload flowed through the catalog's profile mapping
-    // into the fake helpers.
-    expect(completeSignInCalls).toEqual([
+    // into the fake helpers. The identity is unknown to the core, so
+    // redemption took the sign-up path.
+    expect(helperCalls).toEqual([
       {
-        provider: "acme",
-        providerAccountId: "acme-sub-1",
-        profile: { id: "acme-sub-1", email: "ada@example.com", name: "Ada" },
+        kind: "signUp",
+        claims: {
+          provider: "acme",
+          providerAccountId: "acme-sub-1",
+          profile: { id: "acme-sub-1", email: "ada@example.com", name: "Ada" },
+        },
+      },
+    ]);
+  });
+
+  test("signs a returning identity in rather than signing it up again", async () => {
+    const t = setup();
+    const code = await mintTicket(t);
+
+    // Only the core knows the account has been seen before.
+    resolvedUserId.value = "user-1";
+    const bundle = await t.mutation(completeSignInAcme, {
+      code,
+      state: "state-1",
+    });
+
+    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(helperCalls).toEqual([
+      {
+        kind: "signIn",
+        claims: {
+          provider: "acme",
+          providerAccountId: "acme-sub-1",
+          profile: { id: "acme-sub-1", email: "ada@example.com", name: "Ada" },
+        },
       },
     ]);
   });
@@ -294,11 +337,14 @@ describe("completeSignIn", () => {
     });
 
     expect(bundle).toEqual(FAKE_BUNDLE);
-    expect(completeSignInCalls).toEqual([
+    expect(helperCalls).toEqual([
       {
-        provider: "acmeInfo",
-        providerAccountId: "42",
-        profile: { id: "42", login: "octocat" },
+        kind: "signUp",
+        claims: {
+          provider: "acmeInfo",
+          providerAccountId: "42",
+          profile: { id: "42", login: "octocat" },
+        },
       },
     ]);
   });
@@ -310,7 +356,7 @@ describe("completeSignIn", () => {
       state: "state-1",
     });
     expect(result).toBeNull();
-    expect(completeSignInCalls).toHaveLength(0);
+    expect(helperCalls).toHaveLength(0);
   });
 
   test("a wrong state returns null and preserves the ticket", async () => {
@@ -347,7 +393,7 @@ describe("completeSignIn", () => {
       state: "state-1",
     });
     expect(second).toBeNull();
-    expect(completeSignInCalls).toHaveLength(1);
+    expect(helperCalls).toHaveLength(1);
   });
 
   test("an expired ticket returns null", async () => {
@@ -361,7 +407,7 @@ describe("completeSignIn", () => {
       state: "state-1",
     });
     expect(result).toBeNull();
-    expect(completeSignInCalls).toHaveLength(0);
+    expect(helperCalls).toHaveLength(0);
   });
 
   test("a profile mapping that returns an empty id throws", async () => {

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -45,7 +45,7 @@ const resolvedUserId = { value: null as string | null };
 
 /**
  * When set, the fake helpers throw this instead of returning a bundle, modeling
- * the app rejecting the sign-in from its `onSignUp` / `onSignIn` callback.
+ * the app rejecting the sign-in from its `createUser` / `onSignIn` callback.
  */
 const helperFailure = { error: undefined as Error | undefined };
 

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -195,7 +195,7 @@ export function setupOauth<
 
   const { authMutation } = core.bindProvider({
     name: providerName,
-    onSignUp: callbacks.onSignUp,
+    createUser: callbacks.createUser,
     onSignIn: callbacks.onSignIn,
   });
 
@@ -271,7 +271,7 @@ export function setupOauth<
    *
    * The component calls are subtransactions of this mutation, so a
    * failure anywhere (including the app rejecting the sign-in from
-   * `onSignUp` / `onSignIn`) rolls back the ticket claim. Only a
+   * `createUser` / `onSignIn`) rolls back the ticket claim. Only a
    * successful redemption consumes the ticket.
    */
   // TODO: dowski - return the shared `vSignInSuccess` envelope like the other

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -2,8 +2,8 @@ import { mutationGeneric } from "convex/server";
 import { v } from "convex/values";
 import {
   vTokenBundle,
-  type CreateOrUpdateUserFn,
   type TokenBundle,
+  type UserCallbacks,
 } from "../../lib/types";
 import type { AuthCore } from "../../components/core/setup";
 import type { ComponentApi } from "./_generated/component.js";
@@ -152,7 +152,7 @@ export function setupOauth<
   core: AuthCore<UsersTable>,
   providerName: Provider,
   catalog: OauthCatalog<Profile, UserInfo>,
-  createOrUpdateUser: CreateOrUpdateUserFn<Provider, Profile, UsersTable>,
+  callbacks: UserCallbacks<Provider, Profile, UsersTable>,
   options: OauthProviderOptions,
 ) {
   // Validate the app-supplied options up front so mistakes fail at deploy
@@ -195,7 +195,8 @@ export function setupOauth<
 
   const { authMutation } = core.bindProvider({
     name: providerName,
-    createOrUpdateUser,
+    onSignUp: callbacks.onSignUp,
+    onSignIn: callbacks.onSignIn,
   });
 
   /**
@@ -270,7 +271,7 @@ export function setupOauth<
    *
    * The component calls are subtransactions of this mutation, so a
    * failure anywhere (including the app rejecting the sign-in from
-   * `createOrUpdateUser`) rolls back the ticket claim. Only a
+   * `onSignUp` / `onSignIn`) rolls back the ticket claim. Only a
    * successful redemption consumes the ticket.
    */
   // TODO: dowski - return the shared `vSignInSuccess` envelope like the other
@@ -311,10 +312,19 @@ export function setupOauth<
         );
       }
 
-      return await ctx.convexAuth.completeSignIn({
-        providerAccountId: profile.id,
-        profile,
-      });
+      // The same redemption flow serves a first sign-in and a return visit, so
+      // resolve the identity to pick a path. This handler is a mutation, so the
+      // lookup and the write it decides on are one transaction.
+      const existingUserId = await ctx.convexAuth.resolveUserId(profile.id);
+      return existingUserId === null
+        ? await ctx.convexAuth.completeSignUp({
+            providerAccountId: profile.id,
+            profile,
+          })
+        : await ctx.convexAuth.completeSignIn({
+            providerAccountId: profile.id,
+            profile,
+          });
     },
   });
 

--- a/packages/docs/content/docs/login-providers/anonymous.mdx
+++ b/packages/docs/content/docs/login-providers/anonymous.mdx
@@ -53,8 +53,8 @@ Add an empty `users` table to your schema in `convex/schema.ts`.
 Convex Auth will create a row for each account. You can also add application-specific fields to this table if necessary.
 
 The table does not have to be called `users` — if yours has another name, pass
-it to `setupCore`, and every provider's `attachUserCallback` will then require
-a callback typed with that table's ids:
+it to `setupCore`, and every provider's `attachUserCallbacks` will then require
+callbacks typed with that table's ids:
 
 ```ts title="convex/auth.ts"
 const core = setupCore({ component: components.auth, usersTable: "members" });
@@ -73,6 +73,13 @@ const core = setupCore({ component: components.auth, usersTable: "members" });
 
 ### Set up user creation
 
+Write an `onSignUp` mutation that creates a row in your `users` table and
+returns its id. The provider calls it for every anonymous sign-in.
+
+Providers that can recognize a returning account also take an optional
+`onSignIn` callback. The anonymous provider does not: every anonymous sign-in
+establishes a new account, so there is no return visit to hook.
+
 <include lang="ts" meta='title="convex/users.ts"'>
   ../../../../../examples/react-minimal/convex/users.ts
 </include>
@@ -89,7 +96,7 @@ rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { setupAnonymous }" highlight="export const { signInAnonymous } = setupAnonymous(core, {...}).attachUserCallback(internal.users.createOrUpdateUser);"'
+  meta='title="convex/auth.ts" highlight="import { setupAnonymous }" highlight="export const { signInAnonymous } = setupAnonymous(core, {...}).attachUserCallbacks({ onSignUp: internal.users.onSignUp });"'
 >
   ../../../../../examples/react-minimal/convex/auth.ts
 </include>

--- a/packages/docs/content/docs/login-providers/anonymous.mdx
+++ b/packages/docs/content/docs/login-providers/anonymous.mdx
@@ -73,12 +73,13 @@ const core = setupCore({ component: components.auth, usersTable: "members" });
 
 ### Set up user creation
 
-Write an `onSignUp` mutation that creates a row in your `users` table and
-returns its id. The provider calls it for every anonymous sign-in.
+Write a `createUser` mutation that creates a row in your `users` table and
+returns its id. The provider calls it for every anonymous sign-in, since each
+one establishes a new account.
 
-Providers that can recognize a returning account also take an optional
-`onSignIn` callback. The anonymous provider does not: every anonymous sign-in
-establishes a new account, so there is no return visit to hook.
+You can also attach an optional `onSignIn` mutation, called with the resolved
+`userId` right afterwards. It is the same hook every other provider gets, so
+work an app does on any sign-in has one home.
 
 <include lang="ts" meta='title="convex/users.ts"'>
   ../../../../../examples/react-minimal/convex/users.ts
@@ -96,7 +97,7 @@ rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { setupAnonymous }" highlight="export const { signInAnonymous } = setupAnonymous(core, {...}).attachUserCallbacks({ onSignUp: internal.users.onSignUp });"'
+  meta='title="convex/auth.ts" highlight="import { setupAnonymous }" highlight="export const { signInAnonymous } = setupAnonymous(core, {...}).attachUserCallbacks({ createUser: internal.users.createUser });"'
 >
   ../../../../../examples/react-minimal/convex/auth.ts
 </include>

--- a/packages/docs/content/docs/login-providers/anonymous.mdx
+++ b/packages/docs/content/docs/login-providers/anonymous.mdx
@@ -77,10 +77,6 @@ Write a `createUser` mutation that creates a row in your `users` table and
 returns its id. The provider calls it for every anonymous sign-in, since each
 one establishes a new account.
 
-You can also attach an optional `onSignIn` mutation, called with the resolved
-`userId` right afterwards. It is the same hook every other provider gets, so
-work an app does on any sign-in has one home.
-
 <include lang="ts" meta='title="convex/users.ts"'>
   ../../../../../examples/react-minimal/convex/users.ts
 </include>

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -55,8 +55,8 @@ Add a `users` table to your schema in `convex/schema.ts` with a `username` strin
 Convex Auth will create a row for each account. You can also add application-specific fields to this table if necessary.
 
 The table does not have to be called `users` — if yours has another name, pass
-it to `setupCore`, and every provider's `attachUserCallback` will then require
-a callback typed with that table's ids:
+it to `setupCore`, and every provider's `attachUserCallbacks` will then require
+callbacks typed with that table's ids:
 
 ```ts title="convex/auth.ts"
 const core = setupCore({ component: components.auth, usersTable: "members" });
@@ -75,6 +75,13 @@ const core = setupCore({ component: components.auth, usersTable: "members" });
 
 ### Set up user creation
 
+Write an `onSignUp` mutation that creates a row in your `users` table and
+returns its id. The provider calls it the first time it sees an account.
+
+You can also attach an optional `onSignIn` mutation, called with the resolved
+`userId` whenever an existing account signs back in. Use it to sync your user
+record from the latest profile, or leave it out if there is nothing to do.
+
 <include lang="ts" meta='title="convex/users.ts"'>
   ../../../../../examples/react-password/convex/users.ts
 </include>
@@ -91,7 +98,7 @@ creates your user rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { setupUsernamePassword }" highlight="export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(...).attachUserCallback(internal.users.createOrUpdateUser);"'
+  meta='title="convex/auth.ts" highlight="import { setupUsernamePassword }" highlight="export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(...).attachUserCallbacks({ onSignUp: internal.users.onSignUp });"'
 >
   ../../../../../examples/react-password/convex/auth.ts
 </include>

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -75,12 +75,13 @@ const core = setupCore({ component: components.auth, usersTable: "members" });
 
 ### Set up user creation
 
-Write an `onSignUp` mutation that creates a row in your `users` table and
+Write a `createUser` mutation that creates a row in your `users` table and
 returns its id. The provider calls it the first time it sees an account.
 
 You can also attach an optional `onSignIn` mutation, called with the resolved
-`userId` whenever an existing account signs back in. Use it to sync your user
-record from the latest profile, or leave it out if there is nothing to do.
+`userId` on every sign-in, the first one included. Anything you want to happen
+each time someone signs in belongs there, so `createUser` only has to handle
+what is true at creation time. Leave it out if there is nothing to do.
 
 <include lang="ts" meta='title="convex/users.ts"'>
   ../../../../../examples/react-password/convex/users.ts
@@ -98,7 +99,7 @@ creates your user rows, in `convex/auth.ts`:
 
 <include
   lang="ts"
-  meta='title="convex/auth.ts" highlight="import { setupUsernamePassword }" highlight="export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(...).attachUserCallbacks({ onSignUp: internal.users.onSignUp });"'
+  meta='title="convex/auth.ts" highlight="import { setupUsernamePassword }" highlight="export const { signUpWithPassword, signInWithPassword } = setupUsernamePassword(...).attachUserCallbacks({ createUser: internal.users.createUser });"'
 >
   ../../../../../examples/react-password/convex/auth.ts
 </include>


### PR DESCRIPTION
Split the user callback to differentiate new and returning users

The provider APIs now take a createUser function and an optional onSignIn function

createUser is called only the first time a user signs in. onSignIn is called on every sign in, including the first.

The bulk of the changes are in `core/public.ts` and `core/setup.ts`, but lots of other files were touched in smaller ways (mostly docs/naming). The examples are all updated and show how the API is used. The Next.js one shows how `onSignIn` might be used across providers and the others show that it is optional and doesn't need to be provided.