### PR TITLE
Add oauth React hooks

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -41,6 +41,21 @@ preserving the login-CSRF property.
 rejected at setup (`packages/core/src/oauth/component/setup.ts`), so React
 Native apps must return via https universal links / app links.
 
+React Native also has no page URL for the client to work from: it defines
+`window` but no `window.location`. So the startup handler that finishes a flow
+from callback params does nothing there, and `signIn` requires an explicit
+`redirectTo` (`packages/core/src/oauth/client.ts`). Supporting React Native
+properly means deciding what `redirectTo` looks like when it can't be a page
+URL.
+
+## OAuth isn't wired into the Next.js client
+
+`ConvexAuthNextjsProvider` builds its `AuthClient` with no ambient sign-ins and
+takes no prop for them (`packages/core/src/nextjs/index.tsx`), so `oauth()` is
+never registered and the OAuth hooks throw wherever they're used under SSR. The
+sign-in api pointed at the auth proxy is already there, so what's missing is the
+registration.
+
 ## Apple sign-in isn't supported yet
 
 Two gaps. The callback route only accepts GET redirects, and Apple POSTs the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "./providers/anonymous/react": "./src/components/anonymous/react.tsx",
     "./providers/anonymous/*": "./src/components/anonymous/*.ts",
     "./providers/oauth/convex.config.js": "./src/oauth/component/convex.config.ts",
+    "./providers/oauth/react": "./src/oauth/react.ts",
     "./providers/oauth/*": "./src/oauth/component/*.ts",
     "./providers/password/convex.config.js": "./src/components/password/convex.config.ts",
     "./providers/password/react": "./src/components/password/react.tsx",

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -1,101 +1,22 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { getFunctionName, makeFunctionReference } from "convex/server";
 import type { AuthSignInApi } from "../browser/ambientSignInClient";
 import { AuthClient, type AuthState } from "../browser/sessionManager";
-import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
+import { InMemoryStorage } from "../browser/storage";
 import type { TokenBundle } from "../lib/types";
