### PR TITLE
argon2id-wasm: publish compiled JS instead of raw TypeScript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This is Convex Auth, an authentication framework built on top of Convex. We’re
 This is a pnpm monorepo:
 
 - `packages/core` — the auth package, published as `@convex-dev/auth`. Owns sessions, accounts, and JWT minting (the provider-agnostic core), plus the bundled providers: the anonymous provider and the password provider (which stores and verifies passwords keyed by an opaque user id). It also owns the username component, a non-provider component that maps a username onto an opaque user id.
-- `packages/argon2id-wasm` — the `argon2id-wasm` package wrapping the argon2id WASM hasher used by the password provider. Its `prepare` script builds the Rust/WASM output when it's missing.
+- `packages/argon2id-wasm` — the `argon2id-wasm` package wrapping the argon2id WASM hasher used by the password provider. It publishes compiled JavaScript plus declarations from `dist/`, so consumers never typecheck its source. Its `prepack` script builds the Rust/WASM output and then compiles the TypeScript wrapper, which keeps the Rust toolchain a publish-time requirement — `pnpm install` and TypeScript-only work don't need it. `packages/core` depends on the published package, not the workspace one, for the same reason.
 - `examples/` — example apps, each an in-repo Convex backend run from its own
   directory:
   - `react-minimal` wires up the core with the anonymous provider.

--- a/packages/argon2id-wasm/package.json
+++ b/packages/argon2id-wasm/package.json
@@ -1,9 +1,10 @@
 {
   "name": "argon2id-wasm",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "description": "argon2id password hashing in WASM",
   "license": "Apache-2.0",
   "files": [
+    "dist",
     "src/index.ts",
     "src/wasm.d.ts",
     "rust/pkg"
@@ -11,11 +12,17 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "build:wasm": "cd rust && just build",
-    "prepack": "pnpm run build:wasm",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build:wasm && pnpm run build",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/argon2id-wasm/tsconfig.build.json
+++ b/packages/argon2id-wasm/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  // Builds the published package: ESM JavaScript plus declarations under
+  // `dist/`. Consumers resolve `dist/`, never `src/`, so their `tsconfig.json`
+  // never typechecks our sources.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // `rust/pkg/argon2_wasm.js` is resolved through its checked-in `.d.ts`, so
+    // it stays out of the program (and out of `rootDir`) entirely.
+    "allowJs": false,
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "rust/target"]
+}


### PR DESCRIPTION
Prep work for converting all of `convex-auth` to ship `.js` and `.d.ts` files

The goal is to ease the burden on users of `convex-auth`, so they don't have to comply with various TypeScript decisions and usages we've made in the framework.

We need to start with argon2id-wasm and publish it, as it's a dependency of the larger library.