### PR TITLE
Fix an SSR token refresh race condition

### DIFF
--- a/packages/core/src/browser/sessionManager.test.ts
+++ b/packages/core/src/browser/sessionManager.test.ts
@@ -1,6 +1,10 @@
 import { makeFunctionReference } from "convex/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import type { SlimTokenBundle, TokenBundle } from "../lib/types.ts";
+import type {
+  RefreshResult,
+  SlimTokenBundle,
+  TokenBundle,
+} from "../lib/types.ts";
 import type {
   AmbientSignInClient,
   AuthSignInApi,
@@ -46,6 +50,27 @@ function bundle(n: number): TokenBundle {
   };
 }
 
+/** A `rotated` refresh outcome carrying `bundle(n)`. */
+function rotated(n: number): RefreshResult {
+  return { kind: "rotated", tokens: bundle(n) };
+}
+
+/**
+ * A `reused` outcome: a concurrent caller had already rotated the token we
+ * presented, so only an access token comes back.
+ */
+function reused(n: number): RefreshResult {
+  const { accessToken, accessTokenExpiresAt, refreshTokenExpiresAt, userId } =
+    bundle(n);
+  return {
+    kind: "reused",
+    accessToken,
+    accessTokenExpiresAt,
+    refreshTokenExpiresAt,
+    userId,
+  };
+}
+
 // `storage` is typed as the interface rather than the concrete default so the
 // async-store tests below can pass their own implementation.
 function makeClient(
@@ -55,7 +80,7 @@ function makeClient(
   const client = new AuthClient({
     mode: "spa",
     authApi: {
-      refreshSession: async () => null,
+      refreshSession: async () => ({ kind: "noSession" }),
       signOut: async () => {},
       ...authApi,
     },
@@ -128,7 +153,7 @@ describe("AuthClient", () => {
   });
 
   test("fetchAccessToken returns the cached token without forcing", async () => {
-    const refreshSession = vi.fn(async () => bundle(2));
+    const refreshSession = vi.fn(async () => rotated(2));
     const { client } = makeClient({ refreshSession });
     await client.init();
     await client.setSession(bundle(1));
@@ -141,7 +166,7 @@ describe("AuthClient", () => {
   test("forced fetch rotates the session via refreshSession", async () => {
     const refreshSession = vi.fn(async (rt: string) => {
       expect(rt).toBe("refresh-1");
-      return bundle(2);
+      return rotated(2);
     });
     const { client, storage } = makeClient({ refreshSession });
     await client.init();
@@ -155,9 +180,52 @@ describe("AuthClient", () => {
     );
   });
 
-  test("a null refresh clears the session", async () => {
+  test("a reused refresh takes the access token and keeps the stored refresh token", async () => {
+    const refreshSession = vi.fn(async () => reused(2));
+    const { client, storage } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    const token = await client.fetchAccessToken({ forceRefreshToken: true });
+
+    // A concurrent caller already rotated `refresh-1` and persisted the
+    // replacement. Clearing ours here would leave this client with no way to
+    // rotate, and it would expire silently at the next access-token expiry.
+    expect(token).toBe("access-2");
+    expect(storage.getItem(`${JWT_STORAGE_KEY}_${SUFFIX}`)).toBe("access-2");
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-1",
+    );
+    expect(client.getSnapshot()).toMatchObject({
+      isAuthenticated: true,
+      token: "access-2",
+    });
+  });
+
+  test("a reused refresh is not a sign-out", async () => {
+    // The next forced fetch must still reach the server with the stored token,
+    // rather than short-circuiting as if there were no session.
+    const refreshSession = vi
+      .fn<(rt: string) => Promise<RefreshResult>>()
+      .mockResolvedValueOnce(reused(2))
+      .mockResolvedValueOnce(rotated(3));
+    const { client, storage } = makeClient({ refreshSession });
+    await client.init();
+    await client.setSession(bundle(1));
+
+    await client.fetchAccessToken({ forceRefreshToken: true });
+    expect(await client.fetchAccessToken({ forceRefreshToken: true })).toBe(
+      "access-3",
+    );
+    expect(refreshSession).toHaveBeenNthCalledWith(2, "refresh-1");
+    expect(storage.getItem(`${REFRESH_TOKEN_STORAGE_KEY}_${SUFFIX}`)).toBe(
+      "refresh-3",
+    );
+  });
+
+  test("a noSession refresh result clears the session", async () => {
     const { client, storage } = makeClient({
-      refreshSession: async () => null,
+      refreshSession: async () => ({ kind: "noSession" }),
     });
     await client.init();
     await client.setSession(bundle(1));
@@ -175,7 +243,7 @@ describe("AuthClient", () => {
     const { promise, resolve } = Promise.withResolvers<void>();
     const refreshSession = vi.fn(async () => {
       await promise;
-      return bundle(2);
+      return rotated(2);
     });
     const { client } = makeClient({ refreshSession });
     await client.init();
@@ -364,7 +432,10 @@ function makeClientWithSignIns(
 ) {
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" }),
+      signOut: async () => {},
+    },
     storage,
     storageNamespace: NAMESPACE,
     ambientSignIns: { signIns, signInApi: SIGN_IN_API },
@@ -742,7 +813,7 @@ describe("AuthClient (async storage)", () => {
       // The rotated token must be read back out of the async store, not just
       // held in memory.
       expect(rt).toBe("refresh-1");
-      return bundle(2);
+      return rotated(2);
     });
     const storage = new AsyncTokenStorage();
     const { client } = makeClient({ refreshSession }, storage);

--- a/packages/core/src/browser/sessionManager.ts
+++ b/packages/core/src/browser/sessionManager.ts
@@ -1,4 +1,8 @@
-import type { SlimTokenBundle, TokenBundle } from "../lib/types.ts";
+import type {
+  RefreshResult,
+  SlimTokenBundle,
+  TokenBundle,
+} from "../lib/types.ts";
 import { KeyedStore, type SignInValuesReader } from "./keyedStore.ts";
 import { runWithMutex } from "./mutex.ts";
 import type {
@@ -17,12 +21,13 @@ import {
  * The refresh and sign-out API for a **SPA** client, where JS holds the
  * refresh token directly.
  *
- * Refreshing rotates the token and returns a full {@link TokenBundle}
- * (including the next refresh token to persist), or `null` when the session is
- * gone.
+ * Refreshing resolves to a {@link RefreshResult}: `rotated` carries the next
+ * refresh token to persist, `reused` means a concurrent caller had already
+ * rotated this one and only an access token comes back, and `noSession` means
+ * the session is gone.
  */
 export interface SpaAuthApi {
-  refreshSession: (refreshToken: string) => Promise<TokenBundle | null>;
+  refreshSession: (refreshToken: string) => Promise<RefreshResult>;
   signOut: (refreshToken: string) => Promise<void>;
 }
 
@@ -46,7 +51,7 @@ interface AuthClientConfigBase {
   /** Namespace for storage keys; typically the deployment URL. */
   storageNamespace: string;
   /**
-   * An access token to adopt on {@link AuthClient.init}, typically provided by
+   * An access token to store on {@link AuthClient.init}, typically provided by
    * an SSR host.
    */
   initialAccessToken?: string | null;
@@ -110,6 +115,24 @@ function hasRefreshToken(
 }
 
 /**
+ * A refresh outcome in the terms this client persists it, normalized across the
+ * two session models:
+ *
+ *  - `rotated`: a session to store whole. A full {@link TokenBundle} under SPA or
+ *    an access-only {@link SlimTokenBundle} under SSR where the host moved the
+ *    refresh token into the cookie.
+ *  - `reused`: a concurrent caller had already rotated the token we presented,
+ *    inside its grace window. Take the access token and leave the existing
+ *    stored refresh token alone. Only SPA sees this arm; under SSR the host
+ *    resolves a reuse itself and the browser gets an ordinary access-only reply.
+ *  - `noSession`: the session is gone; clear it.
+ */
+type RefreshOutcome =
+  | { kind: "rotated"; session: TokenBundle | SlimTokenBundle }
+  | { kind: "reused"; accessToken: string }
+  | { kind: "noSession" };
+
+/**
  * Returns the global `window` object when it supports DOM event listeners,
  * otherwise `null`.
  *
@@ -141,18 +164,20 @@ function domEventTarget(): Pick<
  * a token bundle.
  */
 export class AuthClient {
-  /**
-   * Rotate the session, resolving to the new bundle or `null` when the session
-   * is gone.
-   */
-  readonly #refresh: () => Promise<TokenBundle | SlimTokenBundle | null>;
+  /** Refresh the session, resolving to one of the {@link RefreshOutcome} arms. */
+  readonly #refresh: () => Promise<RefreshOutcome>;
   /** Revoke the session on the server. */
   readonly #signOutInternal: () => Promise<void>;
   readonly #storage: NamespacedStorage;
   readonly #verbose: boolean;
   readonly #lockKey: string;
   readonly #initialAccessToken: string | null;
-  /** Which side owns the refresh token. Enforced in {@link AuthClient.#adopt}. */
+  /**
+   * Which side owns the refresh token: this client (SPA) or an httpOnly cookie
+   * (SSR). Enforced in {@link AuthClient.#storeFullTokenResult}, and decides in
+   * {@link AuthClient.#storeAccessOnly} whether a stored refresh token is ours
+   * to keep when only an access token comes back.
+   */
   readonly #mode: "spa" | "ssr";
 
   #accessToken: string | null = null;
@@ -185,8 +210,16 @@ export class AuthClient {
       this.#refresh = async () => {
         const refreshToken = await this.#currentRefreshToken();
         // No token means there's no session to refresh — don't call the API.
-        if (refreshToken === null) return null;
-        return authApi.refreshSession(refreshToken);
+        if (refreshToken === null) return { kind: "noSession" };
+        const result = await authApi.refreshSession(refreshToken);
+        switch (result.kind) {
+          case "rotated":
+            return { kind: "rotated", session: result.tokens };
+          case "reused":
+            return { kind: "reused", accessToken: result.accessToken };
+          case "noSession":
+            return { kind: "noSession" };
+        }
       };
       this.#signOutInternal = async () => {
         const refreshToken = await this.#currentRefreshToken();
@@ -195,8 +228,15 @@ export class AuthClient {
     } else {
       const { authApi } = config;
       // The refresh token is in an httpOnly cookie that the API reads
-      // server-side, so it isn't passed directly.
-      this.#refresh = () => authApi.refreshSession();
+      // server-side, so it isn't passed directly. The host collapses a rotation
+      // and a grace-window reuse into the same access-only reply, having already
+      // written whichever cookies each case calls for.
+      this.#refresh = async () => {
+        const session = await authApi.refreshSession();
+        return session === null
+          ? { kind: "noSession" }
+          : { kind: "rotated", session };
+      };
       this.#signOutInternal = () => authApi.signOut();
     }
 
@@ -360,7 +400,7 @@ export class AuthClient {
   setSession = async (
     session: TokenBundle | SlimTokenBundle,
   ): Promise<void> => {
-    await this.#adopt(session);
+    await this.#storeFullTokenResult(session);
   };
 
   /**
@@ -421,7 +461,7 @@ export class AuthClient {
         () => this.#refresh(),
         (message) => this.#log(`refresh: ${message}`),
       );
-      await this.#adopt(result);
+      await this.#handleRefresh(result);
       return this.#accessToken;
     });
   };
@@ -436,12 +476,35 @@ export class AuthClient {
   }
 
   /**
-   * Adopt a sign-in or refresh result, persisting it by its shape:
+   * Persist the outcome of a refresh.
+   *
+   * This either extends/updates the signed in state via new tokens or
+   * transitions the client to signed out.
+   */
+  async #handleRefresh(result: RefreshOutcome): Promise<void> {
+    switch (result.kind) {
+      case "noSession":
+        await this.#storeTokens(null);
+        return;
+      case "rotated":
+        await this.#storeFullTokenResult(result.session);
+        return;
+      case "reused":
+        this.#log("refresh reused a concurrently rotated token");
+        await this.#storeAccessOnly(result);
+        return;
+    }
+  }
+
+  /**
+   * Store the tokens for a sign-in or refresh result, persisting it by its shape:
    *  - a full {@link TokenBundle} stores both refresh and access tokens
    *  - a {@link SlimTokenBundle} stores just the access token
    *  - `null` clears the session
    */
-  async #adopt(result: TokenBundle | SlimTokenBundle | null): Promise<void> {
+  async #storeFullTokenResult(
+    result: TokenBundle | SlimTokenBundle | null,
+  ): Promise<void> {
     if (result === null) {
       await this.#storeTokens(null);
       return;
@@ -496,13 +559,19 @@ export class AuthClient {
 
   /**
    * Stores just the access token and notifies subscribers.
+   *
+   * Any stored refresh token is left in place when this client owns one (SPA),
+   * since the only way to get here in that mode is a grace-window reuse, where
+   * the stored token is the live replacement a concurrent caller persisted.
    */
-  async #storeAccessOnly(session: SlimTokenBundle): Promise<void> {
-    // Null out/remove any existing refresh token. It shouldn't be set unless
-    // this was somehow a client instance configured for SPA use being
-    // "upgraded" to SSR use.
-    this.#refreshToken = null;
-    await this.#storage.remove(REFRESH_TOKEN_STORAGE_KEY);
+  async #storeAccessOnly(session: { accessToken: string }): Promise<void> {
+    if (this.#mode === "ssr") {
+      // Null out/remove any existing refresh token. It shouldn't be set unless
+      // this was somehow a client instance configured for SPA use being
+      // "upgraded" to SSR use.
+      this.#refreshToken = null;
+      await this.#storage.remove(REFRESH_TOKEN_STORAGE_KEY);
+    }
 
     this.#accessToken = session.accessToken;
     await this.#storage.set(JWT_STORAGE_KEY, session.accessToken);

--- a/packages/core/src/components/anonymous/react.test.tsx
+++ b/packages/core/src/components/anonymous/react.test.tsx
@@ -31,7 +31,10 @@ const signInAnonymous = {} as SignInAnonymousMutation;
 function renderAnonymousAuth() {
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,
   });

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -40,13 +40,24 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           refreshToken: string;
           refreshTokenTtlSeconds?: number;
         },
-        {
-          accessToken: string;
-          accessTokenExpiresAt: number;
-          refreshToken: string;
-          refreshTokenExpiresAt: number;
-          userId: string;
-        } | null,
+        | {
+            kind: "rotated";
+            tokens: {
+              accessToken: string;
+              accessTokenExpiresAt: number;
+              refreshToken: string;
+              refreshTokenExpiresAt: number;
+              userId: string;
+            };
+          }
+        | {
+            kind: "reused";
+            accessToken: string;
+            accessTokenExpiresAt: number;
+            refreshTokenExpiresAt: number;
+            userId: string;
+          }
+        | { kind: "noSession" },
         Name
       >;
       signIn: FunctionReference<

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -51,9 +51,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             };
           }
         | {
-            kind: "reused";
             accessToken: string;
             accessTokenExpiresAt: number;
+            kind: "reused";
             refreshTokenExpiresAt: number;
             userId: string;
           }

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   type AuthClaims,
   type TokenBundle,
+  type RefreshResult,
   USE_USER_ID_AS_ACCOUNT_ID,
 } from "../../lib/types.ts";
 import { sha256Hex } from "../../lib/crypto.ts";
@@ -90,10 +91,21 @@ async function signIn(t: ConvexTestApi, c: AuthClaims) {
   });
 }
 
-/** Assert a refresh succeeded (a session was minted) and narrow away `null`. */
-function expectBundle(bundle: TokenBundle | null): TokenBundle {
-  expect(bundle).not.toBeNull();
-  return bundle as TokenBundle;
+/** Assert a refresh rotated the token, and narrow to the new bundle. */
+function expectRotated(result: RefreshResult): TokenBundle {
+  expect(result.kind).toBe("rotated");
+  return (result as Extract<RefreshResult, { kind: "rotated" }>).tokens;
+}
+
+/**
+ * Assert a refresh resolved through the grace window without rotating, and
+ * narrow to the access-only session.
+ */
+function expectReused(
+  result: RefreshResult,
+): Extract<RefreshResult, { kind: "reused" }> {
+  expect(result.kind).toBe("reused");
+  return result as Extract<RefreshResult, { kind: "reused" }>;
 }
 
 /** Exchange a refresh token, as a client rotating its session does. */
@@ -387,47 +399,69 @@ describe("refresh", () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
-    const rotated = expectBundle(
-      await t.mutation(api.public.refresh, {
-        refreshToken: bundle.refreshToken,
-        issuer: ISSUER,
-      }),
-    );
+    const rotated = expectRotated(await refresh(t, bundle.refreshToken));
     expect(rotated.refreshToken).not.toBe(bundle.refreshToken);
     expect(rotated.userId).toBe(bundle.userId);
 
     // The newly minted refresh token works for the next rotation.
-    const again = expectBundle(
-      await t.mutation(api.public.refresh, {
-        refreshToken: rotated.refreshToken,
-        issuer: ISSUER,
-      }),
-    );
+    const again = expectRotated(await refresh(t, rotated.refreshToken));
     expect(again.refreshToken).not.toBe(rotated.refreshToken);
   });
 
-  test("honors the grace window for a just-rotated token (concurrent refresh)", async () => {
+  test("a just-rotated token resolves via the grace window without rotating again", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
-    await t.mutation(api.public.refresh, {
-      refreshToken: bundle.refreshToken,
-      issuer: ISSUER,
-    });
+    await refresh(t, bundle.refreshToken);
 
     // A second refresh presenting the ORIGINAL (now previous) token still
-    // resolves via the grace window rather than being rejected.
-    const viaGrace = expectBundle(
-      await t.mutation(api.public.refresh, {
-        refreshToken: bundle.refreshToken,
-        issuer: ISSUER,
-      }),
-    );
-    expect(viaGrace.refreshToken).toBeTruthy();
+    // resolves via the grace window rather than being rejected — but reports
+    // `reused` and mints only an access token.
+    const viaGrace = expectReused(await refresh(t, bundle.refreshToken));
+    expect(viaGrace.accessToken).toBeTruthy();
     expect(viaGrace.userId).toBe(bundle.userId);
+    expect(viaGrace).not.toHaveProperty("refreshToken");
   });
 
-  test("returns null and clears the session once the refresh token has expired", async () => {
+  test("a grace-window refresh leaves the winner's token current", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+
+    // The caller that wins the race rotates and is handed the replacement.
+    const winner = expectRotated(await refresh(t, bundle.refreshToken));
+    const hashAfterWin = await currentHash(t);
+    const spentAfterWin = await spentHashes(t);
+
+    // The straggler presents the token the winner already spent.
+    expectReused(await refresh(t, bundle.refreshToken));
+
+    // Rotating here would spend the winner's brand-new token, and the winner
+    // would be signed out — as suspected theft — once it left the grace window.
+    // So the grace arm must write nothing at all.
+    expect(await currentHash(t)).toBe(hashAfterWin);
+    expect(await spentHashes(t)).toEqual(spentAfterWin);
+
+    // The winner's token is still the live one.
+    expectRotated(await refresh(t, winner.refreshToken));
+  });
+
+  test("every racer sharing one token succeeds, and exactly one rotates", async () => {
+    const t = setup();
+    const bundle = await signUp(t, claims());
+
+    const kinds: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      kinds.push((await refresh(t, bundle.refreshToken)).kind);
+    }
+
+    // Nobody is signed out, and the chain forks nowhere: one rotation, and one
+    // spent hash to show for it.
+    expect(kinds).toEqual(["rotated", "reused", "reused", "reused", "reused"]);
+    expect(await sessionCount(t)).toBe(1);
+    expect(await spentHashes(t)).toHaveLength(1);
+  });
+
+  test("reports no session and clears it once the refresh token has expired", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
@@ -439,38 +473,29 @@ describe("refresh", () => {
       });
     });
 
-    const result = await t.mutation(api.public.refresh, {
-      refreshToken: bundle.refreshToken,
-      issuer: ISSUER,
-    });
-    expect(result).toBeNull();
+    const result = await refresh(t, bundle.refreshToken);
+    expect(result.kind).toBe("noSession");
 
     // The dead session was removed in the same transaction.
-    const remaining = await t.run(
-      async (ctx) => (await ctx.db.query("sessions").collect()).length,
-    );
-    expect(remaining).toBe(0);
+    expect(await sessionCount(t)).toBe(0);
   });
 
-  test("returns null for an unknown refresh token", async () => {
+  test("reports no session for an unknown refresh token", async () => {
     const t = setup();
-    const result = await t.mutation(api.public.refresh, {
-      refreshToken: "not-a-real-token",
-      issuer: ISSUER,
-    });
-    expect(result).toBeNull();
+    const result = await refresh(t, "not-a-real-token");
+    expect(result.kind).toBe("noSession");
   });
 
   test("an unknown token revokes nothing", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
-    expect(await refresh(t, "not-a-real-token")).toBeNull();
+    expect((await refresh(t, "not-a-real-token")).kind).toBe("noSession");
 
     // Revoking on an unrecognized token would let anyone sign anyone else out
     // by presenting a made-up string. The live session is untouched.
     expect(await sessionCount(t)).toBe(1);
-    expect(expectBundle(await refresh(t, bundle.refreshToken))).toBeTruthy();
+    expect(expectRotated(await refresh(t, bundle.refreshToken))).toBeTruthy();
   });
 
   test("retires the rotated-away hash and never the current one", async () => {
@@ -478,13 +503,13 @@ describe("refresh", () => {
     const bundle = await signUp(t, claims());
 
     const first = await currentHash(t);
-    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    const rotated = expectRotated(await refresh(t, bundle.refreshToken));
     const second = await currentHash(t);
 
     expect(second).not.toBe(first);
     expect(await spentHashes(t)).toEqual([first]);
 
-    expectBundle(await refresh(t, rotated.refreshToken));
+    expectRotated(await refresh(t, rotated.refreshToken));
     // One spent hash per rotation, and the live token is never among them.
     expect(await spentHashes(t)).toEqual([first, second]);
     expect(await spentHashes(t)).not.toContain(await currentHash(t));
@@ -507,18 +532,18 @@ describe("refresh-token reuse detection", () => {
     const stolen = await signUp(t, claims());
 
     // The thief gets there first, so the session's live token is now theirs.
-    const thief = expectBundle(await refresh(t, stolen.refreshToken));
+    const thief = expectRotated(await refresh(t, stolen.refreshToken));
     vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
 
     // The victim presents the token they still hold. It was rotated away too
     // long ago to be a concurrent refresh, so the session dies.
-    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect((await refresh(t, stolen.refreshToken)).kind).toBe("noSession");
     expect(await sessionCount(t)).toBe(0);
     expect(await spentHashes(t)).toEqual([]);
 
     // Revocation is mutual: the thief's token stops working too, which is the
     // whole point — otherwise they keep renewing the session forever.
-    expect(await refresh(t, thief.refreshToken)).toBeNull();
+    expect((await refresh(t, thief.refreshToken)).kind).toBe("noSession");
   });
 
   test("detects a replay several rotations back", async () => {
@@ -529,58 +554,58 @@ describe("refresh-token reuse detection", () => {
     // fixed-size history. Retention is by age, so depth doesn't save them.
     let latest = stolen;
     for (let i = 0; i < 5; i++) {
-      latest = expectBundle(await refresh(t, latest.refreshToken));
+      latest = expectRotated(await refresh(t, latest.refreshToken));
     }
     expect(await spentHashes(t)).toHaveLength(5);
     vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
 
-    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect((await refresh(t, stolen.refreshToken)).kind).toBe("noSession");
     expect(await sessionCount(t)).toBe(0);
-    expect(await refresh(t, latest.refreshToken)).toBeNull();
+    expect((await refresh(t, latest.refreshToken)).kind).toBe("noSession");
   });
 
   test("a replay inside the grace window is still a concurrent refresh", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
 
-    expectBundle(await refresh(t, bundle.refreshToken));
+    expectRotated(await refresh(t, bundle.refreshToken));
     vi.advanceTimersByTime(REFRESH_GRACE_MS - 1_000);
 
     // Two tabs sharing a cookie land here routinely; it must not be mistaken
     // for theft.
-    expect(expectBundle(await refresh(t, bundle.refreshToken))).toBeTruthy();
+    expectReused(await refresh(t, bundle.refreshToken));
     expect(await sessionCount(t)).toBe(1);
   });
 
   test("a replay after the session is already gone is a no-op", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
-    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    const rotated = expectRotated(await refresh(t, bundle.refreshToken));
     await t.mutation(api.public.signOut, {
       refreshToken: rotated.refreshToken,
     });
     vi.advanceTimersByTime(REFRESH_GRACE_MS + 1);
 
     // Two replays racing each other both resolve a session the other deleted.
-    await expect(refresh(t, bundle.refreshToken)).resolves.toBeNull();
+    expect((await refresh(t, bundle.refreshToken)).kind).toBe("noSession");
   });
 
   test("pruning retires spent hashes, and with them the detection", async () => {
     const t = setup();
     const stolen = await signUp(t, claims());
-    const live = expectBundle(await refresh(t, stolen.refreshToken));
+    const live = expectRotated(await refresh(t, stolen.refreshToken));
     expect(await spentHashes(t)).toHaveLength(1);
 
     vi.advanceTimersByTime(SPENT_TOKEN_HORIZON_MS + 1);
     // The next rotation pays for the row it adds by erasing the expired one.
-    const next = expectBundle(await refresh(t, live.refreshToken));
+    const next = expectRotated(await refresh(t, live.refreshToken));
     expect(await spentHashes(t)).toEqual([await sha256Hex(live.refreshToken)]);
 
     // Past the horizon the stolen token is merely unknown, so it revokes
     // nothing. Detection is best-effort by construction.
-    expect(await refresh(t, stolen.refreshToken)).toBeNull();
+    expect((await refresh(t, stolen.refreshToken)).kind).toBe("noSession");
     expect(await sessionCount(t)).toBe(1);
-    expectBundle(await refresh(t, next.refreshToken));
+    expectRotated(await refresh(t, next.refreshToken));
   });
 
   test("the detection horizon outlives the grace window", () => {
@@ -604,17 +629,13 @@ describe("signOut", () => {
     expect(remaining).toBe(0);
 
     // Refreshing the signed-out session is no longer possible.
-    const afterSignOut = await t.mutation(api.public.refresh, {
-      refreshToken: bundle.refreshToken,
-      issuer: ISSUER,
-    });
-    expect(afterSignOut).toBeNull();
+    expect((await refresh(t, bundle.refreshToken)).kind).toBe("noSession");
   });
 
   test("revokes when given a token a refresh just rotated away", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
-    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    const rotated = expectRotated(await refresh(t, bundle.refreshToken));
 
     // A tab that signs out just after a sibling refreshed presents the token
     // it still holds. Matching only the current hash would no-op here and
@@ -623,13 +644,13 @@ describe("signOut", () => {
 
     expect(await sessionCount(t)).toBe(0);
     expect(await spentHashes(t)).toEqual([]);
-    expect(await refresh(t, rotated.refreshToken)).toBeNull();
+    expect((await refresh(t, rotated.refreshToken)).kind).toBe("noSession");
   });
 
   test("erases the session's spent hashes along with it", async () => {
     const t = setup();
     const bundle = await signUp(t, claims());
-    const rotated = expectBundle(await refresh(t, bundle.refreshToken));
+    const rotated = expectRotated(await refresh(t, bundle.refreshToken));
     expect(await spentHashes(t)).toHaveLength(1);
 
     await t.mutation(api.public.signOut, {
@@ -690,7 +711,7 @@ describe("token lifetime configuration", () => {
     );
 
     // The rotated token gets the configured lifetime too.
-    const rotated = expectBundle(
+    const rotated = expectRotated(
       await t.mutation(api.public.refresh, {
         refreshToken: bundle.refreshToken,
         issuer: ISSUER,

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -13,6 +13,8 @@ import {
   type AuthClaims,
   vTokenBundle,
   type TokenBundle,
+  vRefreshResult,
+  type RefreshResult,
   USE_USER_ID_AS_ACCOUNT_ID,
 } from "../../lib/types.ts";
 import { signJwt, generateRefreshToken } from "./crypto.ts";
@@ -587,15 +589,34 @@ async function sessionBySpentHash(
 }
 
 /**
- * Rotate a refresh token and mint a fresh access token.
+ * Exchange a refresh token for a fresh access token, rotating when the
+ * presented token is the session's current one.
  *
- * Returns `null` when the session can't be refreshed.
+ * The outcomes are the arms of {@link vRefreshResult}:
  *
- * That can happen with an unknown token, one past its refresh-token lifetime,
- * or a previously used token past the grace refresh window.
+ *  * `rotated`: the token was current. It is spent, a replacement is minted,
+ *    and the caller persists both tokens.
+ *  * `reused`: a concurrent caller had already rotated this token, and it is
+ *    still inside `REFRESH_GRACE_MS`. A fresh access token is minted
+ *    *but not a new refresh token* (more on this below).
+ *  * `noSession`: unknown token, one past its refresh-token lifetime, or a
+ *    spent token past the grace window (which also revokes the session).
+ *    The client must reflect this as being signed out.
  *
- * A dead session is a normal outcome the caller should handle by updating its
- * authenticated state.
+ * Here's why the `reused` outcome doesn't rotate or include a refresh token.
+ *
+ * If two refresh requests race with the same refresh token, and we rotated for
+ * both of them, the "winner" of the race would have their newly rotated token
+ * immediately marked as spent when the "loser" has their token also rotated.
+ * If the HTTP response to the "winner's" request came in after the "loser",
+ * that spent refresh token would be stored on the client (last writer "wins").
+ * A later attempt to refresh with that stored (and spent) token wouldn't look
+ * any different than a client presenting a stolen/leaked refresh token, and
+ * the session would be ended as a safety measure.
+ *
+ * Since we don't rotate, the loser of the refresh race above won't get a new
+ * refresh token but will be told to reuse whatever token already exists (the
+ * one issued to the winner).
  */
 export const refresh = mutation({
   args: {
@@ -604,8 +625,8 @@ export const refresh = mutation({
     accessTokenTtlSeconds: v.optional(v.number()),
     refreshTokenTtlSeconds: v.optional(v.number()),
   },
-  returns: v.union(vTokenBundle, v.null()),
-  handler: async (ctx, args): Promise<TokenBundle | null> => {
+  returns: vRefreshResult,
+  handler: async (ctx, args): Promise<RefreshResult> => {
     // Resolve the TTL config well before use below - it does some validation
     // of the config that will throw if invalid, and that should be
     // unconditional.
@@ -613,11 +634,15 @@ export const refresh = mutation({
 
     const hash = await sha256Hex(args.refreshToken);
     let { session, isValid } = await sessionByHash(ctx, hash);
+    // Whether the presented token was already rotated away by a concurrent
+    // caller, which is what separates a rotation from a grace-window reuse.
+    let isSpent = false;
     if (session === null) {
       // This is not the current refresh token - it might still be valid for refresh though.
+      isSpent = true;
       ({ session, isValid } = await sessionBySpentHash(ctx, hash));
     }
-    if (session === null) return null;
+    if (session === null) return { kind: "noSession" };
     if (!isValid) {
       // Past its refresh-token lifetime or a spent token past the grace
       // window: delete the session and grant no more tokens.
@@ -626,11 +651,33 @@ export const refresh = mutation({
           "This could be due to a bug or a leaked refresh token.",
       );
       await deleteSession(ctx, session._id);
-      return null;
+      return { kind: "noSession" };
+    }
+
+    if (isSpent) {
+      // Deliberately no writes: no spent-token insert, no session patch, not
+      // even `lastRefreshedAt`. See the note above.
+      const access = await mintAccessToken(
+        session.userId,
+        args.issuer,
+        ttl.accessTokenTtlSeconds,
+      );
+      return {
+        kind: "reused",
+        accessToken: access.token,
+        accessTokenExpiresAt: access.expiresAt,
+        // The winner's rotation already extended this; carry it so a caller
+        // storing the access token in a cookie gives it a rotation's lifetime.
+        refreshTokenExpiresAt: session.refreshTokenExpiresAt,
+        userId: session.userId,
+      };
     }
 
     const now = Date.now();
-    return await rotateSession(ctx, session, now, args.issuer, ttl);
+    return {
+      kind: "rotated",
+      tokens: await rotateSession(ctx, session, now, args.issuer, ttl),
+    };
   },
 });
 

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -14,8 +14,9 @@ import {
 import { ObjectType, PropertyValidators, v, Validator } from "convex/values";
 import type { ComponentApi } from "./_generated/component.ts";
 import {
-  vTokenBundle,
   type TokenBundle,
+  vRefreshResult,
+  type RefreshResult,
   type ConvexAuthCtx,
   type UserCallbacks,
 } from "../../lib/types.ts";
@@ -98,18 +99,19 @@ export type AuthCore<UsersTable extends string = string> = {
     Promise<null>
   >;
   /**
-   * Refreshes a session using the given token, rotating the refresh token.
+   * Refreshes a session using the given token, rotating the refresh token when
+   * the presented one is current.
    *
-   * A successful refresh returns a new token bundle. A failed refresh (an
-   * unknown or expired token) returns `null` and leaves no usable session
-   * behind (an expired session is deleted as part of the same call). Callers,
-   * including the client, should treat a `null` result as signed-out and clear
-   * any stored session.
+   * Resolves to one of the {@link RefreshResult} outcomes. `rotated` carries a
+   * new token bundle to persist. `reused` means a concurrent caller had already
+   * rotated this token within its grace window: take the access token and keep
+   * the refresh token already in storage, since the winner's response carries
+   * the replacement. A `noSession` result should be treated as signed-out.
    */
   refreshSession: RegisteredMutation<
     "public",
     { refreshToken: string },
-    Promise<TokenBundle | null>
+    Promise<RefreshResult>
   >;
   /**
    * Reports whether the caller's access token identifies a signed-in user.
@@ -229,8 +231,8 @@ export function setupCore<UsersTable extends string = "users">(options: {
 
   const refreshSession = mutationGeneric({
     args: { refreshToken: v.string() },
-    returns: v.union(vTokenBundle, v.null()),
-    handler: async (ctx, args): Promise<TokenBundle | null> => {
+    returns: vRefreshResult,
+    handler: async (ctx, args): Promise<RefreshResult> => {
       return await ctx.runMutation(component.public.refresh, {
         refreshToken: args.refreshToken,
         issuer: issuer(),

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -150,7 +150,10 @@ afterEach(() => {
 function makeWrapper() {
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,
   });

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -60,7 +60,10 @@ const flows = [
 function renderFlow(useFlow: () => Flow) {
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,
   });

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -60,9 +60,12 @@ export type SlimTokenBundle = {
 
 /**
  * Strip down a {@link TokenBundle} down to a {@link SlimTokenBundle},
- * dropping the refresh token so it is never sent to the browser.
+ * dropping the refresh token so it is never sent to the browser. Also accepts a
+ * {@link ReusedSession}, which has no refresh token to drop.
  */
-export function makeSlimBundle(bundle: TokenBundle): SlimTokenBundle {
+export function makeSlimBundle(
+  bundle: TokenBundle | ReusedSession,
+): SlimTokenBundle {
   return {
     accessToken: bundle.accessToken,
     accessTokenExpiresAt: bundle.accessTokenExpiresAt,
@@ -101,13 +104,48 @@ export type ClientView<T> = T extends { tokens: TokenBundle }
   ? Omit<T, "tokens"> & { tokens: SlimTokenBundle }
   : T;
 
-/** The app's `refreshSession` mutation reference: exchange a refresh token for a
- * fresh {@link TokenBundle}, or `null` when the session is gone. */
+/**
+ * A session whose refresh token a concurrent caller had already rotated:
+ * everything a {@link TokenBundle} carries except the refresh token.
+ *
+ * There cannot be a refresh token here, since the current one is persisted only
+ * as a hash. `refreshTokenExpiresAt` is not secret and is carried so a caller
+ * storing the access token in a cookie can give it a rotation's lifetime.
+ */
+export type ReusedSession = Omit<TokenBundle, "refreshToken">;
+
+/**
+ * The result of refreshing a session. The `kind` will be one of:
+ *
+ *  * `rotated`: the presented token was current and has been exchanged for the
+ *    bundle in `tokens`. Persist both tokens.
+ *  * `reused`: a concurrent caller had already rotated the presented token,
+ *    which is still inside its grace window. Take the access token and treat a
+ *    previously stored refresh token as current.
+ *  * `noSession`: the token is unknown, or was rotated too long ago to honor.
+ *    Clear any stored session, treat it as signed out.
+ */
+export const vRefreshResult = v.union(
+  v.object({ kind: v.literal("rotated"), tokens: vTokenBundle }),
+  v.object({
+    kind: v.literal("reused"),
+    accessToken: v.string(),
+    accessTokenExpiresAt: v.number(),
+    refreshTokenExpiresAt: v.number(),
+    userId: v.string(),
+  }),
+  v.object({ kind: v.literal("noSession") }),
+);
+
+export type RefreshResult = Infer<typeof vRefreshResult>;
+
+/** The app's `refreshSession` mutation reference: exchange a refresh token for
+ * a fresh session. See {@link vRefreshResult} for the outcomes. */
 export type RefreshSessionFn = FunctionReference<
   "mutation",
   "public",
   { refreshToken: string },
-  TokenBundle | null
+  RefreshResult
 >;
 
 /** The app's `signOut` mutation reference: revoke the session for a refresh

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -42,7 +42,7 @@ describe("OAuth client", () => {
         new AuthClient({
           mode: "spa",
           authApi: {
-            refreshSession: async () => null,
+            refreshSession: async () => ({ kind: "noSession" as const }),
             signOut: async () => {},
           },
           storage: new InMemoryStorage(),

--- a/packages/core/src/oauth/react.test.tsx
+++ b/packages/core/src/oauth/react.test.tsx
@@ -108,7 +108,10 @@ describe("OAuth React client", () => {
   test("the hooks throw when oauth() is not registered", () => {
     const client = new AuthClient({
       mode: "spa",
-      authApi: { refreshSession: async () => null, signOut: async () => {} },
+      authApi: {
+        refreshSession: async () => ({ kind: "noSession" as const }),
+        signOut: async () => {},
+      },
       storage: new InMemoryStorage(),
       storageNamespace: NAMESPACE,
     });

--- a/packages/core/src/oauth/testFlow.ts
+++ b/packages/core/src/oauth/testFlow.ts
@@ -95,7 +95,10 @@ export function oauthClient(storage: TokenStorage): {
   const signInApi = { mutation, action: vi.fn() } as unknown as AuthSignInApi;
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage,
     storageNamespace: NAMESPACE,
     ambientSignIns: { signIns: [oauth()], signInApi },

--- a/packages/core/src/react/client.test.tsx
+++ b/packages/core/src/react/client.test.tsx
@@ -34,7 +34,7 @@ function makeClient(
   const client = new AuthClient({
     mode: "spa",
     authApi: {
-      refreshSession: async () => null,
+      refreshSession: async () => ({ kind: "noSession" as const }),
       signOut: async () => {},
       ...authApi,
     },

--- a/packages/core/src/react/providers.test.tsx
+++ b/packages/core/src/react/providers.test.tsx
@@ -14,7 +14,10 @@ const NAMESPACE = "https://happy-animal-123.convex.cloud";
 function makeClient() {
   return new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,
   });
@@ -28,7 +31,10 @@ function makeProbeClient() {
   const probe: { values?: SignInValues } = {};
   const client = new AuthClient({
     mode: "spa",
-    authApi: { refreshSession: async () => null, signOut: async () => {} },
+    authApi: {
+      refreshSession: async () => ({ kind: "noSession" as const }),
+      signOut: async () => {},
+    },
     storage: new InMemoryStorage(),
     storageNamespace: NAMESPACE,
     ambientSignIns: {

--- a/packages/core/src/server/cookies.ts
+++ b/packages/core/src/server/cookies.ts
@@ -16,7 +16,7 @@ import {
   JWT_STORAGE_KEY,
   REFRESH_TOKEN_STORAGE_KEY,
 } from "../browser/storage.ts";
-import type { TokenBundle } from "../lib/types.ts";
+import type { ReusedSession, TokenBundle } from "../lib/types.ts";
 
 /** The cookie holding the current access token (a JWT). */
 export const AUTH_JWT_COOKIE = JWT_STORAGE_KEY;
@@ -106,37 +106,67 @@ function invariantCookieOptions(): Omit<CookieOptions, "secure"> {
 }
 
 /**
+ * The attributes an auth cookie is written with: the invariant ones merged under
+ * the deployment-specific ones, and a lifetime taken from the refresh token's
+ * expiry. Both cookies live that long; the access token expires sooner and gets
+ * refreshed via {@link ServerAuthSession.getToken}.
+ */
+function authCookieOptions(
+  refreshTokenExpiresAt: number,
+  options: AuthCookieOptions,
+): CookieOptions {
+  // Pick the allowed fields rather than spreading, so a wider object
+  // (e.g. from untyped JS) cannot override the invariant attributes.
+  return {
+    ...invariantCookieOptions(),
+    path: options.path ?? "/",
+    domain: options.domain,
+    secure: options.secure,
+    expires: new Date(refreshTokenExpiresAt),
+  };
+}
+
+/**
  * Write the tokens in a `bundle` as cookies.
  *
- * The access token is stored in in {@link AUTH_JWT_COOKIE} and the refresh
- * token in {@link AUTH_REFRESH_COOKIE}. Both live as long as the refresh
- * token, although the access token will likely expire sooner and need to be
- * refreshed). The invariant attributes (httpOnly etc.) are merged in, so the
- * refresh cookie is httpOnly and never reaches client JS.
+ * The access token is stored in {@link AUTH_JWT_COOKIE} and the refresh token
+ * in {@link AUTH_REFRESH_COOKIE}. The invariant attributes (httpOnly etc.) are
+ * merged in, so the refresh cookie is httpOnly and never reaches client JS.
  *
- * This is the one place that knows which cookies hold a session and how their
- * lifetimes derive from the bundle, so refresh, the proxy, and every provider's
- * sign-in handler shape cookies identically.
+ * This is the one place that knows which cookies hold a session, so refresh,
+ * the proxy, and every provider's sign-in handler shape writes cookies
+ * identically.
  */
 export async function writeAuthCookies(
   cookies: CookieStore,
   bundle: TokenBundle,
   options: AuthCookieOptions,
 ): Promise<void> {
-  // Pick the allowed fields rather than spreading, so a wider object
-  // (e.g. from untyped JS) cannot override the invariant attributes.
-  const base = {
-    ...invariantCookieOptions(),
-    path: options.path ?? "/",
-    domain: options.domain,
-    secure: options.secure,
-  };
-  const expires = new Date(bundle.refreshTokenExpiresAt);
-  await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, { ...base, expires });
-  await cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, {
-    ...base,
-    expires,
-  });
+  const attributes = authCookieOptions(bundle.refreshTokenExpiresAt, options);
+  await cookies.set(AUTH_JWT_COOKIE, bundle.accessToken, attributes);
+  await cookies.set(AUTH_REFRESH_COOKIE, bundle.refreshToken, attributes);
+}
+
+/**
+ * Write only the access-token cookie, leaving {@link AUTH_REFRESH_COOKIE} as it
+ * was.
+ *
+ * For the `reused` outcome of a refresh, where a prior concurrent caller's
+ * response carries the replacement refresh token: writing one here would race
+ * it, and could leave the browser holding a token about to fall out of its
+ * grace window. The access token is still written, since for an SSR host the
+ * cookie is the only channel from a request-level refresh to the render.
+ */
+export async function writeAccessCookie(
+  cookies: CookieStore,
+  session: ReusedSession,
+  options: AuthCookieOptions,
+): Promise<void> {
+  await cookies.set(
+    AUTH_JWT_COOKIE,
+    session.accessToken,
+    authCookieOptions(session.refreshTokenExpiresAt, options),
+  );
 }
 
 /**

--- a/packages/core/src/server/handlers.test.ts
+++ b/packages/core/src/server/handlers.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => mutationMock.mockReset());
 describe("refreshHandler", () => {
   test("rotates the session and returns access-only tokens", async () => {
     // Set up the refresh mutation to return new tokens.
-    mutationMock.mockResolvedValue(bundle(2));
+    mutationMock.mockResolvedValue({ kind: "rotated", tokens: bundle(2) });
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
       refreshSession: fnRef,
@@ -79,6 +79,41 @@ describe("refreshHandler", () => {
     expect(refresh).toContain("HttpOnly");
   });
 
+  test("a reused refresh replies like a rotation but writes only the JWT cookie", async () => {
+    // A concurrent caller had already rotated this token inside its grace
+    // window, so only an access token comes back.
+    const { refreshToken: _, ...reused } = bundle(2);
+    mutationMock.mockResolvedValue({ kind: "reused", ...reused });
+    const handler = refreshHandler({
+      convexUrl: "https://x.convex.cloud",
+      refreshSession: fnRef,
+      cookieOptions: { secure: false },
+    });
+
+    const res = await handler(requestWithRefresh("refresh-1"));
+    expect(res.status).toBe(200);
+
+    // Indistinguishable from a rotation to the browser, which never sees a
+    // refresh token under SSR and so has nothing to do differently.
+    expect(await res.json()).toEqual({
+      tokens: {
+        accessToken: "access-2",
+        accessTokenExpiresAt: 1_000,
+        userId: "user-1",
+      },
+    });
+
+    // The winning caller's response carries the replacement refresh token;
+    // writing one here would race it.
+    const setCookies = res.headers.getSetCookie();
+    expect(
+      setCookies.find((c) => c.startsWith(`${AUTH_JWT_COOKIE}=`)),
+    ).toContain("access-2");
+    expect(
+      setCookies.some((c) => c.startsWith(`${AUTH_REFRESH_COOKIE}=`)),
+    ).toBe(false);
+  });
+
   test("with no refresh cookie replies 401 without calling Convex", async () => {
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
@@ -93,8 +128,8 @@ describe("refreshHandler", () => {
   });
 
   test("replies 401 and clears cookies when the refresh token is unknown", async () => {
-    // Set up the refresh mutation to not recognize the token and to return null.
-    mutationMock.mockResolvedValue(null);
+    // Set up the refresh mutation to not recognize the token.
+    mutationMock.mockResolvedValue({ kind: "noSession" });
     const handler = refreshHandler({
       convexUrl: "https://x.convex.cloud",
       refreshSession: fnRef,

--- a/packages/core/src/server/handlers.ts
+++ b/packages/core/src/server/handlers.ts
@@ -54,10 +54,15 @@ export interface RefreshHandlerConfig {
 }
 
 /**
- * A handler that rotates the session from the httpOnly refresh-token cookie and
- * rewrites both cookies, replying with an {@link AuthSessionResponse} carrying
- * the fresh bundle. When there is no session to rotate (missing or unrecognized
- * refresh cookie) it replies 401 with `tokens: null`.
+ * A handler that refreshes the session from the httpOnly refresh-token cookie,
+ * replying with an {@link AuthSessionResponse} carrying the fresh access token.
+ * When there is no session left (missing or unrecognized refresh cookie) it
+ * replies 401 with `tokens: null`.
+ *
+ * A rotation and a grace-window reuse produce the same reply, since the browser
+ * never sees a refresh token under SSR and so has nothing to do differently.
+ * The two differ only in which cookies {@link ServerAuthSession.refresh} wrote:
+ * both cookies for a rotation, the access-token cookie alone for a reuse.
  */
 export function refreshHandler(config: RefreshHandlerConfig): RequestHandler {
   const client = new ConvexHttpClient(config.convexUrl);
@@ -72,14 +77,16 @@ export function refreshHandler(config: RefreshHandlerConfig): RequestHandler {
       cookies,
       cookieOptions: config.cookieOptions,
     });
-    const bundle = await session.refresh();
+    const result = await session.refresh();
     const res =
-      bundle === null
+      result.kind === "noSession"
         ? Response.json({ tokens: null } satisfies AuthSessionResponse, {
             status: 401,
           })
         : Response.json({
-            tokens: makeSlimBundle(bundle),
+            tokens: makeSlimBundle(
+              result.kind === "rotated" ? result.tokens : result,
+            ),
           } satisfies AuthSessionResponse);
     cookies.applyTo(res.headers);
     return res;

--- a/packages/core/src/server/session.test.ts
+++ b/packages/core/src/server/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import type { TokenBundle } from "../lib/types.ts";
+import type { RefreshResult, TokenBundle } from "../lib/types.ts";
 import {
   AuthCookieOptions,
   CookieDeleteOptions,
@@ -56,8 +56,24 @@ class FakeCookies implements CookieStore {
   }
 }
 
+/** A `rotated` refresh outcome carrying `bundle`. */
+function rotated(bundle: TokenBundle): RefreshResult {
+  return { kind: "rotated", tokens: bundle };
+}
+
+/** A `reused` outcome: a concurrent caller already rotated the presented token. */
+function reused(bundle: TokenBundle): RefreshResult {
+  return {
+    kind: "reused",
+    accessToken: bundle.accessToken,
+    accessTokenExpiresAt: bundle.accessTokenExpiresAt,
+    refreshTokenExpiresAt: bundle.refreshTokenExpiresAt,
+    userId: bundle.userId,
+  };
+}
+
 function newSession(
-  refreshSession: RefreshSession = async () => null,
+  refreshSession: RefreshSession = async () => ({ kind: "noSession" }),
   cookies = new FakeCookies(),
   cookieOptions: AuthCookieOptions = { secure: false },
 ) {
@@ -72,7 +88,7 @@ function newSession(
 describe("ServerAuthSession", () => {
   test("getToken returns a comfortably-valid cookie token without refreshing", async () => {
     vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const refreshSession = vi.fn(async () => rotated(newTokenBundle(2)));
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 60));
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
@@ -88,7 +104,7 @@ describe("ServerAuthSession", () => {
     const next = newTokenBundle(2);
     const refreshSession = vi.fn(async (rt: string) => {
       expect(rt).toBe("refresh-1");
-      return next;
+      return rotated(next);
     });
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // within the 10s skew
@@ -103,9 +119,28 @@ describe("ServerAuthSession", () => {
     vi.restoreAllMocks();
   });
 
+  test("a reused refresh writes only the JWT cookie, leaving the refresh cookie", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const next = newTokenBundle(2);
+    const refreshSession = vi.fn(async () => reused(next));
+    const cookies = new FakeCookies();
+    cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // within the 10s skew
+    cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
+    const { session } = newSession(refreshSession, cookies);
+
+    expect(await session.getToken()).toBe(next.accessToken);
+    expect(cookies.get(AUTH_JWT_COOKIE)).toBe(next.accessToken);
+    // The concurrent caller that won the rotation carries the replacement in
+    // its own response. Writing one here would race that, and the loser holds a
+    // token that is signed out once it leaves the grace window.
+    expect(cookies.get(AUTH_REFRESH_COOKIE)).toBe("refresh-1");
+    expect(cookies.options.get(AUTH_JWT_COOKIE)?.httpOnly).toBe(true);
+    vi.restoreAllMocks();
+  });
+
   test("getToken refreshes when the JWT cookie is missing", async () => {
     vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const refreshSession = vi.fn(async () => rotated(newTokenBundle(2)));
     const cookies = new FakeCookies();
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
     const { session } = newSession(refreshSession, cookies);
@@ -115,12 +150,15 @@ describe("ServerAuthSession", () => {
     vi.restoreAllMocks();
   });
 
-  test("a null refresh clears both cookies and yields no token", async () => {
+  test("a noSession refresh clears both cookies and yields no token", async () => {
     vi.spyOn(Date, "now").mockReturnValue(nowMs);
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5));
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession(async () => null, cookies);
+    const { session } = newSession(
+      async () => ({ kind: "noSession" }),
+      cookies,
+    );
 
     expect(await session.getToken()).toBeNull();
     expect(cookies.get(AUTH_JWT_COOKIE)).toBeUndefined();
@@ -133,11 +171,15 @@ describe("ServerAuthSession", () => {
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5));
     cookies.set(AUTH_REFRESH_COOKIE, "refresh-1");
-    const { session } = newSession(async () => null, cookies, {
-      secure: false,
-      path: "/app",
-      domain: "example.com",
-    });
+    const { session } = newSession(
+      async () => ({ kind: "noSession" }),
+      cookies,
+      {
+        secure: false,
+        path: "/app",
+        domain: "example.com",
+      },
+    );
 
     expect(await session.getToken()).toBeNull();
     for (const name of [AUTH_JWT_COOKIE, AUTH_REFRESH_COOKIE]) {
@@ -151,7 +193,7 @@ describe("ServerAuthSession", () => {
 
   test("getToken returns null when there is no refresh cookie", async () => {
     vi.spyOn(Date, "now").mockReturnValue(nowMs);
-    const refreshSession = vi.fn(async () => newTokenBundle(2));
+    const refreshSession = vi.fn(async () => rotated(newTokenBundle(2)));
     const cookies = new FakeCookies();
     cookies.set(AUTH_JWT_COOKIE, jwt(NOW + 5)); // expiring, and nothing to refresh with
     const { session } = newSession(refreshSession, cookies);

--- a/packages/core/src/server/session.ts
+++ b/packages/core/src/server/session.ts
@@ -12,32 +12,33 @@
  * top of an HTTP client and a {@link CookieStore} built on its
  * request/response cookies, and tests supply a fake. The SSR host accesses the
  * refresh token (from the cookie), passes it in a refresh request to the
- * Convex backend and gets back a full {@link TokenBundle}. It uses that bundle
- * to update the cookie values and communicate the refreshed access token to
- * the client.
+ * Convex backend and gets back a {@link RefreshResult}. It uses that to update
+ * the cookie values and communicate the refreshed access token to the client.
+ *
+ * Which cookies get written depends on the outcome; see
+ * {@link ServerAuthSession.refresh}.
  *
  * @module
  */
 
-import type { TokenBundle } from "../lib/types.ts";
+import type { RefreshResult, TokenBundle } from "../lib/types.ts";
 import {
   AUTH_JWT_COOKIE,
   AUTH_REFRESH_COOKIE,
   AuthCookieOptions,
   CookieStore,
   clearAuthCookies,
+  writeAccessCookie,
   writeAuthCookies,
 } from "./cookies.ts";
 import { isTokenExpiring } from "./jwt.ts";
 
 /**
- * Rotate a refresh token into a fresh {@link TokenBundle}, or `null` when the
- * session is gone (unknown or expired refresh token). A framework binding
- * usually implements this over a Convex HTTP client; tests pass a fake.
+ * Exchange a refresh token for a fresh session, resolving to one of the
+ * {@link RefreshResult} outcomes. A framework binding usually implements this
+ * over a Convex HTTP client; tests pass a fake.
  */
-export type RefreshSession = (
-  refreshToken: string,
-) => Promise<TokenBundle | null>;
+export type RefreshSession = (refreshToken: string) => Promise<RefreshResult>;
 
 /** Configuration for a {@link ServerAuthSession}. */
 export interface ServerAuthSessionConfig {
@@ -81,27 +82,46 @@ export class ServerAuthSession {
     if (token !== null && !isTokenExpiring(token, this.#refreshSkewSeconds)) {
       return token;
     }
-    const bundle = await this.refresh();
-    return bundle?.accessToken ?? null;
+    // Both `rotated` and `reused` carry a usable access token.
+    const result = await this.refresh();
+    switch (result.kind) {
+      case "rotated":
+        return result.tokens.accessToken;
+      case "reused":
+        return result.accessToken;
+      case "noSession":
+        return null;
+    }
   }
 
   /**
-   * Force a refresh from the refresh-token cookie. On success rotates the
-   * tokens and rewrites both cookies; on failure (unknown/expired token) clears
-   * them. Returns the new bundle or `null`.
+   * Force a refresh from the refresh-token cookie, updating the cookies to match
+   * the outcome:
+   *
+   *  * `rotated`: rewrite both cookies with the new bundle.
+   *  * `reused`: rewrite only the access-token cookie. A previous concurrent
+   *     caller already received a new refresh token which will be used for future
+   *     refreshes.
+   *  * `noSession`: clear both.
    */
-  async refresh(): Promise<TokenBundle | null> {
+  async refresh(): Promise<RefreshResult> {
     const refreshToken = (await this.#cookies.get(AUTH_REFRESH_COOKIE)) ?? null;
     if (refreshToken === null) {
-      return null;
+      return { kind: "noSession" };
     }
-    const bundle = await this.#refreshSession(refreshToken);
-    if (bundle === null) {
-      await this.#clear();
-      return null;
+    const result = await this.#refreshSession(refreshToken);
+    switch (result.kind) {
+      case "rotated":
+        await this.setTokens(result.tokens);
+        break;
+      case "reused":
+        await writeAccessCookie(this.#cookies, result, this.#cookieOptions);
+        break;
+      case "noSession":
+        await this.#clear();
+        break;
     }
-    await this.setTokens(bundle);
-    return bundle;
+    return result;
   }
 
   /**


### PR DESCRIPTION
Previously, every refresh rotated the existing refresh token for a session and stored and returned a new one.

Concurrent refreshes would therefore result in two rotations, and depending on the order in which the HTTP responses came in, one that was no longer current could be stored as the refresh token. That would lead to a later forced log out.

Now a refresh with a token that is no longer current but is within the grace window for accepting a spent token doesn't rotate or return a new refresh token. Instead it returns an access token to allow the caller to proceed and only the winner of the race to refresh carries a new refresh token cookie in the HTTP response.