+import { oauth } from "./client";
 import {
-  OAUTH_ACTIONS_KEY,
-  OAUTH_FLOW_ERROR_KEY,
-  OAUTH_SETUP_ID,
-  oauth,
-  type OauthActions,
-  type OauthFlowError,
-  type OauthProviderRefs,
-} from "./client";
-
-const NAMESPACE = "https://happy-animal-123.convex.cloud";
-
-const bundle: TokenBundle = {
-  accessToken: "access-1",
-  accessTokenExpiresAt: 0,
-  refreshToken: "refresh-1",
-  refreshTokenExpiresAt: 0,
-  userId: "user-1",
-};
-
-// A stand-in provider. The refs carry real paths because `signIn` saves the
-// completeSignIn path and completion rebuilds the reference from it, so
-// assertions compare paths with `getFunctionName`, not references.
-const acmeStart = makeFunctionReference<"mutation">("auth:startSignInAcme");
-const acmeComplete = makeFunctionReference<"mutation">(
-  "auth:completeSignInAcme",
-);
-const ACME_REFS: OauthProviderRefs = {
-  providerName: "acme",
-  startSignIn: acmeStart,
-  completeSignIn: acmeComplete,
-};
-
-/** The oauth sign-in's scoped storage view over `storage`. */
-function flowStorage(storage: InMemoryStorage) {
-  return new NamespacedStorage(storage, NAMESPACE).forSignIn(OAUTH_SETUP_ID);
-}
-
-/** Store a pending flow the way `signIn` would before navigating away. */
-function seedPendingFlow(
-  storage: InMemoryStorage,
-  {
-    providerName = "acme",
-    state = "state-1",
-    completeSignIn = "auth:completeSignInAcme",
-  } = {},
-) {
-  void flowStorage(storage).set(
-    "flow",
-    JSON.stringify({ providerName, state, completeSignIn }),
-  );
-}
-
-/** Run the real oauth setup against an AuthClient with a fake sign-in api. */
-function setupOAuth({ storage = new InMemoryStorage() } = {}) {
-  const mutation = vi.fn();
-  const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
-  const client = new AuthClient({
-    mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
-    storage,
-    storageNamespace: NAMESPACE,
-    ambientSignIns: { signIns: [oauth()], signInApi },
-  });
-  const oauthValues = client.ambientSignInValues(OAUTH_SETUP_ID);
-  const actions = oauthValues.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
-  const flowError = () =>
-    oauthValues.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
-  return { client, mutation, actions, flowError, storage };
-}
-
-// Save original navigator.product value so it can be restored. Can't just mock
-// the window entirely as we do elsewhere because this test runs in jsdom env.
-const ORIGINAL_PRODUCT = Object.getOwnPropertyDescriptor(
-  window.navigator,
-  "product",
-);
-
-/** Undo the React Native stub's shadowing of `navigator.product`. */
-function restoreNavigatorProduct(): void {
-  if (ORIGINAL_PRODUCT === undefined) {
-    delete (window.navigator as { product?: string }).product;
-  } else {
-    Object.defineProperty(window.navigator, "product", ORIGINAL_PRODUCT);
-  }
-}
-
-/** The function path the fake `mutation` was called with. */
-function calledPath(mutation: ReturnType<typeof vi.fn>, call = 0): string {
-  return getFunctionName(mutation.mock.calls[call]![0] as never);
-}
+  ACME_REFS,
+  NAMESPACE,
+  bundle,
+  calledPath,
+  flowStorage,
+  readFlow,
+  restoreNavigatorProduct,
+  seedPendingFlow,
+  setupOAuth,
+  stubReactNative,
+} from "./testFlow";
 
 describe("OAuth client", () => {
   afterEach(() => {
@@ -253,7 +174,7 @@ describe("OAuth client", () => {
 
     expect(flowError()?.code).toBe("access_denied");
     // The flow ended in an error, so the stored state can never complete.
-    await vi.waitFor(() => expect(flowStorage(storage).get("flow")).toBeNull());
+    await vi.waitFor(() => expect(readFlow(storage)).toBeNull());
   });
 
   test("an unknown error param normalizes to oauth_error", async () => {
@@ -323,12 +244,7 @@ describe("OAuth client", () => {
   });
 
   test("signIn starts a flow, persists it, and returns the redirect", async () => {
-    // The React Native branch returns the URL instead of navigating, which
-    // also keeps jsdom (no navigation support) happy.
-    Object.defineProperty(window.navigator, "product", {
-      value: "ReactNative",
-      configurable: true,
-    });
+    stubReactNative();
     const { mutation, actions, storage } = setupOAuth();
     mutation.mockResolvedValueOnce({
       redirect: "https://provider.example/auth?client_id=x",
@@ -339,7 +255,7 @@ describe("OAuth client", () => {
       redirectTo: "http://localhost/app",
     });
 
-    expect(mutation).toHaveBeenCalledExactlyOnceWith(acmeStart, {
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(ACME_REFS.startSignIn, {
       redirectTo: "http://localhost/app",
     });
     expect(outcome).toEqual({
@@ -347,13 +263,11 @@ describe("OAuth client", () => {
     });
     // The persisted flow carries the completeSignIn function path, so
     // completion can run on a page that never held the references.
-    expect(flowStorage(storage).get("flow")).toBe(
-      JSON.stringify({
-        providerName: "acme",
-        state: "state-1",
-        completeSignIn: "auth:completeSignInAcme",
-      }),
-    );
+    expect(readFlow(storage)).toEqual({
+      providerName: "acme",
+      state: "state-1",
+      completeSignIn: "auth:completeSignInAcme",
+    });
   });
 
   test("signIn with a code completes the pending flow", async () => {
@@ -376,10 +290,7 @@ describe("OAuth client", () => {
 
   test("signIn clears a previous flow error", async () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
-    Object.defineProperty(window.navigator, "product", {
-      value: "ReactNative",
-      configurable: true,
-    });
+    stubReactNative();
     const { client, mutation, actions, flowError } = setupOAuth();
     await client.init();
     expect(flowError()?.code).toBe("access_denied");
@@ -388,7 +299,8 @@ describe("OAuth client", () => {
       redirect: "https://provider.example/auth",
       state: "state-2",
     });
-    await actions.signIn(ACME_REFS);
+    // React Native has no page URL to default to, so `redirectTo` is required.
+    await actions.signIn(ACME_REFS, { redirectTo: "http://localhost/app" });
 
     expect(flowError()).toBeNull();
   });

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -69,7 +69,8 @@ export type OauthFlowError = {
 /** Options accepted by {@link OauthActions.signIn}. */
 export type SignInOptions = {
   /**
-   * Where the flow returns to when it finishes. Defaults to the current URL.
+   * Where the flow returns to when it finishes. Defaults to the current URL,
+   * and is required where there is no current URL, such as React Native.
    * Must be an http or https URL. Custom schemes like `myapp://` are not
    * supported yet.
    */
@@ -122,10 +123,13 @@ const SERVER_ERRORS: ReadonlySet<string> = new Set([
 const OAUTH_FLOW_STORAGE_KEY = "flow";
 
 /** What `signIn` saves before it navigates to the identity provider. */
-type PendingFlow = {
+export type PendingFlow = {
   /** Which provider the flow belongs to. */
   providerName: string;
-  /** The state minted at sign-in. Proof this client started the flow. */
+  /**
+   * The state the server gave back at sign-in. Proof this client started the
+   * flow.
+   */
   state: string;
   /**
    * The path of the provider's `completeSignIn` mutation, from
@@ -137,6 +141,18 @@ type PendingFlow = {
    */
   completeSignIn: string;
 };
+
+/**
+ * The current page URL, or null where there is none. React Native defines
+ * `window` but no `window.location`, so checking for `window` alone isn't
+ * enough.
+ */
+function currentHref(): string | null {
+  if (typeof window === "undefined" || window.location === undefined) {
+    return null;
+  }
+  return window.location.href;
+}
 
 /**
  * Read and remove the saved sign-in flow. It is removed even if the redeem
@@ -233,10 +249,11 @@ export function oauth(): AmbientSignInClient {
      * own purposes is left alone.
      */
     const handleCallback = (): void => {
-      if (typeof window === "undefined") {
+      const href = currentHref();
+      if (href === null) {
         return;
       }
-      const url = new URL(window.location.href);
+      const url = new URL(href);
       const code = url.searchParams.get(OAUTH_CODE_PARAM);
       const errorParam = url.searchParams.get(OAUTH_ERROR_PARAM);
       if (code === null && errorParam === null) {
@@ -268,12 +285,23 @@ export function oauth(): AmbientSignInClient {
 
     /** Start a provider's flow, or finish a saved one when `code` is given. */
     const signIn: OauthActions["signIn"] = async (refs, options) => {
-      setFlowError(null);
       if (options?.code !== undefined) {
+        setFlowError(null);
         return { signedIn: await completeFlow(options.code) };
       }
+      const href = currentHref();
+      const redirectTo = options?.redirectTo ?? href;
+      if (redirectTo === null) {
+        throw new Error(
+          "`redirectTo` is required where there is no current page URL, " +
+            "such as React Native.",
+        );
+      }
+      // Cleared here rather than at the top, so a call that throws above
+      // leaves any error the app is showing alone.
+      setFlowError(null);
       const { redirect, state } = await signInApi.mutation(refs.startSignIn, {
-        redirectTo: options?.redirectTo ?? window.location.href,
+        redirectTo,
       });
       await storage.set(
         OAUTH_FLOW_STORAGE_KEY,
@@ -284,9 +312,10 @@ export function oauth(): AmbientSignInClient {
         } satisfies PendingFlow),
       );
       const url = new URL(redirect);
-      // Don't navigate in React Native. The app opens the returned URL in an
-      // in-app browser and finishes with `signIn(refs, { code })`.
-      if (navigator.product !== "ReactNative") {
+      // Don't navigate where there's no page URL to leave. React Native has
+      // none, so it gets the url back, opens it in an in-app browser, and
+      // finishes with `signIn(refs, { code })`.
+      if (href !== null && navigator.product !== "ReactNative") {
         window.location.href = url.toString();
       }
       return { redirect: url };

--- a/packages/core/src/oauth/clientEnvironment.test.ts
+++ b/packages/core/src/oauth/clientEnvironment.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+//
+// jsdom always has a `window.location`, so the client's no-page-URL cases need
+// their own file with a node environment.
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ACME_REFS, readFlow, setupOAuth } from "./testFlow";
+
+describe("OAuth client with no page URL", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("init does nothing when there is no window", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client, mutation } = setupOAuth();
+
+    await client.init();
+
+    expect(logged).not.toHaveBeenCalled();
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("init does nothing when the window has no location", async () => {
+    // The React Native shape. Reading `window.location.href` here would throw,
+    // and the thrown error would be logged as a failed init callback.
+    vi.stubGlobal("window", {});
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client, mutation } = setupOAuth();
+
+    await client.init();
+
+    expect(logged).not.toHaveBeenCalled();
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("signIn without redirectTo says redirectTo is required", async () => {
+    vi.stubGlobal("window", {});
+    const { actions, mutation } = setupOAuth();
+
+    await expect(actions.signIn(ACME_REFS)).rejects.toThrow(
+      /`redirectTo` is required/,
+    );
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("a signIn that throws leaves the previous flow error alone", async () => {
+    vi.stubGlobal("window", {});
+    const { actions, flowError } = setupOAuth();
+    // A code with no stored flow is the cheapest way to put an error in place.
+    await actions.signIn(ACME_REFS, { code: "code-1" });
+    expect(flowError()?.code).toBe("invalid_flow");
+
+    await expect(actions.signIn(ACME_REFS)).rejects.toThrow();
+
+    expect(flowError()?.code).toBe("invalid_flow");
+  });
+
+  test("signIn with redirectTo starts a flow without navigating", async () => {
+    // Assigning `window.location.href` would throw here, so a flow that starts
+    // must not try. React Native opens the returned url itself.
+    vi.stubGlobal("window", {});
+    const { actions, mutation, storage } = setupOAuth();
+    mutation.mockResolvedValueOnce({
+      redirect: "https://provider.example/auth",
+      state: "state-1",
+    });
+
+    const outcome = await actions.signIn(ACME_REFS, {
+      redirectTo: "https://app.example/done",
+    });
+
+    expect(outcome).toEqual({
+      redirect: new URL("https://provider.example/auth"),
+    });
+    expect(readFlow(storage)).toEqual({
+      providerName: "acme",
+      state: "state-1",
+      completeSignIn: "auth:completeSignInAcme",
+    });
+  });
+});

--- a/packages/core/src/oauth/react.test.tsx
+++ b/packages/core/src/oauth/react.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { anyApi, makeFunctionReference } from "convex/server";
+import { ReactNode, StrictMode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AuthClient } from "../browser/sessionManager";
+import { InMemoryStorage } from "../browser/storage";
+import { useAuthToken } from "../react";
+import { AuthProvider, useAuth } from "../react/client";
+import { stubSignInApi } from "../react/testSignInApi";
+import {
+  useOauth,
+  useOauthSignIn,
+  useSignInWithGithub,
+  useSignInWithGoogle,
+  type OauthProviderApi,
+  type OauthProviderRefs,
+} from "./react";
+import {
+  ACME_REFS,
+  NAMESPACE,
+  bundle,
+  calledPath,
+  oauthClient,
+  readFlow,
+  restoreNavigatorProduct,
+  seedPendingFlow,
+  stubReactNative,
+} from "./testFlow";
+
+// Function references with the paths a generated `api.auth` would have. Nothing
+// resolves them. The sign-in api is a mock, so these are addresses the
+// assertions compare.
+const googleStart = makeFunctionReference<"mutation">(
+  "auth:startSignInGoogle",
+) as OauthProviderApi["startSignIn"];
+const googleComplete = makeFunctionReference<"mutation">(
+  "auth:completeSignInGoogle",
+) as OauthProviderApi["completeSignIn"];
+
+/** The part of a generated `api.auth` the Google hook reads. */
+const TYPED_API = {
+  startSignInGoogle: googleStart,
+  completeSignInGoogle: googleComplete,
+};
+
+/** The part of a generated `api.auth` the GitHub hook reads. */
+const GITHUB_API = {
+  startSignInGithub: makeFunctionReference<"mutation">(
+    "auth:startSignInGithub",
+  ) as OauthProviderApi["startSignIn"],
+  completeSignInGithub: makeFunctionReference<"mutation">(
+    "auth:completeSignInGithub",
+  ) as OauthProviderApi["completeSignIn"],
+};
+
+/** What the Google hook builds from {@link TYPED_API}, for seeding a flow. */
+const GOOGLE_REFS: OauthProviderRefs = {
+  providerName: "google",
+  startSignIn: googleStart,
+  completeSignIn: googleComplete,
+};
+
+/** Auth state plus the Google sign-in, which most tests here read. */
+function useGoogleFlow(api = TYPED_API) {
+  return {
+    auth: useAuth(),
+    token: useAuthToken(),
+    oauth: useSignInWithGoogle(api),
+    flowError: useOauth().flowError,
+  };
+}
+
+/** Render `hook` in the tree the way `ConvexAuthProvider` sets it up. */
+function renderOAuth<T>(
+  hook: () => T,
+  {
+    storage = new InMemoryStorage(),
+    strictMode = false,
+    onMutation,
+  }: {
+    storage?: InMemoryStorage;
+    strictMode?: boolean;
+    /** Configure the mutation mock before render (mount effects call it). */
+    onMutation?: (mutation: ReturnType<typeof vi.fn>) => void;
+  } = {},
+) {
+  const { client, signInApi, mutation } = oauthClient(storage);
+  onMutation?.(mutation);
+  const tree = (children: ReactNode) => (
+    <AuthProvider authClient={client} signInApi={signInApi}>
+      {children}
+    </AuthProvider>
+  );
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    strictMode ? <StrictMode>{tree(children)}</StrictMode> : tree(children);
+  const rendered = renderHook(hook, { wrapper });
+  return { ...rendered, client, mutation, storage };
+}
+
+describe("OAuth React client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(null, "", "/");
+    restoreNavigatorProduct();
+  });
+
+  test("the hooks throw when oauth() is not registered", () => {
+    const client = new AuthClient({
+      mode: "spa",
+      authApi: { refreshSession: async () => null, signOut: async () => {} },
+      storage: new InMemoryStorage(),
+      storageNamespace: NAMESPACE,
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AuthProvider authClient={client} signInApi={stubSignInApi().signInApi}>
+        {children}
+      </AuthProvider>
+    );
+    expect(() =>
+      renderHook(() => useSignInWithGoogle(TYPED_API), { wrapper }),
+    ).toThrow(/No OAuth setup is registered/);
+    expect(() => renderHook(() => useOauth(), { wrapper })).toThrow(
+      /No OAuth setup is registered/,
+    );
+  });
+
+  test("StrictMode double-mount redeems a callback code once", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage, GOOGLE_REFS);
+
+    const { result, mutation } = renderOAuth(useGoogleFlow, {
+      storage,
+      strictMode: true,
+      onMutation: (mutation) => mutation.mockResolvedValueOnce(bundle),
+    });
+
+    await waitFor(() => expect(result.current.auth.isAuthenticated).toBe(true));
+    expect(mutation).toHaveBeenCalledOnce();
+    // Completion rebuilt the reference from the persisted function path.
+    expect(calledPath(mutation)).toBe("auth:completeSignInGoogle");
+    expect(mutation.mock.calls[0]![1]).toEqual({
+      code: "code-1",
+      state: "state-1",
+    });
+    expect(result.current.token).toBe("access-1");
+    expect(result.current.flowError).toBeNull();
+    expect(window.location.search).toBe("");
+  });
+
+  test("a callback error param reaches useOauth's flowError", async () => {
+    window.history.replaceState(null, "", "/?convexAuthError=access_denied");
+
+    const { result, mutation } = renderOAuth(useGoogleFlow);
+
+    await waitFor(() =>
+      expect(result.current.flowError?.code).toBe("access_denied"),
+    );
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("signIn from the hook starts a flow with the picked references", async () => {
+    stubReactNative();
+    const { result, mutation, storage } = renderOAuth(useGoogleFlow);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    mutation.mockResolvedValueOnce({
+      redirect: "https://provider.example/auth?client_id=x",
+      state: "state-1",
+    });
+
+    const outcome = await act(async () => {
+      return await result.current.oauth.signInGoogle({
+        redirectTo: "http://localhost/app",
+      });
+    });
+
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(googleStart, {
+      redirectTo: "http://localhost/app",
+    });
+    expect(outcome).toEqual({
+      redirect: new URL("https://provider.example/auth?client_id=x"),
+    });
+    // The persisted flow carries the completeSignIn function path, so
+    // completion can run on a page that never mounted the hook.
+    expect(readFlow(storage)).toEqual({
+      providerName: "google",
+      state: "state-1",
+      completeSignIn: "auth:completeSignInGoogle",
+    });
+  });
+
+  test("signInGithub starts a flow with the GitHub references", async () => {
+    stubReactNative();
+    const { result, mutation, storage } = renderOAuth(() => ({
+      auth: useAuth(),
+      oauth: useSignInWithGithub(GITHUB_API),
+    }));
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    mutation.mockResolvedValueOnce({
+      redirect: "https://github.example/auth",
+      state: "state-2",
+    });
+
+    await act(async () => {
+      await result.current.oauth.signInGithub({
+        redirectTo: "http://localhost/app",
+      });
+    });
+
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(
+      GITHUB_API.startSignInGithub,
+      { redirectTo: "http://localhost/app" },
+    );
+    expect(readFlow(storage)).toEqual({
+      providerName: "github",
+      state: "state-2",
+      completeSignIn: "auth:completeSignInGithub",
+    });
+  });
+
+  test("useOauthSignIn runs a provider that ships no hook of its own", async () => {
+    stubReactNative();
+    const { result, mutation, storage } = renderOAuth(() => ({
+      auth: useAuth(),
+      oauth: useOauthSignIn(ACME_REFS),
+    }));
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    mutation.mockResolvedValueOnce({
+      redirect: "https://acme.example/auth",
+      state: "state-3",
+    });
+
+    const outcome = await act(async () => {
+      return await result.current.oauth.signIn({
+        redirectTo: "http://localhost/app",
+      });
+    });
+
+    expect(mutation).toHaveBeenCalledExactlyOnceWith(ACME_REFS.startSignIn, {
+      redirectTo: "http://localhost/app",
+    });
+    expect(outcome).toEqual({
+      redirect: new URL("https://acme.example/auth"),
+    });
+    expect(readFlow(storage)).toEqual({
+      providerName: "acme",
+      state: "state-3",
+      completeSignIn: "auth:completeSignInAcme",
+    });
+  });
+
+  test("signInGoogle keeps a stable identity across rerenders", async () => {
+    // `anyApi` is what the generated `api` is, and it returns a new reference
+    // object on every property access. The hook's memo has to key on the
+    // function paths for the identity below to hold.
+    const { result, rerender } = renderOAuth(() =>
+      useGoogleFlow(anyApi.auth as unknown as typeof TYPED_API),
+    );
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+    const first = result.current.oauth.signInGoogle;
+
+    rerender();
+
+    expect(result.current.oauth.signInGoogle).toBe(first);
+  });
+
+  test("the hook params accept the api module structurally", () => {
+    type GoogleParam = Parameters<typeof useSignInWithGoogle>[0];
+    const apiModule = {
+      ...TYPED_API,
+      signOut: undefined as unknown,
+      startSignInGithub: undefined as unknown,
+    };
+    const full: GoogleParam = apiModule;
+    void full;
+    // @ts-expect-error - missing completeSignInGoogle must not typecheck.
+    const missing: GoogleParam = { startSignInGoogle: googleStart };
+    void missing;
+  });
+});

--- a/packages/core/src/oauth/react.ts
+++ b/packages/core/src/oauth/react.ts
@@ -1,0 +1,171 @@
+/**
+ * React client for the OAuth providers, exported at
+ * `@convex-dev/auth/providers/oauth/react`.
+ *
+ * OAuth is registered by default in `ConvexAuthProvider`. Each supported
+ * provider ships a hook that reads its sign-in functions from the module you
+ * pass in, usually the generated `api.auth`. {@link useOauth} returns the
+ * state that isn't tied to one provider.
+ *
+ * ```tsx
+ * const { signInGoogle } = useSignInWithGoogle(api.auth);
+ * const { flowError } = useOauth();
+ * await signInGoogle();
+ * ```
+ *
+ * Apps that re-exported the functions under other names pass them explicitly.
+ * `useSignInWithGoogle({ startSignInGoogle: api.auth.begin, completeSignInGoogle: api.auth.finish })`
+ *
+ * @module
+ */
+"use client";
+
+import { getFunctionName } from "convex/server";
+import { useMemo } from "react";
+import { useAmbientSignInValue } from "../react/providers";
+import {
+  OAUTH_ACTIONS_KEY,
+  OAUTH_FLOW_ERROR_KEY,
+  OAUTH_SETUP_ID,
+  type OauthActions,
+  type OauthFlowError,
+  type OauthProviderApi,
+  type OauthProviderRefs,
+  type SignInOptions,
+  type SignInOutcome,
+} from "./client";
+
+export { oauth } from "./client";
+export type {
+  OauthActions,
+  OauthFlowError,
+  OauthFlowErrorCode,
+  OauthProviderApi,
+  OauthProviderRefs,
+  SignInOptions,
+  SignInOutcome,
+} from "./client";
+
+/** What every hook here throws when the OAuth setup published nothing. */
+const NOT_REGISTERED_ERROR =
+  "No OAuth setup is registered. ConvexAuthProvider registers oauth() from " +
+  "@convex-dev/auth/providers/oauth/react by default, so include it yourself " +
+  "if you set the `ambientSignIns` prop. OAuth isn't supported under " +
+  "ConvexAuthNextjsProvider yet.";
+
+/** What {@link useOauth} returns. */
+export type UseOauthReturn = {
+  /**
+   * Why the last sign-in attempt failed, or `null`. Cleared on the next
+   * sign-in. Your app supplies the message text for each `code`.
+   */
+  flowError: OauthFlowError | null;
+};
+
+/**
+ * Read OAuth state that isn't tied to one provider. A flow completes on
+ * whichever page it redirects back to, so `flowError` can appear on a page
+ * that never calls a sign-in hook. An app-level error banner can read it
+ * here without any provider's function references.
+ */
+export function useOauth(): UseOauthReturn {
+  const flowError = useAmbientSignInValue<OauthFlowError | null>(
+    OAUTH_SETUP_ID,
+    OAUTH_FLOW_ERROR_KEY,
+  );
+  // The value is published at setup, so `undefined` means oauth() was never
+  // registered.
+  if (flowError === undefined) {
+    throw new Error(NOT_REGISTERED_ERROR);
+  }
+  return { flowError };
+}
+
+/** What {@link useOauthSignIn} returns. */
+export type UseOauthSignInReturn = {
+  /**
+   * Start the provider's OAuth flow (or, with `options.code`, complete one
+   * started elsewhere). Navigates away to the identity provider on the web.
+   * React Native isn't supported yet. It gets the `redirect` URL back to open
+   * in an in-app browser, but `options.redirectTo` is required there and can
+   * only be an http or https URL (see {@link SignInOptions}).
+   */
+  signIn: (options?: SignInOptions) => Promise<SignInOutcome>;
+};
+
+/**
+ * Run one OAuth provider's sign-in flow from its function references. The
+ * per-provider hooks like {@link useSignInWithGoogle} call this with their
+ * own references.
+ *
+ * A failure while starting the flow rejects the returned promise. After the
+ * redirect back there is no caller left to catch anything, so failures from
+ * then on are reported through {@link useOauth}'s `flowError` instead.
+ */
+export function useOauthSignIn(refs: OauthProviderRefs): UseOauthSignInReturn {
+  const actions = useAmbientSignInValue<OauthActions>(
+    OAUTH_SETUP_ID,
+    OAUTH_ACTIONS_KEY,
+  );
+  // Generated api objects create a fresh reference object on every property
+  // access, so the memo depends on the function paths instead. The `refs` it
+  // captures can then be from an earlier render, which is fine because the
+  // deps cover all three of its fields.
+  const startPath = getFunctionName(refs.startSignIn);
+  const completePath = getFunctionName(refs.completeSignIn);
+  const { providerName } = refs;
+  const signIn = useMemo(() => {
+    if (actions === undefined) {
+      throw new Error(NOT_REGISTERED_ERROR);
+    }
+    return (options?: SignInOptions): Promise<SignInOutcome> =>
+      actions.signIn(refs, options);
+  }, [actions, providerName, startPath, completePath]);
+  return { signIn };
+}
+
+/** What {@link useSignInWithGoogle} returns. */
+export type UseSignInWithGoogleReturn = {
+  /** Start Google's OAuth flow. See {@link UseOauthSignInReturn.signIn}. */
+  signInGoogle: UseOauthSignInReturn["signIn"];
+};
+
+/**
+ * Sign in with Google. Pass the module exporting the provider's functions
+ * (usually the generated `api.auth`), or an object mapping the canonical keys
+ * to renamed exports.
+ */
+export function useSignInWithGoogle(api: {
+  startSignInGoogle: OauthProviderApi["startSignIn"];
+  completeSignInGoogle: OauthProviderApi["completeSignIn"];
+}): UseSignInWithGoogleReturn {
+  const { signIn } = useOauthSignIn({
+    providerName: "google",
+    startSignIn: api.startSignInGoogle,
+    completeSignIn: api.completeSignInGoogle,
+  });
+  return { signInGoogle: signIn };
+}
+
+/** What {@link useSignInWithGithub} returns. */
+export type UseSignInWithGithubReturn = {
+  /** Start GitHub's OAuth flow. See {@link UseOauthSignInReturn.signIn}. */
+  signInGithub: UseOauthSignInReturn["signIn"];
+};
+
+/**
+ * Sign in with GitHub. Pass the module exporting the provider's functions
+ * (usually the generated `api.auth`), or an object mapping the canonical keys
+ * to renamed exports.
+ */
+export function useSignInWithGithub(api: {
+  startSignInGithub: OauthProviderApi["startSignIn"];
+  completeSignInGithub: OauthProviderApi["completeSignIn"];
+}): UseSignInWithGithubReturn {
+  const { signIn } = useOauthSignIn({
+    providerName: "github",
+    startSignIn: api.startSignInGithub,
+    completeSignIn: api.completeSignInGithub,
+  });
+  return { signInGithub: signIn };
+}

--- a/packages/core/src/oauth/testFlow.ts
+++ b/packages/core/src/oauth/testFlow.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared test setup for the OAuth client and its React hooks.
+ *
+ * @module
+ */
+import { getFunctionName, makeFunctionReference } from "convex/server";
+import { vi } from "vitest";
+import type { AuthSignInApi } from "../browser/ambientSignInClient";
+import { AuthClient } from "../browser/sessionManager";
+import { InMemoryStorage, NamespacedStorage } from "../browser/storage";
+import type { TokenBundle } from "../lib/types";
+import {
+  OAUTH_ACTIONS_KEY,
+  OAUTH_FLOW_ERROR_KEY,
+  OAUTH_SETUP_ID,
+  oauth,
+  type OauthActions,
+  type OauthFlowError,
+  type OauthProviderRefs,
+  type PendingFlow,
+} from "./client";
+
+/** The deployment url the tests namespace their storage under. */
+export const NAMESPACE = "https://happy-animal-123.convex.cloud";
+
+/** A session for the sign-in mutations to resolve with. */
+export const bundle: TokenBundle = {
+  accessToken: "access-1",
+  accessTokenExpiresAt: 0,
+  refreshToken: "refresh-1",
+  refreshTokenExpiresAt: 0,
+  userId: "user-1",
+};
+
+/**
+ * A stand-in provider, for tests that don't care which provider ran. The refs
+ * carry paths that look like an app's because `signIn` saves the completeSignIn
+ * path and completion rebuilds the reference from it, so assertions compare
+ * paths, not references.
+ */
+export const ACME_REFS: OauthProviderRefs = {
+  providerName: "acme",
+  startSignIn: makeFunctionReference<"mutation">("auth:startSignInAcme"),
+  completeSignIn: makeFunctionReference<"mutation">("auth:completeSignInAcme"),
+};
+
+/** The oauth setup's scoped storage view over `storage`. */
+export function flowStorage(storage: InMemoryStorage) {
+  return new NamespacedStorage(storage, NAMESPACE).forSignIn(OAUTH_SETUP_ID);
+}
+
+/**
+ * The pending flow as stored, or null. `InMemoryStorage` reads synchronously,
+ * unlike the async stores the storage type also allows.
+ */
+export function readFlow(storage: InMemoryStorage): PendingFlow | null {
+  const raw = flowStorage(storage).get("flow") as string | null | undefined;
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  return JSON.parse(raw) as PendingFlow;
+}
+
+/** Store a pending flow the way `signIn` would before navigating away. */
+export function seedPendingFlow(
+  storage: InMemoryStorage,
+  refs: OauthProviderRefs = ACME_REFS,
+  state = "state-1",
+): void {
+  void flowStorage(storage).set(
+    "flow",
+    JSON.stringify({
+      providerName: refs.providerName,
+      state,
+      completeSignIn: getFunctionName(refs.completeSignIn),
+    } satisfies PendingFlow),
+  );
+}
+
+/**
+ * An AuthClient with the real oauth setup registered, plus the `mutation` mock
+ * standing in for the Convex call. The mock records the function reference it
+ * was called with, so tests can assert which function ran.
+ */
+export function oauthClient(storage: InMemoryStorage): {
+  client: AuthClient;
+  signInApi: AuthSignInApi;
+  mutation: ReturnType<typeof vi.fn>;
+} {
+  const mutation = vi.fn();
+  const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
+  const client = new AuthClient({
+    mode: "spa",
+    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    storage,
+    storageNamespace: NAMESPACE,
+    ambientSignIns: { signIns: [oauth()], signInApi },
+  });
+  return { client, signInApi, mutation };
+}
+
+/** {@link oauthClient} plus the values the oauth setup published. */
+export function setupOAuth({ storage = new InMemoryStorage() } = {}) {
+  const { client, mutation } = oauthClient(storage);
+  const oauthValues = client.ambientSignInValues(OAUTH_SETUP_ID);
+  const actions = oauthValues.get<OauthActions>(OAUTH_ACTIONS_KEY)!;
+  const flowError = () =>
+    oauthValues.get<OauthFlowError | null>(OAUTH_FLOW_ERROR_KEY);
+  return { client, mutation, actions, flowError, storage };
+}
+
+/** The function path the `mutation` mock was called with. */
+export function calledPath(
+  mutation: ReturnType<typeof vi.fn>,
+  call = 0,
+): string {
+  return getFunctionName(mutation.mock.calls[call]![0] as never);
+}
+
+/**
+ * Take the client's React Native branch, which returns the redirect url
+ * instead of navigating. jsdom has a location, so without this the client
+ * would try to navigate and jsdom would log a not-implemented error.
+ */
+export function stubReactNative(): void {
+  Object.defineProperty(window.navigator, "product", {
+    value: "ReactNative",
+    configurable: true,
+  });
+}
+
+/**
+ * Undo {@link stubReactNative}. jsdom keeps `product` on `Navigator.prototype`,
+ * so deleting the stubbed own property reveals the real value again.
+ */
+export function restoreNavigatorProduct(): void {
+  delete (window.navigator as { product?: string }).product;
+}

--- a/packages/core/src/react/index.test.tsx
+++ b/packages/core/src/react/index.test.tsx
@@ -8,6 +8,7 @@ import type {
   AmbientSignInClient,
   AuthSignInApi,
 } from "../browser/ambientSignInClient";
+import { useOauth } from "../oauth/react";
 import { ConvexAuthProvider, useAuthSignInApi } from "./index";
 import { useAmbientSignInValue } from "./providers";
 
@@ -28,6 +29,14 @@ function makeConvexClient() {
 function ProbeStatus() {
   const status = useAmbientSignInValue<string>("probe", "status");
   return <div>{status ?? "missing"}</div>;
+}
+
+/**
+ * Renders the flow error from the default oauth setup. The hook throws when
+ * oauth() was never registered, so rendering this at all is the assertion.
+ */
+function OauthFlowError() {
+  return <div>{String(useOauth().flowError)}</div>;
 }
 
 describe("ConvexAuthProvider ambient sign-ins", () => {
@@ -109,5 +118,15 @@ describe("ConvexAuthProvider ambient sign-ins", () => {
     );
     await expect(captured[0].mutation(signIn, {})).resolves.toBe("result");
     expect(mutationSpy).toHaveBeenCalledWith(signIn, {});
+  });
+
+  test("oauth() is registered when no ambient sign-ins are given", () => {
+    const client = makeConvexClient();
+    render(
+      <ConvexAuthProvider client={client} api={API}>
+        <OauthFlowError />
+      </ConvexAuthProvider>,
+    );
+    expect(screen.getByText("null")).toBeDefined();
   });
 });

--- a/packages/core/src/react/index.tsx
+++ b/packages/core/src/react/index.tsx
@@ -24,6 +24,7 @@ import type {
 } from "../browser/ambientSignInClient";
 import { AuthClient } from "../browser/sessionManager";
 import { TokenStorage, defaultStorage } from "../browser/storage";
+import { oauth } from "../oauth/client";
 import type { ConvexAuthApi } from "../lib/types";
 import {
   AuthProvider,
@@ -60,17 +61,6 @@ export { useAuthSignInApi, type AuthSignInApi } from "./client";
  *     </ConvexAuthProvider>
  *   );
  * }
- * ```
- *
- * Auth methods that run on their own at startup plug in via the
- * `ambientSignIns` prop, e.g. OAuth:
- *
- * ```tsx
- * <ConvexAuthProvider
- *   client={convex}
- *   api={{ refreshSession: api.auth.refreshSession, signOut: api.auth.signOut }}
- *   ambientSignIns={[oauth({ providers })]}
- * >
  * ```
  */
 export function ConvexAuthProvider({
@@ -115,10 +105,15 @@ export function ConvexAuthProvider({
    */
   storageNamespace?: string;
   /**
-   * Ambient sign-ins, one per auth method that runs on its own at client
-   * startup (e.g. `oauth(...)` from
-   * `@convex-dev/auth/providers/oauth/react`). Read once when the client is
-   * created and not expected to change.
+   * Advanced. Ambient sign-ins run initialization for auth providers that can
+   * take action outside of a user activated sign in flow, such as reading an
+   * oauth code from a url query param.
+   *
+   * Setting this replaces the default (`[oauth()]`) entirely rather than adding
+   * to it. Pass `[]` to register nothing, or include `oauth()` (from
+   * `@convex-dev/auth/providers/oauth/react`) yourself to keep it alongside
+   * other sign-ins. Read once when the client is created and not expected to
+   * change.
    */
   ambientSignIns?: AmbientSignInClient[];
   children: ReactNode;
@@ -151,9 +146,7 @@ export function ConvexAuthProvider({
       },
       storage: storage ?? defaultStorage(),
       storageNamespace: storageNamespace ?? client.url,
-      // Setups run in the constructor, so anything they publish exists
-      // before the first render reads it.
-      ambientSignIns: { signIns: ambientSignIns ?? [], signInApi },
+      ambientSignIns: { signIns: ambientSignIns ?? [oauth()], signInApi },
     });
     return { authClient, signInApi };
     // `client` identity is what matters. The other props are read once at


### PR DESCRIPTION
- Per-provider hooks (`useSignInWithGoogle`, `useSignInWithGithub`)
- `ConvexAuthProvider` registers `oauth()` by default, no-op if not used