### PR TITLE
authEmail: rename the setEmail purpose to setPrimaryEmail

### DIFF
--- a/examples/react-email-password/convex/emailPassword.test.ts
+++ b/examples/react-email-password/convex/emailPassword.test.ts
@@ -124,7 +124,7 @@ async function seedChallenge(
     email: string;
     userId: string;
     purpose:
-      { kind: "addEmail" } | { kind: "setEmail" } | { kind: "passwordReset" };
+      { kind: "addEmail" } | { kind: "setPrimaryEmail" } | { kind: "passwordReset" };
     code: string;
     secret: string;
   },
@@ -452,7 +452,7 @@ describe("completeChangeEmail", () => {
     await seedChallenge(t, {
       email: "new@example.com",
       userId,
-      purpose: { kind: "setEmail" },
+      purpose: { kind: "setPrimaryEmail" },
       code: "code1",
       secret: "secret1",
     });

--- a/packages/core/src/components/email/_generated/component.ts
+++ b/packages/core/src/components/email/_generated/component.ts
@@ -36,7 +36,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         {
           code: string;
-          purpose: "addEmail" | "setEmail" | "passwordReset";
+          purpose: "addEmail" | "setPrimaryEmail" | "passwordReset";
           secret: string;
         },
         | {
@@ -57,7 +57,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { code: string; secret: string },
         | {
             email: string;
-            purpose: "addEmail" | "setEmail" | "passwordReset";
+            purpose: "addEmail" | "setPrimaryEmail" | "passwordReset";
             status: "pending";
           }
         | { status: "invalid" },
@@ -79,7 +79,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           };
           purpose:
             | { kind: "addEmail"; userId: string }
-            | { kind: "setEmail"; userId: string }
+            | { kind: "setPrimaryEmail"; userId: string }
             | { kind: "passwordReset" };
           url: string;
         },

--- a/packages/core/src/components/email/challenge.test.ts
+++ b/packages/core/src/components/email/challenge.test.ts
@@ -3,7 +3,7 @@ import { convexTest } from "convex-test";
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { api } from "./_generated/api.ts";
 import schema from "./schema.ts";
-import { seedEmail, seedChallenge, ADD_EMAIL, SET_EMAIL } from "./testSetup.ts";
+import { seedEmail, seedChallenge, ADD_EMAIL, SET_PRIMARY_EMAIL } from "./testSetup.ts";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -74,13 +74,13 @@ describe("challenge.complete", () => {
     });
   });
 
