### PR TITLE
Passkey: call the start mutations on the Convex client

### DIFF
--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { ConvexProvider, type ConvexReactClient } from "convex/react";
 import { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthClient } from "../../browser/sessionManager.js";
@@ -10,21 +11,24 @@ import { AuthProvider, useAuth } from "../../react/client.js";
 import { useAuthToken } from "../../react/index.js";
 import { PasskeyApi, PasskeySignInResult, usePasskey } from "./react.js";
 
-// The hook runs its mutations through the injected `AuthSignInApi`, so
-// the tests substitute a signInApi rather than mocking `convex/react`. The
-// passkey hook calls several different mutations, so this signInApi
-// dispatches on the reference (a string sentinel here) to one mock per
-// mutation.
+// The hook calls several different mutations, so both call paths dispatch on
+// the reference (a string sentinel here) to one mock per mutation.
 const mutations = {
   startSignIn: vi.fn(),
   finishSignIn: vi.fn(),
   finishSignUp: vi.fn(),
   startAutofillSignIn: vi.fn(),
 };
-const signInApi = {
-  mutation: (fn: unknown, args: unknown) =>
-    mutations[fn as keyof typeof mutations](args),
-} as unknown as AuthSignInApi;
+const runMutation = (fn: unknown, args: unknown) =>
+  mutations[fn as keyof typeof mutations](args);
+
+// The two session-minting mutations run through the injected `AuthSignInApi`,
+// which the tests substitute rather than mocking a transport.
+const signInApi = { mutation: runMutation } as unknown as AuthSignInApi;
+
+// The two challenge mutations run on the Convex client from `useConvex()`,
+// which the tests stand in for with the same dispatcher.
+const convexClient = { mutation: runMutation } as unknown as ConvexReactClient;
 
 const passkeyApi = {
   startSignIn: "startSignIn",
@@ -141,7 +145,7 @@ function makeWrapper() {
   });
   return ({ children }: { children: ReactNode }) => (
     <AuthProvider authClient={client} signInApi={signInApi}>
-      {children}
+      <ConvexProvider client={convexClient}>{children}</ConvexProvider>
     </AuthProvider>
   );
 }

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -14,6 +14,7 @@
  */
 "use client";
 
+import { useConvex } from "convex/react";
 import type { FunctionReference } from "convex/server";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ClientView } from "../../lib/types.js";
@@ -382,9 +383,15 @@ export function usePasskey(
 
   const { autofill: autofillEnabled = true } = options;
   const { setSession } = useAuthActions();
-  // Running through the signInApi rather than `useMutation` is what lets
-  // this hook serve both session models (SPA + SSR).
+  // Running the two finishing mutations through the signInApi rather than
+  // `useMutation` is what lets this hook serve both session models (SPA +
+  // SSR): under SSR they go through the auth proxy, which keeps the refresh
+  // token in an httpOnly cookie.
   const signInApi = useAuthSignInApi();
+  // The two starting mutations mint a challenge rather than a session, so
+  // they go straight to the deployment in both models. The proxy only speaks
+  // the sign-in envelope and would refuse their shape.
+  const convex = useConvex();
 
   // The identifier-first (modal) flow's state.
   const [pending, setPending] = useState(false);
@@ -411,13 +418,13 @@ export function usePasskey(
   // coordination exists.
   const autofillHandleRef = useRef<AutofillHandle | null>(null);
 
-  // The flows read the mutation references, the sign-in API and
+  // The flows read the mutation references, the two call paths and
   // `setSession` through a ref: their identities are not stable across
   // renders (Convex's generated `api` object creates a new reference on
   // every property access), and neither `signIn`'s identity nor the
   // pending browser request must change on a render.
-  const currentRef = useRef({ passkeyApi, signInApi, setSession });
-  currentRef.current = { passkeyApi, signInApi, setSession };
+  const currentRef = useRef({ passkeyApi, signInApi, convex, setSession });
+  currentRef.current = { passkeyApi, signInApi, convex, setSession };
 
   const signIn = useCallback(
     async ({
@@ -446,9 +453,10 @@ export function usePasskey(
             userError: { error: "WEBAUTHN_UNSUPPORTED" },
           };
         }
-        const { passkeyApi, signInApi, setSession } = currentRef.current;
+        const { passkeyApi, signInApi, convex, setSession } =
+          currentRef.current;
 
-        const start = await signInApi.mutation(passkeyApi.startSignIn, {
+        const start = await convex.mutation(passkeyApi.startSignIn, {
           username,
         });
         if (!start.success) {
@@ -622,8 +630,8 @@ export function usePasskey(
         setAutofillStatus("waiting");
         let start;
         try {
-          const { passkeyApi, signInApi } = currentRef.current;
-          start = await signInApi.mutation(passkeyApi.startAutofillSignIn, {});
+          const { passkeyApi, convex } = currentRef.current;
+          start = await convex.mutation(passkeyApi.startAutofillSignIn, {});
         } catch (cause) {
           setAutofillLastError(foldClientError(cause));
           setAutofillStatus("stopped");

--- a/packages/core/src/server/signInProxy.test.ts
+++ b/packages/core/src/server/signInProxy.test.ts
@@ -96,6 +96,19 @@ describe("token interception", () => {
     expect(cookies).toContain("HttpOnly");
   });
 
+  test("keeps the fields a provider adds beside the bundle", async () => {
+    // `finishSignIn` of the passkey provider returns the username alongside the
+    // tokens. The refresh token is the only thing the proxy removes.
+    upstream({
+      status: "success",
+      value: { success: true, tokens: bundle(), username: "alice" },
+    });
+
+    const body = await (await handler(call(envelope()))).json();
+    expect(body.value.username).toBe("alice");
+    expect(body.value.tokens.refreshToken).toBeUndefined();
+  });
+
   test("passes a failure arm through untouched and writes no cookies", async () => {
     upstream({
       status: "success",
@@ -112,6 +125,20 @@ describe("token interception", () => {
     // application result carries the reason.
     expect(response.status).toBe(200);
     expect(setCookies(response)).toBe("");
+  });
+
+  test("refuses a challenge-minting function, which is why those bypass the proxy", async () => {
+    // What `startSignIn` of the passkey provider returns. A provider must run
+    // this one on the Convex client, not through the sign-in API: the proxy
+    // classifies every reply as the sign-in envelope, and this is not one.
+    upstream({
+      status: "success",
+      value: { success: true, step: "register", rpId: "app.test" },
+    });
+
+    const response = await handler(call(envelope()));
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain("did not return a sign-in result");
   });
 
   test("fails closed when an exposed function returns an unrecognized shape", async () => {


### PR DESCRIPTION
Something that I didn’t catch in my review of #463 is that the `usePasskey` hook was using `signInApi` to call all actions. This is incorrect as `signInApi` is only useful for actions that can potentially issue bundles. 

This PR changes the code so that it uses the bare Convex client when necessary.