### PR TITLE
Passkey management: add the usePasskeyManagement React hook

### DIFF
--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -9,10 +9,12 @@
  */
 
 import type * as authentication from "../authentication.js";
+import type * as ceremonies from "../ceremonies.js";
 import type * as cleanup from "../cleanup.js";
 import type * as helpers from "../helpers.js";
 import type * as management_add from "../management/add.js";
 import type * as management_list from "../management/list.js";
+import type * as management_react from "../management/react.js";
 import type * as management_remove from "../management/remove.js";
 import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
@@ -30,10 +32,12 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   authentication: typeof authentication;
+  ceremonies: typeof ceremonies;
   cleanup: typeof cleanup;
   helpers: typeof helpers;
   "management/add": typeof management_add;
   "management/list": typeof management_list;
+  "management/react": typeof management_react;
   "management/remove": typeof management_remove;
   purposes: typeof purposes;
   react: typeof react;

--- a/packages/core/src/components/passkey/ceremonies.ts
+++ b/packages/core/src/components/passkey/ceremonies.ts
@@ -1,0 +1,203 @@
+/**
+ * The browser side of the passkey provider: the WebAuthn ceremonies
+ * (`navigator.credentials`) and the failures that only the client produces.
+ *
+ * The React hooks of the provider sit on this module. The sign-in hook
+ * (`react.tsx`) and the management hook (`management/react.tsx`) run the
+ * same two ceremonies, thus the ceremonies live here and neither hook
+ * imports the other.
+ *
+ * @module
+ */
+
+import type { CredentialDescriptor } from "./validation.ts";
+
+/**
+ * Failures the client produces that the server never returns. The hooks
+ * fold them into the result so callers handle *every* failure through the
+ * one `userError` switch and never need their own `try`/`catch`:
+ *
+ * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
+ *   refused the ceremony (`NotAllowedError`), or a second call came in
+ *   while one was already running (the browser would refuse the second
+ *   modal ceremony anyway). This is the most common failure; show a calm
+ *   "the operation was cancelled" message.
+ * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
+ *   page is not a secure context.
+ * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
+ *   unexpected server error). The thrown value is preserved on `cause` for
+ *   callers that want to inspect or log it.
+ */
+export type ClientFailure = {
+  success: false;
+  userError:
+    | { error: "CEREMONY_ABORTED" }
+    | { error: "WEBAUTHN_UNSUPPORTED" }
+    | { error: "OTHER_ERROR"; cause: unknown };
+};
+
+/** Tell whether this page can run a WebAuthn ceremony at all. */
+export function supportsWebAuthn(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof PublicKeyCredential !== "undefined" &&
+    window.isSecureContext
+  );
+}
+
+function isCeremonyAborted(cause: unknown): boolean {
+  // `NotAllowedError` is what the browser throws when the user dismisses
+  // the dialog, when the ceremony times out, and when the page is not
+  // allowed to run one. A `null` credential is handled separately.
+  return cause instanceof DOMException && cause.name === "NotAllowedError";
+}
+
+/**
+ * Fold a thrown value into the {@link ClientFailure} `userError` shape, so
+ * callers handle every failure through the one `userError` switch.
+ */
+export function foldClientError(cause: unknown): ClientFailure["userError"] {
+  if (isCeremonyAborted(cause)) {
+    return { error: "CEREMONY_ABORTED" };
+  }
+  return { error: "OTHER_ERROR", cause };
+}
+
+/** The arguments a server function needs from a WebAuthn assertion. */
+export type AssertionArgs = {
+  credentialId: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  signature: ArrayBuffer;
+};
+
+/**
+ * Turn an assertion credential into the arguments of the finishing
+ * mutation. Shared between the modal paths and the autofill path.
+ */
+export function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    // `rawId` carries the credential ID bytes; `credential.id` is the
+    // base64url form and must not be sent.
+    credentialId: credential.rawId,
+    authenticatorData: response.authenticatorData,
+    clientDataJSON: response.clientDataJSON,
+    signature: response.signature,
+  };
+}
+
+/**
+ * Turn the credential descriptors from the server into the WebAuthn shape
+ * of `allowCredentials` and `excludeCredentials`.
+ */
+function credentialDescriptors(
+  credentials: CredentialDescriptor[],
+): PublicKeyCredentialDescriptor[] {
+  return credentials.map(({ id, transports }) => ({
+    type: "public-key",
+    id,
+    // The database stores a string array, we’re converting here
+    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
+    transports: transports as AuthenticatorTransport[] | undefined,
+  }));
+}
+
+/** The server data that a registration ceremony needs. */
+export type RegistrationCeremonyStart = {
+  challenge: ArrayBuffer;
+  userHandle: ArrayBuffer;
+  excludeCredentials: CredentialDescriptor[];
+  rpId: string;
+  rpName: string;
+};
+
+/** The arguments a registration ceremony produces for the server. */
+export type RegistrationCeremonyArgs = {
+  attestationObject: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  transports?: string[];
+};
+
+/**
+ * Run the modal registration ceremony and return the arguments of the
+ * finishing mutation, or `null` when the browser returns no credential.
+ *
+ * `displayName` becomes the WebAuthn `user.name` and `user.displayName`:
+ * the text that the passkey manager shows next to the passkey.
+ */
+export async function runRegistrationCeremony(
+  displayName: string,
+  start: RegistrationCeremonyStart,
+): Promise<RegistrationCeremonyArgs | null> {
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      challenge: start.challenge,
+      rp: { id: start.rpId, name: start.rpName },
+      // The handle comes from the server: at sign-up the app user id
+      // cannot be used, because the user row does not exist yet.
+      user: {
+        id: start.userHandle,
+        name: displayName,
+        displayName,
+      },
+      // Exactly the algorithms the server accepts (ES256 and RS256; see
+      // the verification in `registration.ts`).
+      pubKeyCredParams: [
+        { type: "public-key", alg: -7 }, // ES256
+        { type: "public-key", alg: -257 }, // RS256
+      ],
+      // A discoverable credential is required for autofill, and the
+      // server hard-requires user verification.
+      authenticatorSelection: {
+        residentKey: "required",
+        requireResidentKey: true,
+        userVerification: "required",
+      },
+      attestation: "none",
+      excludeCredentials: credentialDescriptors(start.excludeCredentials),
+    },
+  })) as PublicKeyCredential | null;
+  if (credential === null) {
+    return null;
+  }
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    attestationObject: response.attestationObject,
+    clientDataJSON: response.clientDataJSON,
+    // Older browsers have no `getTransports`. Then the server stores no
+    // transports for this credential.
+    transports:
+      typeof response.getTransports === "function"
+        ? response.getTransports()
+        : undefined,
+  };
+}
+
+/** The server data that an authentication ceremony needs. */
+export type AuthenticationCeremonyStart = {
+  challenge: ArrayBuffer;
+  allowCredentials: CredentialDescriptor[];
+  rpId: string;
+};
+
+/**
+ * Run the modal authentication ceremony and return the assertion
+ * arguments, or `null` when the browser returns no credential.
+ */
+export async function runAuthenticationCeremony(
+  start: AuthenticationCeremonyStart,
+): Promise<AssertionArgs | null> {
+  const credential = (await navigator.credentials.get({
+    publicKey: {
+      challenge: start.challenge,
+      rpId: start.rpId,
+      allowCredentials: credentialDescriptors(start.allowCredentials),
+      userVerification: "required",
+    },
+  })) as PublicKeyCredential | null;
+  if (credential === null) {
+    return null;
+  }
+  return assertionArgs(credential);
+}

