### PR TITLE
Fix the pkg.pr.new install URL

### DIFF
--- a/packages/core/src/cli/init.test.ts
+++ b/packages/core/src/cli/init.test.ts
@@ -105,7 +105,7 @@ describe("convex-auth init CLI", () => {
     expect(error).toBeDefined();
     expect(error!.message).toContain("is not a dependency");
     expect(error!.message).toContain(
-      "pnpm add @convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
+      "pnpm add @convex-dev/auth@https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot",
     );
     // It must not touch env vars or write any files on this path.
     expect(setEnvCalls).toEqual([]);
@@ -260,7 +260,7 @@ describe("installCommand", () => {
   ])("%s uses the right add command", (pm, prefix) => {
     expect(installCommand(pm)).toContain(prefix);
     expect(installCommand(pm)).toContain(
-      "@convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
+      "@convex-dev/auth@https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot",
     );
   });
 

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -51,7 +51,7 @@ const DOCS_URL = "https://auth-v2.previews.convex.dev";
 // TODO(nicolas) Replace by the real URL after it’s released
 
 /** Where to grab the v2 (reboot) build from until it's on npm proper. */
-const INSTALL_SPEC = `${AUTH_PACKAGE}@https://pkg.pr.new/${AUTH_PACKAGE}@reboot`;
+const INSTALL_SPEC = `${AUTH_PACKAGE}@https://pkg.pr.new/get-convex/convex-auth/${AUTH_PACKAGE}@reboot`;
 // TODO(nicolas) Replace by the real package path after it’s released
 
 /** Files scaffolded into the project's `convex/` directory, in write order. */

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -22,22 +22,22 @@ Add the Convex Auth package to your project:
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tab value="npm">
     ```sh
-    npm i https://pkg.pr.new/@convex-dev/auth@reboot
+    npm i https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot
     ```
   </Tab>
   <Tab value="pnpm">
     ```sh
-    pnpm add https://pkg.pr.new/@convex-dev/auth@reboot
+    pnpm add https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot
     ```
   </Tab>
   <Tab value="yarn">
     ```sh
-    yarn add https://pkg.pr.new/@convex-dev/auth@reboot
+    yarn add https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot
     ```
   </Tab>
   <Tab value="bun">
     ```sh
-    bun add https://pkg.pr.new/@convex-dev/auth@reboot
+    bun add https://pkg.pr.new/get-convex/convex-auth/@convex-dev/auth@reboot
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
The URL was missing the owner/repo path, so it 404ed both in the docs and in
the CLI's own recovery instruction (INSTALL_SPEC).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>