### PR TITLE
authEmail: bind addEmail and setPrimaryEmail links to their user

### DIFF
--- a/examples/react-email-password/convex/emailPassword.test.ts
+++ b/examples/react-email-password/convex/emailPassword.test.ts
@@ -250,9 +250,29 @@ describe("completeSignUp", () => {
       secret: "secret1",
     });
 
-    const result = await t.mutation(api.auth.completeSignUp, {
+    // A link is bound to its user: another user cannot complete it.
+    const other = await t.mutation(api.auth.completeSignUp, {
       code: "code1",
       secret: "secret1",
+      userId: "someone-else",
+    });
+    expect(other).toEqual({
+      success: false,
+      userError: { error: "INVALID_LINK" },
+    });
+    // The wrong user burned the link; seed it again for the happy path.
+    await seedChallenge(t, {
+      email: EMAIL,
+      userId,
+      purpose: { kind: "addEmail" },
+      code: "code2",
+      secret: "secret2",
+    });
+
+    const result = await t.mutation(api.auth.completeSignUp, {
+      code: "code2",
+      secret: "secret2",
+      userId,
     });
     expect(result).toEqual({ success: true, tokens: SESSION_TOKENS });
 
@@ -269,6 +289,7 @@ describe("completeSignUp", () => {
     const result = await t.mutation(api.auth.completeSignUp, {
       code: "unknown",
       secret: "whatever",
+      userId: "nobody",
     });
     expect(result).toEqual({
       success: false,
@@ -311,6 +332,7 @@ describe("completeSignUp", () => {
     const first = await t.mutation(api.auth.completeSignUp, {
       code: "code2",
       secret: "secret2",
+      userId: user2,
     });
     expect(first).toEqual({ success: true, tokens: SESSION_TOKENS });
 
@@ -318,6 +340,7 @@ describe("completeSignUp", () => {
     const second = await t.mutation(api.auth.completeSignUp, {
       code: "code1",
       secret: "secret1",
+      userId: user1,
     });
     expect(second).toEqual({
       success: false,
@@ -465,10 +488,22 @@ describe("completeChangeEmail", () => {
       secret: "secret1",
     });
 
-    const result = await t.mutation(api.auth.completeChangeEmail, {
+    // Without a session, the link cannot be completed.
+    const signedOut = await t.mutation(api.auth.completeChangeEmail, {
       code: "code1",
       secret: "secret1",
     });
+    expect(signedOut).toEqual({
+      success: false,
+      userError: { error: "NOT_LOGGED_IN" },
+    });
+
+    const result = await t
+      .withIdentity({ subject: userId })
+      .mutation(api.auth.completeChangeEmail, {
+        code: "code1",
+        secret: "secret1",
+      });
     expect(result).toEqual({ success: true });
 
     // Sign-in works with the new address, and no longer with the old one.
@@ -496,10 +531,13 @@ describe("completeChangeEmail", () => {
 
   test("rejects a bad code with INVALID_LINK", async () => {
     const t = await setup();
-    const result = await t.mutation(api.auth.completeChangeEmail, {
-      code: "unknown",
-      secret: "whatever",
-    });
+    const userId = await seedSignedUpUser(t);
+    const result = await t
+      .withIdentity({ subject: userId })
+      .mutation(api.auth.completeChangeEmail, {
+        code: "unknown",
+        secret: "whatever",
+      });
     expect(result).toEqual({
       success: false,
       userError: { error: "INVALID_LINK" },

--- a/examples/react-email-password/src/routes/confirmEmailChange.tsx
+++ b/examples/react-email-password/src/routes/confirmEmailChange.tsx
@@ -89,6 +89,8 @@ export function ConfirmEmailChange() {
             switch (result.userError.error) {
               case "INVALID_LINK":
                 return "The link is not valid anymore. Start the change again.";
+              case "NOT_LOGGED_IN":
+                return "Log in first, then open the link again.";
               case "EMAIL_TAKEN":
                 return "Another account validated this email address first.";
               case "MISSING_SECRET":

--- a/packages/core/src/components/email/_generated/component.ts
+++ b/packages/core/src/components/email/_generated/component.ts
@@ -28,7 +28,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         complete: FunctionReference<
           "mutation",
           "internal",
-          { code: string; secret: string },
+          { code: string; secret: string; userId: string },
           | { email: string; success: true; userId: string }
           | {
               success: false;
@@ -39,7 +39,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         getStatus: FunctionReference<
           "query",
           "internal",
-          { code: string; secret: string },
+          { code: string; secret: string; userId: string },
           { email: string; status: "pending" } | { status: "invalid" },
           Name
         >;
@@ -145,7 +145,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         complete: FunctionReference<
           "mutation",
           "internal",
-          { code: string; secret: string },
+          { code: string; secret: string; userId: string },
           | {
               email: string;
               previousPrimaryEmail: string | null;
@@ -161,7 +161,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         getStatus: FunctionReference<
           "query",
           "internal",
-          { code: string; secret: string },
+          { code: string; secret: string; userId: string },
           { email: string; status: "pending" } | { status: "invalid" },
           Name
         >;

--- a/packages/core/src/components/email/challenge/addEmail.test.ts
+++ b/packages/core/src/components/email/challenge/addEmail.test.ts
@@ -32,6 +32,7 @@ describe("challenge.addEmail.complete", () => {
     const result = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toEqual({
       success: true,
@@ -59,6 +60,7 @@ describe("challenge.addEmail.complete", () => {
     const result = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toMatchObject({ success: true });
     const emails = await t.query(api.verifiedEmails.getEmails, {
@@ -89,6 +91,7 @@ describe("challenge.addEmail.complete", () => {
     const result = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toEqual({
       success: false,
@@ -115,6 +118,7 @@ describe("challenge.addEmail.complete", () => {
     const result = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toMatchObject({
       success: true,
@@ -147,8 +151,69 @@ describe("challenge.addEmail.complete", () => {
       await t.mutation(api.challenge.addEmail.complete, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
+  });
+});
+
+describe("the userId of an addEmail challenge", () => {
+  test("another userId fails with INVALID_LINK and burns the link", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: ADD_EMAIL,
+      code: "code1",
+      secret: "secret1",
+    });
+
+    expect(
+      await t.mutation(api.challenge.addEmail.complete, {
+        code: "code1",
+        secret: "secret1",
+        userId: "user2",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+    // Nothing was recorded for either user, and the link is gone.
+    expect(
+      await t.query(api.verifiedEmails.getUserIdByEmail, {
+        email: "alice@example.com",
+      }),
+    ).toBeNull();
+    expect(
+      await t.mutation(api.challenge.addEmail.complete, {
+        code: "code1",
+        secret: "secret1",
+        userId: "user1",
+      }),
+    ).toEqual({ success: false, userError: { error: "INVALID_LINK" } });
+  });
+
+  test("getStatus with another userId reports invalid and keeps the row", async () => {
+    const t = setup();
+    await seedChallenge(t, {
+      email: "alice@example.com",
+      userId: "user1",
+      purpose: ADD_EMAIL,
+      code: "code1",
+      secret: "secret1",
+    });
+
+    expect(
+      await t.query(api.challenge.addEmail.getStatus, {
+        code: "code1",
+        secret: "secret1",
+        userId: "user2",
+      }),
+    ).toEqual({ status: "invalid" });
+    expect(
+      await t.query(api.challenge.addEmail.getStatus, {
+        code: "code1",
+        secret: "secret1",
+        userId: "user1",
+      }),
+    ).toEqual({ status: "pending", email: "alice@example.com" });
   });
 });
 

--- a/packages/core/src/components/email/challenge/addEmail.ts
+++ b/packages/core/src/components/email/challenge/addEmail.ts
@@ -67,19 +67,19 @@ const completeResult = v.union(
 type CompleteResult = Infer<typeof completeResult>;
 
 /**
- * Complete an `addEmail` challenge: record the address for the user. Fails
- * with `EMAIL_TAKEN` when another user verified the address after the start.
+ * Complete an `addEmail` challenge: record the address for the user. The
+ * `userId` must be the one given at start. Fails with `EMAIL_TAKEN` when
+ * another user verified the address after the start.
  */
 export const complete = mutation({
-  args: vClaimArgs,
+  args: { ...vClaimArgs, userId: v.string() },
   returns: completeResult,
   handler: async (ctx, args): Promise<CompleteResult> => {
     const row = await claimChallenge(ctx, { ...args, purpose: PURPOSE });
     if (row === null) {
       return INVALID_LINK;
     }
-    // A row of this kind always has a user: `start` requires one.
-    const userId = row.userId as string;
+    const { userId } = args;
     const taken = await addressTakenError(ctx, row.normalizedEmail);
     if (taken !== null) {
       return { success: false, userError: taken };
@@ -98,7 +98,7 @@ export const complete = mutation({
 
 /** Report the state of an `addEmail` challenge without claiming it. */
 export const getStatus = query({
-  args: vClaimArgs,
+  args: { ...vClaimArgs, userId: v.string() },
   returns: vChallengeStatus,
   handler: async (ctx, args): Promise<ChallengeStatus> =>
     await getChallengeStatus(ctx, { ...args, purpose: PURPOSE }),

--- a/packages/core/src/components/email/challenge/common.test.ts
+++ b/packages/core/src/components/email/challenge/common.test.ts
@@ -38,12 +38,14 @@ describe("the one-shot claim", () => {
     const first = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(first).toMatchObject({ success: true });
 
     const second = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(second).toEqual({
       success: false,
@@ -64,6 +66,7 @@ describe("the one-shot claim", () => {
     const wrong = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "not-the-secret",
+      userId: "user1",
     });
     expect(wrong).toEqual({
       success: false,
@@ -74,6 +77,7 @@ describe("the one-shot claim", () => {
     const retry = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(retry).toEqual({
       success: false,
@@ -95,6 +99,7 @@ describe("the one-shot claim", () => {
     const result = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toEqual({
       success: false,
@@ -116,6 +121,7 @@ describe("the one-shot claim", () => {
     const wrongKind = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(wrongKind).toEqual({
       success: false,
@@ -125,6 +131,7 @@ describe("the one-shot claim", () => {
     const rightKind = await t.mutation(api.challenge.addEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(rightKind).toEqual({
       success: false,
@@ -147,6 +154,7 @@ describe("getStatus", () => {
     const status = await t.query(api.challenge.setPrimaryEmail.getStatus, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(status).toEqual({ status: "pending", email: "alice@example.com" });
 
@@ -154,6 +162,7 @@ describe("getStatus", () => {
     const result = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toMatchObject({ success: true });
   });
@@ -180,18 +189,21 @@ describe("getStatus", () => {
       await t.query(api.challenge.addEmail.getStatus, {
         code: "unknown",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ status: "invalid" });
     expect(
       await t.query(api.challenge.addEmail.getStatus, {
         code: "code1",
         secret: "wrong",
+        userId: "user1",
       }),
     ).toEqual({ status: "invalid" });
     expect(
       await t.query(api.challenge.addEmail.getStatus, {
         code: "code2",
         secret: "secret2",
+        userId: "user2",
       }),
     ).toEqual({ status: "invalid" });
   });
@@ -210,12 +222,14 @@ describe("getStatus", () => {
       await t.query(api.challenge.setPrimaryEmail.getStatus, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ status: "invalid" });
     expect(
       await t.query(api.challenge.addEmail.getStatus, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ status: "pending", email: "alice@example.com" });
   });
@@ -243,6 +257,7 @@ describe("concurrent challenges", () => {
     const first = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(first).toMatchObject({ success: true, userId: "user1" });
 
@@ -252,11 +267,13 @@ describe("concurrent challenges", () => {
       await t.query(api.challenge.setPrimaryEmail.getStatus, {
         code: "code2",
         secret: "secret2",
+        userId: "user2",
       }),
     ).toMatchObject({ status: "pending" });
     const second = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code2",
       secret: "secret2",
+      userId: "user2",
     });
     expect(second).toEqual({
       success: false,
@@ -285,6 +302,7 @@ describe("concurrent challenges", () => {
       await t.mutation(api.challenge.setPrimaryEmail.complete, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toMatchObject({ success: true, userId: "user1" });
 
@@ -292,6 +310,7 @@ describe("concurrent challenges", () => {
       await t.mutation(api.challenge.setPrimaryEmail.complete, {
         code: "code2",
         secret: "secret2",
+        userId: "user2",
       }),
     ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
   });
@@ -328,6 +347,7 @@ describe("the pending challenge address", () => {
       await t.query(api.challenge.addEmail.getStatus, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ status: "pending", email: "Alice@Example.com" });
   });

--- a/packages/core/src/components/email/challenge/common.ts
+++ b/packages/core/src/components/email/challenge/common.ts
@@ -178,11 +178,15 @@ export async function createChallenge(
 
 // --- Complete and status ---------------------------------------------------
 
-/** What a completion or a status query expects to find in the row. */
+/**
+ * What a completion or a status query expects to find in the row: the
+ * purpose of the function that the caller uses, and the `userId` that the
+ * caller asserts (`null` for a flow without a user). Both must equal the
+ * stored values, so a link can never complete a flow for another user.
+ */
 export type ExpectedChallenge = {
   purpose: ChallengePurpose;
-  // The `userId` that the caller asserts. `undefined` skips the check.
-  userId?: string | null;
+  userId: string | null;
 };
 
 async function findByCode(
@@ -218,7 +222,7 @@ async function matches(
     row.secretHash === (await sha256Hex(args.secret)) &&
     row.expiresAt >= Date.now() &&
     samePurpose(row.purpose, args.purpose) &&
-    (args.userId === undefined || row.userId === args.userId)
+    row.userId === args.userId
   );
 }
 

--- a/packages/core/src/components/email/challenge/setPrimaryEmail.test.ts
+++ b/packages/core/src/components/email/challenge/setPrimaryEmail.test.ts
@@ -33,6 +33,7 @@ describe("challenge.setPrimaryEmail.complete", () => {
     const result = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toEqual({
       success: true,
@@ -64,6 +65,7 @@ describe("challenge.setPrimaryEmail.complete", () => {
     const result = await t.mutation(api.challenge.setPrimaryEmail.complete, {
       code: "code1",
       secret: "secret1",
+      userId: "user1",
     });
     expect(result).toEqual({
       success: true,
@@ -92,6 +94,7 @@ describe("challenge.setPrimaryEmail.complete", () => {
       await t.mutation(api.challenge.setPrimaryEmail.complete, {
         code: "code1",
         secret: "secret1",
+        userId: "user1",
       }),
     ).toEqual({ success: false, userError: { error: "EMAIL_TAKEN" } });
     // The old primary stays in place.

--- a/packages/core/src/components/email/challenge/setPrimaryEmail.ts
+++ b/packages/core/src/components/email/challenge/setPrimaryEmail.ts
@@ -68,19 +68,19 @@ type CompleteResult = Infer<typeof completeResult>;
 
 /**
  * Complete a `setPrimaryEmail` challenge: remove the old primary address and
- * record the new one as primary. Fails with `EMAIL_TAKEN` when another user
- * verified the address after the start.
+ * record the new one as primary. The `userId` must be the one given at
+ * start. Fails with `EMAIL_TAKEN` when another user verified the address
+ * after the start.
  */
 export const complete = mutation({
-  args: vClaimArgs,
+  args: { ...vClaimArgs, userId: v.string() },
   returns: completeResult,
   handler: async (ctx, args): Promise<CompleteResult> => {
     const row = await claimChallenge(ctx, { ...args, purpose: PURPOSE });
     if (row === null) {
       return INVALID_LINK;
     }
-    // A row of this kind always has a user: `start` requires one.
-    const userId = row.userId as string;
+    const { userId } = args;
     const taken = await addressTakenError(ctx, row.normalizedEmail);
     if (taken !== null) {
       return { success: false, userError: taken };
@@ -115,7 +115,7 @@ export const complete = mutation({
 
 /** Report the state of a `setPrimaryEmail` challenge without claiming it. */
 export const getStatus = query({
-  args: vClaimArgs,
+  args: { ...vClaimArgs, userId: v.string() },
   returns: vChallengeStatus,
   handler: async (ctx, args): Promise<ChallengeStatus> =>
     await getChallengeStatus(ctx, { ...args, purpose: PURPOSE }),

--- a/packages/core/src/components/email/react.test.tsx
+++ b/packages/core/src/components/email/react.test.tsx
@@ -65,7 +65,11 @@ afterEach(() => {
 
 describe("useSignUpWithEmailPassword", () => {
   test("success stores the secret and does not sign in", async () => {
-    runMutation.mockResolvedValue({ success: true, secret: "secret-1" });
+    runMutation.mockResolvedValue({
+      success: true,
+      secret: "secret-1",
+      userId: "user-1",
+    });
     const { result } = renderWithProviders(() =>
       useSignUpWithEmailPassword(mutation),
     );
@@ -79,10 +83,18 @@ describe("useSignUpWithEmailPassword", () => {
       });
     });
 
-    expect(returned).toEqual({ success: true, secret: "secret-1" });
-    // The secret is kept for the completion step; no session was adopted.
+    expect(returned).toEqual({
+      success: true,
+      secret: "secret-1",
+      userId: "user-1",
+    });
+    // The secret and the user are kept for the completion step; no session
+    // was adopted.
     expect(secretStorage.get("__convexAuthEmailPasswordSignUpSecret")).toBe(
       "secret-1",
+    );
+    expect(secretStorage.get("__convexAuthEmailPasswordSignUpUserId")).toBe(
+      "user-1",
     );
     expect(result.current.auth.isAuthenticated).toBe(false);
   });
@@ -136,6 +148,7 @@ describe("useSignUpWithEmailPassword", () => {
 describe("useCompleteSignUp", () => {
   test("consumes the stored secret and adopts the session", async () => {
     secretStorage.set("__convexAuthEmailPasswordSignUpSecret", "secret-1");
+    secretStorage.set("__convexAuthEmailPasswordSignUpUserId", "user-1");
     runMutation.mockResolvedValue({ success: true, tokens: bundle });
     const { result } = renderWithProviders(() => useCompleteSignUp(mutation));
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
@@ -147,16 +160,22 @@ describe("useCompleteSignUp", () => {
       returned = await result.current.hook.completeSignUp({ code: "code-1" });
     });
 
-    // The mutation received the code from the link plus the stored secret.
+    // The mutation received the code from the link plus the stored secret
+    // and user.
     expect(runMutation).toHaveBeenCalledWith({
       code: "code-1",
       secret: "secret-1",
+      userId: "user-1",
     });
     expect(returned).toEqual({ success: true, tokens: bundle });
     expect(result.current.auth.isAuthenticated).toBe(true);
-    // The secret is cleared once it has served its purpose.
+    // The secret and the user are cleared once they have served their
+    // purpose.
     expect(
       secretStorage.get("__convexAuthEmailPasswordSignUpSecret"),
+    ).toBeNull();
+    expect(
+      secretStorage.get("__convexAuthEmailPasswordSignUpUserId"),
     ).toBeNull();
   });
 
@@ -180,8 +199,28 @@ describe("useCompleteSignUp", () => {
     expect(result.current.auth.isAuthenticated).toBe(false);
   });
 
+  test("returns MISSING_SECRET when the user is missing from storage", async () => {
+    secretStorage.set("__convexAuthEmailPasswordSignUpSecret", "secret-1");
+    const { result } = renderWithProviders(() => useCompleteSignUp(mutation));
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: Awaited<
+      ReturnType<typeof result.current.hook.completeSignUp>
+    >;
+    await act(async () => {
+      returned = await result.current.hook.completeSignUp({ code: "code-1" });
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "MISSING_SECRET" },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
   test("keeps the secret when completion fails", async () => {
     secretStorage.set("__convexAuthEmailPasswordSignUpSecret", "secret-1");
+    secretStorage.set("__convexAuthEmailPasswordSignUpUserId", "user-1");
     runMutation.mockResolvedValue({
       success: false,
       userError: { error: "INVALID_LINK" },

--- a/packages/core/src/components/email/react.tsx
+++ b/packages/core/src/components/email/react.tsx
@@ -48,6 +48,10 @@ const SECRET_STORAGE_KEYS: Record<EmailPasswordFlow, string> = {
   recovery: "__convexAuthEmailPasswordRecoverySecret",
 };
 
+// The sign-up link is bound to the new user, and nobody is signed in until
+// the link is opened, so the browser keeps the `userId` next to the secret.
+const SIGN_UP_USER_ID_STORAGE_KEY = "__convexAuthEmailPasswordSignUpUserId";
+
 /**
  * A failure the client produces that the server never returns: the mutation
  * threw (a network blip, a bug, an unexpected server error) rather than
@@ -81,7 +85,7 @@ type SignUpMutation = FunctionReference<
 type CompleteSignUpMutation = FunctionReference<
   "mutation",
   "public",
-  { code: string; secret: string },
+  { code: string; secret: string; userId: string },
   ClientView<CompleteSignUpResult>
 >;
 
@@ -130,7 +134,7 @@ type CompleteRecoveryMutation = FunctionReference<
 type GetChallengeStatusQuery = FunctionReference<
   "query",
   "public",
-  { code: string; secret: string; flow: EmailPasswordFlow },
+  { code: string; secret: string; flow: EmailPasswordFlow; userId?: string },
   ChallengeStatus
 >;
 
@@ -229,6 +233,7 @@ export function useSignUpWithEmailPassword(signUpMutation: SignUpMutation) {
           const result = await signInApi.mutation(signUpMutation, credentials);
           if (result.success) {
             await storage.set(SECRET_STORAGE_KEYS.signUp, result.secret);
+            await storage.set(SIGN_UP_USER_ID_STORAGE_KEY, result.userId);
           }
           return result;
         } catch (cause) {
@@ -264,7 +269,13 @@ export function useCompleteSignUp(
       track(async () => {
         try {
           const secret = await storage.get(SECRET_STORAGE_KEYS.signUp);
-          if (secret === null || secret === undefined) {
+          const userId = await storage.get(SIGN_UP_USER_ID_STORAGE_KEY);
+          if (
+            secret === null ||
+            secret === undefined ||
+            userId === null ||
+            userId === undefined
+          ) {
             return {
               success: false,
               userError: { error: "MISSING_SECRET" },
@@ -273,10 +284,12 @@ export function useCompleteSignUp(
           const result = await signInApi.mutation(completeSignUpMutation, {
             code,
             secret,
+            userId,
           });
           if (result.success) {
             await setSession(result.tokens);
             await storage.remove(SECRET_STORAGE_KEYS.signUp);
+            await storage.remove(SIGN_UP_USER_ID_STORAGE_KEY);
           }
           return result;
         } catch (cause) {
@@ -544,15 +557,32 @@ export function useChallengeStatus(
   { code, flow }: { code: string; flow: EmailPasswordFlow },
 ): UseChallengeStatusResult {
   const storage = useSecretStorage();
-  // `undefined` = still reading storage; `null` = no secret in this browser.
-  const [secret, setSecret] = useState<string | null | undefined>(undefined);
+  // What the starting browser kept: the secret, and for sign-up the user.
+  // `undefined` = still reading storage; `null` = this browser did not start
+  // the flow.
+  const [kept, setKept] = useState<
+    { secret: string; userId?: string } | null | undefined
+  >(undefined);
 
   useEffect(() => {
     let canceled = false;
     void (async () => {
-      const value = await storage.get(SECRET_STORAGE_KEYS[flow]);
-      if (!canceled) {
-        setSecret(value ?? null);
+      const secret = await storage.get(SECRET_STORAGE_KEYS[flow]);
+      const userId =
+        flow === "signUp"
+          ? await storage.get(SIGN_UP_USER_ID_STORAGE_KEY)
+          : undefined;
+      if (canceled) {
+        return;
+      }
+      if (
+        secret === null ||
+        secret === undefined ||
+        (flow === "signUp" && (userId === null || userId === undefined))
+      ) {
+        setKept(null);
+      } else {
+        setKept({ secret, userId: userId ?? undefined });
       }
     })();
     return () => {
@@ -562,13 +592,13 @@ export function useChallengeStatus(
 
   const status = useQuery(
     statusQuery,
-    secret === null || secret === undefined ? "skip" : { code, secret, flow },
+    kept === null || kept === undefined ? "skip" : { code, flow, ...kept },
   );
 
-  if (secret === undefined) {
+  if (kept === undefined) {
     return undefined;
   }
-  if (secret === null) {
+  if (kept === null) {
     return { status: "missingSecret" };
   }
   return status;

--- a/packages/core/src/components/email/setup.ts
+++ b/packages/core/src/components/email/setup.ts
@@ -16,6 +16,7 @@ import {
   queryGeneric,
   type FunctionReference,
   type GenericMutationCtx,
+  type GenericQueryCtx,
   type GenericDataModel,
 } from "convex/server";
 import { Infer, v } from "convex/values";
@@ -161,7 +162,13 @@ export type EmailPasswordOptions = {
 const vNotLoggedIn = v.object({ error: v.literal("NOT_LOGGED_IN") });
 
 const signUpResult = v.union(
-  v.object({ success: v.literal(true), secret: v.string() }),
+  v.object({
+    success: v.literal(true),
+    secret: v.string(),
+    // The new user. The browser keeps it with the secret and gives both back
+    // to `completeSignUp`, which binds the link to this user.
+    userId: v.string(),
+  }),
   v.object({
     success: v.literal(false),
     userError: v.union(startChallengeUserError, setPasswordUserError),
@@ -233,7 +240,7 @@ const completeChangeEmailResult = v.union(
   v.object({ success: v.literal(true) }),
   v.object({
     success: v.literal(false),
-    userError: completeChallengeUserError,
+    userError: v.union(vNotLoggedIn, completeChallengeUserError),
   }),
 );
 
@@ -368,7 +375,9 @@ export function setupEmailPassword<UsersTable extends string>(
   };
 
   /** The signed-in user's id, or `null` when there is no session. */
-  const sessionUserId = async (ctx: MutationCtx): Promise<string | null> => {
+  const sessionUserId = async (
+    ctx: GenericQueryCtx<GenericDataModel>,
+  ): Promise<string | null> => {
     const identity = await ctx.auth.getUserIdentity();
     return identity === null ? null : identity.subject;
   };
@@ -489,7 +498,7 @@ export function setupEmailPassword<UsersTable extends string>(
               );
             }
 
-            return { success: true, secret: start.secret };
+            return { success: true, secret: start.secret, userId };
           },
         }),
 
@@ -499,15 +508,15 @@ export function setupEmailPassword<UsersTable extends string>(
          * Validation and sign-in happen in one transaction.
          */
         completeSignUp: authMutation({
-          args: { code: v.string(), secret: v.string() },
+          args: { code: v.string(), secret: v.string(), userId: v.string() },
           returns: completeSignUpResult,
           handler: async (
             ctx,
-            { code, secret },
+            { code, secret, userId },
           ): Promise<CompleteSignUpResult> => {
             const complete = await ctx.runMutation(
               component.challenge.addEmail.complete,
-              { code, secret },
+              { code, secret, userId },
             );
             if (!complete.success) {
               return { success: false, userError: complete.userError };
@@ -660,9 +669,15 @@ export function setupEmailPassword<UsersTable extends string>(
             ctx,
             { code, secret },
           ): Promise<CompleteChangeEmailResult> => {
+            // The link is bound to the user who started the change, so the
+            // same user must be signed in to complete it.
+            const userId = await sessionUserId(ctx);
+            if (userId === null) {
+              return { success: false, userError: { error: "NOT_LOGGED_IN" } };
+            }
             const complete = await ctx.runMutation(
               component.challenge.setPrimaryEmail.complete,
-              { code, secret },
+              { code, secret, userId },
             );
             if (!complete.success) {
               return { success: false, userError: complete.userError };
@@ -828,29 +843,43 @@ export function setupEmailPassword<UsersTable extends string>(
          * call this to show which address the link is for before the user
          * confirms. `flow` names the landing page, so a link from another
          * flow reports `invalid`.
+         *
+         * A link is bound to a user. The sign-up landing page gives the
+         * `userId` that `signUp` returned (nobody is signed in yet); the
+         * change-email page relies on the session; recovery has no user.
          */
         getChallengeStatus: queryGeneric({
           args: {
             code: v.string(),
             secret: v.string(),
             flow: vEmailPasswordFlow,
+            userId: v.optional(v.string()),
           },
           returns: vChallengeStatus,
           handler: async (
             ctx,
-            { code, secret, flow },
+            { code, secret, flow, userId },
           ): Promise<ChallengeStatus> => {
             switch (flow) {
-              case "signUp":
+              case "signUp": {
+                if (userId === undefined) {
+                  return { status: "invalid" };
+                }
                 return await ctx.runQuery(
                   component.challenge.addEmail.getStatus,
-                  { code, secret },
+                  { code, secret, userId },
                 );
-              case "changeEmail":
+              }
+              case "changeEmail": {
+                const sessionUser = await sessionUserId(ctx);
+                if (sessionUser === null) {
+                  return { status: "invalid" };
+                }
                 return await ctx.runQuery(
                   component.challenge.setPrimaryEmail.getStatus,
-                  { code, secret },
+                  { code, secret, userId: sessionUser },
                 );
+              }
               case "recovery":
                 return await ctx.runQuery(
                   component.challenge.custom.getStatus,


### PR DESCRIPTION
complete and getStatus of the two built-in kinds now take the userId
that start received, and fail when it differs, like the custom kind
already does. The recipe returns the new userId from signUp, the React
hooks keep it in storage next to the secret and give it back at
completion, and completeChangeEmail requires the session of the user who
started the change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>