--- a/packages/core/src/components/passkey/management/react.test.tsx
+++ b/packages/core/src/components/passkey/management/react.test.tsx
@@ -1,0 +1,454 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ConvexProvider, type ConvexReactClient } from "convex/react";
+import { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ListPasskeysResult } from "./list.ts";
+import {
+  type AddPasskeyResult,
+  type PasskeyManagementApi,
+  type RemovePasskeyResult,
+  usePasskeyManagement,
+} from "./react.tsx";
+
+// The flows call several different functions and the tests assert their
+// order, so every step of a flow records its name here.
+const callOrder: string[] = [];
+
+// The hook calls several different mutations, so the client dispatches on
+// the reference (a string sentinel here) to one mock per mutation.
+const mutations = {
+  startAddPasskey: vi.fn(),
+  verifyAddPasskey: vi.fn(),
+  finishAddPasskey: vi.fn(),
+  startRemovePasskey: vi.fn(),
+  finishRemovePasskey: vi.fn(),
+};
+const runMutation = (fn: unknown, args: unknown) => {
+  callOrder.push(fn as string);
+  return mutations[fn as keyof typeof mutations](args);
+};
+
+// `useQuery` reads its value through `watchQuery` on the client, so the
+// substituted client hands out a watch over this variable.
+let listResult: ListPasskeysResult | undefined;
+const listListeners = new Set<() => void>();
+
+const convexClient = {
+  mutation: runMutation,
+  watchQuery: () => ({
+    localQueryResult: () => listResult,
+    onUpdate: (listener: () => void) => {
+      listListeners.add(listener);
+      return () => {
+        listListeners.delete(listener);
+      };
+    },
+    journal: () => undefined,
+  }),
+} as unknown as ConvexReactClient;
+
+const managementApi = {
+  listPasskeys: "listPasskeys",
+  startAddPasskey: "startAddPasskey",
+  verifyAddPasskey: "verifyAddPasskey",
+  finishAddPasskey: "finishAddPasskey",
+  startRemovePasskey: "startRemovePasskey",
+  finishRemovePasskey: "finishRemovePasskey",
+} as unknown as PasskeyManagementApi;
+
+// The browser WebAuthn surface. jsdom has none, so the tests install a
+// fake `PublicKeyCredential` and `navigator.credentials`.
+const credentialsCreate = vi.fn();
+const credentialsGet = vi.fn();
+
+class FakePublicKeyCredential {}
+
+const addStart = {
+  success: true,
+  challenge: new ArrayBuffer(16),
+  allowCredentials: [{ id: new ArrayBuffer(8), transports: ["internal"] }],
+  rpId: "localhost",
+};
+
+const addVerified = {
+  success: true,
+  challenge: new ArrayBuffer(16),
+  userHandle: new ArrayBuffer(16),
+  excludeCredentials: [{ id: new ArrayBuffer(8), transports: ["hybrid"] }],
+  rpId: "localhost",
+  rpName: "Test app",
+  username: "alice",
+};
+
+const removeStart = {
+  success: true,
+  challenge: new ArrayBuffer(16),
+  allowCredentials: [{ id: new ArrayBuffer(4), transports: ["usb"] }],
+  rpId: "localhost",
+};
+
+// A stand-in for the credential `navigator.credentials.create()` returns.
+const attestationCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    attestationObject: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    getTransports: () => ["internal", "hybrid"],
+  },
+};
+
+// A stand-in for the credential `navigator.credentials.get()` returns.
+const assertionCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    authenticatorData: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    signature: new ArrayBuffer(3),
+  },
+};
+
+const assertionArgs = {
+  credentialId: assertionCredential.rawId,
+  authenticatorData: assertionCredential.response.authenticatorData,
+  clientDataJSON: assertionCredential.response.clientDataJSON,
+  signature: assertionCredential.response.signature,
+};
+
+// `vi.unstubAllGlobals()` does not undo `Object.defineProperty`, so the
+// tests restore the original `navigator.credentials` own property (or its
+// absence) themselves.
+const originalCredentials = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "credentials",
+);
+
+beforeEach(() => {
+  vi.stubGlobal("PublicKeyCredential", FakePublicKeyCredential);
+  vi.stubGlobal("isSecureContext", true);
+  Object.defineProperty(window.navigator, "credentials", {
+    value: {
+      create: (options: unknown) => {
+        callOrder.push("create");
+        return credentialsCreate(options);
+      },
+      get: (options: unknown) => {
+        callOrder.push("get");
+        return credentialsGet(options);
+      },
+    },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  if (originalCredentials === undefined) {
+    delete (window.navigator as { credentials?: unknown }).credentials;
+  } else {
+    Object.defineProperty(window.navigator, "credentials", originalCredentials);
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  for (const mock of Object.values(mutations)) {
+    mock.mockReset();
+  }
+  credentialsCreate.mockReset();
+  credentialsGet.mockReset();
+  callOrder.length = 0;
+  listResult = undefined;
+  listListeners.clear();
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ConvexProvider client={convexClient}>{children}</ConvexProvider>;
+}
+
+function renderManagement() {
+  return renderHook(
+    // A new api object on every render, like Convex's generated `api`
+    // proxy, whose property accesses never compare equal.
+    () => usePasskeyManagement({ ...managementApi }),
+    { wrapper },
+  );
+}
+
+describe("usePasskeyManagement addPasskey", () => {
+  test("runs both ceremonies and calls the five functions in order", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.verifyAddPasskey.mockResolvedValue(addVerified);
+    credentialsCreate.mockResolvedValue(attestationCredential);
+    mutations.finishAddPasskey.mockResolvedValue({
+      success: true,
+      passkeyId: "passkey-2",
+    });
+    const { result } = renderManagement();
+
+    let returned!: AddPasskeyResult;
+    await act(async () => {
+      returned = await result.current.addPasskey();
+    });
+
+    expect(callOrder).toEqual([
+      "startAddPasskey",
+      "get",
+      "verifyAddPasskey",
+      "create",
+      "finishAddPasskey",
+    ]);
+    const [request] = credentialsGet.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialRequestOptions },
+    ];
+    expect(request.publicKey.allowCredentials).toEqual([
+      {
+        type: "public-key",
+        id: addStart.allowCredentials[0].id,
+        transports: ["internal"],
+      },
+    ]);
+    // `rawId` carries the credential ID bytes, not the base64url `id`.
+    expect(mutations.verifyAddPasskey).toHaveBeenCalledWith(assertionArgs);
+
+    const [creation] = credentialsCreate.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialCreationOptions },
+    ];
+    expect(creation.publicKey.excludeCredentials).toEqual([
+      {
+        type: "public-key",
+        id: addVerified.excludeCredentials[0].id,
+        transports: ["hybrid"],
+      },
+    ]);
+    expect(creation.publicKey.user).toEqual({
+      id: addVerified.userHandle,
+      name: "alice",
+      displayName: "alice",
+    });
+    expect(mutations.finishAddPasskey).toHaveBeenCalledWith({
+      attestationObject: attestationCredential.response.attestationObject,
+      clientDataJSON: attestationCredential.response.clientDataJSON,
+      transports: ["internal", "hybrid"],
+    });
+    expect(returned).toEqual({ success: true, passkeyId: "passkey-2" });
+  });
+
+  test("an account without a username gets a plain display name", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.verifyAddPasskey.mockResolvedValue({
+      ...addVerified,
+      username: null,
+    });
+    credentialsCreate.mockResolvedValue(attestationCredential);
+    mutations.finishAddPasskey.mockResolvedValue({
+      success: true,
+      passkeyId: "passkey-2",
+    });
+    const { result } = renderManagement();
+
+    await act(async () => {
+      await result.current.addPasskey();
+    });
+
+    const [creation] = credentialsCreate.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialCreationOptions },
+    ];
+    expect(creation.publicKey.user.name).toBe("user");
+    expect(creation.publicKey.user.displayName).toBe("user");
+  });
+
+  test("a cancelled first dialog stops the flow before the verification", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    credentialsGet.mockRejectedValue(
+      new DOMException("The operation was cancelled.", "NotAllowedError"),
+    );
+    const { result } = renderManagement();
+
+    let returned!: AddPasskeyResult;
+    await act(async () => {
+      returned = await result.current.addPasskey();
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    expect(callOrder).toEqual(["startAddPasskey", "get"]);
+    expect(result.current.pending).toBe(false);
+  });
+
+  test("a cancelled second dialog stops the flow after the verification", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.verifyAddPasskey.mockResolvedValue(addVerified);
+    credentialsCreate.mockRejectedValue(
+      new DOMException("The operation was cancelled.", "NotAllowedError"),
+    );
+    const { result } = renderManagement();
+
+    let returned!: AddPasskeyResult;
+    await act(async () => {
+      returned = await result.current.addPasskey();
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    // The re-authentication is spent and the registration challenge stays
+    // unused until it expires. No passkey is added, thus the user simply
+    // starts again.
+    expect(mutations.finishAddPasskey).not.toHaveBeenCalled();
+  });
+
+  test("a null credential also folds into CEREMONY_ABORTED", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    credentialsGet.mockResolvedValue(null);
+    const { result } = renderManagement();
+
+    let returned!: AddPasskeyResult;
+    await act(async () => {
+      returned = await result.current.addPasskey();
+    });
+
+    expect(returned).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    expect(mutations.verifyAddPasskey).not.toHaveBeenCalled();
+  });
+
+  test("pending is true while the flow runs", async () => {
+    mutations.startAddPasskey.mockResolvedValue(addStart);
+    let resolveCeremony!: (value: unknown) => void;
+    credentialsGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCeremony = resolve;
+      }),
+    );
+    mutations.verifyAddPasskey.mockResolvedValue(addVerified);
+    credentialsCreate.mockResolvedValue(attestationCredential);
+    mutations.finishAddPasskey.mockResolvedValue({
+      success: true,
+      passkeyId: "passkey-2",
+    });
+    const { result } = renderManagement();
+    expect(result.current.pending).toBe(false);
+
+    let flow!: Promise<AddPasskeyResult>;
+    act(() => {
+      flow = result.current.addPasskey();
+    });
+    await waitFor(() => expect(result.current.pending).toBe(true));
+
+    // A second flow while one runs must not start another ceremony.
+    let second!: RemovePasskeyResult;
+    await act(async () => {
+      second = await result.current.removePasskey("passkey-1");
+    });
+    expect(second).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+    expect(mutations.startRemovePasskey).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCeremony(assertionCredential);
+      await flow;
+    });
+    expect(result.current.pending).toBe(false);
+  });
+
+  test("the callbacks keep one identity across re-renders", async () => {
+    const { result, rerender } = renderManagement();
+    const first = result.current;
+    rerender();
+    expect(result.current.addPasskey).toBe(first.addPasskey);
+    expect(result.current.removePasskey).toBe(first.removePasskey);
+  });
+});
+
+describe("usePasskeyManagement removePasskey", () => {
+  test("runs the assertion and sends the target with it", async () => {
+    mutations.startRemovePasskey.mockResolvedValue(removeStart);
+    credentialsGet.mockResolvedValue(assertionCredential);
+    mutations.finishRemovePasskey.mockResolvedValue({ success: true });
+    const { result } = renderManagement();
+
+    let returned!: RemovePasskeyResult;
+    await act(async () => {
+      returned = await result.current.removePasskey("passkey-1");
+    });
+
+    expect(callOrder).toEqual([
+      "startRemovePasskey",
+      "get",
+      "finishRemovePasskey",
+    ]);
+    expect(mutations.startRemovePasskey).toHaveBeenCalledWith({
+      passkeyId: "passkey-1",
+    });
+    const [request] = credentialsGet.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialRequestOptions },
+    ];
+    expect(request.publicKey.allowCredentials).toEqual([
+      {
+        type: "public-key",
+        id: removeStart.allowCredentials[0].id,
+        transports: ["usb"],
+      },
+    ]);
+    expect(mutations.finishRemovePasskey).toHaveBeenCalledWith({
+      passkeyId: "passkey-1",
+      ...assertionArgs,
+    });
+    expect(returned).toEqual({ success: true });
+  });
+
+  test("a server userError passes through without a ceremony", async () => {
+    const failure = { success: false, userError: { error: "LAST_PASSKEY" } };
+    mutations.startRemovePasskey.mockResolvedValue(failure);
+    const { result } = renderManagement();
+
+    let returned!: RemovePasskeyResult;
+    await act(async () => {
+      returned = await result.current.removePasskey("passkey-1");
+    });
+
+    expect(returned).toEqual(failure);
+    expect(credentialsGet).not.toHaveBeenCalled();
+    expect(mutations.finishRemovePasskey).not.toHaveBeenCalled();
+  });
+});
+
+describe("usePasskeyManagement passkeys", () => {
+  test("stays undefined while the subscription loads", () => {
+    const { result } = renderManagement();
+    expect(result.current.passkeys).toBe(undefined);
+    expect(result.current.listError).toBe(null);
+  });
+
+  test("unwraps the success arm of the query", () => {
+    const storedPasskeys = [
+      {
+        passkeyId: "passkey-1",
+        name: "MacBook",
+        credentialId: new ArrayBuffer(8),
+        createdAt: 1,
+      },
+    ];
+    listResult = { success: true, passkeys: storedPasskeys };
+    const { result } = renderManagement();
+
+    expect(result.current.passkeys).toEqual(storedPasskeys);
+    expect(result.current.listError).toBe(null);
+  });
+
+  test("reports a signed-out session through listError", () => {
+    listResult = { success: false, userError: { error: "NOT_SIGNED_IN" } };
+    const { result } = renderManagement();
+
+    expect(result.current.passkeys).toBe(undefined);
+    expect(result.current.listError).toEqual({ error: "NOT_SIGNED_IN" });
+  });
+});

