### PR TITLE
Report every oauth client failure through flowError

### DIFF
--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -264,7 +264,7 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isAuthenticated).toBe(false);
   });
 
-  test("an app rejection with non-string data gets the default copy", async () => {
+  test("an app rejection with non-string data carries no message", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
@@ -274,7 +274,9 @@ describe("OAuth client", () => {
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("rejected"));
-    expect(flowError()?.message).toBe("Sign-in was declined.");
+    // Only a string carries copy the app meant for the user, so there is
+    // nothing to show here.
+    expect(flowError()?.message).toBeUndefined();
   });
 
   test("a rejecting storage during redemption sets oauth_error", async () => {

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -279,7 +279,7 @@ describe("OAuth client", () => {
     expect(flowError()?.message).toBeUndefined();
   });
 
-  test("a rejecting storage during redemption sets oauth_error", async () => {
+  test("a rejected storage read during redemption sets oauth_error", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     // Fail reads of the saved flow key, the way an async storage might. Reads
     // of the session tokens still work.
@@ -300,7 +300,7 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isLoading).toBe(false);
   });
 
-  test("a rejecting storage during error cleanup keeps the flow error", async () => {
+  test("a rejected storage removal during error cleanup keeps the flow error", async () => {
     window.history.replaceState(null, "", "/?convexAuthError=access_denied");
     const storage: TokenStorage = {
       getItem: () => null,

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -244,7 +244,7 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isLoading).toBe(false);
   });
 
-  test("an app rejection surfaces its ConvexError copy as rejected", async () => {
+  test("an app rejection sets rejected with the ConvexError message", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
@@ -264,7 +264,7 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isAuthenticated).toBe(false);
   });
 
-  test("an app rejection with non-string data carries no message", async () => {
+  test("an app rejection with non-string data has no message", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
@@ -274,15 +274,15 @@ describe("OAuth client", () => {
     await client.init();
 
     await vi.waitFor(() => expect(flowError()?.code).toBe("rejected"));
-    // Only a string carries copy the app meant for the user, so there is
-    // nothing to show here.
+    // Only a string is text the app meant for the user, so there is nothing
+    // to show here.
     expect(flowError()?.message).toBeUndefined();
   });
 
   test("a rejecting storage during redemption sets oauth_error", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
-    // Reject only the saved-flow read, the way an async storage might fail.
-    // The client's own token reads stay healthy.
+    // Fail reads of the saved flow key, the way an async storage might. Reads
+    // of the session tokens still work.
     const storage: TokenStorage = {
       getItem: (key) =>
         key.startsWith("__convexAuthProvider_oauth_flow")
@@ -312,8 +312,8 @@ describe("OAuth client", () => {
     await client.init();
 
     expect(flowError()?.code).toBe("access_denied");
-    // Give the cleanup a beat to settle. A rejection escaping it would fail
-    // the run as unhandled.
+    // The cleanup is not awaited, so let the event loop run once for it to
+    // finish. An unhandled rejection from it would fail the test run.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(flowError()?.code).toBe("access_denied");
   });
@@ -336,7 +336,7 @@ describe("OAuth client", () => {
     expect(outcome).toEqual({
       redirect: new URL("https://provider.example/auth?client_id=x"),
     });
-    // The persisted flow carries the completeSignIn function path, so
+    // The persisted flow has the completeSignIn function path, so
     // completion can run on a page that never held the references.
     expect(readFlow(storage)).toEqual({
       providerName: "acme",
@@ -392,7 +392,24 @@ describe("OAuth client", () => {
     expect(flowStorage(storage).get("flow")).toBeNull();
   });
 
-  test("a rejected start surfaces the app's copy and rejects", async () => {
+  test("a start that can't save the flow sets the flow error and rejects", async () => {
+    const storage: TokenStorage = {
+      getItem: () => null,
+      setItem: () => Promise.reject(new Error("storage broken")),
+      removeItem: () => {},
+    };
+    const { mutation, actions, flowError } = setupOAuth({ storage });
+    mutation.mockResolvedValueOnce({
+      redirect: "https://provider.example/auth",
+      state: "state-1",
+    });
+
+    await expect(actions.signIn(ACME_REFS)).rejects.toThrow("storage broken");
+
+    expect(flowError()?.code).toBe("oauth_error");
+  });
+
+  test("a rejected start sets the app's message and rejects", async () => {
     const { mutation, actions, flowError } = setupOAuth();
     mutation.mockRejectedValueOnce(new ConvexError("Sign-ups are closed"));
 

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { ConvexError } from "convex/values";
 import type { AuthSignInApi } from "../browser/ambientSignInClient.js";
 import { AuthClient, type AuthState } from "../browser/sessionManager.js";
-import { InMemoryStorage } from "../browser/storage.js";
+import { InMemoryStorage, type TokenStorage } from "../browser/storage.js";
 import type { TokenBundle } from "../lib/types.js";
 import { oauth } from "./client.js";
 import {
@@ -243,6 +244,78 @@ describe("OAuth client", () => {
     expect(client.getSnapshot().isLoading).toBe(false);
   });
 
+  test("an app rejection surfaces its ConvexError copy as rejected", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, flowError } = setupOAuth({ storage });
+    mutation.mockRejectedValueOnce(
+      new ConvexError("A verified email is required to sign in"),
+    );
+
+    await client.init();
+
+    await vi.waitFor(() =>
+      expect(flowError()).toEqual({
+        code: "rejected",
+        message: "A verified email is required to sign in",
+      }),
+    );
+    expect(client.getSnapshot().isAuthenticated).toBe(false);
+  });
+
+  test("an app rejection with non-string data gets the default copy", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    const storage = new InMemoryStorage();
+    seedPendingFlow(storage);
+    const { client, mutation, flowError } = setupOAuth({ storage });
+    mutation.mockRejectedValueOnce(new ConvexError({ reason: "policy" }));
+
+    await client.init();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("rejected"));
+    expect(flowError()?.message).toBe("Sign-in was declined.");
+  });
+
+  test("a rejecting storage during redemption sets oauth_error", async () => {
+    window.history.replaceState(null, "", "/?convexAuthCode=code-1");
+    // Reject only the pending-flow read (an RN-style async storage failing);
+    // the client's own token reads stay healthy.
+    const storage: TokenStorage = {
+      getItem: (key) =>
+        key.startsWith("__convexAuthProvider_oauth_flow")
+          ? Promise.reject(new Error("storage broken"))
+          : null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    const { client, mutation, flowError } = setupOAuth({ storage });
+
+    await client.init();
+
+    await vi.waitFor(() => expect(flowError()?.code).toBe("oauth_error"));
+    expect(mutation).not.toHaveBeenCalled();
+    expect(client.getSnapshot().isLoading).toBe(false);
+  });
+
+  test("a rejecting storage during error cleanup keeps the flow error", async () => {
+    window.history.replaceState(null, "", "/?convexAuthError=access_denied");
+    const storage: TokenStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => Promise.reject(new Error("storage broken")),
+    };
+    const { client, flowError } = setupOAuth({ storage });
+
+    await client.init();
+
+    expect(flowError()?.code).toBe("access_denied");
+    // Give the voided cleanup a beat to settle — a rejection escaping it
+    // would fail the run as unhandled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(flowError()?.code).toBe("access_denied");
+  });
+
   test("signIn starts a flow, persists it, and returns the redirect", async () => {
     stubReactNative();
     const { mutation, actions, storage } = setupOAuth();
@@ -303,6 +376,30 @@ describe("OAuth client", () => {
     await actions.signIn(ACME_REFS, { redirectTo: "http://localhost/app" });
 
     expect(flowError()).toBeNull();
+  });
+
+  test("a failed start sets the flow error and rejects", async () => {
+    const { mutation, actions, flowError, storage } = setupOAuth();
+    mutation.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(actions.signIn(ACME_REFS)).rejects.toThrow("boom");
+
+    // The flow error is still published even when the caller ignores the
+    // rejection, like a click handler that does not await.
+    expect(flowError()?.code).toBe("oauth_error");
+    expect(flowStorage(storage).get("flow")).toBeNull();
+  });
+
+  test("a rejected start surfaces the app's copy and rejects", async () => {
+    const { mutation, actions, flowError } = setupOAuth();
+    mutation.mockRejectedValueOnce(new ConvexError("Sign-ups are closed"));
+
+    await expect(actions.signIn(ACME_REFS)).rejects.toThrow();
+
+    expect(flowError()).toEqual({
+      code: "rejected",
+      message: "Sign-ups are closed",
+    });
   });
 
   test("a foreign code/error param is ignored and left in the URL", async () => {

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -279,8 +279,8 @@ describe("OAuth client", () => {
 
   test("a rejecting storage during redemption sets oauth_error", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
-    // Reject only the pending-flow read (an RN-style async storage failing);
-    // the client's own token reads stay healthy.
+    // Reject only the saved-flow read, the way an async storage might fail.
+    // The client's own token reads stay healthy.
     const storage: TokenStorage = {
       getItem: (key) =>
         key.startsWith("__convexAuthProvider_oauth_flow")
@@ -310,8 +310,8 @@ describe("OAuth client", () => {
     await client.init();
 
     expect(flowError()?.code).toBe("access_denied");
-    // Give the voided cleanup a beat to settle — a rejection escaping it
-    // would fail the run as unhandled.
+    // Give the cleanup a beat to settle. A rejection escaping it would fail
+    // the run as unhandled.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(flowError()?.code).toBe("access_denied");
   });

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -54,9 +54,8 @@ export type OauthProviderRefs = {
  *
  * - `"access_denied"`: the user cancelled at the identity provider.
  * - `"expired"`: the flow took too long, or the code was already redeemed.
- * - `"rejected"`: the app's own backend refused the sign-in by throwing a
- *   `ConvexError` (e.g. from `createOrUpdateUser`); `message` carries the
- *   error's `data` when it is a string.
+ * - `"rejected"`: the app's own backend turned the sign-in down by throwing
+ *   a `ConvexError`.
  * - `"oauth_error"`: something else went wrong during the provider handshake,
  *   including failing to start it.
  * - `"invalid_flow"`: the callback arrived but this client has no saved flow,
@@ -205,15 +204,15 @@ async function takePendingFlow(
 }
 
 /**
- * Best-effort removal of the pending sign-in flow, for flows that already
- * ended. Failures are swallowed: the flow error the caller sets is the
- * signal, and a rejecting storage must not become an unhandled rejection.
+ * Remove the saved sign-in flow for a flow that already ended. A storage that
+ * rejects is ignored, because the caller has already recorded why the sign-in
+ * failed and a failed cleanup would only add an unhandled rejection.
  */
 async function dropPendingFlow(storage: SignInStorage): Promise<void> {
   try {
     await storage.remove(OAUTH_FLOW_STORAGE_KEY);
   } catch {
-    // The flow was already over; a failed cleanup changes nothing.
+    // Nothing to do. The flow was already over.
   }
 }
 
@@ -242,11 +241,9 @@ export function oauth(): AmbientSignInClient {
     };
 
     /**
-     * Map a thrown sign-in failure to its flow error. An app rejects a
-     * sign-in by throwing a `ConvexError` (the channel the core setup's
-     * `attachUserCallback` documents); its `data`, when a string, is the
-     * app's own user-facing copy. Anything else is a generic handshake
-     * failure.
+     * Turn a thrown sign-in failure into a flow error. An app turns a sign-in
+     * down by throwing a `ConvexError`, and a string `data` on it is the
+     * app's own copy for the user. Anything else is a generic failure.
      */
     const setThrownFlowError = (error: unknown): void => {
       if (error instanceof ConvexError) {
@@ -263,14 +260,14 @@ export function oauth(): AmbientSignInClient {
      * Redeem a callback `code` against the saved flow and adopt the session.
      * The whole thing runs inside `withSignInPending`, including
      * `setSession`, so the auth state stays on loading until the client is
-     * signed in rather than flickering through signed out. Never rejects:
-     * every failure becomes a flow error, so the fire-and-forget startup call
-     * is safe.
+     * signed in rather than flickering through signed out. It never rejects.
+     * Every failure becomes a flow error instead, so callers that don't await
+     * it are safe.
      */
     const completeFlow = async (code: string): Promise<boolean> =>
       await client.withSignInPending(async () => {
-        // The storage read sits inside the try so a rejecting custom storage
-        // is a flow error like any other completion failure.
+        // The storage read is inside the try so that a storage which rejects
+        // becomes a flow error like any other failure here.
         try {
           const pending = await takePendingFlow(storage);
           if (pending === null) {
@@ -377,8 +374,8 @@ export function oauth(): AmbientSignInClient {
         }
         return { redirect: url };
       } catch (error) {
-        // Failing to start still publishes the flow error, so UI bound to it
-        // shows feedback even when the caller ignores the rejection.
+        // Record the failure before rethrowing, so UI reading the flow error
+        // still shows something when the caller ignores the rejection.
         setThrownFlowError(error);
         throw error;
       }

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -71,6 +71,8 @@ export type OauthFlowError = {
   /**
    * Text to show the user. Only set when the app's backend threw a
    * `ConvexError` whose `data` is a string. That string is this text.
+   *
+   * @TODO(erquhart) Look into localization support.
    */
   message?: string;
 };
@@ -201,8 +203,8 @@ async function takePendingFlow(
 
 /**
  * Remove the saved sign-in flow after it has ended. Callers don't await this,
- * so a rejecting storage is ignored instead of becoming an unhandled
- * rejection. The caller already recorded why the sign-in failed.
+ * so a failed removal is ignored instead of becoming an unhandled rejection.
+ * The caller already recorded why the sign-in failed.
  */
 async function dropPendingFlow(storage: SignInStorage): Promise<void> {
   try {
@@ -262,14 +264,16 @@ export function oauth(): AmbientSignInClient {
      */
     const completeFlow = async (code: string): Promise<boolean> =>
       await client.withSignInPending(async () => {
-        // The storage read is inside the try so that a storage which rejects
-        // becomes a flow error like any other failure here.
+        // The storage read is inside the try so that a failed read becomes a
+        // flow error like any other failure here.
         try {
           const pending = await takePendingFlow(storage);
           if (pending === null) {
             setFlowError("invalid_flow");
             return false;
           }
+          // TODO(erquhart) Look at getting this reference without storing
+          // its path.
           const completeSignIn = makeFunctionReference<"mutation">(
             pending.completeSignIn,
           ) as OauthProviderApi["completeSignIn"];

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -55,7 +55,7 @@ export type OauthProviderRefs = {
  * - `"access_denied"`: the user cancelled at the identity provider.
  * - `"expired"`: the flow took too long, or the code was already redeemed.
  * - `"rejected"`: the app's own backend turned the sign-in down by throwing
- *   a `ConvexError`.
+ *   a `ConvexError`, and `message` has its text.
  * - `"oauth_error"`: something else went wrong during the provider handshake,
  *   including failing to start it.
  * - `"invalid_flow"`: the callback arrived but this client has no saved flow,
@@ -64,17 +64,13 @@ export type OauthProviderRefs = {
 export type OauthFlowErrorCode =
   "access_denied" | "expired" | "rejected" | "oauth_error" | "invalid_flow";
 
-/**
- * Why a sign-in failed. A `"rejected"` error can carry the app's own copy for
- * the user.
- */
+/** Why a sign-in failed. */
 export type OauthFlowError = {
   /** Why the sign-in failed. */
   code: OauthFlowErrorCode;
   /**
-   * The app's own copy for the user, taken from the `ConvexError` its backend
-   * threw. Only set for a `"rejected"` error, and only when that error carried
-   * a string.
+   * Text to show the user. Only set when the app's backend threw a
+   * `ConvexError` whose `data` is a string. That string is this text.
    */
   message?: string;
 };
@@ -204,9 +200,9 @@ async function takePendingFlow(
 }
 
 /**
- * Remove the saved sign-in flow for a flow that already ended. A storage that
- * rejects is ignored, because the caller has already recorded why the sign-in
- * failed and a failed cleanup would only add an unhandled rejection.
+ * Remove the saved sign-in flow after it has ended. Callers don't await this,
+ * so a rejecting storage is ignored instead of becoming an unhandled
+ * rejection. The caller already recorded why the sign-in failed.
  */
 async function dropPendingFlow(storage: SignInStorage): Promise<void> {
   try {
@@ -241,9 +237,9 @@ export function oauth(): AmbientSignInClient {
     };
 
     /**
-     * Turn a thrown sign-in failure into a flow error. An app turns a sign-in
-     * down by throwing a `ConvexError`, and a string `data` on it is the
-     * app's own copy for the user. Anything else is a generic failure.
+     * Turn a thrown sign-in failure into a flow error. A `ConvexError` means
+     * the app's backend rejected the sign-in. Anything else is a generic
+     * failure.
      */
     const setThrownFlowError = (error: unknown): void => {
       if (error instanceof ConvexError) {

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -14,6 +14,7 @@ import {
   getFunctionName,
   makeFunctionReference,
 } from "convex/server";
+import { ConvexError } from "convex/values";
 import type { AmbientSignInClient } from "../browser/ambientSignInClient.js";
 import { retryOnNetworkError } from "../browser/retry.js";
 import type { SignInStorage } from "../browser/storage.js";
@@ -53,17 +54,30 @@ export type OauthProviderRefs = {
  *
  * - `"access_denied"`: the user cancelled at the identity provider.
  * - `"expired"`: the flow took too long, or the code was already redeemed.
- * - `"oauth_error"`: something else went wrong during the provider handshake.
+ * - `"rejected"`: the app's own backend refused the sign-in by throwing a
+ *   `ConvexError` (e.g. from `createOrUpdateUser`); `message` carries the
+ *   error's `data` when it is a string.
+ * - `"oauth_error"`: something else went wrong during the provider handshake,
+ *   including failing to start it.
  * - `"invalid_flow"`: the callback arrived but this client has no saved flow,
  *   so it never started this sign-in or already finished it.
  */
 export type OauthFlowErrorCode =
-  "access_denied" | "expired" | "oauth_error" | "invalid_flow";
+  "access_denied" | "expired" | "rejected" | "oauth_error" | "invalid_flow";
 
-/** Why a sign-in failed. */
+/**
+ * Why a sign-in failed. A `"rejected"` error can carry the app's own copy for
+ * the user.
+ */
 export type OauthFlowError = {
   /** Why the sign-in failed. */
   code: OauthFlowErrorCode;
+  /**
+   * The app's own copy for the user, taken from the `ConvexError` its backend
+   * threw. Only set for a `"rejected"` error, and only when that error carried
+   * a string.
+   */
+  message?: string;
 };
 
 /** Options accepted by {@link OauthActions.signIn}. */
@@ -191,6 +205,19 @@ async function takePendingFlow(
 }
 
 /**
+ * Best-effort removal of the pending sign-in flow, for flows that already
+ * ended. Failures are swallowed: the flow error the caller sets is the
+ * signal, and a rejecting storage must not become an unhandled rejection.
+ */
+async function dropPendingFlow(storage: SignInStorage): Promise<void> {
+  try {
+    await storage.remove(OAUTH_FLOW_STORAGE_KEY);
+  } catch {
+    // The flow was already over; a failed cleanup changes nothing.
+  }
+}
+
+/**
  * Client setup for the OAuth providers. It owns the flow's storage and the
  * startup work that finishes a flow. Provider mutations arrive with each
  * {@link OauthActions.signIn} call, so the setup takes no configuration.
@@ -203,27 +230,56 @@ export function oauth(): AmbientSignInClient {
     signInApi,
   }) => {
     /** Set or clear the flow error apps read for sign-in feedback. */
-    const setFlowError = (code: OauthFlowErrorCode | null): void => {
-      values.set(OAUTH_FLOW_ERROR_KEY, code === null ? null : { code });
+    const setFlowError = (
+      code: OauthFlowErrorCode | null,
+      message?: string,
+    ): void => {
+      if (code === null) {
+        values.set(OAUTH_FLOW_ERROR_KEY, null);
+        return;
+      }
+      values.set(OAUTH_FLOW_ERROR_KEY, { code, message });
+    };
+
+    /**
+     * Map a thrown sign-in failure to its flow error. An app rejects a
+     * sign-in by throwing a `ConvexError` (the channel the core setup's
+     * `attachUserCallback` documents); its `data`, when a string, is the
+     * app's own user-facing copy. Anything else is a generic handshake
+     * failure.
+     */
+    const setThrownFlowError = (error: unknown): void => {
+      if (error instanceof ConvexError) {
+        setFlowError(
+          "rejected",
+          typeof error.data === "string" ? error.data : undefined,
+        );
+        return;
+      }
+      setFlowError("oauth_error");
     };
 
     /**
      * Redeem a callback `code` against the saved flow and adopt the session.
      * The whole thing runs inside `withSignInPending`, including
      * `setSession`, so the auth state stays on loading until the client is
-     * signed in rather than flickering through signed out.
+     * signed in rather than flickering through signed out. Never rejects:
+     * every failure becomes a flow error, so the fire-and-forget startup call
+     * is safe.
      */
     const completeFlow = async (code: string): Promise<boolean> =>
       await client.withSignInPending(async () => {
-        const pending = await takePendingFlow(storage);
-        if (pending === null) {
-          setFlowError("invalid_flow");
-          return false;
-        }
-        const completeSignIn = makeFunctionReference<"mutation">(
-          pending.completeSignIn,
-        ) as OauthProviderApi["completeSignIn"];
+        // The storage read sits inside the try so a rejecting custom storage
+        // is a flow error like any other completion failure.
         try {
+          const pending = await takePendingFlow(storage);
+          if (pending === null) {
+            setFlowError("invalid_flow");
+            return false;
+          }
+          const completeSignIn = makeFunctionReference<"mutation">(
+            pending.completeSignIn,
+          ) as OauthProviderApi["completeSignIn"];
           const bundle = await retryOnNetworkError(() =>
             signInApi.mutation(completeSignIn, { code, state: pending.state }),
           );
@@ -235,8 +291,8 @@ export function oauth(): AmbientSignInClient {
           }
           await client.setSession(bundle);
           return true;
-        } catch {
-          setFlowError("oauth_error");
+        } catch (error) {
+          setThrownFlowError(error);
           return false;
         }
       });
@@ -269,7 +325,7 @@ export function oauth(): AmbientSignInClient {
         // The server ended the flow with an error, so the saved state can
         // never be used. Drop it now so a stray code arriving later still
         // reports `invalid_flow`.
-        void storage.remove(OAUTH_FLOW_STORAGE_KEY);
+        void dropPendingFlow(storage);
         setFlowError(
           SERVER_ERRORS.has(errorParam)
             ? (errorParam as OauthFlowErrorCode)
@@ -300,25 +356,32 @@ export function oauth(): AmbientSignInClient {
       // Cleared here rather than at the top, so a call that throws above
       // leaves any error the app is showing alone.
       setFlowError(null);
-      const { redirect, state } = await signInApi.mutation(refs.startSignIn, {
-        redirectTo,
-      });
-      await storage.set(
-        OAUTH_FLOW_STORAGE_KEY,
-        JSON.stringify({
-          providerName: refs.providerName,
-          state,
-          completeSignIn: getFunctionName(refs.completeSignIn),
-        } satisfies PendingFlow),
-      );
-      const url = new URL(redirect);
-      // Don't navigate where there's no page URL to leave. React Native has
-      // none, so it gets the url back, opens it in an in-app browser, and
-      // finishes with `signIn(refs, { code })`.
-      if (href !== null && navigator.product !== "ReactNative") {
-        window.location.href = url.toString();
+      try {
+        const { redirect, state } = await signInApi.mutation(refs.startSignIn, {
+          redirectTo,
+        });
+        await storage.set(
+          OAUTH_FLOW_STORAGE_KEY,
+          JSON.stringify({
+            providerName: refs.providerName,
+            state,
+            completeSignIn: getFunctionName(refs.completeSignIn),
+          } satisfies PendingFlow),
+        );
+        const url = new URL(redirect);
+        // Don't navigate where there's no page URL to leave. React Native has
+        // none, so it gets the url back, opens it in an in-app browser, and
+        // finishes with `signIn(refs, { code })`.
+        if (href !== null && navigator.product !== "ReactNative") {
+          window.location.href = url.toString();
+        }
+        return { redirect: url };
+      } catch (error) {
+        // Failing to start still publishes the flow error, so UI bound to it
+        // shows feedback even when the caller ignores the rejection.
+        setThrownFlowError(error);
+        throw error;
       }
-      return { redirect: url };
     };
 
     values.set(OAUTH_ACTIONS_KEY, { signIn } satisfies OauthActions);

--- a/packages/core/src/oauth/react.ts
+++ b/packages/core/src/oauth/react.ts
@@ -57,7 +57,8 @@ const NOT_REGISTERED_ERROR =
 export type UseOauthReturn = {
   /**
    * Why the last sign-in attempt failed, or `null`. Cleared on the next
-   * sign-in. Your app supplies the message text for each `code`.
+   * sign-in. Your app supplies the message text for each `code`. A
+   * `rejected` error has a `message` from your own backend.
    */
   flowError: OauthFlowError | null;
 };
@@ -98,9 +99,9 @@ export type UseOauthSignInReturn = {
  * per-provider hooks like {@link useSignInWithGoogle} call this with their
  * own references.
  *
- * A failure while starting the flow rejects the returned promise. After the
- * redirect back there is no caller left to catch anything, so failures from
- * then on are reported through {@link useOauth}'s `flowError` instead.
+ * A failure while starting the flow rejects the returned promise. Failures
+ * after the redirect back have no caller left to catch them, so every failure
+ * is also reported through {@link useOauth}'s `flowError`.
  */
 export function useOauthSignIn(refs: OauthProviderRefs): UseOauthSignInReturn {
   const actions = useAmbientSignInValue<OauthActions>(

--- a/packages/core/src/oauth/testFlow.ts
+++ b/packages/core/src/oauth/testFlow.ts
@@ -38,7 +38,7 @@ export const bundle: TokenBundle = {
 
 /**
  * A stand-in provider, for tests that don't care which provider ran. The refs
- * carry paths that look like an app's because `signIn` saves the completeSignIn
+ * have paths that look like an app's because `signIn` saves the completeSignIn
  * path and completion rebuilds the reference from it, so assertions compare
  * paths, not references.
  */
@@ -54,8 +54,8 @@ export function flowStorage(storage: TokenStorage) {
 }
 
 /**
- * The pending flow as stored, or null. Only for the synchronous stores, since
- * the storage type also allows ones that return promises.
+ * The pending flow as stored, or null. Only works with a storage that reads
+ * synchronously, like `InMemoryStorage`, because it does not await the read.
  */
 export function readFlow(storage: TokenStorage): PendingFlow | null {
   const raw = flowStorage(storage).get("flow") as string | null | undefined;

--- a/packages/core/src/oauth/testFlow.ts
+++ b/packages/core/src/oauth/testFlow.ts
@@ -7,7 +7,11 @@ import { getFunctionName, makeFunctionReference } from "convex/server";
 import { vi } from "vitest";
 import type { AuthSignInApi } from "../browser/ambientSignInClient.js";
 import { AuthClient } from "../browser/sessionManager.js";
-import { InMemoryStorage, NamespacedStorage } from "../browser/storage.js";
+import {
+  InMemoryStorage,
+  NamespacedStorage,
+  type TokenStorage,
+} from "../browser/storage.js";
 import type { TokenBundle } from "../lib/types.js";
 import {
   OAUTH_ACTIONS_KEY,
@@ -45,15 +49,15 @@ export const ACME_REFS: OauthProviderRefs = {
 };
 
 /** The oauth setup's scoped storage view over `storage`. */
-export function flowStorage(storage: InMemoryStorage) {
+export function flowStorage(storage: TokenStorage) {
   return new NamespacedStorage(storage, NAMESPACE).forSignIn(OAUTH_SETUP_ID);
 }
 
 /**
- * The pending flow as stored, or null. `InMemoryStorage` reads synchronously,
- * unlike the async stores the storage type also allows.
+ * The pending flow as stored, or null. Only for the synchronous stores, since
+ * the storage type also allows ones that return promises.
  */
-export function readFlow(storage: InMemoryStorage): PendingFlow | null {
+export function readFlow(storage: TokenStorage): PendingFlow | null {
   const raw = flowStorage(storage).get("flow") as string | null | undefined;
   if (raw === null || raw === undefined) {
     return null;
@@ -63,7 +67,7 @@ export function readFlow(storage: InMemoryStorage): PendingFlow | null {
 
 /** Store a pending flow the way `signIn` would before navigating away. */
 export function seedPendingFlow(
-  storage: InMemoryStorage,
+  storage: TokenStorage,
   refs: OauthProviderRefs = ACME_REFS,
   state = "state-1",
 ): void {
@@ -82,7 +86,7 @@ export function seedPendingFlow(
  * standing in for the Convex call. The mock records the function reference it
  * was called with, so tests can assert which function ran.
  */
-export function oauthClient(storage: InMemoryStorage): {
+export function oauthClient(storage: TokenStorage): {
   client: AuthClient;
   signInApi: AuthSignInApi;
   mutation: ReturnType<typeof vi.fn>;
@@ -100,7 +104,9 @@ export function oauthClient(storage: InMemoryStorage): {
 }
 
 /** {@link oauthClient} plus the values the oauth setup published. */
-export function setupOAuth({ storage = new InMemoryStorage() } = {}) {
+export function setupOAuth({
+  storage = new InMemoryStorage() as TokenStorage,
+} = {}) {
   const { client, mutation } = oauthClient(storage);
   const oauthValues = client.ambientSignInValues(OAUTH_SETUP_ID);
   const actions = oauthValues.get<OauthActions>(OAUTH_ACTIONS_KEY)!;


### PR DESCRIPTION
- Add a `rejected` flow error for sign-ins the app's own backend turns down, with the message from its `ConvexError`
- Set `flowError` on start and storage failures too, so a caller that ignores the `signIn` rejection still has something to show
