### PR TITLE
Passkey: Return PROTOCOL_ERROR on user ID mismatch

### DIFF
--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -422,14 +422,47 @@ describe("finishRegistration", () => {
     expect(await handleRows(t)).toHaveLength(1);
   });
 
-  test("throws for a handle that belongs to a different user", async () => {
+  // The add-a-passkey flow, where the signed-in user changes between the
+  // start and the end of the ceremony. The caller verifies the new user,
+  // while the ceremony stays bound to the old one. An untrusted client can
+  // do this at will, thus the component returns a `userError`.
+  test("returns PROTOCOL_ERROR for a handle that belongs to a different user", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user2", {
       startUserId: "user1",
     });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("The handle belongs to a different user.");
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the ceremony belongs to a different user than the verified user",
+    );
+    // No passkey for either user, and the handle of the old owner stays.
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+    expect(await handleRows(t)).toHaveLength(1);
+  });
+
+  test("burns the challenge when the verified user does not own the handle", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user2", {
+      startUserId: "user1",
+    });
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "the ceremony belongs to a different user than the verified user",
+    );
+    expect(await t.run((ctx) => ctx.db.query("challenges").collect())).toEqual(
+      [],
+    );
+    // The attestation cannot be replayed, not even by the original owner.
+    const replay = await t.mutation(api.registration.finishRegistration, {
+      ...args,
+      verifiedUserId: "user1",
+    });
+    expect(replay).toEqual({
+      success: false,
+      userError: { error: "CHALLENGE_EXPIRED" },
+    });
   });
 
   test("throws for an unlinked handle when the user already has one", async () => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -363,10 +363,13 @@ type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
  * transaction, so they see the same rows, and Convex fixes the transaction
  * timestamp, so the challenge TTL check cannot flip between the two calls.
  *
- * The guarantee does not cover throws. This function cannot see the
- * handle-linking invariants of `finishRegistration` (they depend on
- * `verifiedUserId`), so `finishRegistration` can still throw after a
- * successful check, and a throw aborts the transaction.
+ * The guarantee does not cover the handle-linking checks of
+ * `finishRegistration`. This function cannot see them, because they depend
+ * on `verifiedUserId`, which this function does not take. Thus
+ * `finishRegistration` can still fail after a successful check: with a
+ * `PROTOCOL_ERROR` when the ceremony belongs to a different user, or with a
+ * throw when the caller runs the new-account flow for a user that already
+ * has a handle. A throw aborts the transaction.
  */
 export const checkRegistration = query({
   args: registrationCheckArgs,
@@ -393,7 +396,10 @@ export const checkRegistration = query({
  *   "https://app.example.com").
  * - `verifiedUserId`: the user that owns the new passkey. This must always be
  *   the user name of the current user (whether it is a user created in the
- *   same transaction, or the currently logged in user).
+ *   same transaction, or the currently logged in user). When the ceremony
+ *   already has an owner (a known user adds a passkey) and the two disagree,
+ *   the result is a `PROTOCOL_ERROR`: the signed-in user changed during the
+ *   ceremony, which an untrusted client can cause at any time.
  * - `name`: an optional label for the credential. This can be automatically
  *   inferred by the client from the authenticator (e.g. “1Password”),
  *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
@@ -434,14 +440,33 @@ export const finishRegistration = mutation({
       return { success: false, userError: verification.userError };
     }
     const challengeRow = verification.challengeRow;
-    // One use only: the consumed challenge is deleted.
-    await ctx.db.delete("challenges", challengeRow._id);
 
     // Link the handle of the ceremony to the verified user.
     const handle = await ctx.db.get("handles", challengeRow.handleId);
     if (handle === null) {
       throw new Error("The handle of the challenge does not exist.");
     }
+    if (handle.userId !== null && handle.userId !== args.verifiedUserId) {
+      // The add-a-passkey flow: the handle of the ceremony has an owner, and
+      // that owner is not the user that the caller verified. The caller is
+      // not at fault. The signed-in user changed between the start and the
+      // end of the ceremony (a sign-out and a new sign-in, or a race with a
+      // sign-in in a different tab), so the caller verified the new user
+      // while the ceremony stays bound to the old one. An untrusted client
+      // can do this at will, thus the result is a `userError` and not a
+      // throw. The challenge burns, which prevents a replay of the
+      // attestation.
+      console.warn(
+        `Rejected the passkey ceremony: the ceremony belongs to a different ` +
+          `user than the verified user. The signed-in user changed during ` +
+          `the ceremony.`,
+      );
+      await deleteDeadChallenge(ctx, challengeRow);
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
+    }
+    // One use only: the consumed challenge is deleted.
+    await ctx.db.delete("challenges", challengeRow._id);
+
     if (handle.userId === null) {
       // The new-account flow: the handle was made before the user existed.
       const existingHandle = await ctx.db
@@ -458,10 +483,6 @@ export const finishRegistration = mutation({
       await ctx.db.patch("handles", handle._id, {
         userId: args.verifiedUserId,
       });
-    } else if (handle.userId !== args.verifiedUserId) {
-      throw new Error(
-        "Invariant violation: The handle belongs to a different user. finishRegistration is being called incorrectly.",
-      );
     }
 
     const passkeyId = await ctx.db.insert("passkeys", {


### PR DESCRIPTION
finishRegistration threw an invariant error when the handle of the
ceremony had an owner that was not verifiedUserId. Only the
add-a-passkey flow can reach that branch, and it reaches it without any
fault of the caller: the signed-in user can change between the start and
the end of the ceremony, so the caller verifies the new user while the
ceremony stays bound to the old one. An untrusted client can do this at
will, and the caller cannot prevent it, because the owner of the ceremony
is not visible outside the component.

The branch now returns a PROTOCOL_ERROR userError and burns the
challenge, like the other checks that a client can drive. The new-account
flow keeps its throw: there, a conflict means that the caller calls
finishRegistration incorrectly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/get-convex/convex-auth/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

