### PR TITLE
testing: add frontend tests for passkeys

### DIFF
--- a/examples/react-passkey/convex/passkey.test.ts
+++ b/examples/react-passkey/convex/passkey.test.ts
@@ -97,15 +97,12 @@ async function addPasskey(
   authorizeWith: TestCredential,
 ): Promise<{ passkeyId: string; credential: TestCredential }> {
   const caller = as(t, userId);
-  const start = await caller.mutation(
-    api.management.passkeys.startAddPasskey,
-    {},
-  );
+  const start = await caller.mutation(api.auth.startAddPasskey, {});
   if (!start.success) {
     throw new Error(`The add could not start: ${start.userError.error}`);
   }
   const verified = await caller.mutation(
-    api.management.passkeys.verifyAddPasskey,
+    api.auth.verifyAddPasskey,
     await authenticator.assert(authorizeWith, start.challenge),
   );
   if (!verified.success) {
@@ -115,7 +112,7 @@ async function addPasskey(
   }
   const credential = await authenticator.createCredential();
   const finished = await caller.mutation(
-    api.management.passkeys.finishAddPasskey,
+    api.auth.finishAddPasskey,
     authenticator.attest(credential, verified.challenge),
   );
   if (!finished.success) {
@@ -132,10 +129,7 @@ describe("signing up and signing in", () => {
     const users = await t.run((ctx) => ctx.db.query("users").collect());
     expect(users.map((user) => user._id)).toEqual([alice.userId]);
 
-    const list = await as(t, alice.userId).query(
-      api.management.passkeys.listPasskeys,
-      {},
-    );
+    const list = await as(t, alice.userId).query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
     expect(list.passkeys).toHaveLength(1);
     expect(list.passkeys[0]).toEqual({
@@ -169,21 +163,15 @@ describe("signing up and signing in", () => {
   });
 });
 
-describe("api.management.passkeys", () => {
+describe("passkey management", () => {
   test("lists the passkeys of the caller only", async () => {
     const t = await setup();
     const alice = await signUp(t, "alice");
     const bob = await signUp(t, "bob");
     await addPasskey(t, alice.userId, alice.credential);
 
-    const forAlice = await as(t, alice.userId).query(
-      api.management.passkeys.listPasskeys,
-      {},
-    );
-    const forBob = await as(t, bob.userId).query(
-      api.management.passkeys.listPasskeys,
-      {},
-    );
+    const forAlice = await as(t, alice.userId).query(api.auth.listPasskeys, {});
+    const forBob = await as(t, bob.userId).query(api.auth.listPasskeys, {});
     if (!forAlice.success || !forBob.success) {
       throw new Error("Both callers are signed in.");
     }
@@ -198,7 +186,7 @@ describe("api.management.passkeys", () => {
   test("refuses a signed-out caller", async () => {
     const t = await setup();
     await signUp(t, "alice");
-    expect(await t.query(api.management.passkeys.listPasskeys, {})).toEqual({
+    expect(await t.query(api.auth.listPasskeys, {})).toEqual({
       success: false,
       userError: { error: "NOT_SIGNED_IN" },
     });
@@ -209,10 +197,7 @@ describe("api.management.passkeys", () => {
     const alice = await signUp(t, "alice");
     const second = await addPasskey(t, alice.userId, alice.credential);
 
-    const list = await as(t, alice.userId).query(
-      api.management.passkeys.listPasskeys,
-      {},
-    );
+    const list = await as(t, alice.userId).query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
     expect(list.passkeys.map((passkey) => passkey.passkeyId)).toContain(
       second.passkeyId,
@@ -232,10 +217,9 @@ describe("api.management.passkeys", () => {
     const second = await addPasskey(t, alice.userId, alice.credential);
     const caller = as(t, alice.userId);
 
-    const start = await caller.mutation(
-      api.management.passkeys.startRemovePasskey,
-      { passkeyId: second.passkeyId },
-    );
+    const start = await caller.mutation(api.auth.startRemovePasskey, {
+      passkeyId: second.passkeyId,
+    });
     if (!start.success) throw new Error("The account has two passkeys.");
     // The passkey that goes away cannot authorize its own removal, thus the
     // browser must not offer it.
@@ -246,13 +230,13 @@ describe("api.management.passkeys", () => {
     );
 
     expect(
-      await caller.mutation(api.management.passkeys.finishRemovePasskey, {
+      await caller.mutation(api.auth.finishRemovePasskey, {
         passkeyId: second.passkeyId,
         ...(await authenticator.assert(alice.credential, start.challenge)),
       }),
     ).toEqual({ success: true });
 
-    const list = await caller.query(api.management.passkeys.listPasskeys, {});
+    const list = await caller.query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
     expect(list.passkeys).toHaveLength(1);
     expectSameBytes(
@@ -265,11 +249,11 @@ describe("api.management.passkeys", () => {
     const t = await setup();
     const alice = await signUp(t, "alice");
     const caller = as(t, alice.userId);
-    const list = await caller.query(api.management.passkeys.listPasskeys, {});
+    const list = await caller.query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
 
     expect(
-      await caller.mutation(api.management.passkeys.startRemovePasskey, {
+      await caller.mutation(api.auth.startRemovePasskey, {
         passkeyId: list.passkeys[0].passkeyId,
       }),
     ).toEqual({ success: false, userError: { error: "LAST_PASSKEY" } });

--- a/examples/react-passkey/convex/passkey.test.ts
+++ b/examples/react-passkey/convex/passkey.test.ts
@@ -1,0 +1,277 @@
+import { convexTest, type TestConvex } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
+import {
+  createTestAuthenticator,
+  registerPasskeyProvider,
+  type TestCredential,
+} from "@convex-dev/auth/providers/testing/passkey";
+import { registerUsername } from "@convex-dev/auth/providers/testing/username";
+import { api } from "./_generated/api.js";
+import schema from "./schema.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+// The relying party of `convex/auth.ts`. A ceremony that names another one
+// fails verification.
+const authenticator = createTestAuthenticator({
+  rpId: "localhost",
+  origin: "http://localhost:5173",
+});
+
+type T = TestConvex<typeof schema>;
+
+async function setup(): Promise<T> {
+  // The core signs JWTs from these env vars (see core/public.ts). Mint a real
+  // RS256 key pair for each test and stub the env so Vitest can reset it.
+  const { publicKey, privateKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const publicJwk = await exportJWK(publicKey);
+
+  vi.stubEnv("CONVEX_SITE_URL", "https://example.convex.site");
+  vi.stubEnv("AUTH_PRIVATE_KEY", btoa(await exportPKCS8(privateKey)));
+  vi.stubEnv(
+    "AUTH_JWKS",
+    JSON.stringify({
+      keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
+    }),
+  );
+
+  const t = convexTest(schema, modules);
+  registerCore(t);
+  registerPasskeyProvider(t);
+  registerUsername(t);
+  return t;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/** The caller as a signed-in user, the way an access token identifies one. */
+const as = (t: T, userId: string) => t.withIdentity({ subject: userId });
+
+/** Assert that two byte buffers hold the same bytes. */
+function expectSameBytes(a: ArrayBuffer, b: ArrayBuffer | Uint8Array): void {
+  expect(new Uint8Array(a)).toEqual(new Uint8Array(b));
+}
+
+/** Create an account with its first passkey, the way the log-in page does. */
+async function signUp(
+  t: T,
+  username: string,
+): Promise<{ userId: string; credential: TestCredential }> {
+  const start = await t.mutation(api.auth.startSignIn, { username });
+  if (!start.success || start.step !== "register") {
+    throw new Error("The username is not free.");
+  }
+  const credential = await authenticator.createCredential();
+  const result = await t.mutation(api.auth.finishSignUp, {
+    username,
+    ...authenticator.attest(credential, start.challenge),
+  });
+  if (!result.success) {
+    throw new Error(`The sign-up failed: ${result.userError.error}`);
+  }
+  return { userId: result.tokens.userId, credential };
+}
+
+/** Sign in with a passkey of an account that exists. */
+async function signIn(t: T, username: string, credential: TestCredential) {
+  const start = await t.mutation(api.auth.startSignIn, { username });
+  if (!start.success || start.step !== "authenticate") {
+    throw new Error("The username has no account.");
+  }
+  return await t.mutation(
+    api.auth.finishSignIn,
+    await authenticator.assert(credential, start.challenge),
+  );
+}
+
+/** Run the whole add flow and return the passkey it stores. */
+async function addPasskey(
+  t: T,
+  userId: string,
+  authorizeWith: TestCredential,
+): Promise<{ passkeyId: string; credential: TestCredential }> {
+  const caller = as(t, userId);
+  const start = await caller.mutation(
+    api.management.passkeys.startAddPasskey,
+    {},
+  );
+  if (!start.success) {
+    throw new Error(`The add could not start: ${start.userError.error}`);
+  }
+  const verified = await caller.mutation(
+    api.management.passkeys.verifyAddPasskey,
+    await authenticator.assert(authorizeWith, start.challenge),
+  );
+  if (!verified.success) {
+    throw new Error(
+      `The re-authentication failed: ${verified.userError.error}`,
+    );
+  }
+  const credential = await authenticator.createCredential();
+  const finished = await caller.mutation(
+    api.management.passkeys.finishAddPasskey,
+    authenticator.attest(credential, verified.challenge),
+  );
+  if (!finished.success) {
+    throw new Error(`The add failed: ${finished.userError.error}`);
+  }
+  return { passkeyId: finished.passkeyId, credential };
+}
+
+describe("signing up and signing in", () => {
+  test("creates a user with one passkey", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+
+    const users = await t.run((ctx) => ctx.db.query("users").collect());
+    expect(users.map((user) => user._id)).toEqual([alice.userId]);
+
+    const list = await as(t, alice.userId).query(
+      api.management.passkeys.listPasskeys,
+      {},
+    );
+    if (!list.success) throw new Error("The caller is signed in.");
+    expect(list.passkeys).toHaveLength(1);
+    expect(list.passkeys[0]).toEqual({
+      passkeyId: expect.any(String),
+      credentialId: expect.any(ArrayBuffer),
+      createdAt: expect.any(Number),
+    });
+    expectSameBytes(
+      list.passkeys[0].credentialId,
+      alice.credential.credentialId,
+    );
+  });
+
+  test("signs in with the passkey of the account", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+
+    const result = await signIn(t, "alice", alice.credential);
+    expect(result).toEqual({
+      success: true,
+      username: "alice",
+      tokens: {
+        accessToken: expect.any(String),
+        accessTokenExpiresAt: expect.any(Number),
+        refreshToken: expect.any(String),
+        refreshTokenExpiresAt: expect.any(Number),
+        // Same passkey, thus the same app user.
+        userId: alice.userId,
+      },
+    });
+  });
+});
+
+describe("api.management.passkeys", () => {
+  test("lists the passkeys of the caller only", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const bob = await signUp(t, "bob");
+    await addPasskey(t, alice.userId, alice.credential);
+
+    const forAlice = await as(t, alice.userId).query(
+      api.management.passkeys.listPasskeys,
+      {},
+    );
+    const forBob = await as(t, bob.userId).query(
+      api.management.passkeys.listPasskeys,
+      {},
+    );
+    if (!forAlice.success || !forBob.success) {
+      throw new Error("Both callers are signed in.");
+    }
+    expect(forAlice.passkeys).toHaveLength(2);
+    expect(forBob.passkeys).toHaveLength(1);
+    expectSameBytes(
+      forBob.passkeys[0].credentialId,
+      bob.credential.credentialId,
+    );
+  });
+
+  test("refuses a signed-out caller", async () => {
+    const t = await setup();
+    await signUp(t, "alice");
+    expect(await t.query(api.management.passkeys.listPasskeys, {})).toEqual({
+      success: false,
+      userError: { error: "NOT_SIGNED_IN" },
+    });
+  });
+
+  test("adds a second passkey that can sign in on its own", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const second = await addPasskey(t, alice.userId, alice.credential);
+
+    const list = await as(t, alice.userId).query(
+      api.management.passkeys.listPasskeys,
+      {},
+    );
+    if (!list.success) throw new Error("The caller is signed in.");
+    expect(list.passkeys.map((passkey) => passkey.passkeyId)).toContain(
+      second.passkeyId,
+    );
+
+    // The stored credential is a real passkey of the account, not a row.
+    const result = await signIn(t, "alice", second.credential);
+    expect(result).toMatchObject({
+      success: true,
+      tokens: { userId: alice.userId },
+    });
+  });
+
+  test("removes a passkey after a ceremony with another one", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const second = await addPasskey(t, alice.userId, alice.credential);
+    const caller = as(t, alice.userId);
+
+    const start = await caller.mutation(
+      api.management.passkeys.startRemovePasskey,
+      { passkeyId: second.passkeyId },
+    );
+    if (!start.success) throw new Error("The account has two passkeys.");
+    // The passkey that goes away cannot authorize its own removal, thus the
+    // browser must not offer it.
+    expect(start.allowCredentials).toHaveLength(1);
+    expectSameBytes(
+      start.allowCredentials[0].id,
+      alice.credential.credentialId,
+    );
+
+    expect(
+      await caller.mutation(api.management.passkeys.finishRemovePasskey, {
+        passkeyId: second.passkeyId,
+        ...(await authenticator.assert(alice.credential, start.challenge)),
+      }),
+    ).toEqual({ success: true });
+
+    const list = await caller.query(api.management.passkeys.listPasskeys, {});
+    if (!list.success) throw new Error("The caller is signed in.");
+    expect(list.passkeys).toHaveLength(1);
+    expectSameBytes(
+      list.passkeys[0].credentialId,
+      alice.credential.credentialId,
+    );
+  });
+
+  test("refuses to remove the only passkey of the account", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const caller = as(t, alice.userId);
+    const list = await caller.query(api.management.passkeys.listPasskeys, {});
+    if (!list.success) throw new Error("The caller is signed in.");
+
+    expect(
+      await caller.mutation(api.management.passkeys.startRemovePasskey, {
+        passkeyId: list.passkeys[0].passkeyId,
+      }),
+    ).toEqual({ success: false, userError: { error: "LAST_PASSKEY" } });
+  });
+});

--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -11,11 +11,7 @@ import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { registerCore } from "@convex-dev/auth/providers/testing/core";
 import {
-  buildAssertion,
-  buildAttestationObject,
-  buildAuthenticatorData,
-  buildClientDataJSON,
-  generateES256Credential,
+  createTestAuthenticator,
   registerPasskeyProvider,
   type TestCredential,
 } from "@convex-dev/auth/providers/testing/passkey";
@@ -30,19 +26,9 @@ const modules = import.meta.glob("./**/*.ts");
 const RP_ID = "localhost";
 const ORIGIN = "http://localhost:5173";
 
+const authenticator = createTestAuthenticator({ rpId: RP_ID, origin: ORIGIN });
+
 type T = TestConvex<typeof schema>;
-
-type Attestation = {
-  attestationObject: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-};
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength,
-  ) as ArrayBuffer;
-}
 
 /** Assert that two byte buffers hold the same bytes. */
 function expectSameBytes(
@@ -83,29 +69,12 @@ afterEach(() => {
 const as = (t: T, userId: string) => t.withIdentity({ subject: userId });
 
 /** Build the `create()` payloads of a registration ceremony. */
-function attest(
-  challenge: ArrayBuffer,
-  credential: TestCredential,
-): Attestation {
-  const authenticatorData = buildAuthenticatorData({
-    rpId: RP_ID,
-    credential,
-  });
-  return {
-    attestationObject: toArrayBuffer(buildAttestationObject(authenticatorData)),
-    clientDataJSON: toArrayBuffer(
-      buildClientDataJSON({
-        type: "webauthn.create",
-        challenge,
-        origin: ORIGIN,
-      }),
-    ),
-  };
-}
+const attest = (challenge: ArrayBuffer, credential: TestCredential) =>
+  authenticator.attest(credential, challenge);
 
 /** Build the `get()` payloads of an authentication ceremony. */
 const assertWith = (credential: TestCredential, challenge: ArrayBuffer) =>
-  buildAssertion(credential, challenge, { rpId: RP_ID, origin: ORIGIN });
+  authenticator.assert(credential, challenge);
 
 /** Register a new account with its first passkey. */
 async function signUp(
@@ -116,7 +85,7 @@ async function signUp(
   if (!start.success || start.step !== "register") {
     throw new Error("The username is not free.");
   }
-  const credential = await generateES256Credential();
+  const credential = await authenticator.createCredential();
   const result = await t.mutation(api.auth.finishSignUp, {
     username,
     ...attest(start.challenge, credential),
@@ -147,7 +116,7 @@ async function addPasskey(
       `The re-authentication failed: ${verified.userError.error}`,
     );
   }
-  const credential = await generateES256Credential();
+  const credential = await authenticator.createCredential();
   const finished = await caller.mutation(
     api.auth.finishAddPasskey,
     attest(verified.challenge, credential),
@@ -226,7 +195,7 @@ describe("adding a passkey", () => {
       alice.credential.credentialId,
     );
 
-    const credential = await generateES256Credential();
+    const credential = await authenticator.createCredential();
     const finished = await caller.mutation(
       api.auth.finishAddPasskey,
       attest(verified.challenge, credential),
@@ -261,7 +230,7 @@ describe("adding a passkey", () => {
   test("refuses a create() ceremony that no verifyAddPasskey started", async () => {
     const t = await setup();
     const alice = await signUp(t, "alice");
-    const credential = await generateES256Credential();
+    const credential = await authenticator.createCredential();
 
     // No registration challenge exists at all.
     expect(
@@ -282,7 +251,7 @@ describe("adding a passkey", () => {
     if (!start.success || start.step !== "register") {
       throw new Error("The username is free.");
     }
-    const credential = await generateES256Credential();
+    const credential = await authenticator.createCredential();
     await expect(
       as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
@@ -309,7 +278,7 @@ describe("adding a passkey", () => {
     expect(
       await t.mutation(
         api.auth.finishAddPasskey,
-        attest(new ArrayBuffer(32), await generateES256Credential()),
+        attest(new ArrayBuffer(32), await authenticator.createCredential()),
       ),
     ).toEqual(notSignedIn);
   });

--- a/packages/core/src/components/testing/passkey.ts
+++ b/packages/core/src/components/testing/passkey.ts
@@ -11,15 +11,24 @@
 import type { TestConvex } from "convex-test";
 import type { GenericSchema, SchemaDefinition } from "convex/server";
 import { register as registerBatchWorker } from "@convex-dev/batch-worker/test";
+import { toArrayBuffer } from "../passkey/helpers.ts";
 import schema from "../passkey/schema.ts";
+import {
+  buildAssertion,
+  buildAttestationObject,
+  buildAuthenticatorData,
+  buildClientDataJSON,
+  generateES256Credential,
+  type TestCredential,
+} from "../passkey/testAuthenticator.ts";
 const modules = import.meta.glob("../passkey/**/*.ts");
 
 /**
  * Register the passkey provider component with a `convex-test` instance.
  *
- * The component mounts the batch worker for its cleanup loop, so we register
- * that under `<name>/batchWorker` too — the same way it sits below the
- * component when the app `app.use`s the provider's `convex.config`.
+ * The component erases expired challenges through a nested batch worker, so
+ * we register that under `<name>/batchWorker` too. This mirrors how it is
+ * mounted when the app `app.use`s the provider's `convex.config`.
  *
  * @param t - The test convex instance, e.g. from calling `convexTest`.
  * @param name - The name of the component, as registered in convex.config.ts.
@@ -32,8 +41,79 @@ export function registerPasskeyProvider(
   registerBatchWorker(t, `${name}/batchWorker`);
 }
 
-// The software authenticator that the tests of this repo drive. It ships with
-// the other testing helpers so that an app can write its own passkey tests.
-export * from "../passkey/testAuthenticator.ts";
+/** One passkey of the software authenticator, with its private key. */
+export type { TestCredential };
 
-export default { registerPasskeyProvider, schema, modules };
+/** What `navigator.credentials.create()` gives a registration ceremony. */
+export interface TestAttestation {
+  attestationObject: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+}
+
+/** What `navigator.credentials.get()` gives an authentication ceremony. */
+export interface TestAssertion {
+  credentialId: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  signature: ArrayBuffer;
+}
+
+/** A software authenticator that answers the ceremonies of one app. */
+export interface TestAuthenticator {
+  /**
+   * Make a new ES256 credential. The authenticator keeps no state, thus the
+   * caller must hold the result to use the passkey again.
+   */
+  createCredential(): Promise<TestCredential>;
+  /** Answer a registration challenge with a new credential. */
+  attest(credential: TestCredential, challenge: ArrayBuffer): TestAttestation;
+  /** Answer an authentication challenge with an existing credential. */
+  assert(
+    credential: TestCredential,
+    challenge: ArrayBuffer,
+  ): Promise<TestAssertion>;
+}
+
+/**
+ * Make the software authenticator that drives the WebAuthn ceremonies of an
+ * app test. It signs with real WebCrypto keys, thus the provider runs its
+ * true parsing and signature verification against the bytes.
+ *
+ * Give it the same `rpId` and `origin` that the app gives
+ * `setupUsernamePasskey`. Both values are bound here because a ceremony that
+ * names another relying party fails verification with no other hint.
+ *
+ * @param options - The relying party ID and the origin of the app under test.
+ */
+export function createTestAuthenticator({
+  rpId,
+  origin,
+}: {
+  rpId: string;
+  origin: string;
+}): TestAuthenticator {
+  return {
+    createCredential: generateES256Credential,
+
+    attest(credential, challenge) {
+      return {
+        attestationObject: toArrayBuffer(
+          buildAttestationObject(buildAuthenticatorData({ rpId, credential })),
+        ),
+        clientDataJSON: toArrayBuffer(
+          buildClientDataJSON({ type: "webauthn.create", challenge, origin }),
+        ),
+      };
+    },
+
+    assert(credential, challenge) {
+      return buildAssertion(credential, challenge, { rpId, origin });
+    },
+  };
+}
+export default {
+  registerPasskeyProvider,
+  createTestAuthenticator,
+  schema,
+  modules,
+};


### PR DESCRIPTION
registerPasskeyProvider registers the passkey component and its nested
batch worker with a convex-test instance, like the sibling helpers do.
createTestAuthenticator makes a software authenticator that answers
both ceremonies with real WebCrypto signatures, bound to one rpId and
origin so a test cannot silently name the wrong relying party.

The react-passkey example gains a test that drives the tutorial code
end to end through api.auth.* and api.management.passkeys.*: sign-up,
sign-in, list scoping, the two-ceremony add flow, removal with a
different passkey, and the LAST_PASSKEY guard.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>