### PR TITLE
Don’t display access tokens in demos

### DIFF
--- a/examples/react-minimal/src/App.tsx
+++ b/examples/react-minimal/src/App.tsx
@@ -3,7 +3,6 @@ import {
   AuthLoading,
   Unauthenticated,
   useAuthActions,
-  useAuthToken,
 } from "@convex-dev/auth/react";
 import { useAnonymousAuth } from "@convex-dev/auth/providers/anonymous/react";
 import { useQuery } from "convex/react";
@@ -39,14 +38,12 @@ function SignIn() {
 
 function Dashboard() {
   const user = useQuery(api.currentUser.loggedInUser);
-  const token = useAuthToken();
   const { signOut } = useAuthActions();
   return (
     <>
       <p>
         Signed in as <strong>{user ? user.id : "…"}</strong>
       </p>
-      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
       <button onClick={() => signOut()}>Sign out</button>
     </>
   );

--- a/examples/react-passkey/src/routes/dashboard.tsx
+++ b/examples/react-passkey/src/routes/dashboard.tsx
@@ -1,10 +1,9 @@
-import { useAuthActions, useAuthToken } from "@convex-dev/auth/react";
+import { useAuthActions } from "@convex-dev/auth/react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 
 export function Dashboard() {
   const user = useQuery(api.currentUser.loggedInUser);
-  const token = useAuthToken();
   const { signOut } = useAuthActions();
   return (
     <>
@@ -13,7 +12,6 @@ export function Dashboard() {
           Signed in as <strong>{user.username}</strong> ({user.id})
         </p>
       )}
-      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
       <button onClick={() => signOut()}>Sign out</button>
     </>
   );

--- a/examples/react-password/src/routes/dashboard.tsx
+++ b/examples/react-password/src/routes/dashboard.tsx
@@ -1,10 +1,9 @@
-import { useAuthActions, useAuthToken } from "@convex-dev/auth/react";
+import { useAuthActions } from "@convex-dev/auth/react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 
 export function Dashboard() {
   const user = useQuery(api.currentUser.loggedInUser);
-  const token = useAuthToken();
   const { signOut } = useAuthActions();
   return (
     <>
@@ -13,7 +12,6 @@ export function Dashboard() {
           Signed in as <strong>{user.username}</strong> ({user.id})
         </p>
       )}
-      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
       <button onClick={() => signOut()}>Sign out</button>
     </>
   );


### PR DESCRIPTION
Doing this from an app is rare (and you should not display the auth token to users directly!), so it makes sense to remove it from our demos