--- a/packages/core/src/components/passkey/management/react.tsx
+++ b/packages/core/src/components/passkey/management/react.tsx
@@ -1,0 +1,323 @@
+/**
+ * React client for passkey management, re-exported from
+ * `@convex-dev/auth/providers/passkey/react`.
+ *
+ * The `usePasskeyManagement` hook drives the settings page of a signed-in
+ * user: it lists the passkeys of the user, adds one, and removes one. The
+ * sign-in hook (`usePasskey`) is a different hook, because a settings page
+ * and a login form share no state.
+ *
+ * @module
+ */
+"use client";
+
+import { useConvex, useQuery, type ConvexReactClient } from "convex/react";
+import type { FunctionReference } from "convex/server";
+import { useCallback, useRef, useState } from "react";
+import {
+  type AssertionArgs,
+  type ClientFailure,
+  foldClientError,
+  type RegistrationCeremonyArgs,
+  runAuthenticationCeremony,
+  runRegistrationCeremony,
+  supportsWebAuthn,
+} from "../ceremonies.ts";
+import type {
+  FinishAddPasskeyResult,
+  StartAddPasskeyResult,
+  VerifyAddPasskeyResult,
+} from "./add.ts";
+import type { ListPasskeysResult } from "./list.ts";
+import type {
+  FinishRemovePasskeyResult,
+  StartRemovePasskeyResult,
+} from "./remove.ts";
+
+/** The `listPasskeys` query the app re-exports from the provider. */
+type ListPasskeysQuery = FunctionReference<
+  "query",
+  "public",
+  Record<string, never>,
+  ListPasskeysResult
+>;
+
+/** The `startAddPasskey` mutation of the provider. */
+type StartAddPasskeyMutation = FunctionReference<
+  "mutation",
+  "public",
+  Record<string, never>,
+  StartAddPasskeyResult
+>;
+
+/** The `verifyAddPasskey` mutation of the provider. */
+type VerifyAddPasskeyMutation = FunctionReference<
+  "mutation",
+  "public",
+  AssertionArgs,
+  VerifyAddPasskeyResult
+>;
+
+/** The `finishAddPasskey` mutation of the provider. */
+type FinishAddPasskeyMutation = FunctionReference<
+  "mutation",
+  "public",
+  RegistrationCeremonyArgs,
+  FinishAddPasskeyResult
+>;
+
+/** The `startRemovePasskey` mutation of the provider. */
+type StartRemovePasskeyMutation = FunctionReference<
+  "mutation",
+  "public",
+  { passkeyId: string },
+  StartRemovePasskeyResult
+>;
+
+/** The `finishRemovePasskey` mutation of the provider. */
+type FinishRemovePasskeyMutation = FunctionReference<
+  "mutation",
+  "public",
+  AssertionArgs & { passkeyId: string },
+  FinishRemovePasskeyResult
+>;
+
+/**
+ * The function references {@link usePasskeyManagement} drives.
+ * `setupUsernamePasskey` returns them next to the sign-in functions, thus
+ * the app module that re-exports the provider carries them all.
+ */
+export type PasskeyManagementApi = {
+  listPasskeys: ListPasskeysQuery;
+  startAddPasskey: StartAddPasskeyMutation;
+  verifyAddPasskey: VerifyAddPasskeyMutation;
+  finishAddPasskey: FinishAddPasskeyMutation;
+  startRemovePasskey: StartRemovePasskeyMutation;
+  finishRemovePasskey: FinishRemovePasskeyMutation;
+};
+
+/** The display data of one passkey of the user. */
+export type PasskeyMetadata = Extract<
+  ListPasskeysResult,
+  { success: true }
+>["passkeys"][number];
+
+/**
+ * The result of the `addPasskey` callback from
+ * {@link usePasskeyManagement}: the passkey ID on success, or a `userError`
+ * from any step of the flow ({@link ClientFailure} included).
+ */
+export type AddPasskeyResult =
+  | FinishAddPasskeyResult
+  | Extract<StartAddPasskeyResult, { success: false }>
+  | Extract<VerifyAddPasskeyResult, { success: false }>
+  | ClientFailure;
+
+/**
+ * The result of the `removePasskey` callback from
+ * {@link usePasskeyManagement}: the removal happened, or a `userError` from
+ * any step of the flow ({@link ClientFailure} included).
+ */
+export type RemovePasskeyResult =
+  | FinishRemovePasskeyResult
+  | Extract<StartRemovePasskeyResult, { success: false }>
+  | ClientFailure;
+
+// The WebAuthn `user.name` and `user.displayName` of the new passkey when
+// the account has no username. The passkey manager of the browser shows
+// this text, thus it must not be empty.
+const NAMELESS_USER_DISPLAY_NAME = "user";
+
+/**
+ * Client for the passkey settings page of a signed-in user.
+ *
+ * ```tsx
+ * import { usePasskeyManagement } from "@convex-dev/auth/providers/passkey/react";
+ * import { api } from "../convex/_generated/api";
+ *
+ * function PasskeySettings() {
+ *   const { passkeys, addPasskey, removePasskey, pending } =
+ *     usePasskeyManagement(api.auth);
+ *   if (passkeys === undefined) {
+ *     return <p>Loading…</p>;
+ *   }
+ *   return (
+ *     <ul>
+ *       {passkeys.map((passkey) => (
+ *         <li key={passkey.passkeyId}>
+ *           {passkey.name}
+ *           <button
+ *             disabled={pending}
+ *             onClick={() => removePasskey(passkey.passkeyId)}
+ *           >
+ *             Remove
+ *           </button>
+ *         </li>
+ *       ))}
+ *       <button disabled={pending} onClick={() => addPasskey()}>
+ *         Add a passkey
+ *       </button>
+ *     </ul>
+ *   );
+ * }
+ * ```
+ *
+ * Both `addPasskey` and `removePasskey` ask the user to prove again that
+ * they hold a passkey of the account. `addPasskey` thus opens two browser
+ * dialogs one after the other: the first proves the account, the second
+ * makes the new passkey.
+ *
+ * @param managementApi The app module that re-exports the
+ *   passkey-management functions of the provider, for example `api.auth`.
+ */
+export function usePasskeyManagement(managementApi: PasskeyManagementApi) {
+  // Every function of the group acts on the caller of the session and mints
+  // no session of its own, thus they all go straight to the deployment.
+  // (The sign-in hook sends its finishing mutations through the auth proxy
+  // instead; see the comment in `react.tsx`.)
+  const convex = useConvex();
+
+  const [pending, setPending] = useState(false);
+  // The re-entry guard reads through a ref: `pending` from `useState` would
+  // be stale inside the callbacks.
+  const pendingRef = useRef(false);
+
+  // The callbacks read the function references and the client through a
+  // ref: their identities are not stable across renders (Convex's generated
+  // `api` object creates a new reference on every property access), and the
+  // identity of `addPasskey` and `removePasskey` must not change on a
+  // render.
+  const currentRef = useRef({ managementApi, convex });
+  currentRef.current = { managementApi, convex };
+
+  const listed = useQuery(managementApi.listPasskeys, {});
+
+  /**
+   * Run one management flow. The two flows cannot overlap: a browser
+   * refuses a second modal ceremony while one runs, and each flow needs
+   * the full attention of the user.
+   */
+  const runExclusive = useCallback(
+    async <Result,>(
+      flow: (
+        convex: ConvexReactClient,
+        managementApi: PasskeyManagementApi,
+      ) => Promise<Result>,
+    ): Promise<Result | ClientFailure> => {
+      if (pendingRef.current) {
+        return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+      }
+      pendingRef.current = true;
+      setPending(true);
+      try {
+        if (!supportsWebAuthn()) {
+          return {
+            success: false,
+            userError: { error: "WEBAUTHN_UNSUPPORTED" },
+          };
+        }
+        const current = currentRef.current;
+        return await flow(current.convex, current.managementApi);
+      } catch (cause) {
+        return { success: false, userError: foldClientError(cause) };
+      } finally {
+        // Reset even when something throws.
+        pendingRef.current = false;
+        setPending(false);
+      }
+    },
+    [],
+  );
+
+  const addPasskey = useCallback(
+    (): Promise<AddPasskeyResult> =>
+      runExclusive(async (convex, api): Promise<AddPasskeyResult> => {
+        const start = await convex.mutation(api.startAddPasskey, {});
+        if (!start.success) {
+          return start;
+        }
+        const assertion = await runAuthenticationCeremony(start);
+        if (assertion === null) {
+          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        }
+        // The registration challenge that this step mints is the proof of
+        // the assertion above, thus the new passkey needs no other token.
+        const verified = await convex.mutation(api.verifyAddPasskey, assertion);
+        if (!verified.success) {
+          return verified;
+        }
+        const registration = await runRegistrationCeremony(
+          verified.username ?? NAMELESS_USER_DISPLAY_NAME,
+          verified,
+        );
+        if (registration === null) {
+          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        }
+        return await convex.mutation(api.finishAddPasskey, registration);
+      }),
+    [runExclusive],
+  );
+
+  const removePasskey = useCallback(
+    (passkeyId: string): Promise<RemovePasskeyResult> =>
+      runExclusive(async (convex, api): Promise<RemovePasskeyResult> => {
+        const start = await convex.mutation(api.startRemovePasskey, {
+          passkeyId,
+        });
+        if (!start.success) {
+          return start;
+        }
+        const assertion = await runAuthenticationCeremony(start);
+        if (assertion === null) {
+          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        }
+        return await convex.mutation(api.finishRemovePasskey, {
+          passkeyId,
+          ...assertion,
+        });
+      }),
+    [runExclusive],
+  );
+
+  return {
+    /**
+     * The passkeys of the user, newest first as the server gives them.
+     *
+     * `undefined` while the subscription loads, and also when `listError`
+     * says that the query refused to answer.
+     */
+    passkeys: listed?.success === true ? listed.passkeys : undefined,
+    /**
+     * Why the list stays `undefined`, or `null` when nothing went wrong.
+     * The one error today is `NOT_SIGNED_IN`: the session ended while the
+     * page was open. Show the login form again.
+     */
+    listError:
+      listed !== undefined && !listed.success ? listed.userError : null,
+    /**
+     * Adds a passkey to the account of the signed-in user.
+     *
+     * The call opens two browser dialogs: the user first proves the
+     * account with a passkey they already hold, then makes the new
+     * passkey.
+     *
+     * Returns an object with a `success` boolean flag. If it is `false`,
+     * the object has a `userError` field that tells why.
+     */
+    addPasskey,
+    /**
+     * Removes the given passkey from the account of the signed-in user.
+     *
+     * The call opens one browser dialog: the user must authorize the
+     * removal with a DIFFERENT passkey of the account. The server refuses
+     * to remove the last passkey (`LAST_PASSKEY`), thus a user never locks
+     * themselves out.
+     *
+     * Returns an object with a `success` boolean flag. If it is `false`,
+     * the object has a `userError` field that tells why.
+     */
+    removePasskey,
+    /** `true` while an `addPasskey` or `removePasskey` call is running. */
+    pending,
+  };
+}

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -10,6 +10,9 @@
  * - Passkey autofill (conditional mediation) where the user selects an account
  *   directly in the autocompletion list.
  *
