### PR TITLE
usernamePasskey: limit the number of passkeys of one user

### DIFF
--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -30,6 +30,10 @@ import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
 
+// The limit that the passkey component applies to one user. The component
+// does not export it, so the test keeps a copy.
+const MAX_PASSKEYS_PER_USER = 20;
+
 // The relying party of `auth.ts`. The software authenticator has its own
 // defaults, thus every ceremony below names these.
 const RP_ID = "localhost";
@@ -298,6 +302,56 @@ describe("adding a passkey", () => {
         await attest(start.options.challenge, credential),
       ),
     ).toEqual({ success: false, userError: { error: "PROTOCOL_ERROR" } });
+  });
+
+  test("refuses a user who already holds the largest number of passkeys", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const caller = as(t, alice.userId);
+
+    // The sign-up made the first passkey; fill the remaining places.
+    for (let i = 1; i < MAX_PASSKEYS_PER_USER; i++) {
+      await addPasskey(t, alice.userId, alice.credential);
+    }
+    const list = await caller.query(api.auth.listPasskeys, {});
+    if (!list.success) throw new Error("The caller is signed in.");
+    expect(list.passkeys).toHaveLength(MAX_PASSKEYS_PER_USER);
+
+    expect(await caller.mutation(api.auth.startAddPasskey, {})).toEqual({
+      success: false,
+      userError: { error: "TOO_MANY_PASSKEYS" },
+    });
+  });
+
+  test("refuses a ceremony whose last place a second tab took", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const caller = as(t, alice.userId);
+    for (let i = 2; i < MAX_PASSKEYS_PER_USER; i++) {
+      await addPasskey(t, alice.userId, alice.credential);
+    }
+
+    // One place is left: this ceremony starts and gets its challenge.
+    const start = await caller.mutation(api.auth.startAddPasskey, {});
+    if (!start.success) throw new Error("One place is left.");
+    const verified = await caller.mutation(
+      api.auth.verifyAddPasskey,
+      await assertWith(alice.credential, start.options.challenge),
+    );
+    if (!verified.success) throw new Error("The assertion is valid.");
+
+    // A second tab takes the last place before this ceremony finishes.
+    await addPasskey(t, alice.userId, alice.credential);
+
+    expect(
+      await caller.mutation(
+        api.auth.finishAddPasskey,
+        await attest(
+          verified.options.challenge,
+          await generateES256Credential(),
+        ),
+      ),
+    ).toEqual({ success: false, userError: { error: "TOO_MANY_PASSKEYS" } });
   });
 
   test("refuses a signed-out caller", async () => {

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -46,13 +46,38 @@ import {
   buildRegistrationOptions,
 } from "../options.ts";
 
+/**
+ * The largest number of passkeys that one user can hold.
+ *
+ * Each passkey of the user goes into the `allowCredentials` list of every
+ * sign-in and into the `excludeCredentials` list of every registration, thus
+ * an unbounded list grows the payload of every ceremony. The limit is far
+ * above the number of authenticators that a person uses, and the user can
+ * remove a passkey to make room for a new one.
+ *
+ * The component stays permissive; the provider makes the policy, like it does
+ * for the removal of the last passkey.
+ */
+export const MAX_PASSKEYS_PER_USER = 20;
+
+/**
+ * The user-facing error when the user already holds the largest number of
+ * passkeys.
+ */
+const tooManyPasskeysUserError = v.object({
+  error: v.literal("TOO_MANY_PASSKEYS"),
+});
+
 const startAddPasskeyResult = v.union(
   v.object({
     success: v.literal(true),
     // Ready for the re-authentication `navigator.credentials.get()` call.
     options: vPublicKeyCredentialRequestOptionsJSON,
   }),
-  v.object({ success: v.literal(false), userError: notSignedInUserError }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(notSignedInUserError, tooManyPasskeysUserError),
+  }),
 );
 
 export type StartAddPasskeyResult = Infer<typeof startAddPasskeyResult>;
@@ -76,7 +101,11 @@ const finishAddPasskeyResult = v.union(
   v.object({ success: v.literal(true), passkeyId: v.string() }),
   v.object({
     success: v.literal(false),
-    userError: v.union(notSignedInUserError, finishRegistrationUserError),
+    userError: v.union(
+      notSignedInUserError,
+      finishRegistrationUserError,
+      tooManyPasskeysUserError,
+    ),
   }),
 );
 
@@ -91,6 +120,15 @@ export function startAddPasskey(config: UsernamePasskeyConfig) {
       if (userId === null) {
         return { success: false, userError: { error: "NOT_SIGNED_IN" } };
       }
+      const passkeys = await ctx.runQuery(
+        config.component.registration.listPasskeys,
+        { userId },
+      );
+
+      if (passkeys.length >= MAX_PASSKEYS_PER_USER) {
+        return { success: false, userError: { error: "TOO_MANY_PASSKEYS" } };
+      }
+
       const { challenge, allowCredentials } = await ctx.runMutation(
         config.component.authentication.startAuthentication,
         { purpose: ADD_PASSKEY_PURPOSE, userId },
@@ -196,11 +234,18 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
     },
     returns: finishAddPasskeyResult,
     handler: async (ctx, args): Promise<FinishAddPasskeyResult> => {
-      // TODO(nicolas) Add a limit to how many paskseys can be registered
       const userId = await getAuthUserId(ctx);
       if (userId === null) {
         return { success: false, userError: { error: "NOT_SIGNED_IN" } };
       }
+      const passkeys = await ctx.runQuery(
+        config.component.registration.listPasskeys,
+        { userId },
+      );
+      if (passkeys.length >= MAX_PASSKEYS_PER_USER) {
+        return { success: false, userError: { error: "TOO_MANY_PASSKEYS" } };
+      }
+
       const registrationResult = await ctx.runMutation(
         config.component.registration.finishRegistrationForExistingUser,
         {


### PR DESCRIPTION
This modifies the passkey provider functions to add a limit of how many passkeys a given user can have. The goal is to avoid a user having too many passkeys registered, which might be an indicator of abuse and hit Convex query limits. This is enforced at the app level, not at the component level.