-  test("setEmail: replaces and returns the old primary", async () => {
+  test("setPrimaryEmail: replaces and returns the old primary", async () => {
     const t = setup();
     await seedEmail(t, "user1", "old@example.com", true);
     await seedChallenge(t, {
       email: "new@example.com",
       userId: "user1",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code1",
       secret: "secret1",
     });
@@ -88,7 +88,7 @@ describe("challenge.complete", () => {
     const result = await t.mutation(api.challenge.complete, {
       code: "code1",
       secret: "secret1",
-      purpose: "setEmail",
+      purpose: "setPrimaryEmail",
     });
     expect(result).toEqual({
       success: true,
@@ -245,14 +245,14 @@ describe("challenge.complete", () => {
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code1",
       secret: "secret1",
     });
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user2",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code2",
       secret: "secret2",
     });
@@ -260,7 +260,7 @@ describe("challenge.complete", () => {
     const first = await t.mutation(api.challenge.complete, {
       code: "code1",
       secret: "secret1",
-      purpose: "setEmail",
+      purpose: "setPrimaryEmail",
     });
     expect(first).toMatchObject({ success: true, userId: "user1" });
 
@@ -272,7 +272,7 @@ describe("challenge.complete", () => {
     const second = await t.mutation(api.challenge.complete, {
       code: "code2",
       secret: "secret2",
-      purpose: "setEmail",
+      purpose: "setPrimaryEmail",
     });
     expect(second).toEqual({
       success: false,
@@ -338,7 +338,7 @@ describe("challenge.getStatus", () => {
     await seedChallenge(t, {
       email: "alice@example.com",
       userId: "user1",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code1",
       secret: "secret1",
     });
@@ -349,7 +349,7 @@ describe("challenge.getStatus", () => {
     });
     expect(status).toEqual({
       status: "pending",
-      purpose: "setEmail",
+      purpose: "setPrimaryEmail",
       email: "alice@example.com",
     });
 
@@ -357,7 +357,7 @@ describe("challenge.getStatus", () => {
     const result = await t.mutation(api.challenge.complete, {
       code: "code1",
       secret: "secret1",
-      purpose: "setEmail",
+      purpose: "setPrimaryEmail",
     });
     expect(result).toMatchObject({ success: true });
   });
@@ -522,14 +522,14 @@ describe("the pending challenge address", () => {
     await seedChallenge(t, {
       email: "Alice@Example.com",
       userId: "user1",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code1",
       secret: "secret1",
     });
     await seedChallenge(t, {
       email: "alice@EXAMPLE.com",
       userId: "user2",
-      purpose: SET_EMAIL,
+      purpose: SET_PRIMARY_EMAIL,
       code: "code2",
       secret: "secret2",
     });
@@ -538,7 +538,7 @@ describe("the pending challenge address", () => {
       await t.mutation(api.challenge.complete, {
         code: "code1",
         secret: "secret1",
-        purpose: "setEmail",
+        purpose: "setPrimaryEmail",
       }),
     ).toMatchObject({ success: true, userId: "user1" });
 

--- a/packages/core/src/components/email/challenge.ts
+++ b/packages/core/src/components/email/challenge.ts
@@ -178,7 +178,7 @@ const completeChallengeResult = v.union(
     success: v.literal(true),
     userId: v.string(),
     email: v.string(),
-    // For `setEmail`: the address that was primary before this completion
+    // For `setPrimaryEmail`: the address that was primary before this completion
     // replaced it, or `null` when there was none. Callers use it to notify
     // the old address.
     previousPrimaryEmail: v.union(v.string(), v.null()),
@@ -199,8 +199,8 @@ type CompleteChallengeResult = Infer<typeof completeChallengeResult>;
  * never be replayed. An unknown code, a wrong secret, an expired link and a
  * purpose mismatch all return the same `INVALID_LINK` error.
  *
- * For `addEmail` and `setEmail`, completion records the address (see
- * `vChallengePurposeArg` for the primary rules); `setEmail` also returns
+ * For `addEmail` and `setPrimaryEmail`, completion records the address (see
+ * `vChallengePurposeArg` for the primary rules); `setPrimaryEmail` also returns
  * the previous primary address when it replaced one. For `passwordReset`,
  * completion writes nothing and returns the `userId` as the ownership
  * proof.
@@ -248,7 +248,7 @@ export const complete = mutation({
       };
     }
 
-    // addEmail and setEmail: the address must still be free.
+    // addEmail and setPrimaryEmail: the address must still be free.
     const taken = await emailByNormalizedEmail(ctx, row.normalizedEmail);
     if (taken !== null) {
       return { success: false, userError: { error: "EMAIL_TAKEN" } };
@@ -256,7 +256,7 @@ export const complete = mutation({
 
     let previousPrimaryEmail: string | null = null;
     let isPrimary: boolean;
-    if (row.purpose.kind === "setEmail") {
+    if (row.purpose.kind === "setPrimaryEmail") {
       // Replace the old primary address. For a first email (sign-up) there
       // is nothing to replace; for a change-email flow the old address is
       // removed from the account.

--- a/packages/core/src/components/email/schema.ts
+++ b/packages/core/src/components/email/schema.ts
@@ -39,7 +39,7 @@ export default defineSchema({
     // What a successful completion does. See `vChallengePurposeArg`.
     purpose: v.union(
       v.object({ kind: v.literal("addEmail") }),
-      v.object({ kind: v.literal("setEmail") }),
+      v.object({ kind: v.literal("setPrimaryEmail") }),
       v.object({ kind: v.literal("passwordReset") }),
     ),
     // SHA-256 of the code that travels in the emailed link. Only the hash is

--- a/packages/core/src/components/email/setup.ts
+++ b/packages/core/src/components/email/setup.ts
@@ -609,7 +609,7 @@ export function setupEmailPassword<UsersTable extends string>(
 
             const start = await ctx.runMutation(component.challenge.start, {
               email: newEmail,
-              purpose: { kind: "setEmail", userId },
+              purpose: { kind: "setPrimaryEmail", userId },
               url: urls.changeEmail,
               emailSender: await senderConfig(),
             });
@@ -634,7 +634,7 @@ export function setupEmailPassword<UsersTable extends string>(
           ): Promise<CompleteChangeEmailResult> => {
             const complete = await ctx.runMutation(
               component.challenge.complete,
-              { code, secret, purpose: "setEmail" },
+              { code, secret, purpose: "setPrimaryEmail" },
             );
             if (!complete.success) {
               return { success: false, userError: complete.userError };

--- a/packages/core/src/components/email/testSetup.ts
+++ b/packages/core/src/components/email/testSetup.ts
@@ -21,7 +21,7 @@ export async function seedEmail(
 }
 
 export type ChallengePurposeRow =
-  { kind: "addEmail" } | { kind: "setEmail" } | { kind: "passwordReset" };
+  { kind: "addEmail" } | { kind: "setPrimaryEmail" } | { kind: "passwordReset" };
 
 /**
  * Seed a pending challenge row directly, hashing the code and the secret
@@ -53,4 +53,4 @@ export async function seedChallenge(
 }
 
 export const ADD_EMAIL: ChallengePurposeRow = { kind: "addEmail" };
-export const SET_EMAIL: ChallengePurposeRow = { kind: "setEmail" };
+export const SET_PRIMARY_EMAIL: ChallengePurposeRow = { kind: "setPrimaryEmail" };

--- a/packages/core/src/components/email/validation.ts
+++ b/packages/core/src/components/email/validation.ts
@@ -44,16 +44,16 @@ export function validateEmailFormat(
  * - `addEmail`: prove that the address belongs to `userId`, then record it
  *   as an email address for the user (primary if it’s the first email address
  *   or secondary if it’s not).
- * - `setEmail`: similar to addEmail, but used in apps where users have a single
- *   email address. When the challenge is completed, we will always set the new
- *   email address as primary, and remove pre-existing email addresses.
+ * - `setPrimaryEmail`: similar to `addEmail`, but for apps where each user has
+ *   one email address. When the challenge is completed, the new address
+ *   always becomes primary, and the previous primary address is removed.
  * - `passwordReset`: prove that the person owns an address that is already
  *   verified on the account. Completion writes nothing; it returns the
  *   `userId` as the ownership proof.
  */
 export const vChallengePurposeArg = v.union(
   v.object({ kind: v.literal("addEmail"), userId: v.string() }),
-  v.object({ kind: v.literal("setEmail"), userId: v.string() }),
+  v.object({ kind: v.literal("setPrimaryEmail"), userId: v.string() }),
   v.object({ kind: v.literal("passwordReset") }),
 );
 export type ChallengePurposeArg = Infer<typeof vChallengePurposeArg>;
@@ -61,7 +61,7 @@ export type ChallengePurposeArg = Infer<typeof vChallengePurposeArg>;
 /** The purpose kind alone, for completion-side checks. */
 export const vPurposeKind = v.union(
   v.literal("addEmail"),
-  v.literal("setEmail"),
+  v.literal("setPrimaryEmail"),
   v.literal("passwordReset"),
 );
 export type PurposeKind = Infer<typeof vPurposeKind>;
@@ -73,7 +73,7 @@ export type PurposeKind = Infer<typeof vPurposeKind>;
 export const startChallengeUserError = v.union(
   emailFormatUserError,
   // Another user has already verified this address (`addEmail`,
-  // `setEmail`).
+  // `setPrimaryEmail`).
   v.object({ error: v.literal("EMAIL_TAKEN") }),
   // No user has verified this address (`passwordReset`).
   v.object({ error: v.literal("EMAIL_NOT_FOUND") }),


### PR DESCRIPTION
The purpose replaces the primary address of a user, and the new name says so. No behavior change.