### PR TITLE
add release scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Developing guide
+
+## Running locally
+
+```sh
+pnpm install
+```
+
+Then run one of the example apps from its own directory:
+
+```sh
+cd examples/react-password
+pnpm dev
+```
+
+Each example is a self-contained Convex backend that mounts the auth components,
+so the first `pnpm dev` prompts you to pick or create a deployment.
+
+- `examples/react-minimal` uses the core component with the anonymous provider.
+- `examples/react-password` adds the password provider.
+- `examples/react-passkey` adds the passkey provider.
+- `examples/react-github` adds the GitHub Oauth provider.
+- `examples/react-google` adds the Google OAuth provider.
+- `examples/nextjs` covers the Next.js integration.
+
+## Common tasks
+
+- `pnpm build` — compile `@convex-dev/auth` to `dist/` (also runs on install
+  via `prepare`).
+- `pnpm test` — run tests across packages (Vitest).
+- `pnpm typecheck` — typecheck across packages.
+- `pnpm lint` — ESLint.
+- `pnpm format` — Prettier.
+
+## Testing
+
+```sh
+pnpm build
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+`pnpm typecheck` covers `packages/argon2id-wasm`, which needs the generated
+Rust bindings. On a fresh clone those don't exist yet, so either build them once
+(see below) or skip that package:
+
+```sh
+pnpm -r --filter=!argon2id-wasm typecheck
+```
+
+## Rust code
+
+Only `packages/argon2id-wasm` has Rust, and it changes rarely. You need a Rust
+toolchain and `just`.
+
+```sh
+cd packages/argon2id-wasm/rust
+just build   # regenerates pkg/, which the TypeScript wrapper imports
+just test
+just lint
+```
+
+`pkg/` is generated and not committed. `just build` is what makes
+`pnpm typecheck` pass for this package.
+
+## Releasing
+
+Only `@convex-dev/auth` is released by script. `argon2id-wasm` is published by
+hand, see below.
+
+### Building a one-off package
+
+```sh
+cd packages/core
+pnpm pack
+```
+
+### Publishing a new version
+
+Run from the repo root, on `reboot`, with a clean working tree.
+
+For an alpha release:
+
+```sh
+pnpm alpha
+```
+
+For a standard (latest tag) release:
+
+```sh
+pnpm release
+```
+
+### Publishing argon2id-wasm
+
+Only needed when the Rust changes. Its `prepack` builds the Rust and WASM
+output, so this needs the toolchain from the section above.
+
+```sh
+cd packages/argon2id-wasm
+# bump the version in package.json, then
+pnpm publish --tag alpha --publish-branch reboot
+```
+
+Then update the exact `argon2id-wasm` version in `packages/core`'s dependencies
+and run `pnpm install`.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,7 @@ This branch contains a WIP implementation of Convex Auth v2.
 
 ## Getting Started
 
-Use `pnpm install` at the root.
-
-Common tasks:
-
-- `pnpm build` — compile `@convex-dev/auth` to `dist/` (also runs on install
-  via `prepare`).
-- `pnpm test` — run tests across packages (Vitest).
-- `pnpm typecheck` — typecheck across packages.
-- `pnpm lint` — ESLint.
-- `pnpm format` — Prettier.
+TODO: Write the v2 README.
 
 ## Examples
 
@@ -25,3 +16,5 @@ directory (see the example's own README):
 - `examples/react-password` — the core component with the password provider.
 
 Their tests run as part of `pnpm test` at the repo root.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to develop in this repo.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "format:check": "prettier . --check",
     "typecheck": "pnpm -r typecheck",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "alpha": "pnpm --filter @convex-dev/auth alpha",
+    "release": "pnpm --filter @convex-dev/auth release"
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -118,11 +118,15 @@
     }
   },
   "scripts": {
+    "alpha": "pnpm version prerelease --preid alpha && pnpm publish --tag alpha --publish-branch reboot && git push --follow-tags",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "generate:common-passwords": "bun src/components/password/scripts/generateCommonPasswords.script.ts",
     "prepare": "pnpm run build",
-    "typecheck": "tsc --noEmit"
+    "preversion": "pnpm -w install --frozen-lockfile && pnpm -w build && pnpm -w lint && pnpm -r --filter=!argon2id-wasm typecheck && pnpm -w test",
+    "release": "pnpm version patch && pnpm publish --publish-branch reboot && git push --follow-tags",
+    "typecheck": "tsc --noEmit",
+    "version": "(npm whoami || npm login) && vim -c 'normal o' -c 'normal o## '$npm_package_version ../../CHANGELOG.md && prettier -w ../../CHANGELOG.md && git add ../../CHANGELOG.md"
   },
   "dependencies": {
     "@babel/code-frame": "^7.29.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,17 @@
   ],
   "type": "module",
   "sideEffects": false,
+  "scripts": {
+    "alpha": "pnpm version prerelease --preid alpha && pnpm publish --tag alpha --publish-branch reboot && git push --follow-tags",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "generate:common-passwords": "bun src/components/password/scripts/generateCommonPasswords.script.ts",
+    "prepare": "pnpm run build",
+    "preversion": "pnpm -w install --frozen-lockfile && pnpm -w build && pnpm -w lint && pnpm -r --filter=!argon2id-wasm typecheck && pnpm -w test",
+    "release": "pnpm version patch && pnpm publish --publish-branch reboot && git push --follow-tags",
+    "typecheck": "tsc --noEmit",
+    "version": "(npm whoami || npm login) && vim -c 'normal o' -c 'normal o## '$npm_package_version ../../CHANGELOG.md && prettier -w ../../CHANGELOG.md && git add ../../CHANGELOG.md"
+  },
   "exports": {
     "./package.json": "./package.json",
     "./lib/*.js": {
@@ -116,17 +127,6 @@
       "types": "./dist/nextjs/server.d.ts",
       "default": "./dist/nextjs/server.js"
     }
-  },
-  "scripts": {
-    "alpha": "pnpm version prerelease --preid alpha && pnpm publish --tag alpha --publish-branch reboot && git push --follow-tags",
-    "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist",
-    "generate:common-passwords": "bun src/components/password/scripts/generateCommonPasswords.script.ts",
-    "prepare": "pnpm run build",
-    "preversion": "pnpm -w install --frozen-lockfile && pnpm -w build && pnpm -w lint && pnpm -r --filter=!argon2id-wasm typecheck && pnpm -w test",
-    "release": "pnpm version patch && pnpm publish --publish-branch reboot && git push --follow-tags",
-    "typecheck": "tsc --noEmit",
-    "version": "(npm whoami || npm login) && vim -c 'normal o' -c 'normal o## '$npm_package_version ../../CHANGELOG.md && prettier -w ../../CHANGELOG.md && git add ../../CHANGELOG.md"
   },
   "dependencies": {
     "@babel/code-frame": "^7.29.7",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,8 @@ packages:
 # security fix), override this with:
 # `pnpm add <package>@<version> --config.minimumReleaseAge=0`.
 minimumReleaseAge: 10080
+
+# Packages listed here skip the wait above. Avoid adding third party packages
+# to this list.
+minimumReleaseAgeExclude:
+  - argon2id-wasm


### PR DESCRIPTION
Adds alpha and latest release scripts, core only. Follows existing pattern from convex auth v1 and other components.