### PR TITLE
passkey: extract the WebAuthn ceremonies into an internal client module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,6 +100,8 @@
       "types": "./dist/components/password/*.d.ts",
       "default": "./dist/components/password/*.js"
     },
+    "./providers/passkey/client": null,
+    "./providers/passkey/client.js": null,
     "./providers/passkey/*.js": {
       "types": "./dist/components/passkey/*.d.ts",
       "default": "./dist/components/passkey/*.js"

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -10,6 +10,7 @@
 
 import type * as authentication from "../authentication.js";
 import type * as cleanup from "../cleanup.js";
+import type * as client from "../client.js";
 import type * as helpers from "../helpers.js";
 import type * as management_add from "../management/add.js";
 import type * as management_list from "../management/list.js";
@@ -30,6 +31,7 @@ import { anyApi, componentsGeneric } from "convex/server";
 const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   cleanup: typeof cleanup;
+  client: typeof client;
   helpers: typeof helpers;
   "management/add": typeof management_add;
   "management/list": typeof management_list;

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  assertionFromCredential,
+  foldClientError,
+  runAuthenticationCeremony,
+  runRegistrationCeremony,
+  supportsWebAuthn,
+} from "./client.ts";
+
+// The browser WebAuthn surface. jsdom has none, so the tests install a
+// fake `PublicKeyCredential` and `navigator.credentials`.
+const credentialsCreate = vi.fn();
+const credentialsGet = vi.fn();
+
+class FakePublicKeyCredential {}
+
+// A stand-in for the credential `navigator.credentials.create()` returns.
+const attestationCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    attestationObject: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    getTransports: () => ["internal", "hybrid"],
+  },
+};
+
+// A stand-in for the credential `navigator.credentials.get()` returns.
+const assertionCredential = {
+  rawId: new ArrayBuffer(8),
+  response: {
+    authenticatorData: new ArrayBuffer(1),
+    clientDataJSON: new ArrayBuffer(2),
+    signature: new ArrayBuffer(3),
+  },
+};
+
+const registrationOptions = {
+  challenge: new ArrayBuffer(16),
+  rpId: "localhost",
+  rpName: "Test app",
+  userHandle: new ArrayBuffer(16),
+  userName: "alice",
+  userDisplayName: "Alice",
+  excludeCredentials: [{ id: new ArrayBuffer(4), transports: ["internal"] }],
+};
+
+const authenticationOptions = {
+  challenge: new ArrayBuffer(16),
+  rpId: "localhost",
+  allowCredentials: [{ id: new ArrayBuffer(8) }],
+};
+
+// `vi.unstubAllGlobals()` does not undo `Object.defineProperty`, so the
+// tests restore the original `navigator.credentials` own property (or its
+// absence) themselves.
+const originalCredentials = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  "credentials",
+);
+
+beforeEach(() => {
+  vi.stubGlobal("PublicKeyCredential", FakePublicKeyCredential);
+  vi.stubGlobal("isSecureContext", true);
+  Object.defineProperty(window.navigator, "credentials", {
+    value: { create: credentialsCreate, get: credentialsGet },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  if (originalCredentials === undefined) {
+    delete (window.navigator as { credentials?: unknown }).credentials;
+  } else {
+    Object.defineProperty(window.navigator, "credentials", originalCredentials);
+  }
+  vi.unstubAllGlobals();
+  credentialsCreate.mockReset();
+  credentialsGet.mockReset();
+});
+
+describe("supportsWebAuthn", () => {
+  test("true with PublicKeyCredential in a secure context", () => {
+    expect(supportsWebAuthn()).toBe(true);
+  });
+
+  test("false without PublicKeyCredential", () => {
+    vi.stubGlobal("PublicKeyCredential", undefined);
+    expect(supportsWebAuthn()).toBe(false);
+  });
+
+  test("false outside a secure context", () => {
+    vi.stubGlobal("isSecureContext", false);
+    expect(supportsWebAuthn()).toBe(false);
+  });
+});
+
+describe("foldClientError", () => {
+  test("NotAllowedError folds into CEREMONY_ABORTED", () => {
+    expect(
+      foldClientError(new DOMException("cancelled", "NotAllowedError")),
+    ).toEqual({ error: "CEREMONY_ABORTED" });
+  });
+
+  test("AbortError folds into CEREMONY_ABORTED", () => {
+    expect(foldClientError(new DOMException("aborted", "AbortError"))).toEqual({
+      error: "CEREMONY_ABORTED",
+    });
+  });
+
+  test("everything else folds into OTHER_ERROR with the cause", () => {
+    const cause = new Error("network blip");
+    expect(foldClientError(cause)).toEqual({ error: "OTHER_ERROR", cause });
+  });
+});
+
+describe("runRegistrationCeremony", () => {
+  test("maps the options onto the create() call and returns the attestation", async () => {
+    credentialsCreate.mockResolvedValue(attestationCredential);
+
+    const result = await runRegistrationCeremony(registrationOptions);
+
+    expect(result).toEqual({
+      success: true,
+      attestation: {
+        attestationObject: attestationCredential.response.attestationObject,
+        clientDataJSON: attestationCredential.response.clientDataJSON,
+        transports: ["internal", "hybrid"],
+      },
+    });
+    expect(credentialsCreate).toHaveBeenCalledWith({
+      signal: undefined,
+      publicKey: {
+        challenge: registrationOptions.challenge,
+        rp: { id: "localhost", name: "Test app" },
+        user: {
+          id: registrationOptions.userHandle,
+          name: "alice",
+          displayName: "Alice",
+        },
+        pubKeyCredParams: [
+          { type: "public-key", alg: -7 },
+          { type: "public-key", alg: -257 },
+        ],
+        authenticatorSelection: {
+          residentKey: "required",
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        attestation: "none",
+        excludeCredentials: [
+          {
+            type: "public-key",
+            id: registrationOptions.excludeCredentials[0].id,
+            transports: ["internal"],
+          },
+        ],
+      },
+    });
+  });
+
+  test("a response without getTransports reports no transports", async () => {
+    credentialsCreate.mockResolvedValue({
+      rawId: attestationCredential.rawId,
+      response: {
+        attestationObject: attestationCredential.response.attestationObject,
+        clientDataJSON: attestationCredential.response.clientDataJSON,
+      },
+    });
+    const result = await runRegistrationCeremony(registrationOptions);
+    expect(result).toEqual({
+      success: true,
+      attestation: {
+        attestationObject: attestationCredential.response.attestationObject,
+        clientDataJSON: attestationCredential.response.clientDataJSON,
+        transports: undefined,
+      },
+    });
+  });
+
+  test("a null credential folds into CEREMONY_ABORTED", async () => {
+    credentialsCreate.mockResolvedValue(null);
+    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+  });
+
+  test("a thrown NotAllowedError folds into CEREMONY_ABORTED", async () => {
+    credentialsCreate.mockRejectedValue(
+      new DOMException("cancelled", "NotAllowedError"),
+    );
+    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+  });
+
+  test("an unexpected throw folds into OTHER_ERROR with the cause", async () => {
+    const cause = new Error("boom");
+    credentialsCreate.mockRejectedValue(cause);
+    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+      success: false,
+      userError: { error: "OTHER_ERROR", cause },
+    });
+  });
+
+  test("no WebAuthn support folds into WEBAUTHN_UNSUPPORTED", async () => {
+    vi.stubGlobal("PublicKeyCredential", undefined);
+    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+      success: false,
+      userError: { error: "WEBAUTHN_UNSUPPORTED" },
+    });
+    expect(credentialsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("runAuthenticationCeremony", () => {
+  test("maps the options onto the get() call and returns the assertion", async () => {
+    credentialsGet.mockResolvedValue(assertionCredential);
+
+    const result = await runAuthenticationCeremony(authenticationOptions);
+
+    expect(result).toEqual({
+      success: true,
+      assertion: {
+        // `rawId` carries the credential ID bytes, not the base64url `id`.
+        credentialId: assertionCredential.rawId,
+        authenticatorData: assertionCredential.response.authenticatorData,
+        clientDataJSON: assertionCredential.response.clientDataJSON,
+        signature: assertionCredential.response.signature,
+      },
+    });
+    expect(credentialsGet).toHaveBeenCalledWith({
+      signal: undefined,
+      publicKey: {
+        challenge: authenticationOptions.challenge,
+        rpId: "localhost",
+        allowCredentials: [
+          {
+            type: "public-key",
+            id: authenticationOptions.allowCredentials[0].id,
+            transports: undefined,
+          },
+        ],
+        userVerification: "required",
+      },
+    });
+  });
+
+  test("a null credential folds into CEREMONY_ABORTED", async () => {
+    credentialsGet.mockResolvedValue(null);
+    expect(await runAuthenticationCeremony(authenticationOptions)).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+  });
+
+  test("an aborted signal folds into CEREMONY_ABORTED", async () => {
+    credentialsGet.mockImplementation(({ signal }: { signal?: AbortSignal }) =>
+      Promise.reject(
+        signal?.aborted
+          ? new DOMException("aborted", "AbortError")
+          : new Error("expected an aborted signal"),
+      ),
+    );
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      await runAuthenticationCeremony({
+        ...authenticationOptions,
+        signal: controller.signal,
+      }),
+    ).toEqual({
+      success: false,
+      userError: { error: "CEREMONY_ABORTED" },
+    });
+  });
+
+  test("no WebAuthn support folds into WEBAUTHN_UNSUPPORTED", async () => {
+    vi.stubGlobal("PublicKeyCredential", undefined);
+    expect(await runAuthenticationCeremony(authenticationOptions)).toEqual({
+      success: false,
+      userError: { error: "WEBAUTHN_UNSUPPORTED" },
+    });
+    expect(credentialsGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertionFromCredential", () => {
+  test("uses rawId and the assertion response fields", () => {
+    expect(
+      assertionFromCredential(
+        assertionCredential as unknown as PublicKeyCredential,
+      ),
+    ).toEqual({
+      credentialId: assertionCredential.rawId,
+      authenticatorData: assertionCredential.response.authenticatorData,
+      clientDataJSON: assertionCredential.response.clientDataJSON,
+      signature: assertionCredential.response.signature,
+    });
+  });
+});

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -1,0 +1,266 @@
+/**
+ * Framework-agnostic browser client for the passkey provider.
+ *
+ * This module is internal: the public surface of the provider is the React
+ * hooks in `react.tsx`, which are built on it. The `exports` field of the
+ * package blocks `providers/passkey/client`, so an app cannot import this
+ * file. It becomes a public entry point only when a real non-React consumer
+ * asks for one.
+ *
+ * These functions wrap the modal WebAuthn ceremonies
+ * (`navigator.credentials`). They do not depend on React and they do not
+ * call any Convex function: a flow starts a ceremony with data from its
+ * start mutation, runs the ceremony here, and sends the result to its
+ * finish mutation.
+ *
+ * The functions never throw. They return discriminated unions, and they
+ * fold every failure into the {@link PasskeyClientError} shape, so callers
+ * handle every failure through one `userError` switch and never need their
+ * own `try`/`catch`.
+ *
+ * @internal
+ * @module
+ */
+
+import type { CredentialDescriptor } from "./validation.ts";
+
+/**
+ * The failures the browser side produces (the server never returns these):
+ *
+ * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
+ *   refused the ceremony (`NotAllowedError`), or the caller aborted it
+ *   through an `AbortSignal`. This is the most common failure; show a calm
+ *   "sign-in was cancelled" message.
+ * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
+ *   page is not a secure context.
+ * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
+ *   unexpected server error). The thrown value is preserved on `cause` for
+ *   callers that want to inspect or log it.
+ */
+export type PasskeyClientError =
+  | { error: "CEREMONY_ABORTED" }
+  | { error: "WEBAUTHN_UNSUPPORTED" }
+  | { error: "OTHER_ERROR"; cause: unknown };
+
+/**
+ * The output of a registration ceremony: the fields a finish mutation needs
+ * to verify the new passkey (see `finishSignUp` in the username + passkey
+ * recipe).
+ */
+export type PasskeyAttestation = {
+  attestationObject: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  // Older browsers have no `getTransports`. Then the server stores no
+  // transports for this credential.
+  transports?: string[];
+};
+
+/**
+ * The output of an authentication ceremony: the fields a finish mutation
+ * needs to verify the signature (see `finishSignIn` in the username +
+ * passkey recipe).
+ */
+export type PasskeyAssertion = {
+  credentialId: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  clientDataJSON: ArrayBuffer;
+  signature: ArrayBuffer;
+};
+
+/**
+ * The result of {@link runRegistrationCeremony}: the attestation to send to
+ * the finish mutation, or a user-facing `userError`.
+ */
+export type PasskeyRegistrationResult =
+  | { success: true; attestation: PasskeyAttestation }
+  | { success: false; userError: PasskeyClientError };
+
+/**
+ * The result of {@link runAuthenticationCeremony}: the assertion to send to
+ * the finish mutation, or a user-facing `userError`.
+ */
+export type PasskeyAuthenticationResult =
+  | { success: true; assertion: PasskeyAssertion }
+  | { success: false; userError: PasskeyClientError };
+
+/**
+ * Whether this browser can run WebAuthn ceremonies on this page. The
+ * ceremony functions run this check themselves; call it directly to hide a
+ * passkey button up front.
+ */
+export function supportsWebAuthn(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof PublicKeyCredential !== "undefined" &&
+    window.isSecureContext
+  );
+}
+
+function isCeremonyAborted(cause: unknown): boolean {
+  // `NotAllowedError` is what the browser throws when the user dismisses
+  // the dialog, when the ceremony times out, and when the page is not
+  // allowed to run one. `AbortError` is what an `AbortSignal` produces.
+  // A `null` credential is handled separately.
+  return (
+    cause instanceof DOMException &&
+    (cause.name === "NotAllowedError" || cause.name === "AbortError")
+  );
+}
+
+/**
+ * Fold a thrown value into the {@link PasskeyClientError} shape, so callers
+ * handle every failure through one `userError` switch. Useful for custom
+ * flows that call `navigator.credentials` or a mutation themselves.
+ */
+export function foldClientError(cause: unknown): PasskeyClientError {
+  if (isCeremonyAborted(cause)) {
+    return { error: "CEREMONY_ABORTED" };
+  }
+  return { error: "OTHER_ERROR", cause };
+}
+
+/**
+ * Turn the credential descriptors from the server into the WebAuthn shape
+ * of `allowCredentials` and `excludeCredentials`.
+ */
+function credentialDescriptors(
+  credentials: CredentialDescriptor[],
+): PublicKeyCredentialDescriptor[] {
+  return credentials.map(({ id, transports }) => ({
+    type: "public-key",
+    id,
+    // The database stores a string array, we’re converting here
+    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
+    transports: transports as AuthenticatorTransport[] | undefined,
+  }));
+}
+
+/**
+ * Turn an assertion credential from `navigator.credentials.get()` into a
+ * {@link PasskeyAssertion}. Useful for custom flows that run the `get()`
+ * call themselves, for example with conditional mediation.
+ */
+export function assertionFromCredential(
+  credential: PublicKeyCredential,
+): PasskeyAssertion {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    // `rawId` carries the credential ID bytes; `credential.id` is the
+    // base64url form and must not be sent.
+    credentialId: credential.rawId,
+    authenticatorData: response.authenticatorData,
+    clientDataJSON: response.clientDataJSON,
+    signature: response.signature,
+  };
+}
+
+/**
+ * Run a modal registration ceremony (`navigator.credentials.create()`).
+ *
+ * The `challenge`, `userHandle`, and `excludeCredentials` come from a start
+ * mutation. The `userName` and `userDisplayName` are what the browser shows
+ * for the new passkey in its passkey manager; the flow chooses them (for
+ * example, the username the user typed).
+ *
+ * The created passkey is discoverable (required for autofill) and requires
+ * user verification, which is what the server-side verification demands.
+ *
+ * @param options.signal Abort the ceremony (folds into `CEREMONY_ABORTED`).
+ */
+export async function runRegistrationCeremony(options: {
+  challenge: ArrayBuffer;
+  rpId: string;
+  rpName: string;
+  userHandle: ArrayBuffer;
+  userName: string;
+  userDisplayName: string;
+  excludeCredentials: CredentialDescriptor[];
+  signal?: AbortSignal;
+}): Promise<PasskeyRegistrationResult> {
+  if (!supportsWebAuthn()) {
+    return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
+  }
+  try {
+    const credential = (await navigator.credentials.create({
+      signal: options.signal,
+      publicKey: {
+        challenge: options.challenge,
+        rp: { id: options.rpId, name: options.rpName },
+        user: {
+          id: options.userHandle,
+          name: options.userName,
+          displayName: options.userDisplayName,
+        },
+        // Exactly the algorithms the server accepts (ES256 and RS256; see
+        // the verification in `registration.ts`).
+        pubKeyCredParams: [
+          { type: "public-key", alg: -7 }, // ES256
+          { type: "public-key", alg: -257 }, // RS256
+        ],
+        authenticatorSelection: {
+          residentKey: "required",
+          requireResidentKey: true,
+          userVerification: "required",
+        },
+        attestation: "none",
+        excludeCredentials: credentialDescriptors(options.excludeCredentials),
+      },
+    })) as PublicKeyCredential | null;
+    if (credential === null) {
+      return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+    }
+    const response = credential.response as AuthenticatorAttestationResponse;
+    return {
+      success: true,
+      attestation: {
+        attestationObject: response.attestationObject,
+        clientDataJSON: response.clientDataJSON,
+        // Older browsers have no `getTransports`. Then the server stores
+        // no transports for this credential.
+        transports:
+          typeof response.getTransports === "function"
+            ? response.getTransports()
+            : undefined,
+      },
+    };
+  } catch (cause) {
+    return { success: false, userError: foldClientError(cause) };
+  }
+}
+
+/**
+ * Run a modal authentication ceremony (`navigator.credentials.get()`).
+ *
+ * The `challenge` and `allowCredentials` come from a start mutation. An
+ * empty `allowCredentials` lets the user pick any passkey of this relying
+ * party; the picked passkey then identifies the account.
+ *
+ * @param options.signal Abort the ceremony (folds into `CEREMONY_ABORTED`).
+ */
+export async function runAuthenticationCeremony(options: {
+  challenge: ArrayBuffer;
+  rpId: string;
+  allowCredentials: CredentialDescriptor[];
+  signal?: AbortSignal;
+}): Promise<PasskeyAuthenticationResult> {
+  if (!supportsWebAuthn()) {
+    return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
+  }
+  try {
+    const credential = (await navigator.credentials.get({
+      signal: options.signal,
+      publicKey: {
+        challenge: options.challenge,
+        rpId: options.rpId,
+        allowCredentials: credentialDescriptors(options.allowCredentials),
+        userVerification: "required",
+      },
+    })) as PublicKeyCredential | null;
+    if (credential === null) {
+      return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+    }
+    return { success: true, assertion: assertionFromCredential(credential) };
+  } catch (cause) {
+    return { success: false, userError: foldClientError(cause) };
+  }
+}

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -35,6 +35,8 @@ import type {
 } from "./setup.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
 
+export type { PasskeyClientError } from "./client.ts";
+
 /**
  * The `startSignIn` mutation the app re-exports from its `setupCore`.
  */

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -19,13 +19,21 @@ import type { FunctionReference } from "convex/server";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ClientView } from "../../lib/types.ts";
 import { useAuthActions, useAuthSignInApi } from "../../react/index.tsx";
+import {
+  assertionFromCredential,
+  foldClientError,
+  runAuthenticationCeremony,
+  runRegistrationCeremony,
+  supportsWebAuthn,
+  type PasskeyClientError,
+} from "./client.ts";
 import type {
   FinishSignInResult,
   FinishSignUpResult,
   StartAutofillSignInResult,
   StartSignInResult,
 } from "./setup.ts";
-import { CHALLENGE_TTL_MS, type CredentialDescriptor } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./validation.ts";
 
 /**
  * The `startSignIn` mutation the app re-exports from its `setupCore`.
@@ -91,27 +99,16 @@ export type PasskeyApi = {
 };
 
 /**
- * Failures the client produces that the server never returns. The hook
- * folds them into the result so callers handle *every* failure through the
- * one `userError` switch and never need their own `try`/`catch`:
- *
- * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
- *   refused the ceremony (`NotAllowedError`), or a second `signIn` call
- *   came in while one was already running (the browser would refuse the
- *   second modal ceremony anyway). This is the most common failure; show a
- *   calm "sign-in was cancelled" message.
- * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
- *   page is not a secure context.
- * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
- *   unexpected server error). The thrown value is preserved on `cause` for
- *   callers that want to inspect or log it.
+ * Failures the client produces that the server never returns (see
+ * {@link PasskeyClientError}). The hook folds them into the result so
+ * callers handle *every* failure through the one `userError` switch and
+ * never need their own `try`/`catch`. A second `signIn` call while one is
+ * already running also folds into `CEREMONY_ABORTED` (the browser would
+ * refuse the second modal ceremony anyway).
  */
 type ClientFailure = {
   success: false;
-  userError:
-    | { error: "CEREMONY_ABORTED" }
-    | { error: "WEBAUTHN_UNSUPPORTED" }
-    | { error: "OTHER_ERROR"; cause: unknown };
+  userError: PasskeyClientError;
 };
 
 /**
@@ -178,32 +175,6 @@ type AutofillHandle = {
   resume: () => void;
 };
 
-function supportsWebAuthn(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof PublicKeyCredential !== "undefined" &&
-    window.isSecureContext
-  );
-}
-
-function isCeremonyAborted(cause: unknown): boolean {
-  // `NotAllowedError` is what the browser throws when the user dismisses
-  // the dialog, when the ceremony times out, and when the page is not
-  // allowed to run one. A `null` credential is handled separately.
-  return cause instanceof DOMException && cause.name === "NotAllowedError";
-}
-
-/**
- * Fold a thrown value into the {@link ClientFailure} `userError` shape, so
- * callers handle every failure through the one `userError` switch.
- */
-function foldClientError(cause: unknown): ClientFailure["userError"] {
-  if (isCeremonyAborted(cause)) {
-    return { error: "CEREMONY_ABORTED" };
-  }
-  return { error: "OTHER_ERROR", cause };
-}
-
 /**
  * When the thrown value is the abort of the given signal, return the abort
  * reason. Return `null` for every other error, even when the signal aborted
@@ -232,124 +203,6 @@ function autofillAbortReason(
     return "STOP";
   }
   return null;
-}
-
-/** The `finishSignIn` arguments derived from a WebAuthn assertion. */
-type AssertionArgs = {
-  credentialId: ArrayBuffer;
-  authenticatorData: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  signature: ArrayBuffer;
-};
-
-/**
- * Turn an assertion credential into the `finishSignIn` arguments. Shared
- * between the modal authenticate path and the autofill path.
- */
-function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
-  const response = credential.response as AuthenticatorAssertionResponse;
-  return {
-    // `rawId` carries the credential ID bytes; `credential.id` is the
-    // base64url form and must not be sent.
-    credentialId: credential.rawId,
-    authenticatorData: response.authenticatorData,
-    clientDataJSON: response.clientDataJSON,
-    signature: response.signature,
-  };
-}
-
-/**
- * Turn the credential descriptors from the server into the WebAuthn shape
- * of `allowCredentials`.
- */
-function credentialDescriptors(
-  credentials: CredentialDescriptor[],
-): PublicKeyCredentialDescriptor[] {
-  return credentials.map(({ id, transports }) => ({
-    type: "public-key",
-    id,
-    // The database stores a string array, we’re converting here
-    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
-    transports: transports as AuthenticatorTransport[] | undefined,
-  }));
-}
-
-/**
- * Run the modal registration ceremony and return the `finishSignUp`
- * arguments, or `null` when the browser returns no credential.
- */
-async function runRegistrationCeremony(
-  username: string,
-  start: Extract<StartSignInResult, { step: "register" }>,
-): Promise<{
-  username: string;
-  attestationObject: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  transports?: string[];
-} | null> {
-  const credential = (await navigator.credentials.create({
-    publicKey: {
-      challenge: start.challenge,
-      rp: { id: start.rpId, name: start.rpName },
-      // The handle comes from the server: the app user id cannot be used,
-      // because the user row does not exist yet.
-      user: {
-        id: start.userHandle,
-        name: username,
-        displayName: username,
-      },
-      // Exactly the algorithms the server accepts (ES256 and RS256; see
-      // the verification in `registration.ts`).
-      pubKeyCredParams: [
-        { type: "public-key", alg: -7 }, // ES256
-        { type: "public-key", alg: -257 }, // RS256
-      ],
-      // A discoverable credential is required for autofill, and the
-      // server hard-requires user verification.
-      authenticatorSelection: {
-        residentKey: "required",
-        requireResidentKey: true,
-        userVerification: "required",
-      },
-      attestation: "none",
-    },
-  })) as PublicKeyCredential | null;
-  if (credential === null) {
-    return null;
-  }
-  const response = credential.response as AuthenticatorAttestationResponse;
-  return {
-    username,
-    attestationObject: response.attestationObject,
-    clientDataJSON: response.clientDataJSON,
-    // Older browsers have no `getTransports`. Then the server stores no
-    // transports for this credential.
-    transports:
-      typeof response.getTransports === "function"
-        ? response.getTransports()
-        : undefined,
-  };
-}
-
-/**
- * Run the modal authentication ceremony and return the `finishSignIn`
- * arguments, or `null` when the browser returns no credential.
- */
-async function runAuthenticationCeremony(
-  start: Extract<StartSignInResult, { step: "authenticate" }>,
-): Promise<AssertionArgs | null> {
-  const credential = (await navigator.credentials.get({
-    publicKey: {
-      challenge: start.challenge,
-      rpId: start.rpId,
-      allowCredentials: credentialDescriptors(start.allowCredentials),
-      userVerification: "required",
-    },
-  })) as PublicKeyCredential | null;
-  if (credential === null) {
-    return null;
-  }
-  return assertionArgs(credential);
 }
 
 /**
@@ -481,14 +334,26 @@ export function usePasskey(
         }
 
         if (start.step === "register") {
-          const args = await runRegistrationCeremony(username, start);
-          if (args === null) {
-            return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+          const ceremony = await runRegistrationCeremony({
+            challenge: start.challenge,
+            rpId: start.rpId,
+            rpName: start.rpName,
+            // The handle comes from the server: the app user id cannot be
+            // used, because the user row does not exist yet.
+            userHandle: start.userHandle,
+            userName: username,
+            userDisplayName: username,
+            // A sign-up ceremony makes the first passkey of a brand-new
+            // user, so there are no credentials to exclude.
+            excludeCredentials: [],
+          });
+          if (!ceremony.success) {
+            return ceremony;
           }
-          const result = await signInApi.mutation(
-            passkeyApi.finishSignUp,
-            args,
-          );
+          const result = await signInApi.mutation(passkeyApi.finishSignUp, {
+            username,
+            ...ceremony.attestation,
+          });
           if (!result.success) {
             return result;
           }
@@ -496,11 +361,18 @@ export function usePasskey(
           return { ...result, flow: "signUp" };
         }
 
-        const args = await runAuthenticationCeremony(start);
-        if (args === null) {
-          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        const ceremony = await runAuthenticationCeremony({
+          challenge: start.challenge,
+          rpId: start.rpId,
+          allowCredentials: start.allowCredentials,
+        });
+        if (!ceremony.success) {
+          return ceremony;
         }
-        const result = await signInApi.mutation(passkeyApi.finishSignIn, args);
+        const result = await signInApi.mutation(
+          passkeyApi.finishSignIn,
+          ceremony.assertion,
+        );
         if (!result.success) {
           return result;
         }
@@ -694,7 +566,7 @@ export function usePasskey(
           const { passkeyApi, signInApi, setSession } = currentRef.current;
           const result = await signInApi.mutation(
             passkeyApi.finishSignIn,
-            assertionArgs(credential),
+            assertionFromCredential(credential),
           );
           if (result.success) {
             // Residual race with the modal flow: when the user resolves


### PR DESCRIPTION
This is a no-op refactor that moves the WebAuthn ceremony code out of `react.tsx` and into a separate file (`client.ts`). This will make it easier to swap out that code with the SimpleWebauthn code later.

`client.ts` stays internal: the `exports` field of the package blocks `@convex-dev/auth/providers/passkey/client`, because the `providers/passkey/*` wildcard would otherwise make it a public entry point. The public surface stays the React hooks in `react.tsx`, which re-export the client types that apps need.