### PR TITLE
authPasskey: replace VERIFICATION_FAILED by PROTOCOL_ERROR and logs

### DIFF
--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -90,8 +90,6 @@ function errorMessage(
       return "That username was just taken. Try another one.";
     case "CHALLENGE_EXPIRED":
       return "The sign-in attempt took too long. Please try again.";
-    case "VERIFICATION_FAILED":
-      return "The passkey could not be verified. Please try again.";
     case "UNKNOWN_CREDENTIAL":
       return "This passkey is not registered here.";
     case "PROTOCOL_ERROR":

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -42,7 +42,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             userError:
               | { error: "UNKNOWN_CREDENTIAL" }
               | { error: "CHALLENGE_EXPIRED" }
-              | { error: "VERIFICATION_FAILED" }
               | { error: "PROTOCOL_ERROR" };
           },
         Name
@@ -76,9 +75,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              | { error: "CHALLENGE_EXPIRED" }
-              | { error: "VERIFICATION_FAILED" }
-              | { error: "PROTOCOL_ERROR" };
+              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
           },
         Name
       >;
@@ -113,9 +110,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              | { error: "CHALLENGE_EXPIRED" }
-              | { error: "VERIFICATION_FAILED" }
-              | { error: "PROTOCOL_ERROR" };
+              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
           },
         Name
       >;

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -206,7 +206,7 @@ describe("finishAuthentication", () => {
     );
   });
 
-  test("returns VERIFICATION_FAILED when the user is not present or not verified", async () => {
+  test("returns PROTOCOL_ERROR when the user is not present or not verified", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -223,7 +223,7 @@ describe("finishAuthentication", () => {
       });
       expect(result).toEqual({
         success: false,
-        userError: { error: "VERIFICATION_FAILED" },
+        userError: { error: "PROTOCOL_ERROR" },
       });
     }
   });
@@ -310,7 +310,7 @@ describe("finishAuthentication", () => {
     });
   });
 