+ * It also exports the `usePasskeyManagement` hook for the settings page of
+ * a signed-in user (see `management/react.tsx`).
+ *
  * @module
  */
 "use client";
@@ -19,13 +22,31 @@ import type { FunctionReference } from "convex/server";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ClientView } from "../../lib/types.ts";
 import { useAuthActions, useAuthSignInApi } from "../../react/index.tsx";
+import {
+  assertionArgs,
+  type ClientFailure,
+  foldClientError,
+  runAuthenticationCeremony,
+  runRegistrationCeremony,
+  supportsWebAuthn,
+} from "./ceremonies.ts";
 import type {
   FinishSignInResult,
   FinishSignUpResult,
   StartAutofillSignInResult,
   StartSignInResult,
 } from "./setup.ts";
-import { CHALLENGE_TTL_MS, type CredentialDescriptor } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./validation.ts";
+
+// The settings-page hook lives in its own file, but an app gets both hooks
+// from this module.
+export {
+  usePasskeyManagement,
+  type AddPasskeyResult,
+  type PasskeyManagementApi,
+  type PasskeyMetadata,
+  type RemovePasskeyResult,
+} from "./management/react.tsx";
 
 /**
  * The `startSignIn` mutation the app re-exports from its `setupCore`.
@@ -88,30 +109,6 @@ export type PasskeyApi = {
   startAutofillSignIn: StartAutofillSignInMutation;
   finishSignIn: FinishSignInMutation;
   finishSignUp: FinishSignUpMutation;
-};
-
-/**
- * Failures the client produces that the server never returns. The hook
- * folds them into the result so callers handle *every* failure through the
- * one `userError` switch and never need their own `try`/`catch`:
- *
- * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
- *   refused the ceremony (`NotAllowedError`), or a second `signIn` call
- *   came in while one was already running (the browser would refuse the
- *   second modal ceremony anyway). This is the most common failure; show a
- *   calm "sign-in was cancelled" message.
- * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
- *   page is not a secure context.
- * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
- *   unexpected server error). The thrown value is preserved on `cause` for
- *   callers that want to inspect or log it.
- */
-type ClientFailure = {
-  success: false;
-  userError:
-    | { error: "CEREMONY_ABORTED" }
-    | { error: "WEBAUTHN_UNSUPPORTED" }
-    | { error: "OTHER_ERROR"; cause: unknown };
 };
 
 /**
@@ -178,32 +175,6 @@ type AutofillHandle = {
   resume: () => void;
 };
 
-function supportsWebAuthn(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof PublicKeyCredential !== "undefined" &&
-    window.isSecureContext
-  );
-}
-
-function isCeremonyAborted(cause: unknown): boolean {
-  // `NotAllowedError` is what the browser throws when the user dismisses
-  // the dialog, when the ceremony times out, and when the page is not
-  // allowed to run one. A `null` credential is handled separately.
-  return cause instanceof DOMException && cause.name === "NotAllowedError";
-}
-
-/**
- * Fold a thrown value into the {@link ClientFailure} `userError` shape, so
- * callers handle every failure through the one `userError` switch.
- */
-function foldClientError(cause: unknown): ClientFailure["userError"] {
-  if (isCeremonyAborted(cause)) {
-    return { error: "CEREMONY_ABORTED" };
-  }
-  return { error: "OTHER_ERROR", cause };
-}
-
 /**
  * When the thrown value is the abort of the given signal, return the abort
  * reason. Return `null` for every other error, even when the signal aborted
@@ -232,125 +203,6 @@ function autofillAbortReason(
     return "STOP";
   }
   return null;
-}
-
-/** The `finishSignIn` arguments derived from a WebAuthn assertion. */
-type AssertionArgs = {
-  credentialId: ArrayBuffer;
-  authenticatorData: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  signature: ArrayBuffer;
-};
-
-/**
- * Turn an assertion credential into the `finishSignIn` arguments. Shared
- * between the modal authenticate path and the autofill path.
- */
-function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
-  const response = credential.response as AuthenticatorAssertionResponse;
-  return {
-    // `rawId` carries the credential ID bytes; `credential.id` is the
-    // base64url form and must not be sent.
-    credentialId: credential.rawId,
-    authenticatorData: response.authenticatorData,
-    clientDataJSON: response.clientDataJSON,
-    signature: response.signature,
-  };
-}
-
-/**
- * Turn the credential descriptors from the server into the WebAuthn shape
- * of `allowCredentials` and `excludeCredentials`.
- */
-function credentialDescriptors(
-  credentials: CredentialDescriptor[],
-): PublicKeyCredentialDescriptor[] {
-  return credentials.map(({ id, transports }) => ({
-    type: "public-key",
-    id,
-    // The database stores a string array, we’re converting here
-    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
-    transports: transports as AuthenticatorTransport[] | undefined,
-  }));
-}
-
-/**
- * Run the modal registration ceremony and return the `finishSignUp`
- * arguments, or `null` when the browser returns no credential.
- */
-async function runRegistrationCeremony(
-  username: string,
-  start: Extract<StartSignInResult, { step: "register" }>,
-): Promise<{
-  username: string;
-  attestationObject: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  transports?: string[];
-} | null> {
-  const credential = (await navigator.credentials.create({
-    publicKey: {
-      challenge: start.challenge,
-      rp: { id: start.rpId, name: start.rpName },
-      // The handle comes from the server: the app user id cannot be used,
-      // because the user row does not exist yet.
-      user: {
-        id: start.userHandle,
-        name: username,
-        displayName: username,
-      },
-      // Exactly the algorithms the server accepts (ES256 and RS256; see
-      // the verification in `registration.ts`).
-      pubKeyCredParams: [
-        { type: "public-key", alg: -7 }, // ES256
-        { type: "public-key", alg: -257 }, // RS256
-      ],
-      // A discoverable credential is required for autofill, and the
-      // server hard-requires user verification.
-      authenticatorSelection: {
-        residentKey: "required",
-        requireResidentKey: true,
-        userVerification: "required",
-      },
-      attestation: "none",
-      excludeCredentials: credentialDescriptors(start.excludeCredentials),
-    },
-  })) as PublicKeyCredential | null;
-  if (credential === null) {
-    return null;
-  }
-  const response = credential.response as AuthenticatorAttestationResponse;
-  return {
-    username,
-    attestationObject: response.attestationObject,
-    clientDataJSON: response.clientDataJSON,
-    // Older browsers have no `getTransports`. Then the server stores no
-    // transports for this credential.
-    transports:
-      typeof response.getTransports === "function"
-        ? response.getTransports()
-        : undefined,
-  };
-}
-
-/**
- * Run the modal authentication ceremony and return the `finishSignIn`
- * arguments, or `null` when the browser returns no credential.
- */
-async function runAuthenticationCeremony(
-  start: Extract<StartSignInResult, { step: "authenticate" }>,
-): Promise<AssertionArgs | null> {
-  const credential = (await navigator.credentials.get({
-    publicKey: {
-      challenge: start.challenge,
-      rpId: start.rpId,
-      allowCredentials: credentialDescriptors(start.allowCredentials),
-      userVerification: "required",
-    },
-  })) as PublicKeyCredential | null;
-  if (credential === null) {
-    return null;
-  }
-  return assertionArgs(credential);
 }
 
 /**
@@ -486,10 +338,10 @@ export function usePasskey(
           if (args === null) {
             return { success: false, userError: { error: "CEREMONY_ABORTED" } };
           }
-          const result = await signInApi.mutation(
-            passkeyApi.finishSignUp,
-            args,
-          );
+          const result = await signInApi.mutation(passkeyApi.finishSignUp, {
+            username,
+            ...args,
+          });
           if (!result.success) {
             return result;
           }


### PR DESCRIPTION
A settings page drives the management group through one hook:
usePasskeyManagement(api.management.passkeys) returns the live passkey
list, addPasskey(), removePasskey(passkeyId), and a pending flag.
addPasskey pipelines the two browser dialogs (re-authenticate, then
create) behind one call.

The WebAuthn ceremonies move from react.tsx to the new ceremonies.ts,
because both hooks run the same two ceremonies and neither hook can
import the other. No behavior change for usePasskey.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>