### PR TITLE
Examples: keep no fields in the app users table

### DIFF
--- a/examples/react-minimal/convex/currentUser.ts
+++ b/examples/react-minimal/convex/currentUser.ts
@@ -13,7 +13,7 @@ export const loggedInUser = query({
     if (identity === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">;
+    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;

--- a/examples/react-passkey/convex/currentUser.ts
+++ b/examples/react-passkey/convex/currentUser.ts
@@ -1,4 +1,5 @@
 import { query } from "./_generated/server";
+import { components } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 
 /**
@@ -13,12 +14,20 @@ export const loggedInUser = query({
     if (identity === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">;
+    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;
     }
+    const username = await ctx.runQuery(
+      components.authUsername.public.getUsername,
+      { userId },
+    );
+    if (username === null) {
+      // Every user signs up with a username, so this must not occur.
+      throw new Error(`User ${userId} unexpectedly has no username`);
+    }
 
-    return { id: user._id, username: user.username };
+    return { id: user._id, username };
   },
 });

--- a/examples/react-passkey/convex/schema.ts
+++ b/examples/react-passkey/convex/schema.ts
@@ -1,8 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
-import { v } from "convex/values";
 
 export default defineSchema({
-  users: defineTable({
-    username: v.string(),
-  }),
+  users: defineTable({}),
 });

--- a/examples/react-passkey/convex/users.ts
+++ b/examples/react-passkey/convex/users.ts
@@ -2,8 +2,8 @@ import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Create the user row for a new passkey account and return its id. The
- * provider supplies the username it just registered in `profile`.
+ * Create the user row for a new passkey account and return its id. This
+ * example keeps no data in the row, but your app can put a profile here.
  */
 export const createUser = internalMutation({
   args: {
@@ -12,7 +12,7 @@ export const createUser = internalMutation({
     profile: v.object({ username: v.string() }),
   },
   returns: v.id("users"),
-  handler: async (ctx, args) => {
-    return await ctx.db.insert("users", { username: args.profile.username });
+  handler: async (ctx) => {
+    return await ctx.db.insert("users", {});
   },
 });

--- a/examples/react-password/convex/currentUser.ts
+++ b/examples/react-password/convex/currentUser.ts
@@ -1,4 +1,5 @@
 import { query } from "./_generated/server";
+import { components } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 
 /**
@@ -13,12 +14,20 @@ export const loggedInUser = query({
     if (identity === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">;
+    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;
     }
+    const username = await ctx.runQuery(
+      components.authUsername.public.getUsername,
+      { userId },
+    );
+    if (username === null) {
+      // Every user signs up with a username, so this must not occur.
+      throw new Error(`User ${userId} unexpectedly has no username`);
+    }
 
-    return { id: user._id, username: user.username };
+    return { id: user._id, username };
   },
 });

--- a/examples/react-password/convex/schema.ts
+++ b/examples/react-password/convex/schema.ts
@@ -1,8 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
-import { v } from "convex/values";
 
 export default defineSchema({
-  users: defineTable({
-    username: v.string(),
-  }),
+  users: defineTable({}),
 });

--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -2,8 +2,8 @@ import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Create the user row for a new password account and return its id. The
- * provider supplies the username it just registered in `profile`.
+ * Create the user row for a new password account and return its id. This
+ * example keeps no data in the row, but your app can put a profile here.
  */
 export const createUser = internalMutation({
   args: {
@@ -12,7 +12,7 @@ export const createUser = internalMutation({
     profile: v.object({ username: v.string() }),
   },
   returns: v.id("users"),
-  handler: async (ctx, args) => {
-    return await ctx.db.insert("users", { username: args.profile.username });
+  handler: async (ctx) => {
+    return await ctx.db.insert("users", {});
   },
 });

--- a/packages/docs/content/docs/login-providers/password.mdx
+++ b/packages/docs/content/docs/login-providers/password.mdx
@@ -50,7 +50,8 @@ username identifies:
 
 ### Add a `users` table to the schema
 
-Add a `users` table to your schema in `convex/schema.ts` with a `username` string field.
+Add an empty `users` table to your schema in `convex/schema.ts`. The username
+component keeps the username, so the table does not need a field for it.
 
 Convex Auth will create a row for each account. You can also add application-specific fields to this table if necessary.
 
@@ -64,7 +65,7 @@ const core = setupCore({ component: components.auth, usersTable: "members" });
 
 <include
   lang="ts"
-  meta='title="convex/schema.ts" highlight="users: defineTable({...}),"'
+  meta='title="convex/schema.ts" highlight="users: defineTable({}),"'
 >
   ../../../../../examples/react-password/convex/schema.ts
 </include>


### PR DESCRIPTION
The react-password and react-passkey examples duplicated the username into their own `users` table.

The username component already stores that data, so storing a copy of it in the `users` table is a potential source of inconsistencies. While applications might want to create such a copy for various reasons, it’s not a pattern we should encourage, and our official examples should avoid it.

I modified both examples so that instead, they:

- define `users: defineTable({})` with no fields
- have `createUser` insert an empty `users` row
- read the username in `currentUser.loggedInUser` with a component query (`components.authUsername.public.getUsername`), and throw if the user has no username
