### PR TITLE
Add some refresh token reuse detection

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -67,3 +67,28 @@ catalogs assume a static `CLIENT_SECRET` binding.
 Potential fix direction: accept POST on the callback route
 (`packages/core/src/oauth/component/http.ts`), and add a signed-secret
 mechanism to the catalog config (`packages/core/src/oauth/component/setup.ts`).
+
+## Refresh-token reuse detection has a bounded horizon
+
+A spent hash is remembered for `SPENT_TOKEN_HORIZON_MS` (1 hour) and pruned by
+later rotations of the same session.
+
+Spent rows are pruned inline by the rotations of their own session, so a session
+abandoned mid-life leaves its remaining rows behind until it is signed out or
+expires — the same way an abandoned session row itself lingers today. Roughly
+`horizon ÷ refresh interval` rows, about 60 at the defaults.
+
+Nothing bounds that per-session set independently, and both `pruneSpentTokens`
+and `deleteSession` read all of it. At any plausible refresh rate that is a
+few dozen rows, but a session refreshed pathologically often (an unthrottled
+client, or an attacker hammering `refresh` — see the rate-limiting entry above)
+could grow it until those reads exceed the transaction's limits, which would
+make the session unrefreshable and un-signoutable. Accepted for now on the
+basis that the sweep below lands first.
+
+Fix direction: a `@convex-dev/batch-worker` loop over `spentRefreshTokens` by
+`_creationTime`, mirroring `packages/core/src/components/passkey/cleanup.ts`,
+to sweep orphans globally and cap the table regardless of any one session's
+behavior. Bound its idle probe's range read above (the passkey version's
+`gte(cursor)` is unbounded, which would put the whole index tail in the loop's
+read set and thrash on OCC at refresh volume).

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -69,8 +69,10 @@ function setup() {
   return convexTest(schema, modules);
 }
 
+type ConvexTestApi = ReturnType<typeof setup>;
+
 /** Establish a brand new identity: the account, its app user, and a session. */
