### PR TITLE
authEmail: keep concurrent challenges for one address

### DIFF
--- a/examples/react-email-password/convex/emailPassword.test.ts
+++ b/examples/react-email-password/convex/emailPassword.test.ts
@@ -306,14 +306,14 @@ describe("completeSignUp", () => {
     });
     expect(first).toEqual({ success: true, tokens: SESSION_TOKENS });
 
-    // The other sign-up's link can no longer be completed.
+    // The other sign-up's link stays pending, but the address is taken now.
     const second = await t.mutation(api.auth.completeSignUp, {
       code: "code1",
       secret: "secret1",
     });
     expect(second).toEqual({
       success: false,
-      userError: { error: "INVALID_LINK" },
+      userError: { error: "EMAIL_TAKEN" },
     });
   });
 });

--- a/packages/core/src/components/email/challenge.test.ts
+++ b/packages/core/src/components/email/challenge.test.ts
@@ -3,7 +3,12 @@ import { convexTest } from "convex-test";
 import { register as registerRateLimiter } from "@convex-dev/rate-limiter/test";
 import { api } from "./_generated/api.ts";
 import schema from "./schema.ts";
-import { seedEmail, seedChallenge, ADD_EMAIL, SET_PRIMARY_EMAIL } from "./testSetup.ts";
+import {
+  seedEmail,
+  seedChallenge,
+  ADD_EMAIL,
+  SET_PRIMARY_EMAIL,
+} from "./testSetup.ts";
 
 const modules = import.meta.glob("./**/*.ts");
 
@@ -239,7 +244,7 @@ describe("challenge.complete", () => {
     ).toEqual({ userId: "user2", email: "alice@example.com" });
   });
 
-  test("completing a challenge deletes sibling challenges for the email", async () => {
+  test("a concurrent challenge for the same address stays pending, then fails", async () => {
     const t = setup();
     // Two sign-ups race for one address; the first completion wins.
     await seedChallenge(t, {
@@ -264,11 +269,14 @@ describe("challenge.complete", () => {
     });
     expect(first).toMatchObject({ success: true, userId: "user1" });
 
-    // The sibling was deleted, not left to fail with EMAIL_TAKEN.
-    const remaining = await t.run(
-      async (ctx) => (await ctx.db.query("challenges").collect()).length,
-    );
-    expect(remaining).toBe(0);
+    // The other challenge is not deleted. It stays pending, and fails only
+    // when the user tries to complete it.
+    expect(
+      await t.query(api.challenge.getStatus, {
+        code: "code2",
+        secret: "secret2",
+      }),
+    ).toMatchObject({ status: "pending" });
     const second = await t.mutation(api.challenge.complete, {
       code: "code2",
       secret: "secret2",
@@ -276,7 +284,7 @@ describe("challenge.complete", () => {
     });
     expect(second).toEqual({
       success: false,
-      userError: { error: "INVALID_LINK" },
+      userError: { error: "EMAIL_TAKEN" },
     });
   });
 
@@ -517,7 +525,7 @@ describe("the pending challenge address", () => {
     });
   });
 
-  test("completion deletes siblings that use another case of the address", async () => {
+  test("a challenge that uses another case of the address fails after completion", async () => {
     const t = setup();
     await seedChallenge(t, {
       email: "Alice@Example.com",
@@ -542,10 +550,13 @@ describe("the pending challenge address", () => {
       }),
     ).toMatchObject({ success: true, userId: "user1" });
 
-    const remaining = await t.run(
-      async (ctx) => (await ctx.db.query("challenges").collect()).length,
-    );
-    expect(remaining).toBe(0);
+    expect(
+      await t.mutation(api.challenge.complete, {
+        code: "code2",
+        secret: "secret2",
+        purpose: "setPrimaryEmail",
+      }),
+    ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
   });
 });
 

--- a/packages/core/src/components/email/challenge.ts
+++ b/packages/core/src/components/email/challenge.ts
@@ -139,6 +139,9 @@ export const start = mutation({
       }
       userId = existing.userId;
     } else {
+      // TODO: let the caller disable this check. It tells the caller if an
+      // address has an account, which an app that must prevent user
+      // enumeration does not want to reveal before the link is opened.
       if (existing !== null) {
         return { success: false, userError: { error: "EMAIL_TAKEN" } };
       }
@@ -281,18 +284,6 @@ export const complete = mutation({
       userId: row.userId,
       isPrimary,
     });
-
-    // The address is now verified, so every other pending challenge for it
-    // can no longer succeed. Delete them instead of leaving them to fail.
-    const siblings = await ctx.db
-      .query("challenges")
-      .withIndex("by_normalizedEmail", (q) =>
-        q.eq("normalizedEmail", row.normalizedEmail),
-      )
-      .collect();
-    for (const sibling of siblings) {
-      await ctx.db.delete("challenges", sibling._id);
-    }
 
     return {
       success: true,

--- a/packages/core/src/components/email/schema.ts
+++ b/packages/core/src/components/email/schema.ts
@@ -51,6 +51,5 @@ export default defineSchema({
     expiresAt: v.number(),
   })
     .index("by_codeHash", ["codeHash"])
-    .index("by_userId", ["userId"])
-    .index("by_normalizedEmail", ["normalizedEmail"]),
+    .index("by_userId", ["userId"]),
 });


### PR DESCRIPTION
A completion no longer deletes the other pending challenges for the same
address. They stay pending and fail with EMAIL_TAKEN when a user tries to
complete them. The challenges index by normalizedEmail is gone with the
sweep. Also add a TODO about an opt-out of the start-time EMAIL_TAKEN
check for apps that must prevent user enumeration.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>