### PR TITLE
authPasskey: store and echo WebAuthn credential transports

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -49,7 +49,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         { userId?: string },
-        { allowCredentials: Array<ArrayBuffer>; challenge: ArrayBuffer },
+        {
+          allowCredentials: Array<{
+            id: ArrayBuffer;
+            transports?: Array<string>;
+          }>;
+          challenge: ArrayBuffer;
+        },
         Name
       >;
     };
@@ -95,6 +101,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           expectedOrigin: string;
           expectedRpId: string;
           name?: string;
+          transports?: Array<string>;
           verifiedUserId: string;
         },
         | { passkeyId: string; success: true }
@@ -123,7 +130,10 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { userId: string | null },
         {
           challenge: ArrayBuffer;
-          excludeCredentials: Array<ArrayBuffer>;
+          excludeCredentials: Array<{
+            id: ArrayBuffer;
+            transports?: Array<string>;
+          }>;
           userHandle: ArrayBuffer;
         },
         Name

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -30,10 +30,35 @@ describe("startAuthentication", () => {
     );
     expect(new Uint8Array(challenge).length).toBe(32);
     expect(allowCredentials).toHaveLength(1);
-    expectSameBytes(allowCredentials[0], credential.credentialId);
+    expectSameBytes(allowCredentials[0].id, credential.credentialId);
     const [row] = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(row.kind).toBe("authentication");
     expect(row.kind === "authentication" && row.userId).toBe("user1");
+  });
+
+  test("returns the transports of each passkey in allowCredentials", async () => {
+    const t = setup();
+    const stored = await register(t, "user1", { transports: ["hybrid"] });
+    const withoutTransports = await register(t, "user1");
+    const { allowCredentials } = await t.mutation(
+      api.authentication.startAuthentication,
+      { userId: "user1" },
+    );
+
+    const byId = new Map(
+      allowCredentials.map((entry) => [
+        Array.from(new Uint8Array(entry.id)).join(","),
+        entry,
+      ]),
+    );
+    expect(
+      byId.get(stored.credential.credentialId.join(","))?.transports,
+    ).toEqual(["hybrid"]);
+    const absent = byId.get(
+      withoutTransports.credential.credentialId.join(","),
+    );
+    expect(absent).toBeDefined();
+    expect(absent).not.toHaveProperty("transports");
   });
 
   test("stores an unbound challenge with no allowCredentials for the discoverable flow", async () => {

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -18,7 +18,10 @@ import {
   verifyRSASSAPKCS1v15Signature,
 } from "../../vendor/oslo/crypto/rsa.ts";
 import { sha256 } from "../../vendor/oslo/crypto/sha2.ts";
-import { finishAuthenticationUserError } from "./validation.ts";
+import {
+  credentialDescriptor,
+  finishAuthenticationUserError,
+} from "./validation.ts";
 import { consumeChallenge, randomChallenge } from "./helpers.ts";
 import { scheduleChallengeCleanup } from "./cleanup.ts";
 
@@ -28,7 +31,7 @@ import { scheduleChallengeCleanup } from "./cleanup.ts";
 // necessary.
 const startAuthenticationResult = v.object({
   challenge: v.bytes(),
-  allowCredentials: v.array(v.bytes()),
+  allowCredentials: v.array(credentialDescriptor),
 });
 
 /**
@@ -66,7 +69,10 @@ export const startAuthentication = mutation({
       .collect();
     return {
       challenge,
-      allowCredentials: rows.map((row) => row.credentialId),
+      allowCredentials: rows.map((row) => ({
+        id: row.credentialId,
+        transports: row.transports,
+      })),
     };
   },
 });

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -70,12 +70,23 @@ const authenticateStart = {
   success: true,
   step: "authenticate",
   challenge: new ArrayBuffer(16),
-  allowCredentials: [new ArrayBuffer(8)],
+  allowCredentials: [{ id: new ArrayBuffer(8), transports: ["internal"] }],
   rpId: "localhost",
 };
 
 // A stand-in for the credential `navigator.credentials.create()` returns.
 const attestationCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    attestationObject: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    getTransports: () => ["internal", "hybrid"],
+  },
+};
+
+// A stand-in for an older browser, whose attestation response has no
+// `getTransports` method.
+const attestationCredentialWithoutTransports = {
   rawId: new ArrayBuffer(8),
   response: {
     attestationObject: new ArrayBuffer(1),
@@ -183,10 +194,30 @@ describe("usePasskey signIn", () => {
       username: "alice",
       attestationObject: attestationCredential.response.attestationObject,
       clientDataJSON: attestationCredential.response.clientDataJSON,
+      transports: ["internal", "hybrid"],
     });
     expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("access-1");
+  });
+
+  test("sends no transports when the browser has no getTransports", async () => {
+    mutations.startSignIn.mockResolvedValue(registerStart);
+    credentialsCreate.mockResolvedValue(attestationCredentialWithoutTransports);
+    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
+    const { result } = renderPasskey();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: PasskeySignInResult;
+    await act(async () => {
+      returned = await result.current.passkey.signIn({ username: "alice" });
+    });
+
+    expect(returned.success).toBe(true);
+    const [args] = mutations.finishSignUp.mock.calls[0] as [
+      { transports?: string[] },
+    ];
+    expect(args.transports).toBe(undefined);
   });
 
   test("sign-in success runs the authentication ceremony and adopts the session", async () => {
@@ -205,6 +236,16 @@ describe("usePasskey signIn", () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
 
+    const [request] = credentialsGet.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialRequestOptions },
+    ];
+    expect(request.publicKey.allowCredentials).toEqual([
+      {
+        type: "public-key",
+        id: authenticateStart.allowCredentials[0].id,
+        transports: ["internal"],
+      },
+    ]);
     // `rawId` carries the credential ID bytes, not the base64url `id`.
     expect(mutations.finishSignIn).toHaveBeenCalledWith({
       credentialId: assertionCredential.rawId,

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -25,7 +25,7 @@ import type {
   StartAutofillSignInResult,
   StartSignInResult,
 } from "./setup.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS, type CredentialDescriptor } from "./validation.ts";
 
 /**
  * The `startSignIn` mutation the app re-exports from its `setupCore`.
@@ -62,6 +62,7 @@ type FinishSignUpMutation = FunctionReference<
     username: string;
     attestationObject: ArrayBuffer;
     clientDataJSON: ArrayBuffer;
+    transports?: string[];
   },
   ClientView<FinishSignUpResult>
 >;
@@ -258,6 +259,23 @@ function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
 }
 
 /**
+ * Turn the credential descriptors from the server into the WebAuthn shape
+ * of `allowCredentials` and `excludeCredentials`.
+ */
+function credentialDescriptors(
+  credentials: CredentialDescriptor[],
+): PublicKeyCredentialDescriptor[] {
+  return credentials.map(({ id, transports }) => ({
+    type: "public-key",
+    id,
+    // The DOM type lists only the transports that were known when it was
+    // written, but the WebAuthn spec lets new values appear. The stored
+    // strings go through unchanged.
+    transports: transports as AuthenticatorTransport[] | undefined,
+  }));
+}
+
+/**
  * Run the modal registration ceremony and return the `finishSignUp`
  * arguments, or `null` when the browser returns no credential.
  */
@@ -268,6 +286,7 @@ async function runRegistrationCeremony(
   username: string;
   attestationObject: ArrayBuffer;
   clientDataJSON: ArrayBuffer;
+  transports?: string[];
 } | null> {
   const credential = (await navigator.credentials.create({
     publicKey: {
@@ -294,10 +313,7 @@ async function runRegistrationCeremony(
         userVerification: "required",
       },
       attestation: "none",
-      excludeCredentials: start.excludeCredentials.map((id) => ({
-        type: "public-key",
-        id,
-      })),
+      excludeCredentials: credentialDescriptors(start.excludeCredentials),
     },
   })) as PublicKeyCredential | null;
   if (credential === null) {
@@ -308,6 +324,12 @@ async function runRegistrationCeremony(
     username,
     attestationObject: response.attestationObject,
     clientDataJSON: response.clientDataJSON,
+    // Older browsers have no `getTransports`. Then the server stores no
+    // transports for this credential.
+    transports:
+      typeof response.getTransports === "function"
+        ? response.getTransports()
+        : undefined,
   };
 }
 
@@ -322,10 +344,7 @@ async function runAuthenticationCeremony(
     publicKey: {
       challenge: start.challenge,
       rpId: start.rpId,
-      allowCredentials: start.allowCredentials.map((id) => ({
-        type: "public-key",
-        id,
-      })),
+      allowCredentials: credentialDescriptors(start.allowCredentials),
       userVerification: "required",
     },
   })) as PublicKeyCredential | null;

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -268,9 +268,8 @@ function credentialDescriptors(
   return credentials.map(({ id, transports }) => ({
     type: "public-key",
     id,
-    // The DOM type lists only the transports that were known when it was
-    // written, but the WebAuthn spec lets new values appear. The stored
-    // strings go through unchanged.
+    // The database stores a string array, we’re converting here
+    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
     transports: transports as AuthenticatorTransport[] | undefined,
   }));
 }

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -361,17 +361,37 @@ describe("finishRegistration", () => {
   });
 
   test.each([
-    ["too many transports", Array.from({ length: 17 }, (_, i) => `t${i}`)],
-    ["a transport that is too long", ["a".repeat(33)]],
-    ["an empty transport", [""]],
-    ["a transport with a non-ASCII character", ["üsb"]],
-    ["a transport with a space", ["smart card"]],
-  ])("throws for %s", async (_name, transports) => {
+    {
+      name: "too many transports",
+      transports: Array.from({ length: 17 }, (_, i) => `t${i}`),
+      message: "Too many transports",
+    },
+    {
+      name: "a transport that is too long",
+      transports: ["a".repeat(33)],
+      message: "has 33 characters",
+    },
+    {
+      name: "an empty transport",
+      transports: [""],
+      message: 'Invalid transport: ""',
+    },
+    {
+      name: "a transport with a non-ASCII character",
+      transports: ["üsb"],
+      message: 'Invalid transport: "üsb"',
+    },
+    {
+      name: "a transport with a space",
+      transports: ["smart card"],
+      message: 'Invalid transport: "smart card"',
+    },
+  ])("throws for $name", async ({ transports, message }) => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1");
     await expect(
       t.mutation(api.registration.finishRegistration, { ...args, transports }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(message);
     expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
       [],
     );

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -360,6 +360,23 @@ describe("finishRegistration", () => {
     expect(row).not.toHaveProperty("transports");
   });
 
+  test.each([
+    ["too many transports", Array.from({ length: 17 }, (_, i) => `t${i}`)],
+    ["a transport that is too long", ["a".repeat(33)]],
+    ["an empty transport", [""]],
+    ["a transport with a non-ASCII character", ["üsb"]],
+    ["a transport with a space", ["smart card"]],
+  ])("throws for %s", async (_name, transports) => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    await expect(
+      t.mutation(api.registration.finishRegistration, { ...args, transports }),
+    ).rejects.toThrow();
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+  });
+
   test("links the handle to the verified user in the new-account flow", async () => {
     const t = setup();
     const { userHandle, args } = await registrationArgs(t, "user1", {

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -229,12 +229,37 @@ describe("startRegistration", () => {
       api.registration.startRegistration,
       { userId: "user1" },
     );
-    const ids = excludeCredentials.map((buffer) =>
-      Array.from(new Uint8Array(buffer)).join(","),
+    const ids = excludeCredentials.map(({ id }) =>
+      Array.from(new Uint8Array(id)).join(","),
     );
     expect(ids).toHaveLength(2);
     expect(ids).toContain(first.credential.credentialId.join(","));
     expect(ids).toContain(second.credential.credentialId.join(","));
+  });
+
+  test("returns the transports of each passkey in excludeCredentials", async () => {
+    const t = setup();
+    const stored = await register(t, "user1", { transports: ["usb", "nfc"] });
+    const withoutTransports = await register(t, "user1");
+    const { excludeCredentials } = await t.mutation(
+      api.registration.startRegistration,
+      { userId: "user1" },
+    );
+
+    const byId = new Map(
+      excludeCredentials.map((entry) => [
+        Array.from(new Uint8Array(entry.id)).join(","),
+        entry,
+      ]),
+    );
+    expect(
+      byId.get(stored.credential.credentialId.join(","))?.transports,
+    ).toEqual(["usb", "nfc"]);
+    const absent = byId.get(
+      withoutTransports.credential.credentialId.join(","),
+    );
+    expect(absent).toBeDefined();
+    expect(absent).not.toHaveProperty("transports");
   });
 
   test("throws when a new handle collides with an existing handle", async () => {
@@ -312,6 +337,27 @@ describe("finishRegistration", () => {
     expect(result.success).toBe(true);
     const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
     expect(row.name).toBe("MacBook Touch ID");
+  });
+
+  test("stores the transports that the client reports", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    const result = await t.mutation(api.registration.finishRegistration, {
+      ...args,
+      transports: ["internal", "hybrid"],
+    });
+    expect(result.success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.transports).toEqual(["internal", "hybrid"]);
+  });
+
+  test("stores no transports when the client reports none", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    const result = await t.mutation(api.registration.finishRegistration, args);
+    expect(result.success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row).not.toHaveProperty("transports");
   });
 
   test("links the handle to the verified user in the new-account flow", async () => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -18,6 +18,7 @@ import {
   FinishRegistrationUserError,
   deletePasskeyUserError,
   transports,
+  validateTransports,
 } from "./validation.ts";
 import {
   deleteDeadChallenge,
@@ -311,7 +312,8 @@ export const checkRegistration = query({
  *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
  * - `transports`: the transports that the browser reported for the new
  *   credential. The value is a hint: a later ceremony sends it back to the
- *   browser, and the verification does not use it.
+ *   browser, and the verification does not use it. The function throws for
+ *   a value that no authenticator can report.
  *
  * The function examines the attestation as
  * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
@@ -333,6 +335,7 @@ export const finishRegistration = mutation({
   },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
+    validateTransports(args.transports);
     const verification = await verifyRegistration(ctx, args);
 
     if (verification.userError !== null) {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -17,7 +17,6 @@ import {
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
-  transports,
   validateTransports,
 } from "./validation.ts";
 import {
@@ -331,7 +330,7 @@ export const finishRegistration = mutation({
     ...registrationCheckArgs,
     verifiedUserId: v.string(),
     name: v.optional(v.string()),
-    transports,
+    transports: v.optional(v.array(v.string())),
   },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -12,9 +12,12 @@ import {
 import { ECDSAPublicKey, p256 } from "../../vendor/oslo/crypto/ecdsa.ts";
 import { RSAPublicKey } from "../../vendor/oslo/crypto/rsa.ts";
 import {
+  credentialDescriptor,
+  CredentialDescriptor,
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
+  transports,
 } from "./validation.ts";
 import {
   deleteDeadChallenge,
@@ -34,7 +37,7 @@ const startRegistrationResult = v.object({
   challenge: v.bytes(),
   // The WebAuthn user handle (`user.id`) for the `create()` call.
   userHandle: v.bytes(),
-  excludeCredentials: v.array(v.bytes()),
+  excludeCredentials: v.array(credentialDescriptor),
 });
 
 /**
@@ -65,7 +68,7 @@ export const startRegistration = mutation({
   returns: startRegistrationResult,
   handler: async (ctx, { userId }) => {
     let handle: { _id: Id<"handles">; handle: ArrayBuffer } | null = null;
-    let excludeCredentials: ArrayBuffer[] = [];
+    let excludeCredentials: CredentialDescriptor[] = [];
     if (userId !== null) {
       // A user has a maximum of one handle: reuse it when it exists.
       handle = await ctx.db
@@ -76,7 +79,10 @@ export const startRegistration = mutation({
         .query("passkeys")
         .withIndex("by_userId", (q) => q.eq("userId", userId))
         .collect();
-      excludeCredentials = rows.map((row) => row.credentialId);
+      excludeCredentials = rows.map((row) => ({
+        id: row.credentialId,
+        transports: row.transports,
+      }));
     }
     if (handle === null) {
       const bytes = randomHandle();
@@ -303,6 +309,9 @@ export const checkRegistration = query({
  * - `name`: an optional label for the credential. This can be automatically
  *   inferred by the client from the authenticator (e.g. “1Password”),
  *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
+ * - `transports`: the transports that the browser reported for the new
+ *   credential. The value is a hint: a later ceremony sends it back to the
+ *   browser, and the verification does not use it.
  *
  * The function examines the attestation as
  * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
@@ -320,6 +329,7 @@ export const finishRegistration = mutation({
     ...registrationCheckArgs,
     verifiedUserId: v.string(),
     name: v.optional(v.string()),
+    transports,
   },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
@@ -372,6 +382,7 @@ export const finishRegistration = mutation({
       algorithm: verification.algorithm,
       publicKey: verification.publicKey,
       counter: verification.counter,
+      transports: args.transports,
     });
     return { success: true, passkeyId };
   },

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -1,5 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { transports } from "./validation.ts";
 
 export default defineSchema({
   // One row for each passkey credential. The component only sees an opaque
@@ -20,6 +21,9 @@ export default defineSchema({
     // expected to be always increasing. This component doesn’t enforce it,
     // but in theory this property could be used to detect cloned passkeys.
     counter: v.number(),
+    // The transports that the browser reported for this credential. The
+    // field is not set when the browser did not report them.
+    transports,
   })
     .index("by_credentialId", ["credentialId"])
     .index("by_userId", ["userId"]),

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -1,6 +1,5 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { transports } from "./validation.ts";
 
 export default defineSchema({
   // One row for each passkey credential. The component only sees an opaque
@@ -21,9 +20,12 @@ export default defineSchema({
     // expected to be always increasing. This component doesn’t enforce it,
     // but in theory this property could be used to detect cloned passkeys.
     counter: v.number(),
-    // The transports that the browser reported for this credential. The
-    // field is not set when the browser did not report them.
-    transports,
+    // The transports that the browser reported for this credential, for
+    // example "internal", "usb", or "hybrid". The field is not set when
+    // the browser did not report them. The values are plain strings,
+    // because the WebAuthn spec lets new transports appear.
+    // https://www.w3.org/TR/webauthn-3/#enum-transport
+    transports: v.optional(v.array(v.string())),
   })
     .index("by_credentialId", ["credentialId"])
     .index("by_userId", ["userId"]),

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -16,7 +16,6 @@ import {
   credentialDescriptor,
   finishAuthenticationUserError,
   finishRegistrationUserError,
-  transports,
 } from "./validation.ts";
 
 /**
@@ -286,7 +285,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             username: v.string(),
             attestationObject: v.bytes(),
             clientDataJSON: v.bytes(),
-            transports,
+            transports: v.optional(v.array(v.string())),
           },
           returns: finishSignUpResult,
           handler: async (ctx, args): Promise<FinishSignUpResult> => {

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -13,8 +13,10 @@ import {
   validateUsernameFormat,
 } from "../username/validation.ts";
 import {
+  credentialDescriptor,
   finishAuthenticationUserError,
   finishRegistrationUserError,
+  transports,
 } from "./validation.ts";
 
 /**
@@ -62,7 +64,7 @@ const startSignInResult = v.union(
     success: v.literal(true),
     step: v.literal("authenticate"),
     challenge: v.bytes(),
-    allowCredentials: v.array(v.bytes()),
+    allowCredentials: v.array(credentialDescriptor),
     rpId: v.string(),
   }),
   // The username is free: register a new account with a new passkey.
@@ -72,7 +74,7 @@ const startSignInResult = v.union(
     challenge: v.bytes(),
     // The WebAuthn user handle (`user.id`) for the `create()` call.
     userHandle: v.bytes(),
-    excludeCredentials: v.array(v.bytes()),
+    excludeCredentials: v.array(credentialDescriptor),
     rpId: v.string(),
     rpName: v.string(),
   }),
@@ -284,6 +286,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             username: v.string(),
             attestationObject: v.bytes(),
             clientDataJSON: v.bytes(),
+            transports,
           },
           returns: finishSignUpResult,
           handler: async (ctx, args): Promise<FinishSignUpResult> => {
@@ -354,6 +357,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 verifiedUserId: tokens.userId,
                 attestationObject: args.attestationObject,
                 clientDataJSON: args.clientDataJSON,
+                transports: args.transports,
               },
             );
             if (!registrationResult.success) {

--- a/packages/core/src/components/passkey/testAuthenticator.ts
+++ b/packages/core/src/components/passkey/testAuthenticator.ts
@@ -239,6 +239,7 @@ export async function register(
     name?: string;
     credential?: TestCredential;
     counter?: number;
+    transports?: string[];
   } = {},
 ): Promise<{ credential: TestCredential; passkeyId: string }> {
   const credential = options.credential ?? (await generateES256Credential());
@@ -255,6 +256,7 @@ export async function register(
     expectedOrigin: ORIGIN,
     verifiedUserId: userId,
     name: options.name,
+    transports: options.transports,
     attestationObject: toArrayBuffer(buildAttestationObject(authData)),
     clientDataJSON: toArrayBuffer(
       buildClientDataJSON({

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -8,19 +8,6 @@ import { Infer, v } from "convex/values";
 export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
- * The ways that the browser can reach an authenticator, for example
- * "internal", "usb", or "hybrid". The browser reports them when it makes a
- * credential. A later ceremony sends them back to the browser, which then
- * shows the correct instructions to the user.
- *
- * The values are plain strings and not an enumeration. The WebAuthn spec
- * lets new transports appear, and it tells a relying party to keep an
- * unknown value without a change.
- * https://www.w3.org/TR/webauthn-3/#enum-transport
- */
-export const transports = v.optional(v.array(v.string()));
-
-/**
  * Constants used for some basic best-effort validation of the
  * `transports` strings. These limits are far above the registered
  * values. They stop a client that does not obey the spec from writing
@@ -91,7 +78,7 @@ export function validateTransports(values: string[] | undefined) {
  */
 export const credentialDescriptor = v.object({
   id: v.bytes(),
-  transports,
+  transports: v.optional(v.array(v.string())),
 });
 export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
 

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -38,6 +38,20 @@ const MAX_TRANSPORT_LENGTH = 32;
 const TRANSPORT_PATTERN = /^[\x21-\x7e]+$/;
 
 /**
+ * Show a transport in an error message. The value comes from the client,
+ * thus it can be long, empty, or contain characters that are not
+ * printable. `JSON.stringify` puts it in quotation marks and replaces
+ * these characters. A long value is cut to keep the message short.
+ */
+function describeTransport(value: string) {
+  const shown =
+    value.length > MAX_TRANSPORT_LENGTH
+      ? `${value.slice(0, MAX_TRANSPORT_LENGTH)}…`
+      : value;
+  return JSON.stringify(shown);
+}
+
+/**
  * Examine the transports that the client reports, before the component
  * stores them.
  *
@@ -60,12 +74,12 @@ export function validateTransports(values: string[] | undefined) {
   for (const value of values) {
     if (value.length > MAX_TRANSPORT_LENGTH) {
       throw new Error(
-        `Transport too long: a transport can have a maximum of ${MAX_TRANSPORT_LENGTH} characters.`,
+        `Transport too long: ${describeTransport(value)} has ${value.length} characters, but a transport can have a maximum of ${MAX_TRANSPORT_LENGTH}.`,
       );
     }
     if (!TRANSPORT_PATTERN.test(value)) {
       throw new Error(
-        "Invalid transport: a transport must be a non-empty string of printable ASCII characters.",
+        `Invalid transport: ${describeTransport(value)} is not a non-empty string of printable ASCII characters.`,
       );
     }
   }

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -8,6 +8,29 @@ import { Infer, v } from "convex/values";
 export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
+ * The ways that the browser can reach an authenticator, for example
+ * "internal", "usb", or "hybrid". The browser reports them when it makes a
+ * credential. A later ceremony sends them back to the browser, which then
+ * shows the correct instructions to the user.
+ *
+ * The values are plain strings and not an enumeration. The WebAuthn spec
+ * lets new transports appear, and it tells a relying party to keep an
+ * unknown value without a change.
+ * https://www.w3.org/TR/webauthn-3/#enum-transport
+ */
+export const transports = v.optional(v.array(v.string()));
+
+/**
+ * One entry of `allowCredentials` or `excludeCredentials`. The WebAuthn
+ * `type` field is not included, because it is always "public-key".
+ */
+export const credentialDescriptor = v.object({
+  id: v.bytes(),
+  transports,
+});
+export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
+
+/**
  * The user-facing errors for `finishRegistration`. An app can show these
  * errors to the end user. The `error` field is a machine-readable code and
  * the discriminant of the union.

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -21,6 +21,57 @@ export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 export const transports = v.optional(v.array(v.string()));
 
 /**
+ * Constants used for some basic best-effort validation of the
+ * `transports` strings. These limits are far above the registered
+ * values. They stop a client that does not obey the spec from writing
+ * large data to the database.
+ *
+ * The WebAuthn spec gives no limit for these values, but each registered
+ * transport is a short word of lowercase letters and hyphens ("usb",
+ * "hybrid", "smart-card").
+ */
+const MAX_TRANSPORTS = 16;
+const MAX_TRANSPORT_LENGTH = 32;
+
+// The characters that a transport can contain: printable ASCII without
+// the space.
+const TRANSPORT_PATTERN = /^[\x21-\x7e]+$/;
+
+/**
+ * Examine the transports that the client reports, before the component
+ * stores them.
+ *
+ * The component does not compare the values with a list of known
+ * transports, because the WebAuthn spec lets new transports appear. It
+ * only refuses the values that no authenticator can report.
+ *
+ * @throws when there are too many values, or when a value is empty, too
+ * long, or not printable ASCII.
+ */
+export function validateTransports(values: string[] | undefined) {
+  if (values === undefined) {
+    return;
+  }
+  if (values.length > MAX_TRANSPORTS) {
+    throw new Error(
+      `Too many transports: a credential can have a maximum of ${MAX_TRANSPORTS}.`,
+    );
+  }
+  for (const value of values) {
+    if (value.length > MAX_TRANSPORT_LENGTH) {
+      throw new Error(
+        `Transport too long: a transport can have a maximum of ${MAX_TRANSPORT_LENGTH} characters.`,
+      );
+    }
+    if (!TRANSPORT_PATTERN.test(value)) {
+      throw new Error(
+        "Invalid transport: a transport must be a non-empty string of printable ASCII characters.",
+      );
+    }
+  }
+}
+
+/**
  * One entry of `allowCredentials` or `excludeCredentials`. The WebAuthn
  * `type` field is not included, because it is always "public-key".
  */


### PR DESCRIPTION
This is a small improvement to the passkeys integration. The WebAuthn standard defines a `transports` field that indicates how a credential can communicate with the client (`internal` for the device itself, `hybrid` for cross-device passkeys, and also `usb`/`nfc`).

This PR changes the passkey implementation so that we:
- store in the `passkeys` table the transport used by the passkey
- echo `transports` back on authentication so that the browser knows which transports to request.

The goal of this PR is to improve the end user experience so that when they log in to their account, their authenticator can show a better UI that is relevant to the type(s) of passkey(s) that they are using. For instance, if they only use USB passkeys, the authenticator can show some UI that asks the user to plug in a USB passkey, instead of asking them to scan a QR code using their phone _or_ plug in a physical passkey.