### PR TITLE
Fix encoding bug in `ECDSAPublicKey.encodeSEC1Uncompressed`

### DIFF
--- a/packages/core/src/vendor/oslo/README.md
+++ b/packages/core/src/vendor/oslo/README.md
@@ -38,5 +38,9 @@ becomes `crypto/ecdsa.ts`).
   like Convex functions). The NIST signature- and hash-verification vectors
   from the `@oslojs/crypto` repository are ported for the algorithms kept here
   (SHA-256, ECDSA P-256, RSASSA-PKCS1-v1.5) in `crypto/nist-vectors.test.ts`.
+- Bug fix in `crypto/ecdsa.ts`: `ECDSAPublicKey.encodeSEC1Uncompressed()` wrote
+  the `y` coordinate left-aligned in its slot. A coordinate smaller than 2^248
+  (about 1 key in 256) was therefore shifted and padded with trailing zeroes,
+  which made every signature check with that key fail.
 
 When changing this code, keep the changes minimal and covered by the tests.

--- a/packages/core/src/vendor/oslo/crypto/ecdsa.test.ts
+++ b/packages/core/src/vendor/oslo/crypto/ecdsa.test.ts
@@ -78,6 +78,27 @@ test("decodeSEC1PublicKey()", () => {
   ).toStrictEqual(publicKey);
 });
 
+// Added to the ported tests: a coordinate that is smaller than 2^248 has fewer
+// than 32 significant bytes, and must be right-aligned in its slot.
+test("ECDSAPublicKey.encodeSEC1Uncompressed() pads short coordinates", () => {
+  const x = 0x00ffn;
+  const y = 0x01n;
+  const encoded = new ECDSAPublicKey(p256, x, y).encodeSEC1Uncompressed();
+  expect(encoded).toStrictEqual(
+    new Uint8Array([
+      0x04,
+      ...new Array<number>(30).fill(0x00),
+      0x00,
+      0xff,
+      ...new Array<number>(31).fill(0x00),
+      0x01,
+    ]),
+  );
+  const decoded = decodeSEC1PublicKey(p256, encoded);
+  expect(decoded.x).toBe(x);
+  expect(decoded.y).toBe(y);
+});
+
 describe("ECDSAPublicKey", async () => {
   const data = new TextEncoder().encode("hello world");
 

--- a/packages/core/src/vendor/oslo/crypto/ecdsa.ts
+++ b/packages/core/src/vendor/oslo/crypto/ecdsa.ts
@@ -351,8 +351,10 @@ export class ECDSAPublicKey {
     bytes[0] = 0x04;
     const xBytes = bigIntBytes(this.x);
     const yBytes = bigIntBytes(this.y);
+    // Both coordinates are right-aligned in their fixed-size slot. `bigIntBytes`
+    // omits the leading zero bytes, which happens for about 1 in 256 keys.
     bytes.set(xBytes, 1 + this.curve.size - xBytes.byteLength);
-    bytes.set(yBytes, 1 + this.curve.size);
+    bytes.set(yBytes, 1 + this.curve.size * 2 - yBytes.byteLength);
     return bytes;
   }
 


### PR DESCRIPTION
Claude found a bug in Oslo that happens 1/256 of the times.

The bug caused the following CI flake: https://github.com/get-convex/convex-auth/actions/runs/32166958695/job/95808699570