### PR TITLE
passkey: rename usePasskey to useUsernamePasskeySignIn

### DIFF
--- a/examples/react-passkey-basic/src/routes/logIn.tsx
+++ b/examples/react-passkey-basic/src/routes/logIn.tsx
@@ -1,7 +1,7 @@
 import {
-  PasskeyAutofillError,
-  PasskeySignInResult,
-  usePasskey,
+  UsernamePasskeyAutofillError,
+  UsernamePasskeySignInResult,
+  useUsernamePasskeySignIn,
 } from "@convex-dev/auth/providers/passkey/react";
 import { useEffect, useState } from "react";
 import { api } from "../../convex/_generated/api";
@@ -10,7 +10,7 @@ export function LogIn() {
   // While this hook is mounted, the browser also offers stored passkeys in
   // the autocompletion list of the username field below (the field carries
   // autoComplete="username webauthn"). Picking one signs in directly.
-  const { signIn, pending, autofill } = usePasskey({
+  const { signIn, pending, autofill } = useUsernamePasskeySignIn({
     startSignIn: api.auth.startSignIn,
     startAutofillSignIn: api.auth.startAutofillSignIn,
     finishSignIn: api.auth.finishSignIn,
@@ -74,8 +74,8 @@ export function LogIn() {
 
 function errorMessage(
   userError:
-    | Extract<PasskeySignInResult, { success: false }>["userError"]
-    | PasskeyAutofillError,
+    | Extract<UsernamePasskeySignInResult, { success: false }>["userError"]
+    | UsernamePasskeyAutofillError,
 ): string | null {
   switch (userError.error) {
     case "ALREADY_PENDING":

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -1,7 +1,7 @@
 import {
-  PasskeyAutofillError,
-  PasskeySignInResult,
-  usePasskey,
+  UsernamePasskeyAutofillError,
+  UsernamePasskeySignInResult,
+  useUsernamePasskeySignIn,
 } from "@convex-dev/auth/providers/passkey/react";
 import { useEffect, useState } from "react";
 import { api } from "../../convex/_generated/api";
@@ -10,7 +10,7 @@ export function LogIn() {
   // While this hook is mounted, the browser also offers stored passkeys in
   // the autocompletion list of the username field below (the field carries
   // autoComplete="username webauthn"). Picking one signs in directly.
-  const { signIn, pending, autofill } = usePasskey({
+  const { signIn, pending, autofill } = useUsernamePasskeySignIn({
     startSignIn: api.auth.startSignIn,
     startAutofillSignIn: api.auth.startAutofillSignIn,
     finishSignIn: api.auth.finishSignIn,
@@ -74,8 +74,8 @@ export function LogIn() {
 
 function errorMessage(
   userError:
-    | Extract<PasskeySignInResult, { success: false }>["userError"]
-    | PasskeyAutofillError,
+    | Extract<UsernamePasskeySignInResult, { success: false }>["userError"]
+    | UsernamePasskeyAutofillError,
 ): string | null {
   switch (userError.error) {
     case "ALREADY_PENDING":

--- a/packages/core/src/components/passkey/flows.ts
+++ b/packages/core/src/components/passkey/flows.ts
@@ -66,7 +66,7 @@ type FinishSignInMutation = FunctionReference<
 >;
 
 /** The mutation references the sign-in flows drive. */
-export type PasskeyApi = {
+export type UsernamePasskeyApi = {
   startSignIn: StartSignInMutation;
   startAutofillSignIn: StartAutofillSignInMutation;
   finishSignIn: FinishSignInMutation;
@@ -78,7 +78,7 @@ export type SignInFlowContext = {
   /** The Convex client of the surrounding provider. */
   convex: ConvexReactClient;
   /** The mutation references the app re-exported from its `setupCore`. */
-  api: PasskeyApi;
+  api: UsernamePasskeyApi;
   /**
    * Runs a mutation that mints a session. The finishing mutations go
    * through this, and not through `convex`, because they must work under
@@ -108,7 +108,7 @@ export type SignInFlowResult =
   | PasskeyClientFailure;
 
 /** The errors the autofill sign-in flow reports. */
-export type PasskeyAutofillError =
+export type UsernamePasskeyAutofillError =
   | Extract<FinishSignInResult, { success: false }>["userError"]
   | PasskeyClientError;
 

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -9,7 +9,11 @@ import type { TokenBundle } from "../../lib/types.ts";
 import type { AuthSignInApi } from "../../react/client.tsx";
 import { AuthProvider, useAuth } from "../../react/client.tsx";
 import { useAuthToken } from "../../react/index.tsx";
-import { PasskeyApi, PasskeySignInResult, usePasskey } from "./react.tsx";
+import {
+  UsernamePasskeyApi,
+  UsernamePasskeySignInResult,
+  useUsernamePasskeySignIn,
+} from "./react.tsx";
 import { usePasskeyAutofill, usePasskeyCeremonySlot } from "./react_impl.tsx";
 
 const noopAutofill = {
@@ -41,7 +45,7 @@ const passkeyApi = {
   startAutofillSignIn: "startAutofillSignIn",
   finishSignIn: "finishSignIn",
   finishSignUp: "finishSignUp",
-} as unknown as PasskeyApi;
+} as unknown as UsernamePasskeyApi;
 
 //------------------------------------------------------------------------------
 // The fake browser ceremonies
@@ -229,13 +233,13 @@ function renderPasskey() {
       token: useAuthToken(),
       // A new api object on every render, like Convex's generated `api`
       // proxy, whose property accesses never compare equal.
-      passkey: usePasskey({ ...passkeyApi }),
+      passkey: useUsernamePasskeySignIn({ ...passkeyApi }),
     }),
     { wrapper: makeWrapper() },
   );
 }
 
-describe("usePasskey signIn", () => {
+describe("useUsernamePasskeySignIn signIn", () => {
   test("sign-up success runs the registration ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(registerStart);
     ceremonyCreate.mockResolvedValue(attestationCredential);
@@ -243,7 +247,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
@@ -267,7 +271,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
@@ -290,7 +294,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
@@ -330,7 +334,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "no" });
     });
@@ -349,7 +353,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
@@ -378,7 +382,7 @@ describe("usePasskey signIn", () => {
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
-    let first!: Promise<PasskeySignInResult>;
+    let first!: Promise<UsernamePasskeySignInResult>;
     act(() => {
       first = result.current.passkey.signIn({ username: "alice" });
     });
@@ -386,7 +390,7 @@ describe("usePasskey signIn", () => {
 
     // The second call must not start another ceremony or deadlock; it
     // returns a folded failure immediately.
-    let second!: PasskeySignInResult;
+    let second!: UsernamePasskeySignInResult;
     await act(async () => {
       second = await result.current.passkey.signIn({ username: "alice" });
     });
@@ -397,7 +401,7 @@ describe("usePasskey signIn", () => {
     expect(mutations.startSignIn).toHaveBeenCalledTimes(1);
 
     // The first call still completes normally.
-    let firstResult!: PasskeySignInResult;
+    let firstResult!: UsernamePasskeySignInResult;
     await act(async () => {
       resolveCeremony(assertionCredential);
       firstResult = await first;
@@ -438,7 +442,7 @@ describe("usePasskey signIn", () => {
   });
 });
 
-describe("usePasskey autofill", () => {
+describe("useUsernamePasskeySignIn autofill", () => {
   test("a rejecting availability check reports available: false and status 'stopped'", async () => {
     const spy = vi
       .spyOn(FakePublicKeyCredential, "isConditionalMediationAvailable")
@@ -546,7 +550,7 @@ describe("usePasskey autofill", () => {
     );
     expect(mutations.startAutofillSignIn).toHaveBeenCalledTimes(1);
 
-    let returned!: PasskeySignInResult;
+    let returned!: UsernamePasskeySignInResult;
     await act(async () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -2,12 +2,12 @@
  * React client for the passkey provider, exported at
  * `@convex-dev/auth/providers/passkey/react`.
  *
- * {@link usePasskey} is the batteries-included hook for the username +
- * passkey login form. It drives the browser-side WebAuthn ceremonies (see
- * `@convex-dev/auth/providers/passkey/client`) against the mutations of a
- * passkey recipe, and it handles both the identifier-first modal flow and
- * passkey autofill (conditional mediation), where the user selects an
- * account directly in the autocompletion list.
+ * {@link useUsernamePasskeySignIn} is the batteries-included hook for the
+ * username + passkey login form. It drives the browser-side WebAuthn
+ * ceremonies (see `@convex-dev/auth/providers/passkey/client`) against the
+ * mutations of a passkey recipe, and it handles both the identifier-first
+ * modal flow and passkey autofill (conditional mediation), where the user
+ * selects an account directly in the autocompletion list.
  *
  * @module
  */
@@ -18,8 +18,8 @@ import { useCallback, useMemo, useRef } from "react";
 import { useAuthActions, useAuthSignInApi } from "../../react/index.tsx";
 import {
   runSignInOrSignUpFlow,
-  type PasskeyApi,
-  type PasskeyAutofillError,
+  type UsernamePasskeyApi,
+  type UsernamePasskeyAutofillError,
   type SignInFlowResult,
 } from "./flows.ts";
 import {
@@ -29,21 +29,25 @@ import {
 } from "./react_impl.tsx";
 
 export type { PasskeyClientError } from "./client.ts";
-export type { PasskeyApi, PasskeyAutofillError } from "./flows.ts";
+export type {
+  UsernamePasskeyApi,
+  UsernamePasskeyAutofillError,
+} from "./flows.ts";
 export type {
   AlreadyPendingFailure,
   PasskeyAutofillStatus,
 } from "./react_impl.tsx";
 
 /**
- * The result of the `signIn` callback from {@link usePasskey}.
+ * The result of the `signIn` callback from {@link useUsernamePasskeySignIn}.
  *
  * A success carries a `flow` discriminant: `"signUp"` when the ceremony
  * created a new account, `"signIn"` when it authenticated an existing one.
  * `ALREADY_PENDING` comes back when a `signIn` call runs while the
  * previous one still does.
  */
-export type PasskeySignInResult = SignInFlowResult | AlreadyPendingFailure;
+export type UsernamePasskeySignInResult =
+  SignInFlowResult | AlreadyPendingFailure;
 
 /**
  * Client for the log in page in the “username + passkey” auth flow.
@@ -55,11 +59,11 @@ export type PasskeySignInResult = SignInFlowResult | AlreadyPendingFailure;
  *   directly in the autocompletion list.
  *
  * ```tsx
- * import { usePasskey } from "@convex-dev/auth/providers/passkey/react";
+ * import { useUsernamePasskeySignIn } from "@convex-dev/auth/providers/passkey/react";
  * import { api } from "../convex/_generated/api";
  *
  * function LogIn() {
- *   const { signIn, pending, autofill } = usePasskey({
+ *   const { signIn, pending, autofill } = useUsernamePasskeySignIn({
  *     startSignIn: api.auth.startSignIn,
  *     startAutofillSignIn: api.auth.startAutofillSignIn,
  *     finishSignIn: api.auth.finishSignIn,
@@ -82,9 +86,11 @@ export type PasskeySignInResult = SignInFlowResult | AlreadyPendingFailure;
  * }
  * ```
  *
- * @param passkeyApi The app's re-exported passkey mutation references.
+ * @param usernamePasskeyApi The app's re-exported passkey mutation references.
  */
-export function usePasskey(passkeyApi: PasskeyApi) {
+export function useUsernamePasskeySignIn(
+  usernamePasskeyApi: UsernamePasskeyApi,
+) {
   const { setSession } = useAuthActions();
 
   // Using useAuthSignInApi for mutations that return a session to support SSR
@@ -95,10 +101,15 @@ export function usePasskey(passkeyApi: PasskeyApi) {
   // referentially stable across renders. We only need to access them in
   // event callbacks, so using a ref ensures we always use the latest
   // function reference from the callback.
-  const ctxRef = useRef({ convex, api: passkeyApi, signInApi, setSession });
-  ctxRef.current = { convex, api: passkeyApi, signInApi, setSession };
+  const ctxRef = useRef({
+    convex,
+    api: usernamePasskeyApi,
+    signInApi,
+    setSession,
+  });
+  ctxRef.current = { convex, api: usernamePasskeyApi, signInApi, setSession };
 
-  const autofill = usePasskeyAutofill<PasskeyAutofillError>({
+  const autofill = usePasskeyAutofill<UsernamePasskeyAutofillError>({
     start: () => {
       const { convex, api } = ctxRef.current;
       return convex.mutation(api.startAutofillSignIn, {});
@@ -123,7 +134,11 @@ export function usePasskey(passkeyApi: PasskeyApi) {
   const { run, pending } = usePasskeyCeremonySlot({ autofill });
 
   const signIn = useCallback(
-    ({ username }: { username: string }): Promise<PasskeySignInResult> =>
+    ({
+      username,
+    }: {
+      username: string;
+    }): Promise<UsernamePasskeySignInResult> =>
       run(() => runSignInOrSignUpFlow(ctxRef.current, { username })),
     [run],
   );

--- a/packages/docs/content/docs/login-providers/passkey.mdx
+++ b/packages/docs/content/docs/login-providers/passkey.mdx
@@ -153,7 +153,8 @@ stored in the autocompletion list of the username field. The field must carry
 
 <Callout type="warn">
   The browser allows only one of these autofill requests at a time, so you
-  should not mount the `usePasskey` hook multiple times simultaneously.
+  should not mount the `useUsernamePasskeySignIn` hook multiple times
+  simultaneously.
 </Callout>
 
 Copy the following code block inside of your app:


### PR DESCRIPTION
This PR is a no-op refactor that renames the `usePasskey` hook. The name of the hook was too generic, while this hook specifically handles the identify-first login page for “username + passkey.”