### PR TITLE
Passkey management: add provider functions

### DIFF
--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -11,6 +11,11 @@
 import type * as authentication from "../authentication.js";
 import type * as cleanup from "../cleanup.js";
 import type * as helpers from "../helpers.js";
+import type * as management_add from "../management/add.js";
+import type * as management_list from "../management/list.js";
+import type * as management_remove from "../management/remove.js";
+import type * as protocol from "../protocol.js";
+import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
 import type * as registration from "../registration.js";
 import type * as setup from "../setup.js";
@@ -28,6 +33,11 @@ const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   cleanup: typeof cleanup;
   helpers: typeof helpers;
+  "management/add": typeof management_add;
+  "management/list": typeof management_list;
+  "management/remove": typeof management_remove;
+  protocol: typeof protocol;
+  purposes: typeof purposes;
   react: typeof react;
   registration: typeof registration;
   setup: typeof setup;

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -14,7 +14,6 @@ import type * as helpers from "../helpers.js";
 import type * as management_add from "../management/add.js";
 import type * as management_list from "../management/list.js";
 import type * as management_remove from "../management/remove.js";
-import type * as protocol from "../protocol.js";
 import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
 import type * as registration from "../registration.js";
@@ -36,7 +35,6 @@ const fullApi: ApiFromModules<{
   "management/add": typeof management_add;
   "management/list": typeof management_list;
   "management/remove": typeof management_remove;
-  protocol: typeof protocol;
   purposes: typeof purposes;
   react: typeof react;
   registration: typeof registration;

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -1,3 +1,32 @@
+/**
+ * The flow that adds a passkey to a signed-in account.
+ *
+ * For security purposes, the user must prove again that they
+ * hold a pre-existing passkey of the account.
+ *
+ * ```
+ *  Client                             Provider
+ *    │                                   │
+ *    │  startAddPasskey()                │
+ *    ├──────────────────────────────────▶│  start the re-authentication
+ *    │◀──────────────────────────────────┤
+ *    │                                   │
+ *    ├─▶ navigator.credentials.get()     │
+ *    │                                   │
+ *    │  verifyAddPasskey(assertion)      │
+ *    ├──────────────────────────────────▶│  verify it, start the registration
+ *    │◀──────────────────────────────────┤
+ *    │                                   │
+ *    ├─▶ navigator.credentials.create()  │
+ *    │                                   │
+ *    │  finishAddPasskey(attestation)    │
+ *    ├──────────────────────────────────▶│  store the new passkey
+ *    │◀──────────────────────────────────┤
+ *    │                                   │
+ * ```
+ *
+ * @module
+ */
 import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import { getAuthUserId } from "../../core/userId.ts";
@@ -20,10 +49,6 @@ const startAddPasskeyResult = v.union(
   v.object({ success: v.literal(false), userError: notSignedInUserError }),
 );
 
-/**
- * The result of `startAddPasskey`: the data for a `get()` call that
- * re-authenticates the user, or a user-facing `userError`.
- */
 export type StartAddPasskeyResult = Infer<typeof startAddPasskeyResult>;
 
 const verifyAddPasskeyResult = v.union(
@@ -42,14 +67,12 @@ const verifyAddPasskeyResult = v.union(
   }),
   v.object({
     success: v.literal(false),
+    // `PROTOCOL_ERROR` also covers an assertion that authenticates a
+    // different user than the caller. See the check in `verifyAddPasskey`.
     userError: v.union(notSignedInUserError, finishAuthenticationUserError),
   }),
 );
 
-/**
- * The result of `verifyAddPasskey`: the data for the `create()` call that
- * makes the new passkey, or a user-facing `userError`.
- */
 export type VerifyAddPasskeyResult = Infer<typeof verifyAddPasskeyResult>;
 
 const finishAddPasskeyResult = v.union(
@@ -60,20 +83,8 @@ const finishAddPasskeyResult = v.union(
   }),
 );
 
-/**
- * The result of `finishAddPasskey`: the ID of the stored passkey, or a
- * user-facing `userError`.
- */
 export type FinishAddPasskeyResult = Infer<typeof finishAddPasskeyResult>;
 
-/**
- * Build the `startAddPasskey` mutation of the provider.
- *
- * The user must prove again that they hold a passkey of the account before
- * they add one. The mutation starts that re-authentication ceremony. Each
- * passkey of the user is acceptable, thus `allowCredentials` holds all of
- * them.
- */
 export function startAddPasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {},
@@ -92,20 +103,6 @@ export function startAddPasskey(config: UsernamePasskeyConfig) {
   });
 }
 
