### PR TITLE
Add backend code for a react-passkey demo with management

### DIFF
--- a/examples/react-passkey-basic/README.md
+++ b/examples/react-passkey-basic/README.md
@@ -1,4 +1,4 @@
-# react-passkey-no-management example
+# react-passkey-basic example
 
 > [!WARNING]
 > This demo is intentionally kept incomplete because it is used as a first step in the passkey tutorial. You should probably not implement an app that doesn’t support passkey management. See [**react-passkey**](../react-passkey/README.md) for a full demo.

--- a/examples/react-passkey-basic/README.md
+++ b/examples/react-passkey-basic/README.md
@@ -1,13 +1,9 @@
-# react-passkey example
+# react-passkey-no-management example
 
-This demo shows:
+> [!WARNING]
+> This demo is intentionally kept incomplete because it is used as a first step in the passkey tutorial. You should probably not implement an app that doesn’t support passkey management. See [**react-passkey**](../react-passkey/README.md) for a full demo.
 
-- The core component.
-- The passkey component, with the identifier-first `UsernamePasskey`
-  provider: one username field. A free username creates a new account with
-  a passkey; an existing username asks for a passkey of that account. The
-  login field also offers passkey autofill (WebAuthn conditional
-  mediation).
+This demo is a simplified version of the [react-passkey](../react-passkey/README.md) demo that doesn’t support passkey management (i.e. the ability for user to add or remove passkeys).
 
 ## Generate code / run
 

--- a/examples/react-passkey/.gitignore
+++ b/examples/react-passkey/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/examples/react-passkey/README.md
+++ b/examples/react-passkey/README.md
@@ -1,7 +1,7 @@
 # react-passkey example
 
 > [!WARNING]
-> **Work in progress**: this demo doesn’t have frontend code yet. See [react-passkey-no-management](../react-passkey-no-management/README.md) if you need a full demo.
+> **Work in progress**: this demo doesn’t have frontend code yet. See [react-passkey-basic](../react-passkey-basic/README.md) if you need a full demo.
 
 <!-- TODO(nicolas) Remove this ↑ -->
 

