### PR TITLE
Password provider: export passwordUserCallbackArgs

### DIFF
--- a/examples/react-password/convex/users.ts
+++ b/examples/react-password/convex/users.ts
@@ -1,16 +1,17 @@
 import { internalMutation } from "./_generated/server";
+import { passwordUserCallbackArgs } from "@convex-dev/auth/providers/password/setup";
 import { v } from "convex/values";
 
 /**
  * Create the user row for a new password account and return its id. This
  * example keeps no data in the row, but your app can put a profile here.
+ *
+ * `passwordUserCallbackArgs` declares the `provider`, `providerAccountId` and
+ * `profile` args the provider sends. Destructure them in the handler when your
+ * app wants them (for example, to store `profile.username` on the row).
  */
 export const createUser = internalMutation({
-  args: {
-    provider: v.literal("password"),
-    providerAccountId: v.string(),
-    profile: v.object({ username: v.string() }),
-  },
+  args: passwordUserCallbackArgs,
   returns: v.id("users"),
   handler: async (ctx) => {
     return await ctx.db.insert("users", {});

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -21,6 +21,25 @@ import {
 const PROVIDER_NAME = "password";
 
 /**
+ * The args of the `createUser` and `onSignIn` mutations an app attaches to the
+ * password provider. Spread it into your mutation's `args` instead of spelling
+ * out `provider`, `providerAccountId` and `profile` yourself:
+ *
+ * ```ts
+ * export const createUser = internalMutation({
+ *   args: passwordUserCallbackArgs,
+ *   returns: v.id("users"),
+ *   handler: async (ctx) => ctx.db.insert("users", {}),
+ * });
+ * ```
+ */
+export const passwordUserCallbackArgs = {
+  provider: v.literal(PROVIDER_NAME),
+  providerAccountId: v.string(),
+  profile: v.object({ username: v.string() }),
+};
+
+/**
  * Options for {@link setupUsernamePassword}.
  */
 export type UsernamePasswordOptions = {


### PR DESCRIPTION
Apps no longer have to spell out provider/providerAccountId/profile in their
createUser and onSignIn mutations.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>