-/**
- * Build the `verifyAddPasskey` mutation of the provider.
- *
- * The mutation does two things in one transaction: it verifies the
- * re-authentication assertion of `startAddPasskey`, and it starts the
- * registration ceremony of the new passkey.
- *
- * The registration challenge that this mutation mints IS the proof of the
- * re-authentication. The provider mints a registration challenge that is
- * bound to a user here and nowhere else: the sign-up flow always gives
- * `userId: null`, because the account does not exist yet. Thus a client
- * that holds such a challenge has completed the assertion above, and
- * `finishAddPasskey` needs no token of its own.
- */
 export function verifyAddPasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
@@ -137,12 +134,18 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
         return { success: false, userError: authenticationResult.userError };
       }
       if (authenticationResult.userId !== userId) {
-        // Not possible: `startAddPasskey` binds the challenge to the caller,
-        // and `finishAuthentication` refuses an assertion from a passkey of
-        // a different user. Throwing rolls the burned challenge back.
-        throw new Error(
-          "Invariant violation: the assertion authenticates a different user than the caller.",
+        // The identity of the caller changed between `startAddPasskey` and
+        // this call: the challenge stays bound to the user who started the
+        // ceremony, and that user is no longer the caller. A sign-out and a
+        // new sign-in, or a race with a sign-in in a different tab, both do
+        // this. The result is a `PROTOCOL_ERROR`, which keeps the challenge
+        // burned and thus prevents a replay of the assertion.
+        console.warn(
+          "Rejected an addition of a passkey because the assertion " +
+            "authenticates a different user than the caller. The caller " +
+            "signed in as a different user after the `startAddPasskey` call.",
         );
+        return { success: false, userError: { error: "PROTOCOL_ERROR" } };
       }
 
       const { challenge, userHandle, excludeCredentials } =
@@ -166,18 +169,6 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
   });
 }
 
-/**
- * Build the `finishAddPasskey` mutation of the provider.
- *
- * TODO(nicolas) Add a limit to the number of passkeys of one user. Without
- * a limit, a signed-in user can grow their passkey list without bound, which
- * grows every `allowCredentials` and `excludeCredentials` list with it.
- *
- * The mutation stores the new credential. The registration challenge inside
- * the attestation carries the proof of the re-authentication (see
- * `verifyAddPasskey`), thus the mutation adds no check of its own beyond the
- * session of the caller.
- */
 export function finishAddPasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
