### PR TITLE
authEmail: opaque challenge purpose and ownership proofs

### DIFF
--- a/packages/core/src/components/email/_generated/component.ts
+++ b/packages/core/src/components/email/_generated/component.ts
@@ -34,19 +34,23 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       complete: FunctionReference<
         "mutation",
         "internal",
-        { code: string; secret: string },
-        | { email: string; isPrimary: boolean; success: true; userId: string }
+        { code: string; purpose: string; secret: string },
         | {
-            success: false;
-            userError: { error: "INVALID_LINK" } | { error: "EMAIL_TAKEN" };
-          },
+            email: string;
+            proof: string;
+            purpose: string;
+            success: true;
+            userId: string | null;
+          }
+        | { success: false; userError: { error: "INVALID_LINK" } },
         Name
       >;
       getStatus: FunctionReference<
         "query",
         "internal",
         { code: string; secret: string },
-        { email: string; status: "pending" } | { status: "invalid" },
+        | { email: string; purpose: string; status: "pending" }
+        | { status: "invalid" },
         Name
       >;
       start: FunctionReference<
@@ -63,21 +67,39 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             sendEmailHandle: string;
             testMode: boolean;
           };
+          purpose: string;
+          ttlMs?: number;
           url: string;
-          userId: string;
+          userId?: string;
         },
         | { secret: string; success: true }
         | {
             success: false;
             userError:
               | { error: "INVALID_EMAIL" }
-              | { error: "EMAIL_TAKEN" }
               | { error: "RATE_LIMITED"; retryAfterMs: number };
           },
         Name
       >;
     };
     verifiedEmails: {
+      add: FunctionReference<
+        "mutation",
+        "internal",
+        { proof: string; setPrimary: boolean },
+        | {
+            email: string;
+            isPrimary: boolean;
+            previousPrimaryEmail: string | null;
+            success: true;
+            userId: string;
+          }
+        | {
+            success: false;
+            userError: { error: "INVALID_PROOF" } | { error: "EMAIL_TAKEN" };
+          },
+        Name
+      >;
       deleteUser: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/components/email/challenge.test.ts
+++ b/packages/core/src/components/email/challenge.test.ts
@@ -15,12 +15,25 @@ function setup() {
   return t;
 }
 
+/** Complete a seeded challenge and return its proof. */
+async function completeSeeded(
+  t: ReturnType<typeof setup>,
+  args: { code: string; secret: string; purpose: string },
+): Promise<string> {
+  const result = await t.mutation(api.challenge.complete, args);
+  if (!result.success) {
+    throw new Error(`Completion failed: ${result.userError.error}`);
+  }
+  return result.proof;
+}
+
 describe("challenge.complete", () => {
-  test("records the address; the first email becomes primary", async () => {
+  test("returns the proof, the address, the user and the purpose", async () => {
     const t = setup();
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
@@ -28,12 +41,204 @@ describe("challenge.complete", () => {
     const result = await t.mutation(api.challenge.complete, {
       code: "code1",
       secret: "secret1",
+      purpose: "signUp",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+    });
+    expect(result.success && result.proof).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+    // Completion writes nothing to verifiedEmails.
+    expect(
+      await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
+    ).toEqual([]);
+  });
+
+  test("returns userId null for a challenge started without a user", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      purpose: "recovery",
+      code: "code1",
+      secret: "secret1",
+    });
+
+    const result = await t.mutation(api.challenge.complete, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "recovery",
+    });
+    expect(result).toMatchObject({
+      success: true,
+      email: "alice@example.com",
+      userId: null,
+    });
+  });
+
+  test("does not check the address against verifiedEmails", async () => {
+    // Recovery challenges target an address that is already verified. The
+    // component leaves the meaning of the purpose to the caller.
+    const t = setup();
+    await seedEmail(t, "user1", "alice@example.com", true);
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "reauth",
+      code: "code1",
+      secret: "secret1",
+    });
+
+    const result = await t.mutation(api.challenge.complete, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "reauth",
+    });
+    expect(result).toMatchObject({ success: true, userId: "user1" });
+  });
+
+  test("the claim is one-shot: a second completion fails", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+      code: "code1",
+      secret: "secret1",
+    });
+
+    const first = await t.mutation(api.challenge.complete, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
+    expect(first).toMatchObject({ success: true });
+
+    const second = await t.mutation(api.challenge.complete, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
+    expect(second).toEqual({
+      success: false,
+      userError: { error: "INVALID_LINK" },
+    });
+    // The second attempt also removed the completed row, so the proof from
+    // the first completion is gone.
+    expect(
+      await t.mutation(api.verifiedEmails.add, {
+        proof: first.success ? first.proof : "",
+        setPrimary: false,
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_PROOF" } });
+  });
+
+  test("a wrong secret fails and still consumes the link", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+      code: "code1",
+      secret: "secret1",
+    });
+
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "code1",
+        secret: "wrong",
+        purpose: "signUp",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+    // The row is gone: even the right secret cannot complete it now.
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "code1",
+        secret: "secret1",
+        purpose: "signUp",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+  });
+
+  test("an expired link fails with INVALID_LINK", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+      code: "code1",
+      secret: "secret1",
+      expiresAt: Date.now() - 1000,
+    });
+
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "code1",
+        secret: "secret1",
+        purpose: "signUp",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+  });
+
+  test("a purpose mismatch fails with INVALID_LINK", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+      code: "code1",
+      secret: "secret1",
+    });
+
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "code1",
+        secret: "secret1",
+        purpose: "recovery",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+  });
+
+  test("an unknown code fails with INVALID_LINK", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "nope",
+        secret: "secret1",
+        purpose: "signUp",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+  });
+});
+
+describe("verifiedEmails.add", () => {
+  test("records the address; the first email becomes primary", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: "signUp",
+      code: "code1",
+      secret: "secret1",
+    });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
+
+    const result = await t.mutation(api.verifiedEmails.add, {
+      proof,
+      setPrimary: false,
     });
     expect(result).toEqual({
       success: true,
       userId: "user1",
       email: "alice@example.com",
       isPrimary: true,
+      previousPrimaryEmail: null,
     });
     expect(
       await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
@@ -46,99 +251,117 @@ describe("challenge.complete", () => {
     await seedChallenge(t, {
       email: "alice2@example.com",
       userId: "user1",
+      purpose: "addEmail",
       code: "code1",
       secret: "secret1",
+    });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "addEmail",
     });
 
-    const result = await t.mutation(api.challenge.complete, {
-      code: "code1",
-      secret: "secret1",
+    const result = await t.mutation(api.verifiedEmails.add, {
+      proof,
+      setPrimary: false,
     });
     expect(result).toMatchObject({ success: true, isPrimary: false });
-    expect(
-      await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
-    ).toEqual([
+    const emails = await t.query(api.verifiedEmails.getEmails, {
+      userId: "user1",
+    });
+    expect(emails).toEqual([
       { email: "alice@example.com", isPrimary: true },
       { email: "alice2@example.com", isPrimary: false },
     ]);
   });
 
-  test("the claim is one-shot: a second completion fails", async () => {
+  test("setPrimary replaces the old primary and returns it", async () => {
     const t = setup();
+    await seedEmail(t, "user1", "old@example.com", true);
+    await seedEmail(t, "user1", "other@example.com", false);
     await seedChallenge(t, {
-      email: "alice@example.com",
+      email: "new@example.com",
       userId: "user1",
+      purpose: "changeEmail",
       code: "code1",
       secret: "secret1",
     });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "changeEmail",
+    });
 
-    expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toMatchObject({ success: true });
-    expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+    const result = await t.mutation(api.verifiedEmails.add, {
+      proof,
+      setPrimary: true,
+    });
+    expect(result).toEqual({
+      success: true,
+      userId: "user1",
+      email: "new@example.com",
+      isPrimary: true,
+      previousPrimaryEmail: "old@example.com",
+    });
+    const emails = await t.query(api.verifiedEmails.getEmails, {
+      userId: "user1",
+    });
+    expect(emails).toEqual([
+      { email: "other@example.com", isPrimary: false },
+      { email: "new@example.com", isPrimary: true },
+    ]);
   });
 
-  test("a wrong secret fails and still consumes the link", async () => {
+  test("the proof is one-shot", async () => {
     const t = setup();
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
 
+    await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false });
     expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "wrong",
-      }),
-    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
-    // The row is gone: even the right secret cannot complete it now.
-    expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+      await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false }),
+    ).toEqual({ success: false, userError: { error: "INVALID_PROOF" } });
     expect(
       await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
-    ).toEqual([]);
+    ).toHaveLength(1);
   });
 
