### PR TITLE
Passkey component: add simple validation for purpose strings

### DIFF
--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -85,6 +85,25 @@ describe("startAuthentication", () => {
     const [row] = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(row.kind === "authentication" && row.userId).toBe(undefined);
   });
+
+  test("refuses a purpose that no constant flow name has", async () => {
+    const t = setup();
+    for (const purpose of ["", "test signIn", "test/sign\u0000In", "é"]) {
+      await expect(
+        t.mutation(api.authentication.startAuthentication, { purpose }),
+      ).rejects.toThrow("Invalid purpose");
+    }
+    // The error shows the start of the purpose, to help the developer find
+    // the value that the app sent.
+    await expect(
+      t.mutation(api.authentication.startAuthentication, {
+        purpose: `${"x".repeat(128)}yyy`,
+      }),
+    ).rejects.toThrow(`Purpose too long: "${"x".repeat(128)}\u2026" has 131`);
+    expect(await t.run((ctx) => ctx.db.query("challenges").collect())).toEqual(
+      [],
+    );
+  });
 });
 
 describe("finishAuthentication", () => {

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -86,7 +86,7 @@ describe("startAuthentication", () => {
     expect(row.kind === "authentication" && row.userId).toBe(undefined);
   });
 
-  test("refuses a purpose that no constant flow name has", async () => {
+  test("refuses purposes with invalid formats", async () => {
     const t = setup();
     for (const purpose of ["", "test signIn", "test/sign\u0000In", "é"]) {
       await expect(

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -42,7 +42,7 @@ const startAuthenticationResult = v.object({
  * sign-in, or a re-authentication before a change of a setting). The
  * component does not parse the value. The app chooses the strings; a
  * purpose must be a short string of printable ASCII (see
- * `validatePurpose`).
+ * {@link validatePurpose}).
  *
  * A purpose must be a constant that names the flow, for example
  * "myApp:signIn". Do not put dynamic data in it, such as a user ID, a

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -148,6 +148,7 @@ export const finishAuthentication = mutation({
   },
   returns: finishAuthenticationResult,
   handler: async (ctx, args): Promise<FinishAuthenticationResult> => {
+    validatePurpose(args.purpose);
     const passkey = await ctx.db
       .query("passkeys")
       .withIndex("by_credentialId", (q) =>

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -21,6 +21,7 @@ import { sha256 } from "../../vendor/oslo/crypto/sha2.ts";
 import {
   credentialDescriptor,
   finishAuthenticationUserError,
+  validatePurpose,
 } from "./validation.ts";
 import { consumeChallenge, okOrNull, randomChallenge } from "./helpers.ts";
 import { scheduleChallengeCleanup } from "./cleanup.ts";
@@ -39,7 +40,14 @@ const startAuthenticationResult = v.object({
  *
  * `purpose` binds the challenge to one flow of the app (for example a
  * sign-in, or a re-authentication before a change of a setting). The
- * component does not parse the value. The app chooses the strings.
+ * component does not parse the value. The app chooses the strings; a
+ * purpose must be a short string of printable ASCII (see
+ * `validatePurpose`).
+ *
+ * A purpose must be a constant that names the flow, for example
+ * "myApp:signIn". Do not put dynamic data in it, such as a user ID, a
+ * time, or a nonce.
+ *
  * `finishAuthentication` must receive the same purpose. A different
  * purpose gets `PROTOCOL_ERROR`.
  *
@@ -58,6 +66,7 @@ export const startAuthentication = mutation({
   args: { purpose: v.string(), userId: v.optional(v.string()) },
   returns: startAuthenticationResult,
   handler: async (ctx, { purpose, userId }) => {
+    validatePurpose(purpose);
     const challenge = randomChallenge();
     await ctx.db.insert("challenges", {
       kind: "authentication",

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -73,7 +73,8 @@ function describePurpose(value: string) {
  * stores it or compares it.
  *
  * The component does not give the purposes a meaning: the app chooses the
- * strings. It only refuses a value that no constant flow name has.
+ * strings. It only refuses a values that are not well formatted
+ * (maximum 128 non-space printable ASCII characters).
  *
  * @throws when the value is empty, too long, or not printable ASCII.
  */

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -44,6 +44,53 @@ export function transportsAreValid(values: string[] | undefined): boolean {
 }
 
 /**
+ * The largest length of a `purpose` string. A purpose names one flow of the
+ * app ("myApp:signIn"), thus a short limit is enough. The limit stops a
+ * caller from writing large data to a challenge row.
+ */
+const MAX_PURPOSE_LENGTH = 128;
+
+// The characters that a purpose can contain: printable ASCII without the
+// space. The component does not parse the value beyond this.
+const PURPOSE_PATTERN = /^[\x21-\x7e]+$/;
+
+/**
+ * Show a purpose in an error message. The value comes from the caller,
+ * thus it can be long, empty, or contain characters that are not
+ * printable. `JSON.stringify` puts it in quotation marks and replaces
+ * these characters. A long value is cut to keep the message short.
+ */
+function describePurpose(value: string) {
+  const shown =
+    value.length > MAX_PURPOSE_LENGTH
+      ? `${value.slice(0, MAX_PURPOSE_LENGTH)}…`
+      : value;
+  return JSON.stringify(shown);
+}
+
+/**
+ * Examine the `purpose` of an authentication challenge, before the component
+ * stores it or compares it.
+ *
+ * The component does not give the purposes a meaning: the app chooses the
+ * strings. It only refuses a value that no constant flow name has.
+ *
+ * @throws when the value is empty, too long, or not printable ASCII.
+ */
+export function validatePurpose(purpose: string) {
+  if (purpose.length > MAX_PURPOSE_LENGTH) {
+    throw new Error(
+      `Purpose too long: ${describePurpose(purpose)} has ${purpose.length} characters, but a purpose can have a maximum of ${MAX_PURPOSE_LENGTH}.`,
+    );
+  }
+  if (!PURPOSE_PATTERN.test(purpose)) {
+    throw new Error(
+      `Invalid purpose: ${describePurpose(purpose)} is not a non-empty string of printable ASCII characters.`,
+    );
+  }
+}
+
+/**
  * One entry of `allowCredentials` or `excludeCredentials`. The WebAuthn
  * `type` field is not included, because it is always "public-key".
  */


### PR DESCRIPTION
This adds very simple validation rules for purposes, just to ensure the caller of the passkey component functions doesn’t store a string that looks incorrect in it.