### PR TITLE
Passkey: return errors instead of throwing for misbehaving client

### DIFF
--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -94,9 +94,14 @@ function errorMessage(
       return "The passkey could not be verified. Please try again.";
     case "UNKNOWN_CREDENTIAL":
       return "This passkey is not registered here.";
+    case "PROTOCOL_ERROR":
+      // The browser sent something that violates the protocol.
+      // This might be caused by a misbehaving client, or by a configuration error.
+      // The Convex logs contain more information about the source of the error.
+      return "This passkey request could not be verified. Please try again, or contact support if the problem persists.";
     case "CEREMONY_ABORTED":
       // The most common failure: the user closed the passkey dialog.
-      return "Sign-in was cancelled.";
+      return "Sign-in was cancelled. Please try again.";
     case "WEBAUTHN_UNSUPPORTED":
       return "This browser does not support passkeys.";
     case "OTHER_ERROR":

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -42,7 +42,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             userError:
               | { error: "UNKNOWN_CREDENTIAL" }
               | { error: "CHALLENGE_EXPIRED" }
-              | { error: "VERIFICATION_FAILED" };
+              | { error: "VERIFICATION_FAILED" }
+              | { error: "PROTOCOL_ERROR" };
           },
         Name
       >;
@@ -69,12 +70,15 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           clientDataJSON: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
+          transports?: Array<string>;
         },
         | { success: true }
         | {
             success: false;
             userError:
-              { error: "CHALLENGE_EXPIRED" } | { error: "VERIFICATION_FAILED" };
+              | { error: "CHALLENGE_EXPIRED" }
+              | { error: "VERIFICATION_FAILED" }
+              | { error: "PROTOCOL_ERROR" };
           },
         Name
       >;
@@ -109,7 +113,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              { error: "CHALLENGE_EXPIRED" } | { error: "VERIFICATION_FAILED" };
+              | { error: "CHALLENGE_EXPIRED" }
+              | { error: "VERIFICATION_FAILED" }
+              | { error: "PROTOCOL_ERROR" };
           },
         Name
       >;

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
-import { expectSameBytes, setup } from "../passkeyTestSetup.ts";
+import {
+  expectProtocolError,
+  expectSameBytes,
+  setup,
+} from "../passkeyTestSetup.ts";
 import {
   ORIGIN,
   RP_ID,
@@ -163,7 +167,7 @@ describe("finishAuthentication", () => {
     expect(challenges).toHaveLength(1);
   });
 
-  test("throws for authenticator data that is too short", async () => {
+  test("returns PROTOCOL_ERROR for authenticator data that is too short", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -171,16 +175,18 @@ describe("finishAuthentication", () => {
       { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-        authenticatorData: new Uint8Array(10).buffer,
-      }),
-    ).rejects.toThrow("Failed to parse authenticator data");
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+          authenticatorData: new Uint8Array(10).buffer,
+        }),
+      "the authenticator data could not be read",
+    );
   });
 
-  test("throws for a relying party ID hash mismatch", async () => {
+  test("returns PROTOCOL_ERROR for a relying party ID hash mismatch", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -190,12 +196,14 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge, {
       rpId: "evil.example.net",
     });
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-      }),
-    ).rejects.toThrow("Relying party ID hash mismatch.");
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+        }),
+      `does not match the expected relying party ID "${RP_ID}"`,
+    );
   });
 
   test("returns VERIFICATION_FAILED when the user is not present or not verified", async () => {
@@ -220,7 +228,7 @@ describe("finishAuthentication", () => {
     }
   });
 
-  test("throws for a registration client data type", async () => {
+  test("returns PROTOCOL_ERROR for a registration client data type", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -230,15 +238,17 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge, {
       type: "webauthn.create",
     });
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-      }),
-    ).rejects.toThrow("Unexpected client data type.");
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+        }),
+      'an authentication ceremony must send "webauthn.get"',
+    );
   });
 
-  test("throws for an unexpected origin", async () => {
+  test("returns PROTOCOL_ERROR for an unexpected origin", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -248,15 +258,17 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge, {
       origin: "https://evil.example.net",
     });
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-      }),
-    ).rejects.toThrow("Unexpected WebAuthn origin.");
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+        }),
+      'the ceremony ran at the origin "https://evil.example.net"',
+    );
   });
 
-  test("throws for a cross-origin ceremony", async () => {
+  test("returns PROTOCOL_ERROR for a cross-origin ceremony", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -266,12 +278,14 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge, {
       crossOrigin: true,
     });
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-      }),
-    ).rejects.toThrow("Cross-origin WebAuthn ceremonies are not allowed.");
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+        }),
+      "the ceremony ran in a cross-origin frame",
+    );
   });
 
   test("returns CHALLENGE_EXPIRED for an expired challenge", async () => {
@@ -361,10 +375,30 @@ describe("finishAuthentication", () => {
     });
   });
 
