### PR TITLE
authPasskey: bind authentication challenges to a purpose

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -33,6 +33,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           credentialId: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
+          purpose: string;
           signature: ArrayBuffer;
         },
         | { passkeyId: string; success: true; userId: string }
@@ -48,7 +49,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       startAuthentication: FunctionReference<
         "mutation",
         "internal",
-        { userId?: string },
+        { purpose: string; userId?: string },
         {
           allowCredentials: Array<{
             id: ArrayBuffer;

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -11,7 +11,15 @@ import {
   register,
 } from "./testAuthenticator.ts";
 
-const EXPECTED = { expectedRpId: RP_ID, expectedOrigin: ORIGIN };
+// The component gives no purpose of its own: each app names its own flows.
+const PURPOSE = "test/signIn";
+const OTHER_PURPOSE = "test/removePasskey";
+
+const EXPECTED = {
+  purpose: PURPOSE,
+  expectedRpId: RP_ID,
+  expectedOrigin: ORIGIN,
+};
 
 // Only the expiry test moves the clock, but the restore is global to keep the
 // other tests on the real clock.
@@ -26,7 +34,7 @@ describe("startAuthentication", () => {
     await register(t, "user2");
     const { challenge, allowCredentials } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     expect(new Uint8Array(challenge).length).toBe(32);
     expect(allowCredentials).toHaveLength(1);
@@ -34,6 +42,7 @@ describe("startAuthentication", () => {
     const [row] = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(row.kind).toBe("authentication");
     expect(row.kind === "authentication" && row.userId).toBe("user1");
+    expect(row.kind === "authentication" && row.purpose).toBe(PURPOSE);
   });
 
   test("returns the transports of each passkey in allowCredentials", async () => {
@@ -42,7 +51,7 @@ describe("startAuthentication", () => {
     const withoutTransports = await register(t, "user1");
     const { allowCredentials } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
 
     const byId = new Map(
@@ -66,7 +75,7 @@ describe("startAuthentication", () => {
     await register(t, "user1");
     const { allowCredentials } = await t.mutation(
       api.authentication.startAuthentication,
-      {},
+      { purpose: PURPOSE },
     );
     expect(allowCredentials).toEqual([]);
     const [row] = await t.run((ctx) => ctx.db.query("challenges").collect());
@@ -80,7 +89,7 @@ describe("finishAuthentication", () => {
     const { credential, passkeyId } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge, {
       counter: 7,
@@ -105,7 +114,7 @@ describe("finishAuthentication", () => {
     const { passkeyId } = await register(t, "user1", { credential });
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
@@ -120,7 +129,7 @@ describe("finishAuthentication", () => {
     const { credential, passkeyId } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      {},
+      { purpose: PURPOSE },
     );
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
@@ -135,7 +144,7 @@ describe("finishAuthentication", () => {
     await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const unregistered = await generateES256Credential();
     const assertion = await buildAssertion(unregistered, challenge);
@@ -159,7 +168,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     await expect(
@@ -176,7 +185,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge, {
       rpId: "evil.example.net",
@@ -194,7 +203,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     // The flag checks run before the challenge is consumed, so the same
     // challenge can serve both variants.
@@ -216,7 +225,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge, {
       type: "webauthn.create",
@@ -234,7 +243,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge, {
       origin: "https://evil.example.net",
@@ -252,7 +261,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge, {
       crossOrigin: true,
@@ -270,7 +279,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     // The age of a challenge is the age of its `_creationTime`, thus the
@@ -293,7 +302,7 @@ describe("finishAuthentication", () => {
     const { credential: credentialB } = await register(t, "userB");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "userA" },
+      { purpose: PURPOSE, userId: "userA" },
     );
     const assertion = await buildAssertion(credentialB, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
@@ -316,7 +325,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const otherKey = await generateES256Credential();
     const assertion = await buildAssertion(credential, challenge, {
@@ -338,7 +347,7 @@ describe("finishAuthentication", () => {
     await register(t, "user1", { credential });
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
@@ -360,7 +369,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     await expect(
@@ -377,7 +386,7 @@ describe("finishAuthentication", () => {
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
-      { userId: "user1" },
+      { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
     const first = await t.mutation(api.authentication.finishAuthentication, {
@@ -393,5 +402,58 @@ describe("finishAuthentication", () => {
       success: false,
       userError: { error: "CHALLENGE_EXPIRED" },
     });
+  });
+
+  test("throws for a different purpose and keeps the challenge bound", async () => {
+    const t = setup();
+    const { credential, passkeyId } = await register(t, "user1");
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { purpose: PURPOSE, userId: "user1" },
+    );
+    const assertion = await buildAssertion(credential, challenge);
+    await expect(
+      t.mutation(api.authentication.finishAuthentication, {
+        ...EXPECTED,
+        ...assertion,
+        purpose: OTHER_PURPOSE,
+      }),
+    ).rejects.toThrow();
+
+    // The throw rolls the delete back, thus the challenge stays usable for
+    // the flow that started it, and only for that flow.
+    const retry = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...assertion,
+    });
+    expect(retry).toEqual({ success: true, userId: "user1", passkeyId });
+  });
+
+  test("keeps the challenges of two purposes independent", async () => {
+    const t = setup();
+    const { credential, passkeyId } = await register(t, "user1");
+    const signIn = await t.mutation(api.authentication.startAuthentication, {
+      purpose: PURPOSE,
+      userId: "user1",
+    });
+    const other = await t.mutation(api.authentication.startAuthentication, {
+      purpose: OTHER_PURPOSE,
+      userId: "user1",
+    });
+
+    // The challenge of the other flow is unusable for the sign-in flow.
+    await expect(
+      t.mutation(api.authentication.finishAuthentication, {
+        ...EXPECTED,
+        ...(await buildAssertion(credential, other.challenge)),
+      }),
+    ).rejects.toThrow();
+
+    // The failed attempt leaves the challenge of the sign-in flow alone.
+    const result = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...(await buildAssertion(credential, signIn.challenge)),
+    });
+    expect(result).toEqual({ success: true, userId: "user1", passkeyId });
   });
 });

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -37,6 +37,12 @@ const startAuthenticationResult = v.object({
 /**
  * Start an authentication ceremony.
  *
+ * `purpose` binds the challenge to one flow of the app (for example a
+ * sign-in, or a re-authentication before a change of a setting). The
+ * component does not parse the value. The app chooses the strings.
+ * `finishAuthentication` must receive the same purpose. A different
+ * purpose burns the challenge.
+ *
  * If `userId` is set, it will force the authentication ceremony to be
  * tied to this particular user. This is necessary in flows where the
  * user is being asked to authenticate to a particular account
@@ -49,13 +55,14 @@ const startAuthenticationResult = v.object({
  * directly to this account).
  */
 export const startAuthentication = mutation({
-  args: { userId: v.optional(v.string()) },
+  args: { purpose: v.string(), userId: v.optional(v.string()) },
   returns: startAuthenticationResult,
-  handler: async (ctx, { userId }) => {
+  handler: async (ctx, { purpose, userId }) => {
     const challenge = randomChallenge();
     await ctx.db.insert("challenges", {
       kind: "authentication",
       challenge,
+      purpose,
       userId,
     });
     await scheduleChallengeCleanup(ctx);
@@ -100,9 +107,13 @@ type FinishAuthenticationResult = Infer<typeof finishAuthenticationResult>;
  * data, the client data, and the assertion signature. It deletes the
  * challenge and returns the `userId` of the user. The app can then make a
  * session for that user.
+ *
+ * `purpose` must be the purpose that `startAuthentication` received. A
+ * different purpose throws.
  */
 export const finishAuthentication = mutation({
   args: {
+    purpose: v.string(),
     expectedRpId: v.string(),
     expectedOrigin: v.string(),
     credentialId: v.bytes(),
@@ -160,6 +171,14 @@ export const finishAuthentication = mutation({
     if (challengeRow === null) {
       return { success: false, userError: { error: "CHALLENGE_EXPIRED" } };
     }
+    if (challengeRow.purpose !== args.purpose) {
+      // A correct client gives the same purpose to both steps. A mismatch
+      // is probably a bug in the caller or client code, not a end-user
+      // error. Throwing will roll `consumeChallenge` back, but that’s okay
+      throw new Error(
+        "The purpose does not match the purpose of the challenge.",
+      );
+    }
     // A challenge with a `userId` (the identifier-first flow) must agree
     // with the owner of the credential. A challenge without a `userId` is a
     // discoverable-credential ceremony. In that flow, each registered
@@ -203,6 +222,7 @@ export const finishAuthentication = mutation({
     // cloned authenticators. But this would require the app to detect this
     // and using it appropriately, and most authenticators will always set it to 0 anyway.
     // https://www.imperialviolet.org/2023/08/05/signature-counters.html
+    // TODO(nicolas) Also record `lastUsedAt` here when the field exists.
     await ctx.db.patch("passkeys", passkey._id, {
       counter: authenticatorData.signatureCounter,
     });

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -108,6 +108,7 @@ describe("consumeChallenge", () => {
     await t.run(async (ctx) => {
       await ctx.db.insert("challenges", {
         kind: "authentication",
+        purpose: "test",
         challenge: toArrayBuffer(challenge),
       });
       expect(await consumeChallenge(ctx, "authentication", challenge)).not.toBe(

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -930,6 +930,7 @@ describe("deleteUser", () => {
     const authenticationChallengeId = await t.run((ctx) =>
       ctx.db.insert("challenges", {
         kind: "authentication",
+        purpose: "test",
         challenge: new Uint8Array(32).fill(0xaa).buffer,
         userId: "user1",
       }),
@@ -971,6 +972,7 @@ describe("deleteUser", () => {
     const otherChallengeId = await t.run((ctx) =>
       ctx.db.insert("challenges", {
         kind: "authentication",
+        purpose: "test",
         challenge: new Uint8Array(32).fill(0xbb).buffer,
         userId: "user2",
       }),
@@ -979,6 +981,7 @@ describe("deleteUser", () => {
     const anonymousChallengeId = await t.run((ctx) =>
       ctx.db.insert("challenges", {
         kind: "authentication",
+        purpose: "test",
         challenge: new Uint8Array(32).fill(0xcc).buffer,
       }),
     );

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -397,6 +397,7 @@ export const finishRegistration = mutation({
  */
 export const listPasskeys = query({
   args: { userId: v.string() },
+  // TODO(nicolas) Also return `lastUsedAt` here when the field exists.
   returns: v.array(
     v.object({
       passkeyId: v.string(),

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -68,6 +68,17 @@ export default defineSchema({
       v.object({
         kind: v.literal("authentication"),
         challenge: v.bytes(),
+        // The flow that this challenge is for, for example a sign-in or a
+        // re-authentication before a change of a setting. The value is
+        // opaque to the component. The start step and the finish step
+        // must give the same purpose, thus an assertion for one flow
+        // cannot complete a different flow. A different purpose
+        // at the finish step burns the challenge.
+        // The purpose string is expected to be a constant string identifying
+        // a specific flow, and should not contain dynamic information.
+        // TODO(nicolas) Make `startAuthentication` return the challenge ID too
+        //               so that callers can attach additional info if needed
+        purpose: v.string(),
         // The user that the challenge is for, if the app knows the user.
         // The field is not set for discoverable-credential ceremonies. In
         // that flow, the assertion identifies the user.

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -56,6 +56,8 @@ export type UsernamePasskeyOptions = {
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "passkey";
 
+export const SIGN_IN_PURPOSE = "usernamePasskey:signIn";
+
 const startSignInResult = v.union(
   // The username has an account: authenticate with a passkey of that
   // account. The challenge is bound to the user.
@@ -220,7 +222,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               // TODO: Should we throw an error instead?
               const { challenge, allowCredentials } = await ctx.runMutation(
                 component.authentication.startAuthentication,
-                { userId },
+                { purpose: SIGN_IN_PURPOSE, userId },
               );
               return {
                 success: true,
@@ -258,7 +260,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
           handler: async (ctx): Promise<StartAutofillSignInResult> => {
             const { challenge } = await ctx.runMutation(
               component.authentication.startAuthentication,
-              {},
+              { purpose: SIGN_IN_PURPOSE },
             );
             return { challenge, rpId };
           },
@@ -398,6 +400,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             const authenticationResult = await ctx.runMutation(
               component.authentication.finishAuthentication,
               {
+                purpose: SIGN_IN_PURPOSE,
                 expectedRpId: rpId,
                 expectedOrigin: origin,
                 credentialId: args.credentialId,


### PR DESCRIPTION
Currently, passkey authentication challenges are only used to log in. We want for auth flows to be reusable for other purposes: for instance, we want the app to be able to implement a feature that asks users to re-authenticate with their passkey before doing a sensitive action. Re-authentication will be used by the upcoming passkey management features (before adding or removing a passkey, the user must re-authenticate).

For security, we want to make sure an authentication that was started for a specific purpose is not used for another one. For this reason, we add a new `purpose` field to passkey login challenges. The mutation that start the challenge and the mutation that completes it are required to provide the same string. I plan to reuse the same mechanism in the upcoming email provider, where preventing confusion of purposes is even more important.