### PR TITLE
Add getAuthUserId

### DIFF
--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -12,8 +12,8 @@
  *
  * @module
  */
+import { getAuthUserId } from "@convex-dev/auth/core";
 import { v } from "convex/values";
-import { Id } from "./_generated/dataModel";
 import { internalMutation, query } from "./_generated/server";
 
 export const createUserAnonymous = internalMutation({
@@ -76,11 +76,10 @@ export const onSignInPassword = internalMutation({
 export const loggedInUser = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (identity === null) {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">;
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;

--- a/examples/react-minimal/convex/currentUser.ts
+++ b/examples/react-minimal/convex/currentUser.ts
@@ -1,5 +1,5 @@
+import { getAuthUserId } from "@convex-dev/auth/core";
 import { query } from "./_generated/server";
-import { Id } from "./_generated/dataModel";
 
 /**
  * The currently signed-in user, or null.
@@ -9,11 +9,10 @@ import { Id } from "./_generated/dataModel";
 export const loggedInUser = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (identity === null) {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;

--- a/examples/react-passkey/convex/currentUser.ts
+++ b/examples/react-passkey/convex/currentUser.ts
@@ -1,6 +1,6 @@
+import { getAuthUserId } from "@convex-dev/auth/core";
 import { query } from "./_generated/server";
 import { components } from "./_generated/api";
-import { Id } from "./_generated/dataModel";
 
 /**
  * The currently signed-in user, or null.
@@ -10,11 +10,10 @@ import { Id } from "./_generated/dataModel";
 export const loggedInUser = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (identity === null) {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;

--- a/examples/react-password/convex/currentUser.ts
+++ b/examples/react-password/convex/currentUser.ts
@@ -1,6 +1,6 @@
+import { getAuthUserId } from "@convex-dev/auth/core";
 import { query } from "./_generated/server";
 import { components } from "./_generated/api";
-import { Id } from "./_generated/dataModel";
 
 /**
  * The currently signed-in user, or null.
@@ -10,11 +10,10 @@ import { Id } from "./_generated/dataModel";
 export const loggedInUser = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (identity === null) {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
       return null;
     }
-    const userId = identity.subject as Id<"users">; // TODO(nicolas) Avoid this
     const user = await ctx.db.get("users", userId);
     if (user === null) {
       return null;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/lib/*.d.ts",
       "default": "./dist/lib/*.js"
     },
+    "./core": {
+      "types": "./dist/components/core/index.d.ts",
+      "default": "./dist/components/core/index.js"
+    },
     "./core/*.js": {
       "types": "./dist/components/core/*.d.ts",
       "default": "./dist/components/core/*.js"

--- a/packages/core/src/components/core/_generated/api.ts
+++ b/packages/core/src/components/core/_generated/api.ts
@@ -10,9 +10,11 @@
 
 import type * as crypto from "../crypto.js";
 import type * as http from "../http.js";
+import type * as index from "../index.js";
 import type * as public_ from "../public.js";
 import type * as setup from "../setup.js";
 import type * as testApp from "../testApp.js";
+import type * as userId from "../userId.js";
 
 import type {
   ApiFromModules,
@@ -24,9 +26,11 @@ import { anyApi, componentsGeneric } from "convex/server";
 const fullApi: ApiFromModules<{
   crypto: typeof crypto;
   http: typeof http;
+  index: typeof index;
   public: typeof public_;
   setup: typeof setup;
   testApp: typeof testApp;
+  userId: typeof userId;
 }> = anyApi as any;
 
 /**

--- a/packages/core/src/components/core/index.ts
+++ b/packages/core/src/components/core/index.ts
@@ -1,0 +1,1 @@
+export { getAuthUserId } from "./userId.ts";

--- a/packages/core/src/components/core/userId.test.ts
+++ b/packages/core/src/components/core/userId.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import type { Auth, UserIdentity } from "convex/server";
+import { getAuthUserId } from "./userId.ts";
+
+/** A ctx whose `auth` reports the given identity, as Convex's would. */
+function ctxWithIdentity(identity: UserIdentity | null) {
+  return {
+    auth: {
+      getUserIdentity: async () => identity,
+    } as unknown as Auth,
+  };
+}
+
+describe("getAuthUserId", () => {
+  test("returns the identity's subject, which the core mints as the user id", async () => {
+    const ctx = ctxWithIdentity({
+      tokenIdentifier: "https://example.convex.site|user-1",
+      subject: "user-1",
+      issuer: "https://example.convex.site",
+    });
+    expect(await getAuthUserId(ctx)).toBe("user-1");
+  });
+
+  test("returns null when the caller has no identity", async () => {
+    expect(await getAuthUserId(ctxWithIdentity(null))).toBe(null);
+  });
+});

--- a/packages/core/src/components/core/userId.ts
+++ b/packages/core/src/components/core/userId.ts
@@ -1,0 +1,33 @@
+import type { Auth } from "convex/server";
+import type { GenericId } from "convex/values";
+
+/**
+ * The ID of the user the caller is signed in as, or `null` when the caller is
+ * not signed in.
+ *
+ * ```ts
+ * import { getAuthUserId } from "@convex-dev/auth/core";
+ *
+ * export const loggedInUser = query({
+ *   args: {},
+ *   handler: async (ctx) => {
+ *     const userId = await getAuthUserId(ctx);
+ *     if (userId === null) {
+ *       return null;
+ *     }
+ *     return await ctx.db.get("users", userId);
+ *   },
+ * });
+ * ```
+ */
+export async function getAuthUserId(ctx: {
+  auth: Auth;
+}): Promise<GenericId<"users"> | null> {
+  // TODO(nicolas) This should validate the session
+
+  const identity = await ctx.auth.getUserIdentity();
+  if (identity === null) {
+    return null;
+  }
+  return identity.subject as GenericId<"users">;
+}


### PR DESCRIPTION
Current examples extract the user ID from the session ID manually. This should be discouraged, and we should have a better API instead.

I’m open to changes in the API name/location