-  test("throws for ES256 signature bytes that are not DER", async () => {
-    // Pins the current behavior: a signature that does not even decode as
-    // DER throws (aborting the transaction) instead of returning
-    // VERIFICATION_FAILED.
+  test("returns VERIFICATION_FAILED for an empty RS256 signature", async () => {
+    // The RSA verification decodes the signature as a big integer, which
+    // refuses zero bytes. The mutation must not throw.
+    const t = setup();
+    const credential = await generateRS256Credential();
+    await register(t, "user1", { credential });
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { purpose: PURPOSE, userId: "user1" },
+    );
+    const assertion = await buildAssertion(credential, challenge);
+    const result = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...assertion,
+      signature: new Uint8Array(0).buffer,
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+  });
+
+  test("returns VERIFICATION_FAILED for ES256 signature bytes that are not DER", async () => {
+    // No authenticator sends bytes that the decoder refuses.
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -372,13 +406,75 @@ describe("finishAuthentication", () => {
       { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-        signature: new Uint8Array(10).buffer,
-      }),
-    ).rejects.toThrow("Failed to decode signature");
+    const result = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...assertion,
+      signature: new Uint8Array(10).buffer,
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+  });
+
+  test("returns VERIFICATION_FAILED for an ES256 signature where s is the order of the curve", async () => {
+    // The DER is correct, but `s` has no inverse modulo the order of the
+    // curve. The verification must not throw.
+    const t = setup();
+    const { credential } = await register(t, "user1");
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { purpose: PURPOSE, userId: "user1" },
+    );
+    const assertion = await buildAssertion(credential, challenge);
+    // SEQUENCE { INTEGER 1, INTEGER n } where n is the order of P-256.
+    const signature = Uint8Array.from([
+      0x30, 0x26, 0x02, 0x01, 0x01, 0x02, 0x21, 0x00, 0xff, 0xff, 0xff, 0xff,
+      0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xbc, 0xe6, 0xfa, 0xad, 0xa7, 0x17, 0x9e, 0x84, 0xf3, 0xb9, 0xca, 0xc2,
+      0xfc, 0x63, 0x25, 0x51,
+    ]);
+    const result = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...assertion,
+      signature: signature.buffer,
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "VERIFICATION_FAILED" },
+    });
+  });
+
+  test("a PROTOCOL_ERROR of a check before the challenge lookup keeps it", async () => {
+    const t = setup();
+    const { credential } = await register(t, "user1");
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { purpose: PURPOSE, userId: "user1" },
+    );
+    // Every protocol check runs before the challenge is consumed, so the
+    // same challenge serves each variant in turn.
+    const variants = [
+      { rpId: "evil.example.net" },
+      { type: "webauthn.create" as const },
+      { origin: "https://evil.example.net" },
+      { crossOrigin: true },
+    ];
+    for (const variant of variants) {
+      const assertion = await buildAssertion(credential, challenge, variant);
+      await expectProtocolError(
+        () =>
+          t.mutation(api.authentication.finishAuthentication, {
+            ...EXPECTED,
+            ...assertion,
+          }),
+        "Rejected the passkey ceremony",
+      );
+    }
+    const challenges = await t.run((ctx) =>
+      ctx.db.query("challenges").collect(),
+    );
+    expect(challenges).toHaveLength(1);
   });
 
   test("rejects a replayed assertion with CHALLENGE_EXPIRED", async () => {
@@ -404,29 +500,34 @@ describe("finishAuthentication", () => {
     });
   });
 
-  test("throws for a different purpose and keeps the challenge bound", async () => {
+  test("returns PROTOCOL_ERROR for a different purpose and burns the challenge", async () => {
     const t = setup();
-    const { credential, passkeyId } = await register(t, "user1");
+    const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
       { purpose: PURPOSE, userId: "user1" },
     );
     const assertion = await buildAssertion(credential, challenge);
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...assertion,
-        purpose: OTHER_PURPOSE,
-      }),
-    ).rejects.toThrow();
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...assertion,
+          purpose: OTHER_PURPOSE,
+        }),
+      `the challenge was created for the purpose "${PURPOSE}", but the ceremony was finished for the purpose "${OTHER_PURPOSE}"`,
+    );
 
-    // The throw rolls the delete back, thus the challenge stays usable for
-    // the flow that started it, and only for that flow.
+    // The purpose check runs after the delete. A mismatch comes from the
+    // code of the app, so the same ceremony would fail again anyway.
     const retry = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
       ...assertion,
     });