@@ -187,6 +178,7 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
     },
     returns: finishAddPasskeyResult,
     handler: async (ctx, args): Promise<FinishAddPasskeyResult> => {
+      // TODO(nicolas) Add a limit to how many paskseys can be registered
       const userId = await getAuthUserId(ctx);
       if (userId === null) {
         return { success: false, userError: { error: "NOT_SIGNED_IN" } };

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -1,0 +1,211 @@
+import { mutationGeneric } from "convex/server";
+import { Infer, v } from "convex/values";
+import { getAuthUserId } from "../../core/userId.ts";
+import { ADD_PASSKEY_PURPOSE } from "../purposes.ts";
+import type { UsernamePasskeyConfig } from "../setup.ts";
+import {
+  credentialDescriptor,
+  finishAuthenticationUserError,
+  finishRegistrationUserError,
+  notSignedInUserError,
+} from "../validation.ts";
+
+const startAddPasskeyResult = v.union(
+  v.object({
+    success: v.literal(true),
+    challenge: v.bytes(),
+    allowCredentials: v.array(credentialDescriptor),
+    rpId: v.string(),
+  }),
+  v.object({ success: v.literal(false), userError: notSignedInUserError }),
+);
+
+/**
+ * The result of `startAddPasskey`: the data for a `get()` call that
+ * re-authenticates the user, or a user-facing `userError`.
+ */
+export type StartAddPasskeyResult = Infer<typeof startAddPasskeyResult>;
+
+const verifyAddPasskeyResult = v.union(
+  v.object({
+    success: v.literal(true),
+    challenge: v.bytes(),
+    // The WebAuthn user handle (`user.id`) for the `create()` call.
+    userHandle: v.bytes(),
+    excludeCredentials: v.array(credentialDescriptor),
+    rpId: v.string(),
+    rpName: v.string(),
+    // The WebAuthn `user.name` and `user.displayName` for the `create()`
+    // call. `null` when the app removed the username of the user; then the
+    // client chooses what to show.
+    username: v.union(v.string(), v.null()),
+  }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(notSignedInUserError, finishAuthenticationUserError),
+  }),
+);
+
+/**
+ * The result of `verifyAddPasskey`: the data for the `create()` call that
+ * makes the new passkey, or a user-facing `userError`.
+ */
+export type VerifyAddPasskeyResult = Infer<typeof verifyAddPasskeyResult>;
+
+const finishAddPasskeyResult = v.union(
+  v.object({ success: v.literal(true), passkeyId: v.string() }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(notSignedInUserError, finishRegistrationUserError),
+  }),
+);
+
+/**
+ * The result of `finishAddPasskey`: the ID of the stored passkey, or a
+ * user-facing `userError`.
+ */
+export type FinishAddPasskeyResult = Infer<typeof finishAddPasskeyResult>;
+
+/**
+ * Build the `startAddPasskey` mutation of the provider.
+ *
+ * The user must prove again that they hold a passkey of the account before
+ * they add one. The mutation starts that re-authentication ceremony. Each
+ * passkey of the user is acceptable, thus `allowCredentials` holds all of
+ * them.
+ */
+export function startAddPasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: {},
+    returns: startAddPasskeyResult,
+    handler: async (ctx): Promise<StartAddPasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+      const { challenge, allowCredentials } = await ctx.runMutation(
+        config.component.authentication.startAuthentication,
+        { purpose: ADD_PASSKEY_PURPOSE, userId },
+      );
+      return { success: true, challenge, allowCredentials, rpId: config.rpId };
+    },
+  });
+}
+
+/**
+ * Build the `verifyAddPasskey` mutation of the provider.
+ *
+ * The mutation does two things in one transaction: it verifies the
+ * re-authentication assertion of `startAddPasskey`, and it starts the
+ * registration ceremony of the new passkey.
+ *
+ * The registration challenge that this mutation mints IS the proof of the
+ * re-authentication. The provider mints a registration challenge that is
+ * bound to a user here and nowhere else: the sign-up flow always gives
+ * `userId: null`, because the account does not exist yet. Thus a client
+ * that holds such a challenge has completed the assertion above, and
+ * `finishAddPasskey` needs no token of its own.
+ */
+export function verifyAddPasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: {
+      credentialId: v.bytes(),
+      authenticatorData: v.bytes(),
+      clientDataJSON: v.bytes(),
+      signature: v.bytes(),
+    },
+    returns: verifyAddPasskeyResult,
+    handler: async (ctx, args): Promise<VerifyAddPasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+
+      const authenticationResult = await ctx.runMutation(
+        config.component.authentication.finishAuthentication,
+        {
+          purpose: ADD_PASSKEY_PURPOSE,
+          expectedRpId: config.rpId,
+          expectedOrigin: config.origin,
+          credentialId: args.credentialId,
+          authenticatorData: args.authenticatorData,
+          clientDataJSON: args.clientDataJSON,
+          signature: args.signature,
+        },
+      );
+      if (!authenticationResult.success) {
+        return { success: false, userError: authenticationResult.userError };
+      }
+      if (authenticationResult.userId !== userId) {
+        // Not possible: `startAddPasskey` binds the challenge to the caller,
+        // and `finishAuthentication` refuses an assertion from a passkey of
+        // a different user. Throwing rolls the burned challenge back.
+        throw new Error(
+          "Invariant violation: the assertion authenticates a different user than the caller.",
+        );
+      }
+
+      const { challenge, userHandle, excludeCredentials } =
+        await ctx.runMutation(config.component.registration.startRegistration, {
+          userId,
+        });
+      const username = await ctx.runQuery(
+        config.usernameComponent.public.getUsername,
+        { userId },
+      );
+      return {
+        success: true,
+        challenge,
+        userHandle,
+        excludeCredentials,
+        rpId: config.rpId,
+        rpName: config.rpName,
+        username,
+      };
+    },
+  });
+}
+
+/**
+ * Build the `finishAddPasskey` mutation of the provider.
+ *
+ * TODO(nicolas) Add a limit to the number of passkeys of one user. Without
+ * a limit, a signed-in user can grow their passkey list without bound, which
+ * grows every `allowCredentials` and `excludeCredentials` list with it.
+ *
+ * The mutation stores the new credential. The registration challenge inside
+ * the attestation carries the proof of the re-authentication (see
+ * `verifyAddPasskey`), thus the mutation adds no check of its own beyond the
+ * session of the caller.
+ */
+export function finishAddPasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: {
+      attestationObject: v.bytes(),
+      clientDataJSON: v.bytes(),
+      transports: v.optional(v.array(v.string())),
+    },
+    returns: finishAddPasskeyResult,
+    handler: async (ctx, args): Promise<FinishAddPasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+      const registrationResult = await ctx.runMutation(
+        config.component.registration.finishRegistration,
+        {
+          expectedRpId: config.rpId,
+          expectedOrigin: config.origin,
+          verifiedUserId: userId,
+          attestationObject: args.attestationObject,
+          clientDataJSON: args.clientDataJSON,
+          transports: args.transports,
+        },
+      );
+      if (!registrationResult.success) {
+        return { success: false, userError: registrationResult.userError };
+      }
+      return { success: true, passkeyId: registrationResult.passkeyId };
+    },
+  });
+}

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -98,6 +98,12 @@ export function startAddPasskey(config: UsernamePasskeyConfig) {
         config.component.authentication.startAuthentication,
         { purpose: ADD_PASSKEY_PURPOSE, userId },
       );
