### PR TITLE
Stop re-exporting the non-SSR shapes from `/ssr`

### DIFF
--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -38,6 +38,8 @@ export type TokenBundle = Infer<typeof vTokenBundle>;
  * SSR auth proxy find the refresh token without knowing which provider produced
  * the response, and lets it reject a shape it doesn't recognize instead of
  * forwarding tokens to the browser.
+ *
+ * @TODO(nicolas) Publish this type to make it easier to write custom providers
  */
 export const vSignInSuccess = v.object({
   success: v.literal(true),

--- a/packages/core/src/ssr/index.ts
+++ b/packages/core/src/ssr/index.ts
@@ -7,6 +7,10 @@
  * handlers, the {@link convexProxyHandler} that serves sign-in, and the
  * {@link setupConvexAuthServer} factory that configures them all once.
  *
+ * The shapes these modules exchange with the browser and the backend (the token
+ * bundles, the sign-in envelope) are deliberately absent: they are not SSR
+ * specific, so this is the wrong entry point to publish them from.
+ *
  * @module
  */
 
@@ -54,15 +58,5 @@ export {
   type ServerAuthChecker,
   type ServerAuthCheckerConfig,
 } from "./isAuthenticated.ts";
-export type {
-  AuthSessionResponse,
-  ClientView,
-  ConvexAuthApi,
-  IsAuthenticatedFn,
-  RefreshSessionFn,
-  SignInSuccess,
-  SignOutFn,
-  SlimTokenBundle,
-  TokenBundle,
-} from "../lib/types.ts";
-export { makeSlimBundle, vSignInSuccess } from "../lib/types.ts";
+export type { AuthSessionResponse } from "../lib/types.ts";
+export { makeSlimBundle } from "../lib/types.ts";


### PR DESCRIPTION
Follows up on Shawn's review of #519:

> Some things like `vSignInSuccess` should eventually move out of there since its not SSR specific

`@convex-dev/auth/ssr` re-exported the shapes that cross the boundary between
the Convex backend and its clients. None of them is SSR specific: a provider
component author who needs `vSignInSuccess` writes a Convex backend function,
and had to import the validator from an entry point named after server-side
rendering.

| Symbol | Before | After |
| --- | --- | --- |
| `vSignInSuccess`, `SignInSuccess` | `/ssr` | not exported |
| `vTokenBundle`, `TokenBundle`, `SlimTokenBundle` | `/ssr` | not exported |
| `ClientView` | `/ssr` | not exported |
| `ConvexAuthApi`, `RefreshSessionFn`, `SignOutFn`, `IsAuthenticatedFn` | `/ssr` | not exported |
| `AuthSessionResponse`, `makeSlimBundle` | `/ssr` | `/ssr` |

They are dropped rather than moved to a new entry point, because nothing
outside the package imports one of them: `examples/` and `packages/docs/` name
none of the six, and every module inside the package reaches them by relative
path through `lib/types.ts`. The four auth function references are also only
ever a field of an exported config type (`ConvexAuthServerConfig`,
`RefreshHandlerConfig`, `ServerAuthCheckerConfig`), so a caller writes
`setupConvexAuthServer({ refreshSession: api.auth.refreshSession, … })` and gets
the type by inference.

Adding an export back is not a breaking change, so the entry point that
publishes these shapes can wait until there is a consumer for it. That is most
likely [the custom-provider guide](https://github.com/get-convex/convex-auth/blob/reboot/packages/docs/content/docs/advanced/creating-custom-providers.mdx),
which is still a stub: an out-of-tree provider is the one caller that genuinely
cannot use inference, since its Convex function has to write
`returns: vSignInSuccess` literally.

`AuthSessionResponse` and `makeSlimBundle` stay in `/ssr` because only the SSR
handlers produce and consume them. `/react` keeps the `ConvexAuthApi` and
`TokenBundle` exports it already had.
