### PR TITLE
Release and codegen fixes

### DIFF
--- a/.github/workflows/convex-codegen.yml
+++ b/.github/workflows/convex-codegen.yml
@@ -49,6 +49,7 @@ jobs:
             examples/react-google
             examples/react-github
             examples/react-password
+            examples/react-passkey
             examples/nextjs
           )
 
@@ -68,6 +69,7 @@ jobs:
           components=(
             packages/core/src/components/anonymous
             packages/core/src/components/core
+            packages/core/src/components/email
             packages/core/src/components/passkey
             packages/core/src/components/password
             packages/core/src/components/username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Initial v2 alpha
 - supports password, passkey, google, github providers
 - nextjs ssr support for password, passkey
 
+## 0.0.95
+
+- fix: a failed OTP/magic-link sign-in no longer consumes the verification code
+  it rejected
+- fix: `signIn` called with only a `code` now resolves with `{ tokens: null }`
+  for every failure instead of rejecting for some
+
 ## 0.0.94
 
 - chore: bump `@auth/core` peer dependency (#320) @eden881

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,10 +32,12 @@
   "scripts": {
     "alpha": "pnpm version prerelease --preid alpha && pnpm publish --tag alpha --publish-branch reboot && git push --follow-tags",
     "build": "tsc -p tsconfig.build.json",
+    "check:clean": "test -z \"$(git status --porcelain=v1 -uno)\" || (echo 'Git working directory not clean.' >&2; exit 1)",
     "clean": "rm -rf dist",
     "generate:common-passwords": "bun src/components/password/scripts/generateCommonPasswords.script.ts",
+    "postversion": "git add package.json ../../CHANGELOG.md && git commit -m \"$npm_new_version\" && git tag -m \"$npm_new_version\" \"v$npm_new_version\"",
     "prepare": "pnpm run build",
-    "preversion": "pnpm -C ../.. install --frozen-lockfile && pnpm -w build && pnpm -w lint && pnpm -r --filter=!argon2id-wasm typecheck && pnpm -w test",
+    "preversion": "pnpm run check:clean && pnpm -C ../.. install --frozen-lockfile && pnpm -w build && pnpm -w lint && pnpm -r --filter=!argon2id-wasm typecheck && pnpm -w test",
     "release": "pnpm version patch && pnpm publish --publish-branch reboot && git push --follow-tags",
     "typecheck": "tsc --noEmit",
     "version": "(npm whoami || npm login) && vim -c 'normal o' -c 'normal o## '$npm_package_version ../../CHANGELOG.md && prettier -w ../../CHANGELOG.md && git add ../../CHANGELOG.md"

--- a/packages/core/src/cli/init.test.ts
+++ b/packages/core/src/cli/init.test.ts
@@ -104,9 +104,7 @@ describe("convex-auth init CLI", () => {
 
     expect(error).toBeDefined();
     expect(error!.message).toContain("is not a dependency");
-    expect(error!.message).toContain(
-      "pnpm add @convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
-    );
+    expect(error!.message).toContain("pnpm add @convex-dev/auth@alpha");
     // It must not touch env vars or write any files on this path.
     expect(setEnvCalls).toEqual([]);
     expect(fs.files.has("/project/convex/auth.ts")).toBe(false);
@@ -259,9 +257,7 @@ describe("installCommand", () => {
     ["yarn", "yarn add"],
   ])("%s uses the right add command", (pm, prefix) => {
     expect(installCommand(pm)).toContain(prefix);
-    expect(installCommand(pm)).toContain(
-      "@convex-dev/auth@https://pkg.pr.new/@convex-dev/auth@reboot",
-    );
+    expect(installCommand(pm)).toContain("@convex-dev/auth@alpha");
   });
 
   test("unknown package managers fall back to npm", () => {

--- a/packages/core/src/cli/program.ts
+++ b/packages/core/src/cli/program.ts
@@ -50,9 +50,8 @@ const AUTH_PACKAGE = "@convex-dev/auth";
 const DOCS_URL = "https://auth-v2.previews.convex.dev";
 // TODO(nicolas) Replace by the real URL after it’s released
 
-/** Where to grab the v2 (reboot) build from until it's on npm proper. */
-const INSTALL_SPEC = `${AUTH_PACKAGE}@https://pkg.pr.new/${AUTH_PACKAGE}@reboot`;
-// TODO(nicolas) Replace by the real package path after it’s released
+/** v2 ships under the `alpha` tag. `latest` is still v1. */
+const INSTALL_SPEC = `${AUTH_PACKAGE}@alpha`;
 
 /** Files scaffolded into the project's `convex/` directory, in write order. */
 export const FILE_TEMPLATES = {

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -22,22 +22,22 @@ Add the Convex Auth package to your project:
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tab value="npm">
     ```sh
-    npm i https://pkg.pr.new/@convex-dev/auth@reboot
+    npm i @convex-dev/auth@alpha
     ```
   </Tab>
   <Tab value="pnpm">
     ```sh
-    pnpm add https://pkg.pr.new/@convex-dev/auth@reboot
+    pnpm add @convex-dev/auth@alpha
     ```
   </Tab>
   <Tab value="yarn">
     ```sh
-    yarn add https://pkg.pr.new/@convex-dev/auth@reboot
+    yarn add @convex-dev/auth@alpha
     ```
   </Tab>
   <Tab value="bun">
     ```sh
-    bun add https://pkg.pr.new/@convex-dev/auth@reboot
+    bun add @convex-dev/auth@alpha
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
- Run release git clean check in repo root
- Update docs and cli to use alpha release
- Check codegen for `examples/react-passkey` and the email component
- Add the `0.0.95` changelog entry from main