+      if (allowCredentials.length === 0) {
+        // TODO: When auth flows are more composable, we should just ask the user to reauthenticate another way.
+        throw new Error(
+          "The signed-in user has no passkey. They can’t add a new passkey, because we can’t ask them to reauthenticate.",
+        );
+      }
       return { success: true, challenge, allowCredentials, rpId: config.rpId };
     },
   });
@@ -195,6 +201,12 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
         },
       );
       if (!registrationResult.success) {
+        // A `PROTOCOL_ERROR` here also covers a registration ceremony that
+        // belongs to a different user than the caller, which happens when the
+        // caller signs in as a different user after the `verifyAddPasskey`
+        // call. `finishRegistration` compares the owner of the ceremony with
+        // `verifiedUserId`, thus this call needs no check of its own. See the
+        // same case in `verifyAddPasskey`.
         return { success: false, userError: registrationResult.userError };
       }
       return { success: true, passkeyId: registrationResult.passkeyId };

--- a/packages/core/src/components/passkey/management/list.ts
+++ b/packages/core/src/components/passkey/management/list.ts
@@ -1,0 +1,40 @@
+import { queryGeneric } from "convex/server";
+import { Infer, v } from "convex/values";
+import { getAuthUserId } from "../../core/userId.ts";
+import type { UsernamePasskeyConfig } from "../setup.ts";
+import { notSignedInUserError } from "../validation.ts";
+
+/**
+ * The passkey metadata shown to the user when managing their passkeys.
+ */
+const passkeyMetadata = v.object({
+  passkeyId: v.string(),
+  name: v.optional(v.string()),
+  credentialId: v.bytes(),
+  createdAt: v.number(),
+});
+
+const listPasskeysResult = v.union(
+  v.object({ success: v.literal(true), passkeys: v.array(passkeyMetadata) }),
+  v.object({ success: v.literal(false), userError: notSignedInUserError }),
+);
+
+export type ListPasskeysResult = Infer<typeof listPasskeysResult>;
+
+export function listPasskeys(config: UsernamePasskeyConfig) {
+  return queryGeneric({
+    args: {},
+    returns: listPasskeysResult,
+    handler: async (ctx): Promise<ListPasskeysResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+      const passkeys = await ctx.runQuery(
+        config.component.registration.listPasskeys,
+        { userId },
+      );
+      return { success: true, passkeys };
+    },
+  });
+}

--- a/packages/core/src/components/passkey/management/list.ts
+++ b/packages/core/src/components/passkey/management/list.ts
@@ -1,3 +1,9 @@
+/**
+ * Allows logged-in users to see the passkeys set up on their account.
+ *
+ * @module
+ */
+
 import { queryGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import { getAuthUserId } from "../../core/userId.ts";

--- a/packages/core/src/components/passkey/management/remove.ts
+++ b/packages/core/src/components/passkey/management/remove.ts
@@ -1,3 +1,27 @@
+/**
+ * The flow that removes a passkey from a signed-in account.
+ *
+ * A different passkey of the same account must authorize the removal. Thus
+ * the flow is one authentication ceremony (`get()`) around the deletion, and
+ * the user can never remove their last passkey.
+ *
+ * ```
+ *  Client                                 Provider
+ *    │                                       │
+ *    │  startRemovePasskey(passkeyId)        │
+ *    ├──────────────────────────────────────▶│  start the authentication
+ *    │◀──────────────────────────────────────┤  (removed passkey excluded)
+ *    │                                       │
+ *    ├─▶ navigator.credentials.get()         │
+ *    │                                       │
+ *    │  finishRemovePasskey(id, assertion)   │
+ *    ├──────────────────────────────────────▶│  verify it, delete the passkey
+ *    │◀──────────────────────────────────────┤
+ *    │                                       │
+ * ```
+ *
+ * @module
+ */
 import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import { getAuthUserId } from "../../core/userId.ts";
@@ -39,10 +63,6 @@ const startRemovePasskeyResult = v.union(
   }),
 );
 
-/**
- * The result of `startRemovePasskey`: the data for a `get()` call that
- * authorizes the removal, or a user-facing `userError`.
- */
 export type StartRemovePasskeyResult = Infer<typeof startRemovePasskeyResult>;
 
 const finishRemovePasskeyResult = v.union(
@@ -51,18 +71,12 @@ const finishRemovePasskeyResult = v.union(
     success: v.literal(false),
     userError: v.union(
       notSignedInUserError,
-      // `PROTOCOL_ERROR` covers an assertion from the passkey that goes
-      // away. See the check in `finishRemovePasskey`.
       finishAuthenticationUserError,
       deletePasskeyUserError,
     ),
   }),
 );
 