-    expect(retry).toEqual({ success: true, userId: "user1", passkeyId });
+    expect(retry).toEqual({
+      success: false,
+      userError: { error: "CHALLENGE_EXPIRED" },
+    });
   });
 
   test("keeps the challenges of two purposes independent", async () => {
@@ -442,12 +543,15 @@ describe("finishAuthentication", () => {
     });
 
     // The challenge of the other flow is unusable for the sign-in flow.
-    await expect(
-      t.mutation(api.authentication.finishAuthentication, {
-        ...EXPECTED,
-        ...(await buildAssertion(credential, other.challenge)),
-      }),
-    ).rejects.toThrow();
+    const otherAssertion = await buildAssertion(credential, other.challenge);
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...otherAssertion,
+        }),
+      "the challenge was created for the purpose",
+    );
 
     // The failed attempt leaves the challenge of the sign-in flow alone.
     const result = await t.mutation(api.authentication.finishAuthentication, {

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -22,7 +22,7 @@ import {
   credentialDescriptor,
   finishAuthenticationUserError,
 } from "./validation.ts";
-import { consumeChallenge, randomChallenge } from "./helpers.ts";
+import { consumeChallenge, okOrNull, randomChallenge } from "./helpers.ts";
 import { scheduleChallengeCleanup } from "./cleanup.ts";
 
 // The challenge and the credential IDs travel as raw bytes (Convex
@@ -41,7 +41,7 @@ const startAuthenticationResult = v.object({
  * sign-in, or a re-authentication before a change of a setting). The
  * component does not parse the value. The app chooses the strings.
  * `finishAuthentication` must receive the same purpose. A different
- * purpose burns the challenge.
+ * purpose gets `PROTOCOL_ERROR`.
  *
  * If `userId` is set, it will force the authentication ceremony to be
  * tied to this particular user. This is necessary in flows where the
@@ -84,6 +84,23 @@ export const startAuthentication = mutation({
   },
 });
 
+/**
+ * Verify an ES256 assertion signature.
+ *
+ * @throws on invalid input
+ */
+function verifyES256Signature(
+  storedPublicKey: Uint8Array,
+  hash: Uint8Array,
+  signature: Uint8Array,
+): boolean {
+  return verifyECDSASignature(
+    decodeSEC1PublicKey(p256, storedPublicKey),
+    hash,
+    decodePKIXECDSASignature(signature),
+  );
+}
+
 const finishAuthenticationResult = v.union(
   v.object({
     success: v.literal(true),
@@ -108,8 +125,7 @@ type FinishAuthenticationResult = Infer<typeof finishAuthenticationResult>;
  * challenge and returns the `userId` of the user. The app can then make a
  * session for that user.
  *
- * `purpose` must be the purpose that `startAuthentication` received. A
- * different purpose throws.
+ * `purpose` must be the purpose that `startAuthentication` received.
  */
 export const finishAuthentication = mutation({
   args: {
@@ -134,18 +150,45 @@ export const finishAuthentication = mutation({
     }
 
     const authenticatorDataBytes = new Uint8Array(args.authenticatorData);
-    const authenticatorData = parseAuthenticatorData(authenticatorDataBytes);
+    const authenticatorData = okOrNull(() =>
+      parseAuthenticatorData(authenticatorDataBytes),
+    );
+    if (authenticatorData === null) {
+      console.warn(
+        `Rejected the passkey ceremony: the authenticator data could not be ` +
+          `read.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
+    }
     if (!authenticatorData.verifyRelyingPartyIdHash(args.expectedRpId)) {
-      throw new Error("Relying party ID hash mismatch.");
+      console.warn(
+        `Rejected the passkey ceremony: the authenticator data does not ` +
+          `match the expected relying party ID ${JSON.stringify(args.expectedRpId)}. ` +
+          `Check that the \`rpId\` of the provider matches the page that ran ` +
+          `the ceremony.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
       return { success: false, userError: { error: "VERIFICATION_FAILED" } };
     }
 
     const clientDataJSONBytes = new Uint8Array(args.clientDataJSON);
-    const clientData = parseClientDataJSON(clientDataJSONBytes);
+    const clientData = okOrNull(() => parseClientDataJSON(clientDataJSONBytes));
+    if (clientData === null) {
+      console.warn(
+        `Rejected the passkey ceremony: the client data JSON could not be ` +
+          `read.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
+    }
     if (clientData.type !== ClientDataType.Get) {
-      throw new Error("Unexpected client data type.");
+      console.warn(
+        `Rejected the passkey ceremony: the client data type is ` +
+          `"webauthn.create", but an authentication ceremony must send ` +
+          `"webauthn.get".`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     if (clientData.origin !== args.expectedOrigin) {
       // Note: This forces the app to provide a single accepted origin.
@@ -157,11 +200,21 @@ export const finishAuthentication = mutation({
       //   [auth.example.com, dashboard.example.com] but NOT marketing.example.com)
       // For these reasons, we will probably want to offer more customization options
       // for this check in the future.
-      throw new Error("Unexpected WebAuthn origin.");
+      console.warn(
+        `Rejected the passkey ceremony: the ceremony ran at the origin ` +
+          `${JSON.stringify(clientData.origin)}, but the expected origin is ` +
+          `${JSON.stringify(args.expectedOrigin)}. Check that the \`origin\` of ` +
+          `the provider matches the page that ran the ceremony.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     if (clientData.crossOrigin === true) {
       // In the future, we could allow the user to explicitly opt out to this.
-      throw new Error("Cross-origin WebAuthn ceremonies are not allowed.");
+      console.warn(
+        `Rejected the passkey ceremony: the ceremony ran in a cross-origin ` +
+          `frame, which is not allowed.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     const challengeRow = await consumeChallenge(
       ctx,
@@ -172,12 +225,16 @@ export const finishAuthentication = mutation({
       return { success: false, userError: { error: "CHALLENGE_EXPIRED" } };
     }
     if (challengeRow.purpose !== args.purpose) {
-      // A correct client gives the same purpose to both steps. A mismatch
-      // is probably a bug in the caller or client code, not a end-user
-      // error. Throwing will roll `consumeChallenge` back, but that’s okay
-      throw new Error(
-        "The purpose does not match the purpose of the challenge.",
+      // A client that redeems an assertion in a flow other than the one
+      // that asked for it does not respect the protocol. The challenge is
+      // consumed at this point: a mismatch comes from the code of the app,
+      // so the same ceremony would fail again anyway.
+      console.warn(
+        `Rejected the passkey ceremony: the challenge was created for the ` +
+          `purpose ${JSON.stringify(challengeRow.purpose)}, but the ceremony ` +
+          `was finished for the purpose ${JSON.stringify(args.purpose)}.`,
       );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     // A challenge with a `userId` (the identifier-first flow) must agree
     // with the owner of the credential. A challenge without a `userId` is a
@@ -200,19 +257,20 @@ export const finishAuthentication = mutation({
     const storedPublicKey = new Uint8Array(passkey.publicKey);
     let valid: boolean;
     if (passkey.algorithm === "ES256") {
-      valid = verifyECDSASignature(
-        decodeSEC1PublicKey(p256, storedPublicKey),
-        hash,
-        // WebAuthn ECDSA signatures use the DER (PKIX) encoding.
-        decodePKIXECDSASignature(signature),
-      );
+      valid =
+        okOrNull(() =>
+          verifyES256Signature(storedPublicKey, hash, signature),
+        ) ?? false;
     } else {
-      valid = verifyRSASSAPKCS1v15Signature(
-        decodePKCS1RSAPublicKey(storedPublicKey),
-        sha256ObjectIdentifier,
-        hash,
-        signature,
-      );
+      valid =
+        okOrNull(() =>
+          verifyRSASSAPKCS1v15Signature(
+            decodePKCS1RSAPublicKey(storedPublicKey),
+            sha256ObjectIdentifier,
+            hash,
+            signature,
+          ),
+        ) ?? false;
     }
     if (!valid) {
       return { success: false, userError: { error: "VERIFICATION_FAILED" } };

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -2,6 +2,17 @@ import { Doc, Id } from "./_generated/dataModel.ts";
 import { MutationCtx, QueryCtx } from "./_generated/server.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
 
+/**
+ * Run `read` and return its value. Return `null` when it throws.
+ */
+export function okOrNull<T>(read: () => T): T | null {
+  try {
+    return read();
+  } catch {
+    return null;
+  }
+}
+
 export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
     ? (bytes.buffer as ArrayBuffer)

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -3,7 +3,11 @@ import { decodePKCS1RSAPublicKey } from "../../vendor/oslo/crypto/rsa.ts";
 import { api } from "./_generated/api.ts";
 import { toArrayBuffer } from "./helpers.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
-import { expectSameBytes, setup } from "../passkeyTestSetup.ts";
+import {
+  expectProtocolError,
+  expectSameBytes,
+  setup,
+} from "../passkeyTestSetup.ts";
 import {
   ORIGIN,
   RP_ID,
@@ -364,34 +368,24 @@ describe("finishRegistration", () => {
     {
       name: "too many transports",
       transports: Array.from({ length: 17 }, (_, i) => `t${i}`),
-      message: "Too many transports",
     },
-    {
-      name: "a transport that is too long",
-      transports: ["a".repeat(33)],
-      message: "has 33 characters",
-    },
-    {
-      name: "an empty transport",
-      transports: [""],
-      message: 'Invalid transport: ""',
-    },
-    {
-      name: "a transport with a non-ASCII character",
-      transports: ["üsb"],
-      message: 'Invalid transport: "üsb"',
-    },
-    {
-      name: "a transport with a space",
-      transports: ["smart card"],
-      message: 'Invalid transport: "smart card"',
-    },
-  ])("throws for $name", async ({ transports, message }) => {
+    { name: "a transport that is too long", transports: ["a".repeat(33)] },
+    { name: "an empty transport", transports: [""] },
+    { name: "a transport with a non-ASCII character", transports: ["üsb"] },
+    { name: "a transport with a space", transports: ["smart card"] },
+  ])("returns PROTOCOL_ERROR for $name", async ({ transports }) => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1");
-    await expect(
-      t.mutation(api.registration.finishRegistration, { ...args, transports }),
-    ).rejects.toThrow(message);
+    // One message covers every rule, thus the values are what the logs
+    // carry about this rejection.
+    await expectProtocolError(
+      () =>
+        t.mutation(api.registration.finishRegistration, {
+          ...args,
+          transports,
+        }),
+      `The client sent: ${JSON.stringify(transports)}.`,
+    );
     expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
       [],
     );
@@ -518,24 +512,26 @@ describe("finishRegistration", () => {
     expect(await handleRows(t)).toHaveLength(1);
   });
 
-  test("throws for an authentication client data type", async () => {
+  test("returns PROTOCOL_ERROR for an authentication client data type", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       clientDataType: "webauthn.get",
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Unexpected client data type.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      'a registration ceremony must send "webauthn.create"',
+    );
   });
 
-  test("throws for an unexpected origin without consuming the challenge", async () => {
+  test("returns PROTOCOL_ERROR for an unexpected origin without consuming the challenge", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       origin: "https://evil.example.net",
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Unexpected WebAuthn origin.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      'the ceremony ran at the origin "https://evil.example.net"',
+    );
     // The origin check happens before the challenge is consumed.
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
@@ -543,22 +539,24 @@ describe("finishRegistration", () => {
     expect(challenges).toHaveLength(1);
   });
 
-  test("throws for a cross-origin ceremony", async () => {
+  test("returns PROTOCOL_ERROR for a cross-origin ceremony", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", { crossOrigin: true });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Cross-origin WebAuthn ceremonies are not allowed.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the ceremony ran in a cross-origin frame",
+    );
   });
 
-  test("throws for a relying party ID hash mismatch", async () => {
+  test("returns PROTOCOL_ERROR for a relying party ID hash mismatch", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       authDataRpId: "evil.example.net",
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Relying party ID hash mismatch.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      `does not match the expected relying party ID "${RP_ID}"`,
+    );
   });
 
   test("returns VERIFICATION_FAILED when the user is not present", async () => {
@@ -607,17 +605,18 @@ describe("finishRegistration", () => {
     expect((await handleRows(t)).map((row) => row.userId)).toEqual(["user1"]);
   });
 
-  test("throws when the attested credential data is missing", async () => {
+  test("returns PROTOCOL_ERROR when the attested credential data is missing", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       includeCredential: false,
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Missing attested credential data.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "carries no attested credential data",
+    );
   });
 
-  test("throws for an unsupported public key algorithm", async () => {
+  test("returns PROTOCOL_ERROR for an unsupported public key algorithm", async () => {
     const t = setup();
     const credential = await generateES256Credential();
     // An EdDSA (-8) COSE key.
@@ -630,12 +629,13 @@ describe("finishRegistration", () => {
       ]),
     );
     const { args } = await registrationArgs(t, "user1", { credential });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Unsupported public key algorithm.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the credential uses the COSE key algorithm -8",
+    );
   });
 
-  test("throws for an unsupported elliptic curve", async () => {
+  test("returns PROTOCOL_ERROR for an unsupported elliptic curve", async () => {
     const t = setup();
     const credential = await generateES256Credential();
     // ES256 with a P-384 (crv 2) key.
@@ -649,26 +649,27 @@ describe("finishRegistration", () => {
       ]),
     );
     const { args } = await registrationArgs(t, "user1", { credential });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("Unsupported elliptic curve (expected P-256).");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the credential uses the elliptic curve 2",
+    );
   });
 
-  test("throws for a duplicate credential ID", async () => {
+  test("returns PROTOCOL_ERROR for a duplicate credential ID", async () => {
     const t = setup();
     await register(t, "user1");
     const { credential } = await register(t, "user1");
     // A second ceremony for a new account, with a credential that exists.
-    // A compliant client cannot cause this, so the mutation throws instead
-    // of returning a user error.
+    // A compliant client cannot cause this.
     const { args } = await registrationArgs(t, "user2", {
       isNewAccountFlow: true,
       credential,
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("The credential is already registered.");
-    // The throw rolls back the mutation: the challenge and its unlinked
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the credential is already registered",
+    );
+    // The check runs before any write, so the challenge and its unlinked
     // handle stay, and the cleanup loop erases them after the TTL.
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
@@ -780,23 +781,38 @@ describe("checkRegistration", () => {
     });
   });
 
-  test("throws for a duplicate credential ID", async () => {
+  test("returns PROTOCOL_ERROR for a duplicate credential ID", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { args } = await registrationArgs(t, "user2", { credential });
-    await expect(
-      t.query(api.registration.checkRegistration, checkArgs(args)),
-    ).rejects.toThrow("The credential is already registered.");
+    await expectProtocolError(
+      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      "the credential is already registered",
+    );
   });
 
-  test("throws for an unexpected origin, like the finish call", async () => {
+  test("returns PROTOCOL_ERROR for an unexpected origin, like the finish call", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       origin: "https://evil.example.net",
     });
-    await expect(
-      t.query(api.registration.checkRegistration, checkArgs(args)),
-    ).rejects.toThrow("Unexpected WebAuthn origin.");
+    await expectProtocolError(
+      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      'the ceremony ran at the origin "https://evil.example.net"',
+    );
+  });
+
+  test("returns PROTOCOL_ERROR for transports that the client made up", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1");
+    await expectProtocolError(
+      () =>
+        t.query(api.registration.checkRegistration, {
+          ...checkArgs(args),
+          transports: ["smart card"],
+        }),
+      'The client sent: ["smart card"].',
+    );
   });
 
   test("a finish with the same arguments succeeds after a successful check", async () => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -17,12 +17,13 @@ import {
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
-  validateTransports,
+  transportsAreValid,
 } from "./validation.ts";
 import {
   deleteDeadChallenge,
   findChallenge,
   isChallengeExpired,
+  okOrNull,
   randomChallenge,
   randomHandle,
   toArrayBuffer,
@@ -128,6 +129,7 @@ const registrationCheckArgs = {
   expectedOrigin: v.string(),
   attestationObject: v.bytes(),
   clientDataJSON: v.bytes(),
+  transports: v.optional(v.array(v.string())),
 };
 
 const _vRegistrationCheckArgs = v.object(registrationCheckArgs);
@@ -165,26 +167,55 @@ type RegistrationVerification =
  * by `MutationCtx`, so both `checkRegistration` (a query) and
  * `finishRegistration` (a mutation) run the exact same code.
  *
- * Failures that the user can correct come back as a `userError`. For a
- * protocol violation, the function throws an error (see
- * `finishRegistration`).
+ * Failures that the user can correct come back as a `userError`. A client
+ * that does not respect the WebAuthn protocol gets `PROTOCOL_ERROR`, and
+ * the backend logs say which check failed.
  */
 async function verifyRegistration(
   ctx: QueryCtx,
   args: RegistrationCheckArgs,
 ): Promise<RegistrationVerification> {
-  const clientData = parseClientDataJSON(new Uint8Array(args.clientDataJSON));
+  if (!transportsAreValid(args.transports)) {
+    console.warn(
+      `Rejected the passkey ceremony: the client reported transports that seem invalid. The client sent: ${JSON.stringify(args.transports).slice(0, 200)}.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+  }
+  const clientData = okOrNull(() =>
+    parseClientDataJSON(new Uint8Array(args.clientDataJSON)),
+  );
+  if (clientData === null) {
+    console.warn(
+      `Rejected the passkey ceremony: the client data JSON could not be read.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+  }
   if (clientData.type !== ClientDataType.Create) {
-    throw new Error("Unexpected client data type.");
+    console.warn(
+      `Rejected the passkey ceremony: the client data type is ` +
+        `"webauthn.get", but a registration ceremony must send ` +
+        `"webauthn.create".`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
   if (clientData.origin !== args.expectedOrigin) {
     // We could allow this verification to be less strict in the future
     // (see the comment in `finishAuthentication`).
-    throw new Error("Unexpected WebAuthn origin.");
+    console.warn(
+      `Rejected the passkey ceremony: the ceremony ran at the origin ` +
+        `${JSON.stringify(clientData.origin)}, but the expected origin is ` +
+        `${JSON.stringify(args.expectedOrigin)}. Check that the \`origin\` of ` +
+        `the provider matches the page that ran the ceremony.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
   if (clientData.crossOrigin === true) {
     // In the future, we could allow the user to explicitly opt out to this.
-    throw new Error("Cross-origin WebAuthn ceremonies are not allowed.");
+    console.warn(
+      `Rejected the passkey ceremony: the ceremony ran in a cross-origin ` +
+        `frame, which is not allowed.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
   const challengeRow = await findChallenge(
     ctx,
@@ -195,37 +226,87 @@ async function verifyRegistration(
     return { userError: { error: "CHALLENGE_EXPIRED" }, challengeRow };
   }
 
-  const attestationObject = parseAttestationObject(
-    new Uint8Array(args.attestationObject),
+  const attestationObject = okOrNull(() =>
+    parseAttestationObject(new Uint8Array(args.attestationObject)),
   );
+  if (attestationObject === null) {
+    console.warn(
+      `Rejected the passkey ceremony: the attestation object could not be ` +
+        `read.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+  }
   const authenticatorData = attestationObject.authenticatorData;
   if (!authenticatorData.verifyRelyingPartyIdHash(args.expectedRpId)) {
-    throw new Error("Relying party ID hash mismatch.");
+    console.warn(
+      `Rejected the passkey ceremony: the authenticator data does not match ` +
+        `the expected relying party ID ${JSON.stringify(args.expectedRpId)}. ` +
+        `Check that the \`rpId\` of the provider matches the page that ran ` +
+        `the ceremony.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
   if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
     return { userError: { error: "VERIFICATION_FAILED" }, challengeRow };
   }
   const credential = authenticatorData.credential;
   if (credential === null) {
-    throw new Error("Missing attested credential data.");
+    console.warn(
+      `Rejected the passkey ceremony: the authenticator data carries no ` +
+        `attested credential data.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
 
   const cosePublicKey = credential.publicKey;
+  // The algorithm is a number, so `null` is never a valid value.
+  const coseAlgorithm = okOrNull(() => cosePublicKey.algorithm());
+  if (coseAlgorithm === null) {
+    console.warn(
+      `Rejected the passkey ceremony: the algorithm of the credential public ` +
+        `key could not be read.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+  }
   let algorithm: "ES256" | "RS256";
   let publicKey: Uint8Array;
-  if (cosePublicKey.algorithm() === coseAlgorithmES256) {
-    const ec2 = cosePublicKey.ec2();
+  if (coseAlgorithm === coseAlgorithmES256) {
+    const ec2 = okOrNull(() => cosePublicKey.ec2());
+    if (ec2 === null) {
+      console.warn(
+        `Rejected the passkey ceremony: the EC2 credential public key could ` +
+          `not be read.`,
+      );
+      return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+    }
     if (ec2.curve !== coseEllipticCurveP256) {
-      throw new Error("Unsupported elliptic curve (expected P-256).");
+      console.warn(
+        `Rejected the passkey ceremony: the credential uses the elliptic ` +
+          `curve ${ec2.curve}, but ES256 requires P-256 ` +
+          `(${coseEllipticCurveP256}).`,
+      );
+      return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
     }
     publicKey = new ECDSAPublicKey(p256, ec2.x, ec2.y).encodeSEC1Uncompressed();
     algorithm = "ES256";
-  } else if (cosePublicKey.algorithm() === coseAlgorithmRS256) {
-    const rsa = cosePublicKey.rsa();
+  } else if (coseAlgorithm === coseAlgorithmRS256) {
+    const rsa = okOrNull(() => cosePublicKey.rsa());
+    if (rsa === null) {
+      console.warn(
+        `Rejected the passkey ceremony: the RSA credential public key could ` +
+          `not be read.`,
+      );
+      return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
+    }
     publicKey = new RSAPublicKey(rsa.n, rsa.e).encodePKCS1();
     algorithm = "RS256";
   } else {
-    throw new Error("Unsupported public key algorithm.");
+    console.warn(
+      `Rejected the passkey ceremony: the credential uses the COSE key ` +
+        `algorithm ${coseAlgorithm}, but the ceremony only offered ES256 ` +
+        `(${coseAlgorithmES256}) and RS256 (${coseAlgorithmRS256}).`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
 
   const credentialId = toArrayBuffer(credential.id);
@@ -238,7 +319,10 @@ async function verifyRegistration(
     // random credential ID for each ceremony, and `excludeCredentials`
     // makes the authenticator refuse a duplicate for this RP. A duplicate
     // here shows a replayed or tampered registration.
-    throw new Error("The credential is already registered.");
+    console.warn(
+      `Rejected the passkey ceremony: the credential is already registered.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
 
   return {
@@ -276,9 +360,7 @@ type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
  * The guarantee does not cover throws. This function cannot see the
  * handle-linking invariants of `finishRegistration` (they depend on
  * `verifiedUserId`), so `finishRegistration` can still throw after a
- * successful check, and a throw aborts the transaction. The function throws
- * on the same protocol violations that make `finishRegistration` throw, so
- * a caller transaction aborts identically for those.
+ * successful check, and a throw aborts the transaction.
  */
 export const checkRegistration = query({
   args: registrationCheckArgs,
@@ -311,16 +393,16 @@ export const checkRegistration = query({
  *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
  * - `transports`: the transports that the browser reported for the new
  *   credential. The value is a hint: a later ceremony sends it back to the
- *   browser, and the verification does not use it. The function throws for
- *   a value that no authenticator can report.
+ *   browser, and the verification does not use it. A value that no
+ *   authenticator can report gets `PROTOCOL_ERROR`.
  *
  * The function examines the attestation as
  * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
  * the credential and deletes the challenge.
  *
- * Failures that the user can correct come back as a `userError`. For a
- * protocol violation, the function throws an error. The error aborts the
- * transaction around the call, so a new user row rolls back with it.
+ * Each failure comes back as a `userError`. A client that does not respect
+ * the WebAuthn protocol gets `PROTOCOL_ERROR`, and the backend logs say
+ * which check failed.
  *
  * A caller that must be sure that this call succeeds before it creates
  * data runs `checkRegistration` first, in the same mutation.
@@ -334,7 +416,6 @@ export const finishRegistration = mutation({
   },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
-    validateTransports(args.transports);
     const verification = await verifyRegistration(ctx, args);
 
     if (verification.userError !== null) {

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -73,7 +73,7 @@ export default defineSchema({
         // opaque to the component. The start step and the finish step
         // must give the same purpose, thus an assertion for one flow
         // cannot complete a different flow. A different purpose
-        // at the finish step burns the challenge.
+        // at the finish step is a protocol violation.
         // The purpose string is expected to be a constant string identifying
         // a specific flow, and should not contain dynamic information.
         // TODO(nicolas) Make `startAuthentication` return the challenge ID too

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -274,8 +274,8 @@ export function setupUsernamePasskey<UsersTable extends string>(
          * The order of the steps gives that guarantee:
          * 1. Checks that write nothing: the username format, the username
          *    conflict, and `checkRegistration` (the full WebAuthn
-         *    verification as a query). Each correctable failure returns a
-         *    `userError` here, before anything exists.
+         *    verification as a query). Each failure, correctable or not,
+         *    returns a `userError` here, before anything exists.
          * 2. Writes that cannot fail after the checks: `completeSignUp` mints
          *    the user, the account, and the session, `setUsername` stores the
          *    username, and `finishRegistration` stores the passkey. None of
@@ -314,6 +314,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 expectedOrigin: origin,
                 attestationObject: args.attestationObject,
                 clientDataJSON: args.clientDataJSON,
+                transports: args.transports,
               },
             );
             if (!checkResult.success) {

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -25,51 +25,22 @@ const MAX_TRANSPORT_LENGTH = 32;
 const TRANSPORT_PATTERN = /^[\x21-\x7e]+$/;
 
 /**
- * Show a transport in an error message. The value comes from the client,
- * thus it can be long, empty, or contain characters that are not
- * printable. `JSON.stringify` puts it in quotation marks and replaces
- * these characters. A long value is cut to keep the message short.
- */
-function describeTransport(value: string) {
-  const shown =
-    value.length > MAX_TRANSPORT_LENGTH
-      ? `${value.slice(0, MAX_TRANSPORT_LENGTH)}…`
-      : value;
-  return JSON.stringify(shown);
-}
-
-/**
  * Examine the transports that the client reports, before the component
  * stores them.
  *
  * The component does not compare the values with a list of known
  * transports, because the WebAuthn spec lets new transports appear. It
  * only refuses the values that no authenticator can report.
- *
- * @throws when there are too many values, or when a value is empty, too
- * long, or not printable ASCII.
  */
-export function validateTransports(values: string[] | undefined) {
-  if (values === undefined) {
-    return;
-  }
-  if (values.length > MAX_TRANSPORTS) {
-    throw new Error(
-      `Too many transports: a credential can have a maximum of ${MAX_TRANSPORTS}.`,
-    );
-  }
-  for (const value of values) {
-    if (value.length > MAX_TRANSPORT_LENGTH) {
-      throw new Error(
-        `Transport too long: ${describeTransport(value)} has ${value.length} characters, but a transport can have a maximum of ${MAX_TRANSPORT_LENGTH}.`,
-      );
-    }
-    if (!TRANSPORT_PATTERN.test(value)) {
-      throw new Error(
-        `Invalid transport: ${describeTransport(value)} is not a non-empty string of printable ASCII characters.`,
-      );
-    }
-  }
+export function transportsAreValid(values: string[] | undefined): boolean {
+  if (values === undefined) return true;
+
+  if (values.length > MAX_TRANSPORTS) return false;
+
+  return values.every(
+    (value) =>
+      value.length <= MAX_TRANSPORT_LENGTH && TRANSPORT_PATTERN.test(value),
+  );
 }
 
 /**
@@ -83,15 +54,27 @@ export const credentialDescriptor = v.object({
 export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
 
 /**
+ * The client broke the WebAuthn protocol: an unexpected origin, an
+ * attestation that no parser can read, a key algorithm that the ceremony
+ * never offered, an assertion that no compliant authenticator makes, and so
+ * on.
+ *
+ * This is the HTTP 400 of the component. Most of the time the client is at
+ * fault, but the same code also covers a configuration mistake of the app
+ * (an `rpId` or an `origin` that does not match the page). The two are not
+ * separated, exactly as a 400 does not say whether the caller wrote a bad
+ * request or configured a bad base URL.
+ *
+ * The end user cannot correct this, so an app shows a generic message. The
+ * component writes which check failed to the backend logs, and never sends
+ * the details to the client.
+ */
+const protocolError = v.object({ error: v.literal("PROTOCOL_ERROR") });
+
+/**
  * The user-facing errors for `finishRegistration`. An app can show these
  * errors to the end user. The `error` field is a machine-readable code and
  * the discriminant of the union.
- *
- * Protocol violations (an unexpected origin, a malformed attestation, an
- * unsupported algorithm, …) are not part of this union. They show a
- * configuration error or a tampered client, not a condition that the user
- * can correct. For these violations, the component throws an error. The
- * error also aborts the transaction around the call.
  */
 export const finishRegistrationUserError = v.union(
   // The challenge is unknown, already used, or too old. The user must start
@@ -99,6 +82,7 @@ export const finishRegistrationUserError = v.union(
   v.object({ error: v.literal("CHALLENGE_EXPIRED") }),
   // The authenticator did not report user presence and user verification.
   v.object({ error: v.literal("VERIFICATION_FAILED") }),
+  protocolError,
 );
 export type FinishRegistrationUserError = Infer<
   typeof finishRegistrationUserError
@@ -109,12 +93,14 @@ export type FinishRegistrationUserError = Infer<
  * errors to the end user.
  */
 export const finishAuthenticationUserError = v.union(
-  // No stored passkey has the credential ID from the assertion.
+  // No stored passkey has the credential ID from the assertion. The
+  // authenticator still offers a passkey that the app deleted.
   v.object({ error: v.literal("UNKNOWN_CREDENTIAL") }),
   v.object({ error: v.literal("CHALLENGE_EXPIRED") }),
   // The assertion is not valid. Possible causes: a bad signature, no user
   // presence or user verification, or a challenge for a different user.
   v.object({ error: v.literal("VERIFICATION_FAILED") }),
+  protocolError,
 );
 export type FinishAuthenticationUserError = Infer<
   typeof finishAuthenticationUserError

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -1,5 +1,5 @@
 import { convexTest, type TestConvex } from "convex-test";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 import { register as registerBatchWorker } from "@convex-dev/batch-worker/test";
 import schema from "./passkey/schema.ts";
 
@@ -22,4 +22,25 @@ export function expectSameBytes(
   b: ArrayBuffer | Uint8Array,
 ): void {
   expect(new Uint8Array(a)).toEqual(new Uint8Array(b));
+}
+
+/**
+ * Assert that a ceremony call rejects a client that does not respect the
+ * WebAuthn protocol: the client gets `PROTOCOL_ERROR` and nothing else, and
+ * the backend logs carry `detail`.
+ */
+export async function expectProtocolError(
+  call: () => Promise<unknown>,
+  detail: string,
+): Promise<void> {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await expect(call()).resolves.toEqual({
+      success: false,
+      userError: { error: "PROTOCOL_ERROR" },
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(detail));
+  } finally {
+    warn.mockRestore();
+  }
 }


### PR DESCRIPTION
Currently, the passkey implementation throws when it receives something unexpected from the client. I was doing this to simplify error handling on the client: we don’t want to require the app to define an error message for every passkey protocol violation.

However, this isn’t great because it can lead to errors to be thrown for an app that’s correctly configured but is used by misbehaving clients. This is bad for using Convex Auth in production, because the developer’s error tracking can contain errors that aren’t their fault. Conceptually, these protocol errors are 4xx errors, not 5xx.

This PR changes the error handling so that we return `{ error: "PROTOCOL_ERROR" }` instead, and `console.warn()` the issue to make it easier to debug (logging is useful because some of these errors might come from app configuration issues).