--- a/examples/react-passkey/README.md
+++ b/examples/react-passkey/README.md
@@ -1,0 +1,31 @@
+# react-passkey example
+
+> [!WARNING]
+> **Work in progress**: this demo doesn’t have frontend code yet. See [react-passkey-no-management](../react-passkey-no-management/README.md) if you need a full demo.
+
+<!-- TODO(nicolas) Remove this ↑ -->
+
+This demo shows:
+
+- The core component.
+- The passkey component, with the identifier-first `UsernamePasskey`
+  provider: one username field. A free username creates a new account with
+  a passkey; an existing username asks for a passkey of that account. The
+  login field also offers passkey autofill (WebAuthn conditional
+  mediation).
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-passkey
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx @convex-dev/auth     # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+npm run dev              # start the Vite frontend
+```
+
+## Deploying
+
+Before you deploy, set `rpId` and `origin` in `convex/auth.ts` to the
+production domain. Passkeys are permanently bound to the `rpId`.

--- a/examples/react-passkey/convex/_generated/api.d.ts
+++ b/examples/react-passkey/convex/_generated/api.d.ts
@@ -1,0 +1,57 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as currentUser from "../currentUser.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  currentUser: typeof currentUser;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  auth: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"auth">;
+  authPasskey: import("@convex-dev/auth/providers/passkey/_generated/component.js").ComponentApi<"authPasskey">;
+  authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;
+};

--- a/examples/react-passkey/convex/_generated/api.js
+++ b/examples/react-passkey/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-passkey/convex/_generated/dataModel.d.ts
+++ b/examples/react-passkey/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-passkey/convex/_generated/server.d.ts
+++ b/examples/react-passkey/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-passkey/convex/_generated/server.js
+++ b/examples/react-passkey/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-passkey/convex/auth.config.ts
+++ b/examples/react-passkey/convex/auth.config.ts
@@ -1,0 +1,13 @@
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;

--- a/examples/react-passkey/convex/auth.ts
+++ b/examples/react-passkey/convex/auth.ts
@@ -1,0 +1,29 @@
+import { components, internal } from "./_generated/api";
+import { setupCore } from "@convex-dev/auth/core/setup";
+import { setupUsernamePasskey } from "@convex-dev/auth/providers/passkey/setup";
+
+const core = setupCore({ component: components.auth });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+export const {
+  startSignIn,
+  startAutofillSignIn,
+  finishSignUp,
+  finishSignIn,
+
+  listPasskeys,
+
+  startAddPasskey,
+  verifyAddPasskey,
+  finishAddPasskey,
+
+  startRemovePasskey,
+  finishRemovePasskey,
+} = setupUsernamePasskey(core, {
+  component: components.authPasskey,
+  usernameComponent: components.authUsername,
+  // The relying party ID and the origin of the Vite dev server. A deployed
+  // app uses its own domain here.
+  rpId: "localhost",
+  origin: "http://localhost:5173",
+}).attachUserCallbacks({ createUser: internal.users.createUser });

--- a/examples/react-passkey/convex/convex.config.ts
+++ b/examples/react-passkey/convex/convex.config.ts
@@ -1,0 +1,24 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import core from "@convex-dev/auth/core/convex.config.js";
+import passkey from "@convex-dev/auth/providers/passkey/convex.config.js";
+import username from "@convex-dev/auth/username/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(core, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(passkey);
+app.use(username);
+
+export default app;

--- a/examples/react-passkey/convex/currentUser.ts
+++ b/examples/react-passkey/convex/currentUser.ts
@@ -1,0 +1,32 @@
+import { getAuthUserId } from "@convex-dev/auth/core";
+import { query } from "./_generated/server";
+import { components } from "./_generated/api";
+
+/**
+ * The currently signed-in user, or null.
+ *
+ * Demonstrates an authenticated query.
+ */
+export const loggedInUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) {
+      return null;
+    }
+    const user = await ctx.db.get("users", userId);
+    if (user === null) {
+      return null;
+    }
+    const username = await ctx.runQuery(
+      components.authUsername.public.getUsername,
+      { userId },
+    );
+    if (username === null) {
+      // Every user signs up with a username, so this must not occur.
+      throw new Error(`User ${userId} unexpectedly has no username`);
+    }
+
+    return { id: user._id, username };
+  },
+});

--- a/examples/react-passkey/convex/schema.ts
+++ b/examples/react-passkey/convex/schema.ts
@@ -1,0 +1,5 @@
+import { defineSchema, defineTable } from "convex/server";
+
+export default defineSchema({
+  users: defineTable({}),
+});

--- a/examples/react-passkey/convex/tsconfig.json
+++ b/examples/react-passkey/convex/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-passkey/convex/users.ts
+++ b/examples/react-passkey/convex/users.ts
@@ -1,0 +1,18 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Create the user row for a new passkey account and return its id. This
+ * example keeps no data in the row, but your app can put a profile here.
+ */
+export const createUser = internalMutation({
+  args: {
+    provider: v.literal("passkey"),
+    providerAccountId: v.string(),
+    profile: v.object({ username: v.string() }),
+  },
+  returns: v.id("users"),
+  handler: async (ctx) => {
+    return await ctx.db.insert("users", {});
+  },
+});

--- a/examples/react-passkey/index.html
+++ b/examples/react-passkey/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convex Auth — react-passkey</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-passkey/package.json
+++ b/examples/react-passkey/package.json
@@ -5,15 +5,22 @@
   "type": "module",
   "dependencies": {
     "@convex-dev/auth": "workspace:*",
-    "convex": "^1.43.0"
+    "convex": "^1.43.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.1"
   },
   "scripts": {
-    "dev": "convex dev",
-    "build": "tsc -p convex --noEmit",
+    "dev": "convex dev --start vite",
+    "build": "vite build && tsc -p convex --noEmit",
     "typecheck": "tsc --noEmit && tsc -p convex --noEmit"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
-    "typescript": "^6.0.3"
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/examples/react-passkey/package.json
+++ b/examples/react-passkey/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "example-react-passkey",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "convex": "^1.43.0"
+  },
+  "scripts": {
+    "dev": "convex dev",
+    "build": "tsc -p convex --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p convex --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.4",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/react-passkey/src/App.tsx
+++ b/examples/react-passkey/src/App.tsx
@@ -1,0 +1,63 @@
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+} from "@convex-dev/auth/react";
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import { Dashboard } from "./routes/dashboard";
+import { LogIn } from "./routes/logIn";
+import "./index.css";
+
+export function App() {
+  return (
+    <main>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <Dashboard />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            <RequireNoAuth>
+              <LogIn />
+            </RequireNoAuth>
+          }
+        />
+      </Routes>
+    </main>
+  );
+}
+
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <Navigate to="/login" replace />
+      </Unauthenticated>
+      <Authenticated>{children}</Authenticated>
+    </>
+  );
+}
+
+function RequireNoAuth({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Authenticated>
+        <Navigate to="/" replace />
+      </Authenticated>
+      <Unauthenticated>{children}</Unauthenticated>
+    </>
+  );
+}

--- a/examples/react-passkey/src/index.css
+++ b/examples/react-passkey/src/index.css
@@ -1,0 +1,35 @@
+body {
+  background-color: oklch(96.8% 0.007 247.896);
+}
+
+main {
+  font-family: system-ui, sans-serif;
+  max-width: 480px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}
+
+/*
+In this demo, we apply a few basic styles on elements themselves
+so that the layout looks okay.
+
+In a real app, you should replace these elements by elements of
+your app’s design system, so that the auth UIs look consistent
+with the rest of your app.
+*/
+
+label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  box-sizing: border-box;
+  font-size: 1rem;
+}

--- a/examples/react-passkey/src/main.tsx
+++ b/examples/react-passkey/src/main.tsx
@@ -1,0 +1,25 @@
+import { ConvexAuthProvider } from "@convex-dev/auth/react";
+import { ConvexReactClient } from "convex/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { api } from "../convex/_generated/api";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexAuthProvider
+      client={convex}
+      api={{
+        refreshSession: api.auth.refreshSession,
+        signOut: api.auth.signOut,
+      }}
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ConvexAuthProvider>
+  </StrictMode>,
+);

--- a/examples/react-passkey/src/routes/dashboard.tsx
+++ b/examples/react-passkey/src/routes/dashboard.tsx
@@ -1,0 +1,18 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export function Dashboard() {
+  const user = useQuery(api.currentUser.loggedInUser);
+  const { signOut } = useAuthActions();
+  return (
+    <>
+      {user && (
+        <p>
+          Signed in as <strong>{user.username}</strong> ({user.id})
+        </p>
+      )}
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -90,15 +90,13 @@ function errorMessage(
       return "That username was just taken. Try another one.";
     case "CHALLENGE_EXPIRED":
       return "The sign-in attempt took too long. Please try again.";
-    case "VERIFICATION_FAILED":
-      return "The passkey could not be verified. Please try again.";
     case "UNKNOWN_CREDENTIAL":
       return "This passkey is not registered here.";
     case "PROTOCOL_ERROR":
       // The browser sent something that violates the protocol.
       // This might be caused by a misbehaving client, or by a configuration error.
       // The Convex logs contain more information about the source of the error.
-      return "This browser sent an invalid passkey request. Please try again, or contact support if the problem persists.";
+      return "This passkey request could not be verified. Please try again, or contact support if the problem persists.";
     case "CEREMONY_ABORTED":
       // The most common failure: the user closed the passkey dialog.
       return "Sign-in was cancelled. Please try again.";

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -1,0 +1,116 @@
+import {
+  PasskeyAutofillError,
+  PasskeySignInResult,
+  usePasskey,
+} from "@convex-dev/auth/providers/passkey/react";
+import { useEffect, useState } from "react";
+import { api } from "../../convex/_generated/api";
+
+export function LogIn() {
+  // While this hook is mounted, the browser also offers stored passkeys in
+  // the autocompletion list of the username field below (the field carries
+  // autoComplete="username webauthn"). Picking one signs in directly.
+  const { signIn, pending, autofill } = usePasskey({
+    startSignIn: api.auth.startSignIn,
+    startAutofillSignIn: api.auth.startAutofillSignIn,
+    finishSignIn: api.auth.finishSignIn,
+    finishSignUp: api.auth.finishSignUp,
+  });
+  const [username, setUsername] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Show autofill failures in the same error area as the modal flow. The
+  // most recent failure from either flow wins.
+  const { lastError } = autofill;
+  useEffect(() => {
+    if (lastError !== null) {
+      setError(errorMessage(lastError));
+    }
+  }, [lastError]);
+
+  // Also lock the form while an autofill sign-in is being verified on the
+  // server.
+  const busy = pending || autofill.status === "signingIn";
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        setError(null);
+        const result = await signIn({ username });
+        if (result.success) {
+          return;
+        }
+        setError(errorMessage(result.userError));
+      }}
+    >
+      <h1>Log in</h1>
+      <p>
+        Enter your username. A free username creates a new account with a
+        passkey; an existing username asks for its passkey.
+      </p>
+      <label>
+        Username
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          autoComplete="username webauthn"
+          required
+          disabled={busy}
+        />
+      </label>
+      {error ? (
+        <p role="alert">
+          <strong>{error}</strong>
+        </p>
+      ) : null}
+      <button type="submit" disabled={busy}>
+        {busy ? "Waiting for your passkey…" : "Continue with a passkey"}
+      </button>
+    </form>
+  );
+}
+
+function errorMessage(
+  userError:
+    | Extract<PasskeySignInResult, { success: false }>["userError"]
+    | PasskeyAutofillError,
+): string {
+  switch (userError.error) {
+    case "USERNAME_TOO_SHORT":
+      return `The username must be at least ${userError.minimumLength} characters.`;
+    case "USERNAME_HAS_SURROUNDING_WHITESPACE":
+      return "The username can't start or end with whitespace.";
+    case "USERNAME_HAS_INVALID_CHARACTERS":
+      return "The username contains characters that aren't allowed.";
+    case "USERNAME_TAKEN":
+      // Only returned when someone claimed the username between the two
+      // steps of the ceremony.
+      return "That username was just taken. Try another one.";
+    case "CHALLENGE_EXPIRED":
+      return "The sign-in attempt took too long. Please try again.";
+    case "VERIFICATION_FAILED":
+      return "The passkey could not be verified. Please try again.";
+    case "UNKNOWN_CREDENTIAL":
+      return "This passkey is not registered here.";
+    case "PROTOCOL_ERROR":
+      // The browser sent something that violates the protocol.
+      // This might be caused by a misbehaving client, or by a configuration error.
+      // The Convex logs contain more information about the source of the error.
+      return "This browser sent an invalid passkey request. Please try again, or contact support if the problem persists.";
+    case "CEREMONY_ABORTED":
+      // The most common failure: the user closed the passkey dialog.
+      return "Sign-in was cancelled. Please try again.";
+    case "WEBAUTHN_UNSUPPORTED":
+      return "This browser does not support passkeys.";
+    case "OTHER_ERROR":
+      // The mutation threw unexpectedly; the original error is available
+      // on `cause` if you want to log or inspect it.
+      console.error("Sign-in failed:", userError.cause);
+      return "Something went wrong. Please try again.";
+    default:
+      userError satisfies never;
+      return `Unknown error: ${JSON.stringify(userError)}`;
+  }
+}

--- a/examples/react-passkey/tsconfig.json
+++ b/examples/react-passkey/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["convex/**/*", "src/**/*", "vite.config.ts"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/examples/react-passkey/vite.config.ts
+++ b/examples/react-passkey/vite.config.ts
@@ -1,0 +1,12 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    // Passkey ceremonies are bound to this origin (see convex/auth.ts).
+    // Fail instead of silently moving to another port.
+    port: 5173,
+    strictPort: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,22 @@ importers:
         specifier: ^8.0.16
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)
 
+  examples/react-passkey:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      convex:
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/react-passkey-basic:
     dependencies:
       '@convex-dev/auth':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,13 +243,13 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.16
-        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)
 
   examples/react-passkey-basic:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,13 +222,34 @@ importers:
       convex:
         specifier: ^1.43.0
         version: 1.43.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.18.1
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
   examples/react-passkey-basic:
     dependencies:


### PR DESCRIPTION
This PR creates a clone of the react-passkey-no-management demo that will be used to showcase passkey _with_ management (adding or removing passkeys from an existing account).

For now all the code is copied from the existing demo, except `convex/auth.ts` (it exposes the new management endpoints).

I also updated the `README.md` files of both demos