-/**
- * The result of `finishRemovePasskey`: the removal happened, or a
- * user-facing `userError`.
- */
 export type FinishRemovePasskeyResult = Infer<typeof finishRemovePasskeyResult>;
 
 /** Tell if two credential IDs hold the same bytes. */
@@ -75,12 +89,6 @@ function sameBytes(a: ArrayBuffer, b: ArrayBuffer): boolean {
   return left.every((byte, index) => byte === right[index]);
 }
 
-/**
- * Build the `startRemovePasskey` mutation of the provider.
- *
- * The removal needs an assertion from a passkey that is not the passkey
- * that goes away, thus the user keeps at least one usable passkey.
- */
 export function startRemovePasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: { passkeyId: v.string() },
@@ -124,17 +132,6 @@ export function startRemovePasskey(config: UsernamePasskeyConfig) {
   });
 }
 
-/**
- * Build the `finishRemovePasskey` mutation of the provider.
- *
- * The mutation runs every check itself, because the challenge does not
- * carry the target: the purpose must agree, the assertion must come from a
- * different passkey than the target, and the target must belong to the
- * caller.
- *
- * TODO(nicolas) The sessions that the removed passkey started stay valid. A
- * later change could end them with the removal.
- */
 export function finishRemovePasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
@@ -167,22 +164,19 @@ export function finishRemovePasskey(config: UsernamePasskeyConfig) {
         return { success: false, userError: authenticationResult.userError };
       }
       if (authenticationResult.userId !== userId) {
-        // Not possible: `startRemovePasskey` binds the challenge to the
-        // caller, and `finishAuthentication` refuses an assertion from a
-        // passkey of a different user. Throwing rolls the burned challenge
-        // back.
-        throw new Error(
-          "Invariant violation: the assertion authenticates a different user than the caller.",
+        // The identity of the caller changed between `startRemovePasskey`
+        // and this call
+        console.warn(
+          "Rejected a passkey removal because the assertion authenticates a " +
+            "different user than the caller. The caller signed in as a " +
+            "different user after the `startRemovePasskey` call.",
         );
+        return { success: false, userError: { error: "PROTOCOL_ERROR" } };
       }
       if (authenticationResult.passkeyId === args.passkeyId) {
-        // A passkey cannot authorize its own removal: a person who holds one
-        // stolen passkey must not be able to erase the passkey of the owner
-        // and keep the account. No correct caller reaches this: the browser
-        // never gets the target in `allowCredentials`, and an app that sends
-        // a `passkeyId` other than the one it started with contradicts its
-        // own challenge. Thus the result is a `PROTOCOL_ERROR`, and the
-        // message goes to the backend logs only.
+        // A passkey cannot authorize its own removal.
+        // This should not happen because we exclude the removed passkey
+        // from `allowCredentials` in `startRemovePasskey`.
         console.warn(
           "Rejected a passkey removal because the assertion comes from the " +
             "passkey that goes away. Check that `finishRemovePasskey` gets " +
@@ -191,6 +185,15 @@ export function finishRemovePasskey(config: UsernamePasskeyConfig) {
         );
         return { success: false, userError: { error: "PROTOCOL_ERROR" } };
       }
+
+      // Note that here, we don’t validate that the passkey ID matches the one
+      // passed to startRemovePasskey. This is okay: if we reached that point,
+      // we know that the passkey’s owner has been re-authenticated, and this is
+      // what we actually care about.
+      // The reason why startRemovePasskey takes a passkeyId is because we want
+      // to exclude the removed passkey from allowCredentials, so that the
+      // user’s authenticator doesn’t suggest it. This is a UX improvement,
+      // but it’s not necessary from a security point of view.
 
       const deleteResult = await ctx.runMutation(
         config.component.registration.deletePasskey,

--- a/packages/core/src/components/passkey/management/remove.ts
+++ b/packages/core/src/components/passkey/management/remove.ts
@@ -91,7 +91,11 @@ function sameBytes(a: ArrayBuffer, b: ArrayBuffer): boolean {
 
 export function startRemovePasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
-    args: { passkeyId: v.string() },
+    args: {
+      // This is used to exclude the passkey being removed from
+      // the list of passkeys suggested by the authenticator.
+      passkeyId: v.string(),
+    },
     returns: startRemovePasskeyResult,
     handler: async (ctx, { passkeyId }): Promise<StartRemovePasskeyResult> => {
       const userId = await getAuthUserId(ctx);

--- a/packages/core/src/components/passkey/management/remove.ts
+++ b/packages/core/src/components/passkey/management/remove.ts
@@ -1,0 +1,205 @@
+import { mutationGeneric } from "convex/server";
+import { Infer, v } from "convex/values";
+import { getAuthUserId } from "../../core/userId.ts";
+import { REMOVE_PASSKEY_PURPOSE } from "../purposes.ts";
+import type { UsernamePasskeyConfig } from "../setup.ts";
+import {
+  credentialDescriptor,
+  deletePasskeyUserError,
+  finishAuthenticationUserError,
+  notSignedInUserError,
+} from "../validation.ts";
+
+/**
+ * The user-facing error when the user tries to remove their only passkey.
+ *
+ * With a username and a passkey, a user can never remove their last passkey
+ * through this provider: a different passkey must authorize the removal.
+ * The component stays permissive and does the deletion; the provider makes
+ * the policy. A future option could let the app allow the removal, for
+ * example when the app knows that the user has a different way to sign in.
+ */
+// TODO(nicolas) Give the app a way to allow the removal of the last passkey.
+const lastPasskeyUserError = v.object({ error: v.literal("LAST_PASSKEY") });
+
+const startRemovePasskeyResult = v.union(
+  v.object({
+    success: v.literal(true),
+    challenge: v.bytes(),
+    allowCredentials: v.array(credentialDescriptor),
+    rpId: v.string(),
+  }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(
+      notSignedInUserError,
+      deletePasskeyUserError,
+      lastPasskeyUserError,
+    ),
+  }),
+);
+
+/**
+ * The result of `startRemovePasskey`: the data for a `get()` call that
+ * authorizes the removal, or a user-facing `userError`.
+ */
+export type StartRemovePasskeyResult = Infer<typeof startRemovePasskeyResult>;
+
+const finishRemovePasskeyResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(
+      notSignedInUserError,
+      // `PROTOCOL_ERROR` covers an assertion from the passkey that goes
+      // away. See the check in `finishRemovePasskey`.
+      finishAuthenticationUserError,
+      deletePasskeyUserError,
+    ),
+  }),
+);
+
+/**
+ * The result of `finishRemovePasskey`: the removal happened, or a
+ * user-facing `userError`.
+ */
+export type FinishRemovePasskeyResult = Infer<typeof finishRemovePasskeyResult>;
+
+/** Tell if two credential IDs hold the same bytes. */
+function sameBytes(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+  const left = new Uint8Array(a);
+  const right = new Uint8Array(b);
+  return left.every((byte, index) => byte === right[index]);
+}
+
+/**
+ * Build the `startRemovePasskey` mutation of the provider.
+ *
+ * The removal needs an assertion from a passkey that is not the passkey
+ * that goes away, thus the user keeps at least one usable passkey.
+ */
+export function startRemovePasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: { passkeyId: v.string() },
+    returns: startRemovePasskeyResult,
+    handler: async (ctx, { passkeyId }): Promise<StartRemovePasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+
+      const passkeys = await ctx.runQuery(
+        config.component.registration.listPasskeys,
+        { userId },
+      );
+      const target = passkeys.find(
+        (passkey) => passkey.passkeyId === passkeyId,
+      );
+      if (target === undefined) {
+        return { success: false, userError: { error: "PASSKEY_NOT_FOUND" } };
+      }
+      if (passkeys.length === 1) {
+        return { success: false, userError: { error: "LAST_PASSKEY" } };
+      }
+
+      const { challenge, allowCredentials } = await ctx.runMutation(
+        config.component.authentication.startAuthentication,
+        { purpose: REMOVE_PASSKEY_PURPOSE, userId },
+      );
+      return {
+        success: true,
+        challenge,
+        // The filter helps the user only: the browser then does not offer
+        // the passkey that goes away. `finishRemovePasskey` refuses such an
+        // assertion again, and that check is the enforcement.
+        allowCredentials: allowCredentials.filter(
+          (candidate) => !sameBytes(candidate.id, target.credentialId),
+        ),
+        rpId: config.rpId,
+      };
+    },
+  });
+}
+
+/**
+ * Build the `finishRemovePasskey` mutation of the provider.
+ *
+ * The mutation runs every check itself, because the challenge does not
+ * carry the target: the purpose must agree, the assertion must come from a
+ * different passkey than the target, and the target must belong to the
+ * caller.
+ *
+ * TODO(nicolas) The sessions that the removed passkey started stay valid. A
+ * later change could end them with the removal.
+ */
+export function finishRemovePasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: {
+      passkeyId: v.string(),
+      credentialId: v.bytes(),
+      authenticatorData: v.bytes(),
+      clientDataJSON: v.bytes(),
+      signature: v.bytes(),
+    },
+    returns: finishRemovePasskeyResult,
+    handler: async (ctx, args): Promise<FinishRemovePasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+
+      const authenticationResult = await ctx.runMutation(
+        config.component.authentication.finishAuthentication,
+        {
+          purpose: REMOVE_PASSKEY_PURPOSE,
+          expectedRpId: config.rpId,
+          expectedOrigin: config.origin,
+          credentialId: args.credentialId,
+          authenticatorData: args.authenticatorData,
+          clientDataJSON: args.clientDataJSON,
+          signature: args.signature,
+        },
+      );
+      if (!authenticationResult.success) {
+        return { success: false, userError: authenticationResult.userError };
+      }
+      if (authenticationResult.userId !== userId) {
+        // Not possible: `startRemovePasskey` binds the challenge to the
+        // caller, and `finishAuthentication` refuses an assertion from a
+        // passkey of a different user. Throwing rolls the burned challenge
+        // back.
+        throw new Error(
+          "Invariant violation: the assertion authenticates a different user than the caller.",
+        );
+      }
+      if (authenticationResult.passkeyId === args.passkeyId) {
+        // A passkey cannot authorize its own removal: a person who holds one
+        // stolen passkey must not be able to erase the passkey of the owner
+        // and keep the account. No correct caller reaches this: the browser
+        // never gets the target in `allowCredentials`, and an app that sends
+        // a `passkeyId` other than the one it started with contradicts its
+        // own challenge. Thus the result is a `PROTOCOL_ERROR`, and the
+        // message goes to the backend logs only.
+        console.warn(
+          "Rejected a passkey removal because the assertion comes from the " +
+            "passkey that goes away. Check that `finishRemovePasskey` gets " +
+            "the same `passkeyId` as the `startRemovePasskey` call that made " +
+            "the challenge.",
+        );
+        return { success: false, userError: { error: "PROTOCOL_ERROR" } };
+      }
+
+      const deleteResult = await ctx.runMutation(
+        config.component.registration.deletePasskey,
+        { userId, passkeyId: args.passkeyId },
+      );
+      if (!deleteResult.success) {
+        return { success: false, userError: deleteResult.userError };
+      }
+      return { success: true };
+    },
+  });
+}