-async function signUp(t: ReturnType<typeof setup>, c: AuthClaims) {
+async function signUp(t: ConvexTestApi, c: AuthClaims) {
   return await t.mutation(api.public.signUp, {
     claims: c,
     createUserHandle: CREATE_USER_HANDLE,
@@ -80,7 +82,7 @@ async function signUp(t: ReturnType<typeof setup>, c: AuthClaims) {
 }
 
 /** Sign a known identity back in, as an app that attached an `onSignIn` does. */
-async function signIn(t: ReturnType<typeof setup>, c: AuthClaims) {
+async function signIn(t: ConvexTestApi, c: AuthClaims) {
   return await t.mutation(api.public.signIn, {
     claims: c,
     onSignInHandle: ON_SIGN_IN_HANDLE,
@@ -95,26 +97,26 @@ function expectBundle(bundle: TokenBundle | null): TokenBundle {
 }
 
 /** Exchange a refresh token, as a client rotating its session does. */
-async function refresh(t: ReturnType<typeof setup>, refreshToken: string) {
+async function refresh(t: ConvexTestApi, refreshToken: string) {
   return await t.mutation(api.public.refresh, { refreshToken, issuer: ISSUER });
 }
 
 /** How many sessions currently exist. */
-async function sessionCount(t: ReturnType<typeof setup>) {
+async function sessionCount(t: ConvexTestApi) {
   return await t.run(
     async (ctx) => (await ctx.db.query("sessions").collect()).length,
   );
 }
 
 /** The hashes rotation has retired, oldest first. */
-async function spentHashes(t: ReturnType<typeof setup>) {
+async function spentHashes(t: ConvexTestApi) {
   return await t.run(async (ctx) =>
     (await ctx.db.query("spentRefreshTokens").collect()).map((r) => r.hash),
   );
 }
 
 /** The hash of the token a session currently accepts. */
-async function currentHash(t: ReturnType<typeof setup>) {
+async function currentHash(t: ConvexTestApi) {
   return await t.run(
     async (ctx) => (await ctx.db.query("sessions").unique())?.refreshTokenHash,
   );

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -1,5 +1,13 @@
 import { convexTest } from "convex-test";
-import { beforeAll, describe, expect, test } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import {
   exportJWK,
   exportPKCS8,
@@ -20,6 +28,8 @@ import {
   type TokenBundle,
   USE_USER_ID_AS_ACCOUNT_ID,
 } from "../../lib/types.ts";
+import { sha256Hex } from "../../lib/crypto.ts";
+import { REFRESH_GRACE_MS, SPENT_TOKEN_HORIZON_MS } from "./public.ts";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -82,6 +92,32 @@ async function signIn(t: ReturnType<typeof setup>, c: AuthClaims) {
 function expectBundle(bundle: TokenBundle | null): TokenBundle {
   expect(bundle).not.toBeNull();
   return bundle as TokenBundle;
+}
+
+/** Exchange a refresh token, as a client rotating its session does. */
+async function refresh(t: ReturnType<typeof setup>, refreshToken: string) {
+  return await t.mutation(api.public.refresh, { refreshToken, issuer: ISSUER });
+}
+
+/** How many sessions currently exist. */
+async function sessionCount(t: ReturnType<typeof setup>) {
+  return await t.run(
+    async (ctx) => (await ctx.db.query("sessions").collect()).length,
+  );
+}
+
+/** The hashes rotation has retired, oldest first. */
+async function spentHashes(t: ReturnType<typeof setup>) {
+  return await t.run(async (ctx) =>
+    (await ctx.db.query("spentRefreshTokens").collect()).map((r) => r.hash),
+  );
+}
+
+/** The hash of the token a session currently accepts. */
+async function currentHash(t: ReturnType<typeof setup>) {
+  return await t.run(
+    async (ctx) => (await ctx.db.query("sessions").unique())?.refreshTokenHash,
+  );
 }
 
 describe("signUp", () => {
@@ -422,6 +458,134 @@ describe("refresh", () => {
     });
     expect(result).toBeNull();
   });
+
+  test("an unknown token revokes nothing", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+
+    expect(await refresh(t, "not-a-real-token")).toBeNull();
+
+    // Revoking on an unrecognized token would let anyone sign anyone else out
+    // by presenting a made-up string. The live session is untouched.
+    expect(await sessionCount(t)).toBe(1);
+    expect(expectBundle(await refresh(t, bundle.refreshToken))).toBeTruthy();
+  });
+
+  test("retires the rotated-away hash and never the current one", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+
+    const first = await currentHash(t);
+    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    const second = await currentHash(t);
+
+    expect(second).not.toBe(first);
+    expect(await spentHashes(t)).toEqual([first]);
+
+    expectBundle(await refresh(t, rotated.refreshToken));
+    // One spent hash per rotation, and the live token is never among them.
+    expect(await spentHashes(t)).toEqual([first, second]);
+    expect(await spentHashes(t)).not.toContain(await currentHash(t));
+  });
+});
+
+describe("refresh-token reuse detection", () => {
+  // `_creationTime` is what dates a spent hash, and it can't be patched, so
+  // aging one past the grace window means moving the clock.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a token replayed past the grace window revokes the session", async () => {
+    const t = setup();
+    const stolen = await signUp(t, claims());
+
+    // The thief gets there first, so the session's live token is now theirs.
+    const thief = expectBundle(await refresh(t, stolen.refreshToken));
+    vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
+
+    // The victim presents the token they still hold. It was rotated away too
+    // long ago to be a concurrent refresh, so the session dies.
+    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect(await sessionCount(t)).toBe(0);
+    expect(await spentHashes(t)).toEqual([]);
+
+    // Revocation is mutual: the thief's token stops working too, which is the
+    // whole point — otherwise they keep renewing the session forever.
+    expect(await refresh(t, thief.refreshToken)).toBeNull();
+  });
+
+  test("detects a replay several rotations back", async () => {
+    const t = setup();
+    const stolen = await signUp(t, claims());
+
+    // A thief who keeps rotating would evict the victim's hash from any
+    // fixed-size history. Retention is by age, so depth doesn't save them.
+    let latest = stolen;
+    for (let i = 0; i < 5; i++) {
+      latest = expectBundle(await refresh(t, latest.refreshToken));
+    }
+    expect(await spentHashes(t)).toHaveLength(5);
+    vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
+
+    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect(await sessionCount(t)).toBe(0);
+    expect(await refresh(t, latest.refreshToken)).toBeNull();
+  });
+
+  test("a replay inside the grace window is still a concurrent refresh", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+
+    expectBundle(await refresh(t, bundle.refreshToken));
+    vi.advanceTimersByTime(REFRESH_GRACE_MS - 1_000);
+
+    // Two tabs sharing a cookie land here routinely; it must not be mistaken
+    // for theft.
+    expect(expectBundle(await refresh(t, bundle.refreshToken))).toBeTruthy();
+    expect(await sessionCount(t)).toBe(1);
+  });
+
+  test("a replay after the session is already gone is a no-op", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    await t.mutation(api.public.signOut, {
+      refreshToken: rotated.refreshToken,
+    });
+    vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
+
+    // Two replays racing each other both resolve a session the other deleted.
+    await expect(refresh(t, bundle.refreshToken)).resolves.toBeNull();
+  });
+
+  test("pruning retires spent hashes, and with them the detection", async () => {
+    const t = setup();
+    const stolen = await signUp(t, claims());
+    const live = expectBundle(await refresh(t, stolen.refreshToken));
+    expect(await spentHashes(t)).toHaveLength(1);
+
+    vi.advanceTimersByTime(SPENT_TOKEN_HORIZON_MS + 1);
+    // The next rotation pays for the row it adds by erasing the expired one.
+    const next = expectBundle(await refresh(t, live.refreshToken));
+    expect(await spentHashes(t)).toEqual([await sha256Hex(live.refreshToken)]);
+
+    // Past the horizon the stolen token is merely unknown, so it revokes
+    // nothing. Detection is best-effort by construction.
+    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect(await sessionCount(t)).toBe(1);
+    expectBundle(await refresh(t, next.refreshToken));
+  });
+
+  test("the detection horizon outlives the grace window", () => {
+    // A spent hash erased while still inside its grace window would turn a
+    // routine concurrent refresh into a forced sign-out.
+    expect(SPENT_TOKEN_HORIZON_MS).toBeGreaterThan(REFRESH_GRACE_MS);
+  });
 });
 
 describe("signOut", () => {
@@ -443,6 +607,35 @@ describe("signOut", () => {
       issuer: ISSUER,
     });
     expect(afterSignOut).toBeNull();
+  });
+
+  test("revokes when given a token a refresh just rotated away", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+
+    // A tab that signs out just after a sibling refreshed presents the token
+    // it still holds. Matching only the current hash would no-op here and
+    // leave the session alive after an explicit sign-out.
+    await t.mutation(api.public.signOut, { refreshToken: bundle.refreshToken });
+
+    expect(await sessionCount(t)).toBe(0);
+    expect(await spentHashes(t)).toEqual([]);
+    expect(await refresh(t, rotated.refreshToken)).toBeNull();
+  });
+
+  test("erases the session's spent hashes along with it", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    expect(await spentHashes(t)).toHaveLength(1);
+
+    await t.mutation(api.public.signOut, {
+      refreshToken: rotated.refreshToken,
+    });
+
+    // A spent hash must never outlive the session it names.
+    expect(await spentHashes(t)).toEqual([]);
   });
 
   test("is idempotent — signing out an already-revoked token does not throw", async () => {

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -621,6 +621,10 @@ export const refresh = mutation({
     if (!isValid) {
       // Past its refresh-token lifetime or a spent token past the grace
       // window: delete the session and grant no more tokens.
+      console.warn(
+        "Spent refresh token used out of grace window: deleting the associated session. " +
+          "This could be due to a bug or a leaked refresh token.",
+      );
       await deleteSession(ctx, session._id);
       return null;
     }

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -33,12 +33,9 @@ const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 // each other into a forced sign-out. Past this, presenting a rotated-away
 // token is treated as theft — see `sessionBySpentHash`.
 export const REFRESH_GRACE_MS = 30 * 1000; // 30 seconds
-// How long a spent hash is remembered. This is the reuse-detection horizon:
-// past it the row is gone and a replayed token reads as unknown, which revokes
-// nothing but also grants nothing.
-//
-// It bounds *detection* only, never normal use — a session's current token is
-// never in the spent table, so an idle client's token still works after weeks.
+// How long a spent refresh token hash is remembered. This is the
+// reuse-detection horizon: past it the row is gone and a replayed token reads
+// as unknown, which revokes nothing but also grants nothing.
 export const SPENT_TOKEN_HORIZON_MS = 60 * 60 * 1000; // 1 hour
 
 // The issuer (CONVEX_SITE_URL) is passed in by the app rather than read here:

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -122,10 +122,13 @@ async function deleteSession(
 /**
  * Erase this session's spent hashes that are past the detection horizon.
  *
- * Cleanup rides on the rotation that creates the work, so a steadily
- * refreshing session keeps its own set trimmed with no background job to run
- * or mount. The `by_session` index orders by creation time within a session,
- * so the expired rows come first and the loop stops at the first live one.
+ * Spent tokens are used to allow concurrent refreshes within a grace window
+ * and to detect illegitamite use of a refresh token. Only a bounded set of
+ * tokens is kept for that purpose though, thus this code to prune documents
+ * older than the `SPENT_TOKEN_HORIZON_MS`.
+ *
+ * Cleanup is triggered by token rotation, so a steadily refreshing session
+ * keeps its own set trimmed with no background job to run or mount.
  */
 async function pruneSpentTokens(
   ctx: MutationCtx,
@@ -137,11 +140,13 @@ async function pruneSpentTokens(
   // background job would add; see KNOWN_ISSUES.md.
   const spent = await ctx.db
     .query("spentRefreshTokens")
-    .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
-    .order("asc")
+    .withIndex("by_session", (q) =>
+      q
+        .eq("sessionId", sessionId)
+        .lte("_creationTime", now - SPENT_TOKEN_HORIZON_MS),
+    )
     .collect();
   for (const row of spent) {
-    if (row._creationTime > now - SPENT_TOKEN_HORIZON_MS) break;
     await ctx.db.delete("spentRefreshTokens", row._id);
   }
 }

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -30,8 +30,16 @@ const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60; // 1 minute
 const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 // How long a just-rotated refresh token stays usable so concurrent refreshes
 // presenting it (parallel SSR loaders, two tabs sharing a cookie) don't race
-// each other into a forced sign-out.
-const REFRESH_GRACE_MS = 30 * 1000; // 30 seconds
+// each other into a forced sign-out. Past this, presenting a rotated-away
+// token is treated as theft — see `refreshWithSpentToken`.
+export const REFRESH_GRACE_MS = 30 * 1000; // 30 seconds
+// How long a spent hash is remembered. This is the reuse-detection horizon:
+// past it the row is gone and a replayed token reads as unknown, which revokes
+// nothing but also grants nothing.
+//
+// It bounds *detection* only, never normal use — a session's current token is
+// never in the spent table, so an idle client's token still works after weeks.
+export const SPENT_TOKEN_HORIZON_MS = 60 * 60 * 1000; // 1 hour
 
 // The issuer (CONVEX_SITE_URL) is passed in by the app rather than read here:
 // inside a component the system var arrives prefixed with the mount's
@@ -65,6 +73,77 @@ function sessionByHash(
       q.eq("refreshTokenHash", refreshTokenHash),
     )
     .unique();
+}
+
+/**
+ * Look up data for a refresh token that has been previously used.
+ *
+ * The returned document stores the refresh time via the `_creationTime` field
+ * as well as the associated `sessionId`.
+ */
+function spentTokenByHash(
+  ctx: QueryCtx,
+  hash: string,
+): Promise<Doc<"spentRefreshTokens"> | null> {
+  return ctx.db
+    .query("spentRefreshTokens")
+    .withIndex("by_hash", (q) => q.eq("hash", hash))
+    .unique();
+}
+
+/**
+ * Erase a session along with every spent refresh hash that points at it.
+ *
+ * Idempotent, because callers can race: two replays of the same stolen token,
+ * or a sign-out arriving alongside one, can both resolve the same session.
+ */
+async function deleteSession(
+  ctx: MutationCtx,
+  sessionId: Id<"sessions">,
+): Promise<void> {
+  // Reads every spent row the session has. That is fine at any plausible refresh
+  // rate — the horizon divided by the refresh interval, ~60 at the defaults — but
+  // it is unbounded in principle. A session refreshed pathologically often
+  // could exceed the transaction's limits and make the session unusable.
+  const spent = await ctx.db
+    .query("spentRefreshTokens")
+    .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+    .collect();
+  for (const row of spent) {
+    await ctx.db.delete("spentRefreshTokens", row._id);
+  }
+  // `delete` throws on an id that is already gone, and the session may have
+  // been deleted by whoever we raced.
+  if ((await ctx.db.get("sessions", sessionId)) !== null) {
+    await ctx.db.delete("sessions", sessionId);
+  }
+}
+
+/**
+ * Erase this session's spent hashes that are past the detection horizon.
+ *
+ * Cleanup rides on the rotation that creates the work, so a steadily
+ * refreshing session keeps its own set trimmed with no background job to run
+ * or mount. The `by_session` index orders by creation time within a session,
+ * so the expired rows come first and the loop stops at the first live one.
+ */
+async function pruneSpentTokens(
+  ctx: MutationCtx,
+  sessionId: Id<"sessions">,
+  now: number,
+): Promise<void> {
+  // A session that stops refreshing keeps its remaining rows until it is
+  // deleted, since nothing rotates it any more. Sweeping those orphans is what a
+  // background job would add; see KNOWN_ISSUES.md.
+  const spent = await ctx.db
+    .query("spentRefreshTokens")
+    .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+    .order("asc")
+    .collect();
+  for (const row of spent) {
+    if (row._creationTime > now - SPENT_TOKEN_HORIZON_MS) break;
+    await ctx.db.delete("spentRefreshTokens", row._id);
+  }
 }
 
 /**
@@ -410,10 +489,95 @@ export const getUserIdByAccount = query({
 });
 
 /**
- * Rotate a refresh token and mint a fresh access token. Returns `null` when the
- * session can't be refreshed. That can happen with an unknown token, or one
- * past its refresh-token lifetime. A dead session is a normal outcome the
- * caller should handle by updating its authenticated state.
+ * Mint a new refresh token for a live session, retiring the one it replaces.
+ *
+ * The retired hash goes into `spentRefreshTokens`, which is what lets a later
+ * presentation of it be recognized as either a concurrent refresh or a replay.
+ */
+async function rotateSession(
+  ctx: MutationCtx,
+  session: Doc<"sessions">,
+  now: number,
+  issuer: string,
+  ttl: TtlConfig,
+): Promise<TokenBundle> {
+  const newRefreshToken = generateRefreshToken();
+  const newRefreshTokenHash = await sha256Hex(newRefreshToken);
+  const refreshTokenExpiresAt = now + ttl.refreshTokenTtlSeconds * 1000;
+  await ctx.db.insert("spentRefreshTokens", {
+    hash: session.refreshTokenHash,
+    sessionId: session._id,
+  });
+  await ctx.db.patch("sessions", session._id, {
+    refreshTokenHash: newRefreshTokenHash,
+    refreshTokenExpiresAt,
+    lastRefreshedAt: now,
+  });
+
+  // Remove any spent tokens past the `SPENT_TOKEN_HORIZON_MS`.
+  await pruneSpentTokens(ctx, session._id, now);
+
+  const access = await mintAccessToken(
+    session.userId,
+    issuer,
+    ttl.accessTokenTtlSeconds,
+  );
+  return {
+    accessToken: access.token,
+    accessTokenExpiresAt: access.expiresAt,
+    refreshToken: newRefreshToken,
+    refreshTokenExpiresAt,
+    userId: session.userId,
+  };
+}
+
+/**
+ * Attempts a refresh with a previously used token.
+ *
+ * Inside the grace window this is a concurrent refresh and rotates normally.
+ *
+ * Outside it, the token was rotated away long enough ago that nobody should
+ * still be presenting it, so it is treated as stolen and the session is
+ * revoked.
+ */
+async function attemptRefreshWithSpentToken(
+  ctx: MutationCtx,
+  hash: string,
+  now: number,
+  issuer: string,
+  ttl: TtlConfig,
+): Promise<TokenBundle | null> {
+  const spent = await spentTokenByHash(ctx, hash);
+  // A token this component has no record of ever issuing. Revoking anything
+  // here would let anyone sign anyone else out by presenting a made-up string,
+  // so an unknown token reports no session and changes nothing.
+  if (spent === null) return null;
+
+  const session = await ctx.db.get("sessions", spent.sessionId);
+  // Already signed out, expired, or revoked a moment ago by a sibling
+  // detecting the same replay. Nothing left to revoke or report.
+  if (session === null) return null;
+
+  if (now - spent._creationTime > REFRESH_GRACE_MS) {
+    await deleteSession(ctx, session._id);
+    return null;
+  }
+  if (session.refreshTokenExpiresAt < now) {
+    await deleteSession(ctx, session._id);
+    return null;
+  }
+  return await rotateSession(ctx, session, now, issuer, ttl);
+}
+
+/**
+ * Rotate a refresh token and mint a fresh access token.
+ *
+ * Returns `null` when the session can't be refreshed. That can happen with an
+ * unknown token, one past its refresh-token lifetime, or one whose session was
+ * just revoked because the token had already been rotated away (see {@link
+ * refreshWithSpentToken}). A dead session is a normal outcome the caller
+ * should handle by updating its authenticated state; the reasons are
+ * deliberately indistinguishable, so a thief learns nothing from the response.
  */
 export const refresh = mutation({
   args: {
@@ -428,58 +592,23 @@ export const refresh = mutation({
     const now = Date.now();
     const hash = await sha256Hex(args.refreshToken);
 
-    // Accept either the current hash or a recently-rotated one still inside its
-    // grace window (the concurrent-refresh case).
-    let session = await sessionByHash(ctx, hash);
-    if (!session) {
-      const prior = await ctx.db
-        .query("sessions")
-        .withIndex("by_previous_refresh_hash", (q) =>
-          q.eq("previousRefreshTokenHash", hash),
-        )
-        .unique();
-      if (
-        prior &&
-        prior.previousRefreshTokenExpiresAt !== undefined &&
-        prior.previousRefreshTokenExpiresAt >= now
-      ) {
-        session = prior;
-      }
+    const session = await sessionByHash(ctx, hash);
+    if (session === null) {
+      return await attemptRefreshWithSpentToken(
+        ctx,
+        hash,
+        now,
+        args.issuer,
+        ttl,
+      );
     }
-    // Unknown token: no session to refresh, and nothing to clean up.
-    if (!session) return null;
     if (session.refreshTokenExpiresAt < now) {
       // Past its refresh-token lifetime: delete the dead row and report no
       // session.
-      await ctx.db.delete("sessions", session._id);
+      await deleteSession(ctx, session._id);
       return null;
     }
-
-    const newRefreshToken = generateRefreshToken();
-    const newRefreshTokenHash = await sha256Hex(newRefreshToken);
-    const refreshTokenExpiresAt = now + ttl.refreshTokenTtlSeconds * 1000;
-    // Retain the hash we're replacing as the previous one, valid for the grace
-    // window, then swap in the freshly-minted token as current.
-    await ctx.db.patch("sessions", session._id, {
-      refreshTokenHash: newRefreshTokenHash,
-      refreshTokenExpiresAt,
-      previousRefreshTokenHash: session.refreshTokenHash,
-      previousRefreshTokenExpiresAt: now + REFRESH_GRACE_MS,
-      lastRefreshedAt: now,
-    });
-
-    const access = await mintAccessToken(
-      session.userId,
-      args.issuer,
-      ttl.accessTokenTtlSeconds,
-    );
-    return {
-      accessToken: access.token,
-      accessTokenExpiresAt: access.expiresAt,
-      refreshToken: newRefreshToken,
-      refreshTokenExpiresAt,
-      userId: session.userId,
-    };
+    return await rotateSession(ctx, session, now, args.issuer, ttl);
   },
 });
 
@@ -488,11 +617,18 @@ export const signOut = mutation({
   args: { refreshToken: v.string() },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const session = await sessionByHash(
-      ctx,
-      await sha256Hex(args.refreshToken),
-    );
-    if (session) await ctx.db.delete("sessions", session._id);
+    const hash = await sha256Hex(args.refreshToken);
+    const session = await sessionByHash(ctx, hash);
+    if (session !== null) {
+      await deleteSession(ctx, session._id);
+      return null;
+    }
+    // Signing out with a token a refresh rotated away — a tab that signs out
+    // just after a sibling refreshed — is a real sign-out request, not a race
+    // to resolve, so revoke regardless of the grace window. Matching only the
+    // current hash would leave the session alive after a sign-out.
+    const spent = await spentTokenByHash(ctx, hash);
+    if (spent !== null) await deleteSession(ctx, spent.sessionId);
     return null;
   },
 });

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -31,7 +31,7 @@ const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 // How long a just-rotated refresh token stays usable so concurrent refreshes
 // presenting it (parallel SSR loaders, two tabs sharing a cookie) don't race
 // each other into a forced sign-out. Past this, presenting a rotated-away
-// token is treated as theft — see `refreshWithSpentToken`.
+// token is treated as theft — see `sessionBySpentHash`.
 export const REFRESH_GRACE_MS = 30 * 1000; // 30 seconds
 // How long a spent hash is remembered. This is the reuse-detection horizon:
 // past it the row is gone and a replayed token reads as unknown, which revokes
@@ -62,17 +62,28 @@ function accountByIdentity(
     .unique();
 }
 
-/** Look up a session by the (current) hash of its refresh token. */
-function sessionByHash(
+/**
+ * Look up a session by the hash of its refresh token.
+ *
+ * Returns an object with the session (if found) and an `isValid` boolean value.
+ *
+ * A session is invalid if the refresh token is expired.
+ */
+async function sessionByHash(
   ctx: QueryCtx,
   refreshTokenHash: string,
-): Promise<Doc<"sessions"> | null> {
-  return ctx.db
+): Promise<{ session: Doc<"sessions"> | null; isValid: boolean }> {
+  const session = await ctx.db
     .query("sessions")
     .withIndex("by_refresh_hash", (q) =>
       q.eq("refreshTokenHash", refreshTokenHash),
     )
     .unique();
+  const now = Date.now();
+  return {
+    session,
+    isValid: session !== null && session.refreshTokenExpiresAt > now,
+  };
 }
 
 /**
@@ -175,6 +186,11 @@ function resolveTtlConfig(args: {
   if (accessTokenTtlSeconds >= refreshTokenTtlSeconds) {
     throw new Error(
       "Access-token TTL must be shorter than the refresh-token TTL.",
+    );
+  }
+  if (refreshTokenTtlSeconds * 1000 < REFRESH_GRACE_MS * 2) {
+    throw new Error(
+      `Refresh-token TTL must be at least ${(REFRESH_GRACE_MS / 1000) * 2} seconds`,
     );
   }
   return { accessTokenTtlSeconds, refreshTokenTtlSeconds };
@@ -494,10 +510,13 @@ export const getUserIdByAccount = query({
 });
 
 /**
- * Mint a new refresh token for a live session, retiring the one it replaces.
+ * Mint a new refresh token for a live session.
  *
- * The retired hash goes into `spentRefreshTokens`, which is what lets a later
- * presentation of it be recognized as either a concurrent refresh or a replay.
+ * The prior refresh token hash for the session goes into the
+ * `spentRefreshTokens` table, which lets a later presentation of it be
+ * recognized as either a concurrent refresh within the `REFRESH_GRACE_MS`
+ * window or an invalid usage (potential stolen token) that should end the
+ * session.
  */
 async function rotateSession(
   ctx: MutationCtx,
@@ -537,52 +556,49 @@ async function rotateSession(
 }
 
 /**
- * Attempts a refresh with a previously used token.
+ * Looks up a session by a spent refresh token hash.
  *
- * Inside the grace window this is a concurrent refresh and rotates normally.
+ * Returns an object with the session (if found) and an `isValid` boolean value.
  *
- * Outside it, the token was rotated away long enough ago that nobody should
- * still be presenting it, so it is treated as stolen and the session is
- * revoked.
+ * A session is invalid if the spent token hash is used past the grace window
+ * or if the current refresh token for the session is expired.
  */
-async function attemptRefreshWithSpentToken(
+async function sessionBySpentHash(
   ctx: MutationCtx,
   hash: string,
-  now: number,
-  issuer: string,
-  ttl: TtlConfig,
-): Promise<TokenBundle | null> {
+): Promise<{ session: Doc<"sessions"> | null; isValid: boolean }> {
   const spent = await spentTokenByHash(ctx, hash);
   // A token this component has no record of ever issuing. Revoking anything
   // here would let anyone sign anyone else out by presenting a made-up string,
   // so an unknown token reports no session and changes nothing.
-  if (spent === null) return null;
+  if (spent === null) return { session: null, isValid: false };
 
   const session = await ctx.db.get("sessions", spent.sessionId);
   // Already signed out, expired, or revoked a moment ago by a sibling
   // detecting the same replay. Nothing left to revoke or report.
-  if (session === null) return null;
+  if (session === null) return { session: null, isValid: false };
 
+  const now = Date.now();
   if (now - spent._creationTime > REFRESH_GRACE_MS) {
-    await deleteSession(ctx, session._id);
-    return null;
+    // Outside of the grace window, invalid.
+    return { session, isValid: false };
   }
-  if (session.refreshTokenExpiresAt < now) {
-    await deleteSession(ctx, session._id);
-    return null;
+  if (session.refreshTokenExpiresAt <= now) {
+    return { session, isValid: false };
   }
-  return await rotateSession(ctx, session, now, issuer, ttl);
+  return { session, isValid: true };
 }
 
 /**
  * Rotate a refresh token and mint a fresh access token.
  *
- * Returns `null` when the session can't be refreshed. That can happen with an
- * unknown token, one past its refresh-token lifetime, or one whose session was
- * just revoked because the token had already been rotated away (see {@link
- * refreshWithSpentToken}). A dead session is a normal outcome the caller
- * should handle by updating its authenticated state; the reasons are
- * deliberately indistinguishable, so a thief learns nothing from the response.
+ * Returns `null` when the session can't be refreshed.
+ *
+ * That can happen with an unknown token, one past its refresh-token lifetime,
+ * or a previously used token past the grace refresh window.
+ *
+ * A dead session is a normal outcome the caller should handle by updating its
+ * authenticated state.
  */
 export const refresh = mutation({
   args: {
@@ -593,26 +609,26 @@ export const refresh = mutation({
   },
   returns: v.union(vTokenBundle, v.null()),
   handler: async (ctx, args): Promise<TokenBundle | null> => {
+    // Resolve the TTL config well before use below - it does some validation
+    // of the config that will throw if invalid, and that should be
+    // unconditional.
     const ttl = resolveTtlConfig(args);
-    const now = Date.now();
-    const hash = await sha256Hex(args.refreshToken);
 
-    const session = await sessionByHash(ctx, hash);
+    const hash = await sha256Hex(args.refreshToken);
+    let { session, isValid } = await sessionByHash(ctx, hash);
     if (session === null) {
-      return await attemptRefreshWithSpentToken(
-        ctx,
-        hash,
-        now,
-        args.issuer,
-        ttl,
-      );
+      // This is not the current refresh token - it might still be valid for refresh though.
+      ({ session, isValid } = await sessionBySpentHash(ctx, hash));
     }
-    if (session.refreshTokenExpiresAt < now) {
-      // Past its refresh-token lifetime: delete the dead row and report no
-      // session.
+    if (session === null) return null;
+    if (!isValid) {
+      // Past its refresh-token lifetime or a spent token past the grace
+      // window: delete the session and grant no more tokens.
       await deleteSession(ctx, session._id);
       return null;
     }
+
+    const now = Date.now();
     return await rotateSession(ctx, session, now, args.issuer, ttl);
   },
 });
@@ -623,7 +639,7 @@ export const signOut = mutation({
   returns: v.null(),
   handler: async (ctx, args) => {
     const hash = await sha256Hex(args.refreshToken);
-    const session = await sessionByHash(ctx, hash);
+    const { session } = await sessionByHash(ctx, hash);
     if (session !== null) {
       await deleteSession(ctx, session._id);
       return null;

--- a/packages/core/src/components/core/schema.ts
+++ b/packages/core/src/components/core/schema.ts
@@ -24,10 +24,12 @@ export default defineSchema({
     .index("by_refresh_hash", ["refreshTokenHash"])
     .index("by_user", ["userId"]),
 
-  // The hashes of refresh tokens that rotation has replaced, so a token the
-  // component issued can still be traced back to its session after it stops
-  // being current. A presented token that lands here is one of two things,
-  // told apart by how long ago the row was created:
+  // The hashes of refresh tokens that rotation has replaced.
+  //
+  // This allows tracing a previously rotated token back to its session. A
+  // presented token that matches a document here is one of two things,
+  // depending on the age of the document (tracked by the system-added
+  // `_creationTime` field):
   //
   //  - Rotated away moments ago: two near-simultaneous refreshes presenting
   //    the same token (parallel SSR loaders, or two browser tabs sharing one
@@ -35,12 +37,6 @@ export default defineSchema({
   //    being rejected and logging the user out.
   //  - Rotated away longer ago: a token that should be in nobody's hands, so
   //    it is treated as stolen and its session is revoked.
-  //
-  // Without this table the second case is invisible: an out-of-grace token
-  // matches nothing and a thief keeps the session indefinitely.
-  //
-  // `_creationTime` is both the grace clock and the retention key, so the row
-  // carries no timestamps of its own.
   spentRefreshTokens: defineTable({
     hash: v.string(),
     sessionId: v.id("sessions"),

--- a/packages/core/src/components/core/schema.ts
+++ b/packages/core/src/components/core/schema.ts
@@ -12,24 +12,39 @@ export default defineSchema({
     .index("by_provider_account", ["provider", "providerAccountId"])
     .index("by_user", ["userId"]),
 
-  // One row per active refresh token (sessions). The raw refresh token is never
-  // stored — only its SHA-256 hash.
-  //
-  // `previousRefreshTokenHash` keeps the *just-rotated* token briefly valid (a
-  // short grace window) so that two near-simultaneous refreshes presenting the
-  // same token — e.g. parallel SSR loaders, or two browser tabs sharing one
-  // cookie — don't fight: the first rotates, the second still resolves via the
-  // previous hash instead of being rejected and logging the user out.
+  // One row per active session, holding only the *current* refresh token's
+  // SHA-256 hash. The raw refresh token is never stored.
   sessions: defineTable({
     userId: v.string(),
     accountId: v.id("accounts"),
     refreshTokenHash: v.string(),
     refreshTokenExpiresAt: v.number(),
-    previousRefreshTokenHash: v.optional(v.string()),
-    previousRefreshTokenExpiresAt: v.optional(v.number()),
     lastRefreshedAt: v.number(),
   })
     .index("by_refresh_hash", ["refreshTokenHash"])
-    .index("by_previous_refresh_hash", ["previousRefreshTokenHash"])
     .index("by_user", ["userId"]),
+
+  // The hashes of refresh tokens that rotation has replaced, so a token the
+  // component issued can still be traced back to its session after it stops
+  // being current. A presented token that lands here is one of two things,
+  // told apart by how long ago the row was created:
+  //
+  //  - Rotated away moments ago: two near-simultaneous refreshes presenting
+  //    the same token (parallel SSR loaders, or two browser tabs sharing one
+  //    cookie). The first rotated; the second still resolves here instead of
+  //    being rejected and logging the user out.
+  //  - Rotated away longer ago: a token that should be in nobody's hands, so
+  //    it is treated as stolen and its session is revoked.
+  //
+  // Without this table the second case is invisible: an out-of-grace token
+  // matches nothing and a thief keeps the session indefinitely.
+  //
+  // `_creationTime` is both the grace clock and the retention key, so the row
+  // carries no timestamps of its own.
+  spentRefreshTokens: defineTable({
+    hash: v.string(),
+    sessionId: v.id("sessions"),
+  })
+    .index("by_hash", ["hash"])
+    .index("by_session", ["sessionId"]),
 });


### PR DESCRIPTION
This prevents a stolen token from being used to refresh a session and lock out a legitimate client.

There's more hardening we can do here but this at least closes the main avenue where an attacker could maintain a session with a stolen token. A concurrently running regular client refresh would eventually trip the reuse detection and delete the session.

This involves tracking previously spent refresh token hashes in a new table, and no longer storing an individual previously used refresh hash in the sessions table.