-  test("an expired link fails with INVALID_LINK", async () => {
+  test("an unknown or expired proof fails with INVALID_PROOF", async () => {
     const t = setup();
+    expect(
+      await t.mutation(api.verifiedEmails.add, {
+        proof: "nope",
+        setPrimary: false,
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_PROOF" } });
+
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
-      expiresAt: Date.now() - 1000,
+      expiresAt: Date.now() + 10,
     });
-
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
     expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
-  });
-
-  test("an unknown code fails with INVALID_LINK", async () => {
-    const t = setup();
-    expect(
-      await t.mutation(api.challenge.complete, {
-        code: "nope",
-        secret: "secret1",
-      }),
-    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+      await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false }),
+    ).toEqual({ success: false, userError: { error: "INVALID_PROOF" } });
   });
 
   test("an address verified by another user after the start fails with EMAIL_TAKEN", async () => {
@@ -146,69 +369,110 @@ describe("challenge.complete", () => {
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
     await seedEmail(t, "user2", "alice@example.com", true);
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
 
     expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
+      await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false }),
     ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
     expect(
       await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
     ).toEqual([]);
   });
+
+  test("throws for a proof from a challenge without a user", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      purpose: "recovery",
+      code: "code1",
+      secret: "secret1",
+    });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "recovery",
+    });
+
+    await expect(
+      t.mutation(api.verifiedEmails.add, { proof, setPrimary: false }),
+    ).rejects.toThrow(/started with a userId/);
+  });
 });
 
 describe("challenge.getStatus", () => {
-  test("reports a pending challenge with its email", async () => {
+  test("reports a pending challenge with its purpose and email", async () => {
     const t = setup();
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "changeEmail",
       code: "code1",
       secret: "secret1",
     });
 
-    expect(
-      await t.query(api.challenge.getStatus, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toEqual({ status: "pending", email: "alice@example.com" });
+    const status = await t.query(api.challenge.getStatus, {
+      code: "code1",
+      secret: "secret1",
+    });
+    expect(status).toEqual({
+      status: "pending",
+      purpose: "changeEmail",
+      email: "alice@example.com",
+    });
 
     // The query does not claim the challenge: completion still works.
-    expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
-    ).toMatchObject({ success: true });
+    const result = await t.mutation(api.challenge.complete, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "changeEmail",
+    });
+    expect(result).toMatchObject({ success: true });
   });
 
-  test("reports invalid for an unknown code, a wrong secret, and an expired challenge", async () => {
+  test("reports invalid for an unknown code, a wrong secret, an expired and a completed challenge", async () => {
     const t = setup();
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
     await seedChallenge(t, {
       email: "bob@example.com",
       userId: "user2",
+      purpose: "signUp",
       code: "code2",
       secret: "secret2",
       expiresAt: Date.now() - 1000,
+    });
+    await seedChallenge(t, {
+      email: "carol@example.com",
+      userId: "user3",
+      purpose: "signUp",
+      code: "code3",
+      secret: "secret3",
+    });
+    await completeSeeded(t, {
+      code: "code3",
+      secret: "secret3",
+      purpose: "signUp",
     });
 
     for (const args of [
       { code: "unknown", secret: "secret1" },
       { code: "code1", secret: "wrong" },
       { code: "code2", secret: "secret2" },
+      { code: "code3", secret: "secret3" },
     ]) {
       expect(await t.query(api.challenge.getStatus, args)).toEqual({
         status: "invalid",
@@ -223,6 +487,7 @@ describe("the challenge address", () => {
     await seedChallenge(t, {
       email: "Alice@Example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
@@ -234,10 +499,12 @@ describe("the challenge address", () => {
       }),
     ).toMatchObject({ email: "Alice@Example.com" });
 
-    await t.mutation(api.challenge.complete, {
+    const proof = await completeSeeded(t, {
       code: "code1",
       secret: "secret1",
+      purpose: "signUp",
     });
+    await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false });
     expect(
       await t.query(api.verifiedEmails.getEmails, { userId: "user1" }),
     ).toEqual([{ email: "Alice@Example.com", isPrimary: true }]);
@@ -255,15 +522,18 @@ describe("the challenge address", () => {
     await seedChallenge(t, {
       email: "Alice@Example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
+    const proof = await completeSeeded(t, {
+      code: "code1",
+      secret: "secret1",
+      purpose: "signUp",
+    });
 
     expect(
-      await t.mutation(api.challenge.complete, {
-        code: "code1",
-        secret: "secret1",
-      }),
+      await t.mutation(api.verifiedEmails.add, { proof, setPrimary: false }),
     ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
   });
 });
@@ -274,14 +544,22 @@ describe("deleteUser with challenges", () => {
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
+      purpose: "signUp",
       code: "code1",
       secret: "secret1",
     });
     await seedChallenge(t, {
       email: "bob@example.com",
       userId: "user2",
+      purpose: "signUp",
       code: "code2",
       secret: "secret2",
+    });
+    await seedChallenge(t, {
+      email: "carol@example.com",
+      purpose: "recovery",
+      code: "code3",
+      secret: "secret3",
     });
 
     await t.mutation(api.verifiedEmails.deleteUser, { userId: "user1" });
@@ -289,7 +567,7 @@ describe("deleteUser with challenges", () => {
     const remaining = await t.run(async (ctx) =>
       (await ctx.db.query("challenges").collect()).map((row) => row.email),
     );
-    expect(remaining).toEqual(["bob@example.com"]);
+    expect(remaining).toEqual(["bob@example.com", "carol@example.com"]);
   });
 });
 
@@ -299,8 +577,8 @@ describe("deleteUser with challenges", () => {
 // TODO: enable when convex-test supports ctx.meta.
 describe("challenge.start", () => {
   test.skip("sends a link and returns the secret", () => {});
+  test.skip("stores the purpose, the user and the expiry", () => {});
   test.skip("rejects a malformed address with INVALID_EMAIL", () => {});
-  test.skip("rejects a taken address with EMAIL_TAKEN", () => {});
   test.skip("rate limits per destination email", () => {});
   test.skip("rate limits per client IP", () => {});
   test.skip("appends the code with ? or & as the URL requires", () => {});

--- a/packages/core/src/components/email/challenge.ts
+++ b/packages/core/src/components/email/challenge.ts
@@ -2,11 +2,9 @@ import { mutation, query } from "./_generated/server.ts";
 import { Infer, v } from "convex/values";
 import { sha256Hex } from "../../lib/crypto.ts";
 import {
-  CHALLENGE_TTL_MS,
+  DEFAULT_CHALLENGE_TTL_MS,
   rateLimiter,
   getClientIp,
-  emailsByUserId,
-  emailByNormalizedEmail,
   buildLink,
   sendChallengeEmail,
 } from "./helpers.ts";
@@ -20,8 +18,10 @@ import {
 } from "./validation.ts";
 
 // A challenge proves that the person who started it owns an email address.
-// On completion, the address is recorded as a verified email of the user
-// the challenge was started for.
+// The component does not know what the caller does with that fact: the
+// `purpose` is an opaque string, and completion returns a proof that the
+// caller can spend with `verifiedEmails.add`, or not spend at all (account
+// recovery, re-authentication before a sensitive action).
 
 const checkStartChallengeResult = v.union(
   v.object({ ok: v.literal(true) }),
@@ -76,26 +76,41 @@ const startChallengeResult = v.union(
 type StartChallengeResult = Infer<typeof startChallengeResult>;
 
 /**
- * Start a challenge: check the address, consume the rate limits, store the
- * hashed code + secret, and send the email.
+ * Start a challenge: check the address format, consume the rate limits,
+ * store the hashed code + secret, and send the email.
  *
  * The emailed link carries the code; the returned secret stays in the
  * starting browser. Completion requires both, so a person who only sees the
  * email (or only sees the database) cannot complete the flow.
  *
- * The address must not be verified for another user (`EMAIL_TAKEN`).
+ * - `purpose` is opaque to the component. `challenge.complete` requires the
+ *   same value, so a link sent for one flow cannot complete another. The
+ *   value is also what `challenge.getStatus` reports to landing pages.
+ * - `userId` binds the challenge to a user. Give it when the proof will be
+ *   spent with `verifiedEmails.add` (the address becomes that user's), or
+ *   when the flow re-authenticates a signed-in user. Leave it out for
+ *   account recovery, where the caller identifies the user from the address
+ *   afterwards (`verifiedEmails.getUserIdByEmail`).
+ * - `ttlMs` is how long the link stays valid. Defaults to one hour.
+ * - `url` is the landing page the link points at; the code is appended as
+ *   the `code` query parameter. The caller controls this value — do not pass
+ *   client-supplied URLs, or the email becomes a phishing vector from a
+ *   legitimate sender.
  *
- * `url` is the landing page the link points at; the code is appended as the
- * `code` query parameter. The caller controls this value — do not pass
- * client-supplied URLs, or the email becomes a phishing vector from a
- * legitimate sender.
+ * The component does not check the address against `verifiedEmails` here:
+ * whether the address must be free (adding an email) or must already be
+ * verified (recovery) depends on the purpose, which only the caller knows.
+ * `verifiedEmails.add` rejects an address that is taken when the proof is
+ * spent.
  */
 export const start = mutation({
   args: {
     email: v.string(),
-    userId: v.string(),
+    purpose: v.string(),
+    userId: v.optional(v.string()),
     url: v.string(),
     emailSender: vEmailSenderConfig,
+    ttlMs: v.optional(v.number()),
   },
   returns: startChallengeResult,
   handler: async (ctx, args): Promise<StartChallengeResult> => {
@@ -104,16 +119,15 @@ export const start = mutation({
       return { success: false, userError: formatError };
     }
     // `email` keeps the case the user gave: the link goes to that address and
-    // a completion records it. `normalizedEmail` is the lookup key.
+    // a spent proof records it. The rate limit key is the normalized form.
     const email = args.email;
-    const normalizedEmail = normalizeEmail(email);
 
     // Consume both rate limits. A failure after `challenge.checkStart`
     // passed in the same mutation is unexpected (same transaction), so
     // callers that pre-checked treat the `RATE_LIMITED` arm as unreachable.
     const ip = await getClientIp(ctx);
     const perEmail = await rateLimiter.limit(ctx, "startChallengePerEmail", {
-      key: normalizedEmail,
+      key: normalizeEmail(email),
     });
     if (!perEmail.ok) {
       return {
@@ -131,18 +145,16 @@ export const start = mutation({
       };
     }
 
-    if ((await emailByNormalizedEmail(ctx, normalizedEmail)) !== null) {
-      return { success: false, userError: { error: "EMAIL_TAKEN" } };
-    }
-
     const code = generateRandomToken();
     const secret = generateRandomToken();
+    const ttlMs = args.ttlMs ?? DEFAULT_CHALLENGE_TTL_MS;
     await ctx.db.insert("challenges", {
       email,
       userId: args.userId,
+      purpose: args.purpose,
       codeHash: await sha256Hex(code),
       secretHash: await sha256Hex(secret),
-      expiresAt: Date.now() + CHALLENGE_TTL_MS,
+      expiresAt: Date.now() + ttlMs,
     });
 
     await sendChallengeEmail(
@@ -150,6 +162,7 @@ export const start = mutation({
       args.emailSender,
       email,
       buildLink(args.url, code),
+      ttlMs,
     );
 
     return { success: true, secret };
@@ -159,9 +172,15 @@ export const start = mutation({
 const completeChallengeResult = v.union(
   v.object({
     success: v.literal(true),
-    userId: v.string(),
+    // The address, with the case that the user gave at start.
     email: v.string(),
-    isPrimary: v.boolean(),
+    // The user given to `challenge.start`, or `null` when there was none.
+    userId: v.union(v.string(), v.null()),
+    purpose: v.string(),
+    // The ownership proof. Spend it with `verifiedEmails.add` in the same
+    // mutation to record the address for `userId`. It is a 256-bit random
+    // token that only this completion knows; it cannot be constructed.
+    proof: v.string(),
   }),
   v.object({
     success: v.literal(false),
@@ -172,18 +191,26 @@ type CompleteChallengeResult = Infer<typeof completeChallengeResult>;
 
 /**
  * Complete a challenge with the code from the link and the secret from the
- * starting browser, and record the address as a verified email of the user.
+ * starting browser.
  *
- * The claim is one-shot: the row is deleted as soon as the code matches,
- * even when the secret is wrong or the link has expired, so a link can never
- * be replayed. An unknown code, a wrong secret and an expired link all
- * return the same `INVALID_LINK` error.
+ * The claim is one-shot: the first call that finds the row decides its fate.
+ * On success the row is marked completed and the returned `proof` is the
+ * only way to act on it. On any failure the row is deleted, so a link can
+ * never be replayed. An unknown code, a wrong secret, an expired link, a
+ * purpose mismatch and an already completed challenge all return the same
+ * `INVALID_LINK` error.
  *
- * The first address of a user becomes primary; later addresses are
- * secondary. TODO: add a component function to change the primary address.
+ * Completion writes nothing to `verifiedEmails`. To record the address for
+ * the bound user, pass `proof` to `verifiedEmails.add` in the same mutation.
+ * For recovery or re-authentication, the returned `email` and `userId` are
+ * the result; the proof stays unspent and the row expires.
  */
 export const complete = mutation({
-  args: { code: v.string(), secret: v.string() },
+  args: {
+    code: v.string(),
+    secret: v.string(),
+    purpose: v.string(),
+  },
   returns: completeChallengeResult,
   handler: async (ctx, args): Promise<CompleteChallengeResult> => {
     const codeHash = await sha256Hex(args.code);
@@ -194,38 +221,37 @@ export const complete = mutation({
     if (row === null) {
       return { success: false, userError: { error: "INVALID_LINK" } };
     }
-    // One-shot claim: delete before any check, so a raced or replayed
-    // completion finds nothing.
-    await ctx.db.delete("challenges", row._id);
-
     if (
+      row.proofHash !== undefined ||
       row.secretHash !== (await sha256Hex(args.secret)) ||
-      row.expiresAt < Date.now()
+      row.expiresAt < Date.now() ||
+      row.purpose !== args.purpose
     ) {
+      // A raced or replayed completion must find nothing.
+      await ctx.db.delete("challenges", row._id);
       return { success: false, userError: { error: "INVALID_LINK" } };
     }
 
-    // The address must still be free: another user may have verified it
-    // after this challenge started.
-    const normalizedEmail = normalizeEmail(row.email);
-    if ((await emailByNormalizedEmail(ctx, normalizedEmail)) !== null) {
-      return { success: false, userError: { error: "EMAIL_TAKEN" } };
-    }
-
-    const isPrimary = (await emailsByUserId(ctx, row.userId)).length === 0;
-    await ctx.db.insert("verifiedEmails", {
-      email: row.email,
-      normalizedEmail,
-      userId: row.userId,
-      isPrimary,
-      source: { kind: "self" },
+    const proof = generateRandomToken();
+    await ctx.db.patch("challenges", row._id, {
+      proofHash: await sha256Hex(proof),
     });
-    return { success: true, userId: row.userId, email: row.email, isPrimary };
+    return {
+      success: true,
+      email: row.email,
+      userId: row.userId ?? null,
+      purpose: row.purpose,
+      proof,
+    };
   },
 });
 
 const challengeStatus = v.union(
-  v.object({ status: v.literal("pending"), email: v.string() }),
+  v.object({
+    status: v.literal("pending"),
+    purpose: v.string(),
+    email: v.string(),
+  }),
   v.object({ status: v.literal("invalid") }),
 );
 type ChallengeStatus = Infer<typeof challengeStatus>;
@@ -233,9 +259,10 @@ type ChallengeStatus = Infer<typeof challengeStatus>;
 /**
  * Report the state of a challenge without claiming it.
  *
- * Landing pages call this to show which address the link will verify before
- * the user confirms. The checks are the same as `challenge.complete`,
- * including the secret, so a person who only has the link learns nothing.
+ * Landing pages call this to show what the link will do (and to which
+ * address) before the user confirms. The checks are the same as
+ * `challenge.complete`, including the secret, so a person who only has the
+ * link learns nothing. A completed challenge reports `invalid`.
  */
 export const getStatus = query({
   args: { code: v.string(), secret: v.string() },
@@ -248,11 +275,12 @@ export const getStatus = query({
       .unique();
     if (
       row === null ||
+      row.proofHash !== undefined ||
       row.secretHash !== (await sha256Hex(args.secret)) ||
       row.expiresAt < Date.now()
     ) {
       return { status: "invalid" };
     }
-    return { status: "pending", email: row.email };
+    return { status: "pending", purpose: row.purpose, email: row.email };
   },
 });

--- a/packages/core/src/components/email/helpers.ts
+++ b/packages/core/src/components/email/helpers.ts
@@ -1,26 +1,25 @@
 import { MutationCtx, QueryCtx } from "./_generated/server.ts";
 import { Doc } from "./_generated/dataModel.ts";
 import { components } from "./_generated/api.ts";
-import {
-  FunctionArgs,
-  FunctionHandle,
-  FunctionReturnType,
-} from "convex/server";
-import type { ResendComponent } from "@convex-dev/resend";
+import { FunctionHandle } from "convex/server";
 import { RateLimiter, HOUR } from "@convex-dev/rate-limiter";
 import { EmailSenderConfig } from "./validation.ts";
 
 // --- Configuration ---------------------------------------------------------
 
-/** How long a link stays valid. TODO: review this value. */
-export const CHALLENGE_TTL_MS = 60 * 60 * 1000; // 1 hour
+/**
+ * How long a link stays valid when the caller gives no `ttlMs`.
+ * Flows with stricter needs pass their own value (OWASP ASVS v5 6.5.5 asks
+ * for at most 10 minutes for password reset). TODO: review this value.
+ */
+export const DEFAULT_CHALLENGE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 // Throttle for starting challenges. Each flow sends an email, so the
 // limits protect the destination mailbox from flooding and the sender's
 // reputation from abuse:
 // - per destination address, so an attacker cannot flood one mailbox;
 // - per client IP, so one machine cannot spray many addresses.
-// TODO(nicolas): review these limits.
+// TODO: review these limits.
 export const rateLimiter = new RateLimiter(components.rateLimiter, {
   startChallengePerEmail: { kind: "token bucket", rate: 5, period: HOUR },
   startChallengePerIp: { kind: "token bucket", rate: 20, period: HOUR },
@@ -38,7 +37,7 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
  */
 export async function getClientIp(ctx: MutationCtx): Promise<string> {
   // Old backends (and convex-test) have no `ctx.meta`.
-  const meta = ctx.meta;
+  const meta = (ctx as Partial<MutationCtx>).meta;
   if (meta === undefined) {
     throw new Error(
       "The email component requires `ctx.meta` for IP rate limiting. " +
@@ -80,16 +79,27 @@ export function emailByNormalizedEmail(
 }
 
 /** The plain-text body of a challenge email. */
-export function challengeEmailText(link: string): string {
+export function challengeEmailText(link: string, ttlMs: number): string {
   // TODO: also offer a short code the user can type, with rate limiting on
   // attempts (a short code is guessable, unlike the 256-bit link code).
+  // TODO: let the caller pass a purpose-specific template.
   return (
     "Open this link to confirm that this email address is yours:\n\n" +
     `${link}\n\n` +
-    "The link stops working after 1 hour, and works only in the browser " +
-    "you started from.\n\n" +
+    `The link stops working after ${describeDuration(ttlMs)}, and works ` +
+    "only in the browser you started from.\n\n" +
     "If you did not request this email, you can ignore it."
   );
+}
+
+/** A human-readable duration for the email text, e.g. "10 minutes". */
+function describeDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) {
+    return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+  }
+  const hours = Math.round(minutes / 60);
+  return hours === 1 ? "1 hour" : `${hours} hours`;
 }
 
 /** The subject line of a challenge email. */
@@ -97,33 +107,28 @@ export function challengeEmailSubject(): string {
   return "Confirm your email address";
 }
 
-/**
- * The landing URL with the `code` query parameter.
- *
- * The URL must be absolute. A fragment stays at the end of the URL, and an
- * existing `code` parameter is replaced.
- */
+/** Append the code to the landing URL, with `?` or `&` as needed. */
 export function buildLink(url: string, code: string): string {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error(
-      `The email component got an invalid landing URL: ${url}. ` +
-        "Give an absolute URL, for example https://example.com/verify.",
-    );
-  }
-  parsed.searchParams.set("code", code);
-  return parsed.toString();
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}code=${encodeURIComponent(code)}`;
 }
 
 /** The `sendEmail` mutation of the `@convex-dev/resend` component. */
-type SendEmailMutation = ResendComponent["lib"]["sendEmail"];
-
 export type SendEmailHandle = FunctionHandle<
   "mutation",
-  FunctionArgs<SendEmailMutation>,
-  FunctionReturnType<SendEmailMutation>
+  {
+    options: {
+      apiKey: string;
+      testMode: boolean;
+      initialBackoffMs: number;
+      retryAttempts: number;
+    };
+    from: string;
+    to: string[];
+    subject: string;
+    text: string;
+  },
+  string
 >;
 
 export async function sendChallengeEmail(
@@ -131,6 +136,7 @@ export async function sendChallengeEmail(
   sender: EmailSenderConfig,
   to: string,
   link: string,
+  ttlMs: number,
 ): Promise<void> {
   await ctx.runMutation(sender.sendEmailHandle as SendEmailHandle, {
     options: {
@@ -142,6 +148,6 @@ export async function sendChallengeEmail(
     from: sender.from,
     to: [to],
     subject: challengeEmailSubject(),
-    text: challengeEmailText(link),
+    text: challengeEmailText(link, ttlMs),
   });
 }

--- a/packages/core/src/components/email/schema.ts
+++ b/packages/core/src/components/email/schema.ts
@@ -27,24 +27,33 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_isPrimary", ["userId", "isPrimary"]),
 
-  // One row for each challenge that has started and is not complete. A
-  // challenge proves that the person who started it owns an email address,
-  // for one user. The completion is a one-shot claim: the first
-  // `challenge.complete` call that finds the row deletes it.
+  // One row for each challenge. A challenge proves that the person who
+  // started it owns an email address. A row is pending until `challenge.complete`
+  // marks it completed (`proofHash` set), and is deleted when
+  // `verifiedEmails.add` spends the proof, or when it expires.
   challenges: defineTable({
     // The address under challenge, with the case that the user gave. This is
-    // the address the email goes to, and the address a completion records.
+    // the address the email goes to, and the address a spent proof records.
     email: v.string(),
-    // The user the address is recorded for on completion.
-    userId: v.string(),
+    // The user the challenge is bound to, when the caller gave one at start.
+    // A proof from a challenge without a user cannot be spent with
+    // `verifiedEmails.add`; it only proves ownership of the address.
+    userId: v.optional(v.string()),
+    // Opaque to the component. `challenge.complete` requires the same value
+    // the caller gave at start, so a link for one flow cannot complete another.
+    purpose: v.string(),
     // SHA-256 of the code that travels in the emailed link. Only the hash is
     // stored, so database access alone cannot complete a challenge.
     codeHash: v.string(),
     // SHA-256 of the secret that stays in the starting browser's storage.
     // Completion requires both the code and the secret.
     secretHash: v.string(),
+    // SHA-256 of the proof that `challenge.complete` returned. Present only
+    // on a completed challenge.
+    proofHash: v.optional(v.string()),
     expiresAt: v.number(),
   })
     .index("by_codeHash", ["codeHash"])
+    .index("by_proofHash", ["proofHash"])
     .index("by_userId", ["userId"]),
 });

--- a/packages/core/src/components/email/testSetup.ts
+++ b/packages/core/src/components/email/testSetup.ts
@@ -30,7 +30,8 @@ export async function seedChallenge(
   t: TestConvex<typeof schema>,
   args: {
     email: string;
-    userId: string;
+    userId?: string;
+    purpose: string;
     code: string;
     secret: string;
     expiresAt?: number;
@@ -40,6 +41,7 @@ export async function seedChallenge(
     await ctx.db.insert("challenges", {
       email: args.email,
       userId: args.userId,
+      purpose: args.purpose,
       codeHash: await sha256Hex(args.code),
       secretHash: await sha256Hex(args.secret),
       expiresAt: args.expiresAt ?? Date.now() + 60_000,

--- a/packages/core/src/components/email/validation.ts
+++ b/packages/core/src/components/email/validation.ts
@@ -54,25 +54,36 @@ export type EmailSource = Infer<typeof vEmailSource>;
  */
 export const startChallengeUserError = v.union(
   emailFormatUserError,
-  // Another user has already verified this address.
-  v.object({ error: v.literal("EMAIL_TAKEN") }),
   v.object({ error: v.literal("RATE_LIMITED"), retryAfterMs: v.number() }),
 );
 export type StartChallengeUserError = Infer<typeof startChallengeUserError>;
 
 /**
  * The user-facing errors for `challenge.complete`. `INVALID_LINK` covers an
- * unknown code, a wrong secret and an expired link: one error for all of
- * them, so the response is not an oracle for attackers.
+ * unknown code, a wrong secret, an expired link, a purpose mismatch and a
+ * link that was already used: one error for all of them, so the response is
+ * not an oracle for attackers.
  */
-export const completeChallengeUserError = v.union(
-  v.object({ error: v.literal("INVALID_LINK") }),
-  // The address was verified by another user after the flow started.
-  v.object({ error: v.literal("EMAIL_TAKEN") }),
-);
+export const completeChallengeUserError = v.object({
+  error: v.literal("INVALID_LINK"),
+});
 export type CompleteChallengeUserError = Infer<
   typeof completeChallengeUserError
 >;
+
+/**
+ * The user-facing errors for `verifiedEmails.add`.
+ *
+ * - `INVALID_PROOF`: the proof is unknown, expired, or already spent. This is
+ *   a programming error in the caller, not something the end user did.
+ * - `EMAIL_TAKEN`: another user verified the address after the challenge
+ *   started.
+ */
+export const addEmailUserError = v.union(
+  v.object({ error: v.literal("INVALID_PROOF") }),
+  v.object({ error: v.literal("EMAIL_TAKEN") }),
+);
+export type AddEmailUserError = Infer<typeof addEmailUserError>;
 
 /**
  * How `challenge.start` sends its email. The caller (the provider recipe)

--- a/packages/core/src/components/email/verifiedEmails.ts
+++ b/packages/core/src/components/email/verifiedEmails.ts
@@ -1,7 +1,8 @@
 import { mutation, query } from "./_generated/server.ts";
-import { v } from "convex/values";
+import { Infer, v } from "convex/values";
+import { sha256Hex } from "../../lib/crypto.ts";
 import { emailsByUserId, emailByNormalizedEmail } from "./helpers.ts";
-import { normalizeEmail } from "./validation.ts";
+import { addEmailUserError, normalizeEmail } from "./validation.ts";
 
 /**
  * Get the verified email addresses of a user.
@@ -40,6 +41,108 @@ export const getUserIdByEmail = query({
   ): Promise<{ userId: string; email: string } | null> => {
     const row = await emailByNormalizedEmail(ctx, normalizeEmail(email));
     return row === null ? null : { userId: row.userId, email: row.email };
+  },
+});
+
+const addEmailResult = v.union(
+  v.object({
+    success: v.literal(true),
+    userId: v.string(),
+    email: v.string(),
+    isPrimary: v.boolean(),
+    // With `setPrimary`: the address that was primary before this call
+    // replaced it, or `null` when there was none. Callers use it to notify
+    // the old address.
+    previousPrimaryEmail: v.union(v.string(), v.null()),
+  }),
+  v.object({ success: v.literal(false), userError: addEmailUserError }),
+);
+type AddEmailResult = Infer<typeof addEmailResult>;
+
+/**
+ * Record a verified email address for a user, by spending the proof that
+ * `challenge.complete` returned.
+ *
+ * The proof is the only way to add an address: there is no argument for the
+ * address or the user, both come from the completed challenge. A proof is
+ * one-shot; the challenge row is deleted here. Call this in the same
+ * mutation as `challenge.complete`.
+ *
+ * - `setPrimary: false`: add the address; it becomes primary only when the
+ *   user has no address yet.
+ * - `setPrimary: true`: the address becomes primary and the previous primary
+ *   address (if any) is removed from the account. Use this in apps where a
+ *   user has a single address.
+ *
+ * TODO: add a component function to change the primary address.
+ *
+ * Throws when the challenge was started without a `userId`: such a proof
+ * only attests ownership of the address and has no user to record it for.
+ */
+export const add = mutation({
+  args: { proof: v.string(), setPrimary: v.boolean() },
+  returns: addEmailResult,
+  handler: async (ctx, args): Promise<AddEmailResult> => {
+    const proofHash = await sha256Hex(args.proof);
+    const row = await ctx.db
+      .query("challenges")
+      .withIndex("by_proofHash", (q) => q.eq("proofHash", proofHash))
+      .unique();
+    if (row === null) {
+      return { success: false, userError: { error: "INVALID_PROOF" } };
+    }
+    // One-shot: the proof is spent whatever happens next.
+    await ctx.db.delete("challenges", row._id);
+    if (row.expiresAt < Date.now()) {
+      return { success: false, userError: { error: "INVALID_PROOF" } };
+    }
+    if (row.userId === undefined) {
+      throw new Error(
+        "verifiedEmails.add needs a challenge that was started with a " +
+          "userId. This proof only attests ownership of the address.",
+      );
+    }
+    const userId = row.userId;
+    const normalizedEmail = normalizeEmail(row.email);
+
+    // The address must still be free: another user may have verified it
+    // after this challenge started.
+    if ((await emailByNormalizedEmail(ctx, normalizedEmail)) !== null) {
+      return { success: false, userError: { error: "EMAIL_TAKEN" } };
+    }
+
+    let previousPrimaryEmail: string | null = null;
+    let isPrimary: boolean;
+    if (args.setPrimary) {
+      const oldPrimary = await ctx.db
+        .query("verifiedEmails")
+        .withIndex("by_userId_isPrimary", (q) =>
+          q.eq("userId", userId).eq("isPrimary", true),
+        )
+        .unique();
+      if (oldPrimary !== null) {
+        previousPrimaryEmail = oldPrimary.email;
+        await ctx.db.delete("verifiedEmails", oldPrimary._id);
+      }
+      isPrimary = true;
+    } else {
+      // The first address of a user always becomes primary.
+      isPrimary = (await emailsByUserId(ctx, userId)).length === 0;
+    }
+    await ctx.db.insert("verifiedEmails", {
+      email: row.email,
+      normalizedEmail,
+      userId,
+      isPrimary,
+      source: { kind: "self" },
+    });
+    return {
+      success: true,
+      userId,
+      email: row.email,
+      isPrimary,
+      previousPrimaryEmail,
+    };
   },
 });
 


### PR DESCRIPTION
The component no longer knows what a challenge is for. `challenge.start`
takes an opaque `purpose` string, an optional `userId` and a `ttlMs`,
and does not consult `verifiedEmails`: whether the address must be free or
already verified depends on the flow, which only the caller knows.

`challenge.complete` writes nothing. It marks the row completed and returns
a one-shot `proof` (a 256-bit token, stored hashed). The new
`verifiedEmails.add({ proof, setPrimary })` is the only way to record an
address, so an address still enters `verifiedEmails` only through a
completed challenge. Recovery and re-authentication flows use the returned
`email` and `userId` and leave the proof unspent; the row then expires.

Removed: the addEmail/setEmail/passwordReset union, the EMAIL_TAKEN and
EMAIL_NOT_FOUND checks in `start`, the sibling sweep on completion, and
`challenges.normalizedEmail`. One email text serves every purpose.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)