--- a/packages/core/src/components/passkey/purposes.ts
+++ b/packages/core/src/components/passkey/purposes.ts
@@ -1,0 +1,8 @@
+/** The re-authentication that signs a user in. */
+export const SIGN_IN_PURPOSE = "usernamePasskey:signIn";
+
+/** The re-authentication that comes before a user adds a passkey. */
+export const ADD_PASSKEY_PURPOSE = "usernamePasskey:addPasskey";
+
+/** The re-authentication that authorizes the removal of a passkey. */
+export const REMOVE_PASSKEY_PURPOSE = "usernamePasskey:removePasskey";

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -17,6 +17,17 @@ import {
   finishAuthenticationUserError,
   finishRegistrationUserError,
 } from "./validation.ts";
+import {
+  finishAddPasskey,
+  startAddPasskey,
+  verifyAddPasskey,
+} from "./management/add.ts";
+import { listPasskeys } from "./management/list.ts";
+import {
+  finishRemovePasskey,
+  startRemovePasskey,
+} from "./management/remove.ts";
+import { SIGN_IN_PURPOSE } from "./purposes.ts";
 
 /**
  * Options for {@link setupUsernamePasskey}.
@@ -53,10 +64,15 @@ export type UsernamePasskeyOptions = {
   rpName?: string;
 };
 
+/**
+ * {@link UsernamePasskeyOptions} with the defaults applied. The provider
+ * functions, including the passkey-management ones, close over this
+ * value.
+ */
+export type UsernamePasskeyConfig = Required<UsernamePasskeyOptions>;
+
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "passkey";
-
-export const SIGN_IN_PURPOSE = "usernamePasskey:signIn";
 
 const startSignInResult = v.union(
   // The username has an account: authenticate with a passkey of that
@@ -139,36 +155,45 @@ export type FinishSignInResult = Infer<typeof finishSignInResult>;
  * An identifier-first username + passkey recipe: the user types a username;
  * when the username has an account, the user authenticates with a passkey
  * of that account; when the username is free, the user registers a new
- * account immediately. Wire it up in `convex/auth.ts`:
+ * account immediately.
+ *
+ * Logged in users can add or remove passkeys.
+ *
+ * Wire it up in `convex/auth.ts`:
  *
  * ```ts
  * const core = setupCore({ component: components.auth });
  * export const { signOut, refreshSession, isAuthenticated } = core;
  *
- * export const { startSignIn, startAutofillSignIn, finishSignUp, finishSignIn } =
- *   setupUsernamePasskey(core, {
- *     component: components.authPasskey,
- *     usernameComponent: components.authUsername,
- *     rpId: "localhost",
- *     origin: "http://localhost:5173",
- *   }).attachUserCallbacks({ createUser: internal.users.createUserPasskey });
- * ```
+ * const {
+ *   startSignIn,
+ *   startAutofillSignIn,
+ *   finishSignUp,
+ *   finishSignIn,
  *
- * The app re-exports the returned `startSignIn` / `startAutofillSignIn` /
- * `finishSignUp` / `finishSignIn` mutations so its clients can call them.
- * The React hooks in `@convex-dev/auth/providers/passkey/react` drive the
- * WebAuthn ceremonies in the browser against these four functions.
+ *   listPasskeys,
+ *
+ *   startAddPasskey,
+ *   verifyAddPasskey,
+ *   finishAddPasskey,
+ *
+ *   startRemovePasskey,
+ *   finishRemovePasskey,
+ * } = setupUsernamePasskey(core, {
+ *   component: components.authPasskey,
+ *   usernameComponent: components.authUsername,
+ *   rpId: "localhost",
+ *   origin: "http://localhost:5173",
+ * }).attachUserCallbacks({ createUser: internal.users.createUserPasskey });
+ * ```
  */
-// TODO(nicolas) There is no flow yet to add more passkeys to an
-// existing account, or to delete one, from this provider. The
-// component supports it (`startRegistration` with a `userId`,
-// `deletePasskey`); the provider does not expose it yet.
 export function setupUsernamePasskey<UsersTable extends string>(
   core: AuthCore<UsersTable>,
   options: UsernamePasskeyOptions,
 ) {
   const { component, usernameComponent, rpId, origin } = options;
   const rpName = options.rpName ?? rpId;
+  const config: UsernamePasskeyConfig = { ...options, rpName };
 
   return {
     /**
@@ -430,6 +455,27 @@ export function setupUsernamePasskey<UsersTable extends string>(
             return { success: true, tokens, username };
           },
         }),
+
+        // The passkey-management functions of a signed-in user.
+        //
+        // TODO(nicolas) These functions do not compose with the other auth
+        // providers yet. They assume that a passkey is the only way into the
+        // account: `startAddPasskey` re-authenticates with an existing
+        // passkey, thus a user who signed in with a different provider and
+        // has no passkey cannot add a first one; and `finishRemovePasskey`
+        // refuses the last passkey, even when the user keeps another way to
+        // sign in.
+        //
+        // None of them mints a session, thus none of them goes through
+        // `authMutation`. Each one resolves the caller with the session of
+        // the request and refuses a signed-out caller. Each mutation
+        // composes the functions of the component in one transaction.
+        listPasskeys: listPasskeys(config),
+        startAddPasskey: startAddPasskey(config),
+        verifyAddPasskey: verifyAddPasskey(config),
+        finishAddPasskey: finishAddPasskey(config),
+        startRemovePasskey: startRemovePasskey(config),
+        finishRemovePasskey: finishRemovePasskey(config),
       };
     },
   };

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -158,3 +158,13 @@ export const deletePasskeyUserError = v.union(
   v.object({ error: v.literal("PASSKEY_NOT_FOUND") }),
 );
 export type DeletePasskeyUserError = Infer<typeof deletePasskeyUserError>;
+
+/**
+ * The user-facing error when the caller of a passkey-management function is
+ * not signed in. Each of those functions acts on the passkeys of the
+ * caller, thus a signed-out caller has nothing to act on.
+ */
+export const notSignedInUserError = v.object({
+  error: v.literal("NOT_SIGNED_IN"),
+});
+export type NotSignedInUserError = Infer<typeof notSignedInUserError>;


### PR DESCRIPTION
This adds new functions to the “username + passkey” auth flow that allow users to manage their passkeys. It allows them to add additional passkeys to their accounts, as well as deleting existing passkeys. Allowing users to have access to these management features is _strongly recommended_: it is very common for users to have multiple passkeys, in particular because some passkeys (e.g. security tokens) can’t be transferred to another device.

For security reasons, adding or removing a passkey requires users to authenticate with another passkey. This prevents an attacker who temporarily has access to a user’s session from keeping access to it by adding its own passkey. This behavior follows Pilcrow’s implementation (https://passwordless-example.auth.pilcrowonpaper.com/account).

In this flow, we currently assume that all accounts have passkeys: this means that we disallow users from removing all passkeys from their account, and that users can’t add passkeys to their account if they don’t already have a passkey. We might need to have a clearer way to allow this provider to be used concurrently with other providers.

There are some unit tests in #561