-  test("returns VERIFICATION_FAILED when the challenge is bound to another user", async () => {
+  test("returns PROTOCOL_ERROR when the challenge is bound to another user", async () => {
     const t = setup();
     await register(t, "userA");
     const { credential: credentialB } = await register(t, "userB");
@@ -325,7 +325,7 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
     // The mismatch happens after consumption: the challenge is burned.
     const challenges = await t.run((ctx) =>
@@ -334,7 +334,7 @@ describe("finishAuthentication", () => {
     expect(challenges).toEqual([]);
   });
 
-  test("returns VERIFICATION_FAILED for an ES256 signature by the wrong key", async () => {
+  test("returns PROTOCOL_ERROR for an ES256 signature by the wrong key", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -351,11 +351,11 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
   });
 
-  test("returns VERIFICATION_FAILED for invalid RS256 signature bytes", async () => {
+  test("returns PROTOCOL_ERROR for invalid RS256 signature bytes", async () => {
     const t = setup();
     const credential = await generateRS256Credential();
     await register(t, "user1", { credential });
@@ -371,11 +371,11 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
   });
 
-  test("returns VERIFICATION_FAILED for an empty RS256 signature", async () => {
+  test("returns PROTOCOL_ERROR for an empty RS256 signature", async () => {
     // The RSA verification decodes the signature as a big integer, which
     // refuses zero bytes. The mutation must not throw.
     const t = setup();
@@ -393,11 +393,11 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
   });
 
-  test("returns VERIFICATION_FAILED for ES256 signature bytes that are not DER", async () => {
+  test("returns PROTOCOL_ERROR for ES256 signature bytes that are not DER", async () => {
     // No authenticator sends bytes that the decoder refuses.
     const t = setup();
     const { credential } = await register(t, "user1");
@@ -413,11 +413,11 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
   });
 
-  test("returns VERIFICATION_FAILED for an ES256 signature where s is the order of the curve", async () => {
+  test("returns PROTOCOL_ERROR for an ES256 signature where s is the order of the curve", async () => {
     // The DER is correct, but `s` has no inverse modulo the order of the
     // curve. The verification must not throw.
     const t = setup();
@@ -441,7 +441,7 @@ describe("finishAuthentication", () => {
     });
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
   });
 

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -170,7 +170,13 @@ export const finishAuthentication = mutation({
       return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
-      return { success: false, userError: { error: "VERIFICATION_FAILED" } };
+      // The ceremony asks for `userVerification: "required"`, thus
+      // `userVerified`/`userPresent` should be set
+      console.warn(
+        `Rejected the passkey ceremony: the authenticator data reports ` +
+          `no user presence or no user verification.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
 
     const clientDataJSONBytes = new Uint8Array(args.clientDataJSON);
@@ -244,7 +250,14 @@ export const finishAuthentication = mutation({
       challengeRow.userId !== undefined &&
       challengeRow.userId !== passkey.userId
     ) {
-      return { success: false, userError: { error: "VERIFICATION_FAILED" } };
+      // A challenge with a `userId` always carries the passkeys of that user
+      // in `allowCredentials`, thus a compliant client cannot send an
+      // assertion from a passkey of a different user.
+      console.warn(
+        `Rejected the passkey ceremony: the challenge was created for a ` +
+          `different user than the owner of the credential.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
 
     const hash = sha256(
@@ -273,7 +286,11 @@ export const finishAuthentication = mutation({
         ) ?? false;
     }
     if (!valid) {
-      return { success: false, userError: { error: "VERIFICATION_FAILED" } };
+      console.warn(
+        `Rejected the passkey ceremony: the assertion signature does not ` +
+          `match the public key of the credential.`,
+      );
+      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
 
     // Here we could compare the signature counter with the stored value to find

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -451,7 +451,7 @@ describe("usePasskey autofill", () => {
     mutations.finishSignIn
       .mockResolvedValueOnce({
         success: false,
-        userError: { error: "VERIFICATION_FAILED" },
+        userError: { error: "CHALLENGE_EXPIRED" },
       })
       .mockResolvedValueOnce({
         success: true,

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -559,26 +559,24 @@ describe("finishRegistration", () => {
     );
   });
 
-  test("returns VERIFICATION_FAILED when the user is not present", async () => {
+  test("returns PROTOCOL_ERROR when the user is not present", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", { userPresent: false });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "VERIFICATION_FAILED" },
-    });
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "no user presence or no user verification",
+    );
   });
 
-  test("returns VERIFICATION_FAILED when the user is not verified", async () => {
+  test("returns PROTOCOL_ERROR when the user is not verified", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       userVerified: false,
     });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "VERIFICATION_FAILED" },
-    });
+    await expectProtocolError(
+      () => t.mutation(api.registration.finishRegistration, args),
+      "no user presence or no user verification",
+    );
   });
 
   test("erases the unlinked handle when the user is not verified", async () => {
@@ -693,7 +691,7 @@ describe("finishRegistration", () => {
     const result = await t.mutation(api.registration.finishRegistration, args);
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
     // The failure burned the challenge, so the cleanup loop cannot find the
     // handle later. The mutation must delete the handle itself.
@@ -714,7 +712,7 @@ describe("finishRegistration", () => {
     const result = await t.mutation(api.registration.finishRegistration, args);
     expect(result).toEqual({
       success: false,
-      userError: { error: "VERIFICATION_FAILED" },
+      userError: { error: "PROTOCOL_ERROR" },
     });
     // The handle belongs to user1, so the failed attempt must not remove it.
     const handles = await t.run((ctx) => ctx.db.query("handles").collect());
@@ -766,19 +764,15 @@ describe("checkRegistration", () => {
     });
   });
 
-  test("returns VERIFICATION_FAILED when the user is not verified", async () => {
+  test("returns PROTOCOL_ERROR when the user is not verified", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
       userVerified: false,
     });
-    const result = await t.query(
-      api.registration.checkRegistration,
-      checkArgs(args),
+    await expectProtocolError(
+      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      "no user presence or no user verification",
     );
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "VERIFICATION_FAILED" },
-    });
   });
 
   test("returns PROTOCOL_ERROR for a duplicate credential ID", async () => {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -247,7 +247,13 @@ async function verifyRegistration(
     return { userError: { error: "PROTOCOL_ERROR" }, challengeRow: null };
   }
   if (!authenticatorData.userPresent || !authenticatorData.userVerified) {
-    return { userError: { error: "VERIFICATION_FAILED" }, challengeRow };
+    // The ceremony asks for `userVerification: "required"`, thus
+    // `userVerified`/`userPresent` should be set
+    console.warn(
+      `Rejected the passkey ceremony: the authenticator data reports no ` +
+        `user presence or no user verification.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow };
   }
   const credential = authenticatorData.credential;
   if (credential === null) {

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -80,8 +80,6 @@ export const finishRegistrationUserError = v.union(
   // The challenge is unknown, already used, or too old. The user must start
   // the ceremony again.
   v.object({ error: v.literal("CHALLENGE_EXPIRED") }),
-  // The authenticator did not report user presence and user verification.
-  v.object({ error: v.literal("VERIFICATION_FAILED") }),
   protocolError,
 );
 export type FinishRegistrationUserError = Infer<
@@ -97,9 +95,6 @@ export const finishAuthenticationUserError = v.union(
   // authenticator still offers a passkey that the app deleted.
   v.object({ error: v.literal("UNKNOWN_CREDENTIAL") }),
   v.object({ error: v.literal("CHALLENGE_EXPIRED") }),
-  // The assertion is not valid. Possible causes: a bad signature, no user
-  // presence or user verification, or a challenge for a different user.
-  v.object({ error: v.literal("VERIFICATION_FAILED") }),
   protocolError,
 );
 export type FinishAuthenticationUserError = Infer<


### PR DESCRIPTION
Now that we added the `PROTOCOL_ERROR` user error in #559, I realized that VERIFICATION_FAILED is a subset of these errors, so it is not necessary to have a separate error case.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/get-convex/convex-auth/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

