### PR TITLE
authPasskey: split the registration functions per flow

### DIFF
--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -279,19 +279,21 @@ describe("adding a passkey", () => {
     const t = await setup();
     const alice = await signUp(t, "alice");
 
-    // The sign-up branch mints a challenge with no user, thus its handle
-    // cannot link to an account that already has one.
+    // The sign-up branch mints a challenge with no user, thus it belongs to
+    // the new-user flow. `finishAddPasskey` runs the existing-user flow, and
+    // the flows never mix: the mismatch is a protocol violation, the message
+    // goes to the backend logs, and the client gets `PROTOCOL_ERROR`.
     const start = await t.mutation(api.auth.startSignIn, { username: "carol" });
     if (!start.success || start.step !== "register") {
       throw new Error("The username is free.");
     }
     const credential = await generateES256Credential();
-    await expect(
-      as(t, alice.userId).mutation(
+    expect(
+      await as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
         await attest(start.challenge, credential),
       ),
-    ).rejects.toThrow("The user already has a different handle");
+    ).toEqual({ success: false, userError: { error: "PROTOCOL_ERROR" } });
   });
 
   test("refuses a signed-out caller", async () => {

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -61,7 +61,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       >;
     };
     registration: {
-      checkRegistration: FunctionReference<
+      checkRegistrationForNewUser: FunctionReference<
         "query",
         "internal",
         {
@@ -94,7 +94,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         null,
         Name
       >;
-      finishRegistration: FunctionReference<
+      finishRegistrationForExistingUser: FunctionReference<
         "mutation",
         "internal",
         {
@@ -105,6 +105,26 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           name?: string;
           transports?: Array<string>;
           verifiedUserId: string;
+        },
+        | { passkeyId: string; success: true }
+        | {
+            success: false;
+            userError:
+              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
+          },
+        Name
+      >;
+      finishRegistrationForNewUser: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          attestationObject: ArrayBuffer;
+          clientDataJSON: ArrayBuffer;
+          expectedOrigin: string;
+          expectedRpId: string;
+          name?: string;
+          newUserId: string;
+          transports?: Array<string>;
         },
         | { passkeyId: string; success: true }
         | {
@@ -126,10 +146,10 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         }>,
         Name
       >;
-      startRegistration: FunctionReference<
+      startRegistrationForExistingUser: FunctionReference<
         "mutation",
         "internal",
-        { userId: string | null },
+        { userId: string },
         {
           challenge: ArrayBuffer;
           excludeCredentials: Array<{
@@ -138,6 +158,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           }>;
           userHandle: ArrayBuffer;
         },
+        Name
+      >;
+      startRegistrationForNewUser: FunctionReference<
+        "mutation",
+        "internal",
+        {},
+        { challenge: ArrayBuffer; userHandle: ArrayBuffer },
         Name
       >;
     };

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -149,7 +149,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       startRegistrationForExistingUser: FunctionReference<
         "mutation",
         "internal",
-        { userId: string },
+        { verifiedUserId: string },
         {
           challenge: ArrayBuffer;
           excludeCredentials: Array<{

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -127,7 +127,7 @@ type FinishAuthenticationResult = Infer<typeof finishAuthenticationResult>;
  * Finish an authentication ceremony.
  *
  * The app supplies `expectedRpId` and `expectedOrigin`, as it does for
- * `finishRegistration`.
+ * the registration finish functions.
  *
  * The function finds the credential. Then it examines the authenticator
  * data, the client data, and the assertion signature. It deletes the

--- a/packages/core/src/components/passkey/cleanup.test.ts
+++ b/packages/core/src/components/passkey/cleanup.test.ts
@@ -18,7 +18,7 @@ function handle(byte: number, userId: string | null = null) {
 
 /**
  * Insert a handle and a registration challenge that points at it, as
- * `startRegistration` does. The age of a challenge is the age of its
+ * `startRegistrationForNewUser` does. The age of a challenge is the age of its
  * `_creationTime`, thus the tests set the clock to `createdAt` before the
  * insert. The handle goes in one millisecond earlier, in its own transaction,
  * so that the challenge gets `createdAt` exactly.
@@ -210,7 +210,7 @@ describe("the cleanup loop", () => {
     );
 
     vi.setSystemTime(START);
-    await t.mutation(api.registration.startRegistration, { userId: null });
+    await t.mutation(api.registration.startRegistrationForNewUser, {});
     // The loop runs in scheduled functions; let them all complete.
     await t.finishAllScheduledFunctions(() => vi.runAllTimers());
 

--- a/packages/core/src/components/passkey/convex.config.ts
+++ b/packages/core/src/components/passkey/convex.config.ts
@@ -13,8 +13,7 @@ import batchWorker from "@convex-dev/batch-worker/convex.config.js";
  * loop that erases the expired challenges (see cleanup.ts).
  *
  * The component has no configuration. The app passes the relying party ID
- * and the origin as arguments to `finishRegistration` and
- * `finishAuthentication`.
+ * and the origin as arguments to the finish functions.
  */
 const component = defineComponent("authPasskey");
 component.use(batchWorker);

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -11,7 +11,7 @@ import { expectSameBytes, setup } from "../passkeyTestSetup.ts";
 import { MutationCtx } from "./_generated/server.ts";
 import { Id } from "./_generated/dataModel.ts";
 
-/** Insert an unlinked handle, as `startRegistration` does. */
+/** Insert an unlinked handle, as `startRegistrationForNewUser` does. */
 function insertHandle(ctx: MutationCtx): Promise<Id<"handles">> {
   return ctx.db.insert("handles", { handle: randomHandle(), userId: null });
 }

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -155,9 +155,10 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
       }
 
       const { challenge, userHandle, excludeCredentials } =
-        await ctx.runMutation(config.component.registration.startRegistration, {
-          userId,
-        });
+        await ctx.runMutation(
+          config.component.registration.startRegistrationForExistingUser,
+          { userId },
+        );
       const username = await ctx.runQuery(
         config.usernameComponent.public.getUsername,
         { userId },
@@ -190,7 +191,7 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
         return { success: false, userError: { error: "NOT_SIGNED_IN" } };
       }
       const registrationResult = await ctx.runMutation(
-        config.component.registration.finishRegistration,
+        config.component.registration.finishRegistrationForExistingUser,
         {
           expectedRpId: config.rpId,
           expectedOrigin: config.origin,
@@ -204,9 +205,9 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
         // A `PROTOCOL_ERROR` here also covers a registration ceremony that
         // belongs to a different user than the caller, which happens when the
         // caller signs in as a different user after the `verifyAddPasskey`
-        // call. `finishRegistration` compares the owner of the ceremony with
-        // `verifiedUserId`, thus this call needs no check of its own. See the
-        // same case in `verifyAddPasskey`.
+        // call. `finishRegistrationForExistingUser` compares the owner of the
+        // ceremony with `verifiedUserId`, thus this call needs no check of its
+        // own. See the same case in `verifyAddPasskey`.
         return { success: false, userError: registrationResult.userError };
       }
       return { success: true, passkeyId: registrationResult.passkeyId };

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -157,7 +157,7 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
       const { challenge, userHandle, excludeCredentials } =
         await ctx.runMutation(
           config.component.registration.startRegistrationForExistingUser,
-          { userId },
+          { verifiedUserId: userId },
         );
       const username = await ctx.runQuery(
         config.usernameComponent.public.getUsername,

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -61,7 +61,6 @@ const registerStart = {
   step: "register",
   challenge: new ArrayBuffer(16),
   userHandle: new ArrayBuffer(16),
-  excludeCredentials: [],
   rpId: "localhost",
   rpName: "Test app",
 };

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -260,7 +260,7 @@ function assertionArgs(credential: PublicKeyCredential): AssertionArgs {
 
 /**
  * Turn the credential descriptors from the server into the WebAuthn shape
- * of `allowCredentials` and `excludeCredentials`.
+ * of `allowCredentials`.
  */
 function credentialDescriptors(
   credentials: CredentialDescriptor[],
@@ -312,7 +312,6 @@ async function runRegistrationCeremony(
         userVerification: "required",
       },
       attestation: "none",
-      excludeCredentials: credentialDescriptors(start.excludeCredentials),
     },
   })) as PublicKeyCredential | null;
   if (credential === null) {

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -33,7 +33,34 @@ function expireChallenge() {
   vi.setSystemTime(Date.now() + CHALLENGE_TTL_MS + 1000);
 }
 
-/** Build valid `finishRegistration` args, with overridable pieces. */
+/**
+ * Make every new handle the same bytes, and return a function that restores
+ * the real randomness. Only the 64-byte values are handles: the challenges
+ * (32 bytes) stay random.
+ */
+function collideHandles() {
+  const getRandomValues = crypto.getRandomValues.bind(crypto);
+  const spy = vi
+    .spyOn(crypto, "getRandomValues")
+    .mockImplementation((array) =>
+      array !== null && array.byteLength === 64
+        ? (array as Uint8Array<ArrayBuffer>).fill(7)
+        : getRandomValues(array as Uint8Array<ArrayBuffer>),
+    );
+  return () => spy.mockRestore();
+}
+
+/**
+ * Build valid finish arguments, with overridable pieces.
+ *
+ * `options.startUserId` says which start function runs: a string starts the
+ * existing-user flow for that user, and `null` starts the new-user flow. It
+ * is `userId` by default.
+ *
+ * The returned `finish` calls the finish function of the flow that started
+ * the ceremony, with `userId` as the user. A test that finishes in the other
+ * flow calls the mutation by itself.
+ */
 async function registrationArgs(
   t: ReturnType<typeof setup>,
   userId: string,
@@ -49,20 +76,12 @@ async function registrationArgs(
     userVerified?: boolean;
     includeCredential?: boolean;
     challenge?: ArrayBuffer;
-    // Run the new-account flow, where no user exists yet and only
-    // `finishRegistration` knows the verified user.
-    isNewAccountFlow?: boolean;
-    // The user that `startRegistration` receives. It is `userId` by default.
-    // `null` starts the new-account flow, which makes an unlinked handle.
     startUserId?: string | null;
   } = {},
 ) {
   const credential = options.credential ?? (await generateES256Credential());
-  const startUserId = options.isNewAccountFlow
-    ? null
-    : options.startUserId !== undefined
-      ? options.startUserId
-      : userId;
+  const startUserId =
+    options.startUserId !== undefined ? options.startUserId : userId;
   let challenge: ArrayBuffer;
   let userHandle: ArrayBuffer | null;
   if (options.challenge !== undefined) {
@@ -71,9 +90,12 @@ async function registrationArgs(
     challenge = options.challenge;
     userHandle = null;
   } else {
-    const started = await t.mutation(api.registration.startRegistration, {
-      userId: startUserId,
-    });
+    const started =
+      startUserId === null
+        ? await t.mutation(api.registration.startRegistrationForNewUser, {})
+        : await t.mutation(api.registration.startRegistrationForExistingUser, {
+            userId: startUserId,
+          });
     challenge = started.challenge;
     userHandle = started.userHandle;
   }
@@ -84,25 +106,33 @@ async function registrationArgs(
     userVerified: options.userVerified,
     credential: options.includeCredential === false ? undefined : credential,
   });
-  return {
-    credential,
-    userHandle,
-    args: {
-      expectedRpId: RP_ID,
-      expectedOrigin: ORIGIN,
-      verifiedUserId: userId,
-      name: options.name,
-      attestationObject: toArrayBuffer(buildAttestationObject(authData)),
-      clientDataJSON: toArrayBuffer(
-        buildClientDataJSON({
-          type: options.clientDataType ?? "webauthn.create",
-          challenge,
-          origin: options.origin ?? ORIGIN,
-          crossOrigin: options.crossOrigin,
-        }),
-      ),
-    },
+  const args = {
+    expectedRpId: RP_ID,
+    expectedOrigin: ORIGIN,
+    name: options.name,
+    attestationObject: toArrayBuffer(buildAttestationObject(authData)),
+    clientDataJSON: toArrayBuffer(
+      buildClientDataJSON({
+        type: options.clientDataType ?? "webauthn.create",
+        challenge,
+        origin: options.origin ?? ORIGIN,
+        crossOrigin: options.crossOrigin,
+      }),
+    ),
   };
+  const finish = (extra: { transports?: string[] } = {}) =>
+    startUserId === null
+      ? t.mutation(api.registration.finishRegistrationForNewUser, {
+          ...args,
+          ...extra,
+          newUserId: userId,
+        })
+      : t.mutation(api.registration.finishRegistrationForExistingUser, {
+          ...args,
+          ...extra,
+          verifiedUserId: userId,
+        });
+  return { credential, userHandle, args, finish };
 }
 
 // Only the expiry tests move the clock, but the restore is global to keep the
@@ -111,12 +141,78 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("startRegistration", () => {
-  test("returns a 32-byte challenge and stores an anonymous registration row", async () => {
+describe("startRegistrationForNewUser", () => {
+  test("stores an anonymous registration row with a 32-byte challenge", async () => {
     const t = setup();
-    const { challenge } = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
+    const { challenge } = await t.mutation(
+      api.registration.startRegistrationForNewUser,
+      {},
+    );
+    expect(new Uint8Array(challenge).length).toBe(32);
+    const rows = await t.run((ctx) => ctx.db.query("challenges").collect());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("registration");
+    expectSameBytes(rows[0].challenge, challenge);
+    // Registration challenges carry no identity: they point at a handle.
+    expect("userId" in rows[0]).toBe(false);
+    const handles = await handleRows(t);
+    expect(rows[0]).toMatchObject({ handleId: handles[0]._id });
+  });
+
+  test("makes an unlinked handle", async () => {
+    const t = setup();
+    const { userHandle } = await t.mutation(
+      api.registration.startRegistrationForNewUser,
+      {},
+    );
+    // 64 bytes is the WebAuthn maximum length for `user.id`.
+    expect(new Uint8Array(userHandle).length).toBe(64);
+
+    const handles = await handleRows(t);
+    expect(handles).toHaveLength(1);
+    expect(handles[0].userId).toBe(null);
+    expectSameBytes(handles[0].handle, userHandle);
+  });
+
+  test("does not reuse the unlinked handle of another ceremony", async () => {
+    const t = setup();
+    const first = await t.mutation(
+      api.registration.startRegistrationForNewUser,
+      {},
+    );
+    const second = await t.mutation(
+      api.registration.startRegistrationForNewUser,
+      {},
+    );
+
+    expect(new Uint8Array(second.userHandle)).not.toEqual(
+      new Uint8Array(first.userHandle),
+    );
+    expect(await handleRows(t)).toHaveLength(2);
+  });
+
+  test("throws when a new handle collides with an existing handle", async () => {
+    const t = setup();
+    const restore = collideHandles();
+    try {
+      await t.mutation(api.registration.startRegistrationForNewUser, {});
+      await expect(
+        t.mutation(api.registration.startRegistrationForNewUser, {}),
+      ).rejects.toThrow("collides with an existing handle");
+    } finally {
+      restore();
+    }
+    expect(await handleRows(t)).toHaveLength(1);
+  });
+});
+
+describe("startRegistrationForExistingUser", () => {
+  test("stores an anonymous registration row with a 32-byte challenge", async () => {
+    const t = setup();
+    const { challenge } = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
     expect(new Uint8Array(challenge).length).toBe(32);
     const rows = await t.run((ctx) => ctx.db.query("challenges").collect());
     expect(rows).toHaveLength(1);
@@ -129,26 +225,10 @@ describe("startRegistration", () => {
     expect(rows[0]).toMatchObject({ handleId: handles[0]._id });
   });
 
-  test("makes an unlinked handle in the new-account flow", async () => {
-    const t = setup();
-    const { userHandle, excludeCredentials } = await t.mutation(
-      api.registration.startRegistration,
-      { userId: null },
-    );
-    // 64 bytes is the WebAuthn maximum length for `user.id`.
-    expect(new Uint8Array(userHandle).length).toBe(64);
-    expect(excludeCredentials).toEqual([]);
-
-    const handles = await handleRows(t);
-    expect(handles).toHaveLength(1);
-    expect(handles[0].userId).toBe(null);
-    expectSameBytes(handles[0].handle, userHandle);
-  });
-
   test("makes a linked handle for a known user with no handle", async () => {
     const t = setup();
     const { userHandle } = await t.mutation(
-      api.registration.startRegistration,
+      api.registration.startRegistrationForExistingUser,
       { userId: "user1" },
     );
     const handles = await handleRows(t);
@@ -159,12 +239,14 @@ describe("startRegistration", () => {
 
   test("reuses the existing handle of a user", async () => {
     const t = setup();
-    const first = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
-    const second = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
+    const first = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
+    const second = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
 
     expectSameBytes(second.userHandle, first.userHandle);
     // Each user has a maximum of one handle.
@@ -186,12 +268,14 @@ describe("startRegistration", () => {
 
   test("makes a separate handle for each user", async () => {
     const t = setup();
-    const first = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
-    const second = await t.mutation(api.registration.startRegistration, {
-      userId: "user2",
-    });
+    const first = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
+    const second = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user2" },
+    );
 
     expect(new Uint8Array(second.userHandle)).not.toEqual(
       new Uint8Array(first.userHandle),
@@ -199,29 +283,24 @@ describe("startRegistration", () => {
     expect(await handleRows(t)).toHaveLength(2);
   });
 
-  test("does not reuse the unlinked handle of another ceremony", async () => {
+  test("does not reuse the unlinked handle of a new-user ceremony", async () => {
     const t = setup();
-    const first = await t.mutation(api.registration.startRegistration, {
-      userId: null,
-    });
-    const second = await t.mutation(api.registration.startRegistration, {
-      userId: null,
-    });
-
-    expect(new Uint8Array(second.userHandle)).not.toEqual(
-      new Uint8Array(first.userHandle),
+    const unlinked = await t.mutation(
+      api.registration.startRegistrationForNewUser,
+      {},
     );
-    expect(await handleRows(t)).toHaveLength(2);
-  });
-
-  test("returns no excludeCredentials without a userId", async () => {
-    const t = setup();
-    await register(t, "user1");
-    const { excludeCredentials } = await t.mutation(
-      api.registration.startRegistration,
-      { userId: null },
+    const started = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
     );
-    expect(excludeCredentials).toEqual([]);
+
+    expect(new Uint8Array(started.userHandle)).not.toEqual(
+      new Uint8Array(unlinked.userHandle),
+    );
+    expect((await handleRows(t)).map((row) => row.userId)).toEqual([
+      null,
+      "user1",
+    ]);
   });
 
   test("returns exactly the user's credential IDs as excludeCredentials", async () => {
@@ -230,7 +309,7 @@ describe("startRegistration", () => {
     const second = await register(t, "user1");
     await register(t, "user2");
     const { excludeCredentials } = await t.mutation(
-      api.registration.startRegistration,
+      api.registration.startRegistrationForExistingUser,
       { userId: "user1" },
     );
     const ids = excludeCredentials.map(({ id }) =>
@@ -241,12 +320,22 @@ describe("startRegistration", () => {
     expect(ids).toContain(second.credential.credentialId.join(","));
   });
 
+  test("returns no excludeCredentials for a user with no passkey", async () => {
+    const t = setup();
+    await register(t, "user1");
+    const { excludeCredentials } = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user2" },
+    );
+    expect(excludeCredentials).toEqual([]);
+  });
+
   test("returns the transports of each passkey in excludeCredentials", async () => {
     const t = setup();
     const stored = await register(t, "user1", { transports: ["usb", "nfc"] });
     const withoutTransports = await register(t, "user1");
     const { excludeCredentials } = await t.mutation(
-      api.registration.startRegistration,
+      api.registration.startRegistrationForExistingUser,
       { userId: "user1" },
     );
 
@@ -268,36 +357,154 @@ describe("startRegistration", () => {
 
   test("throws when a new handle collides with an existing handle", async () => {
     const t = setup();
-    // Make each new handle the same bytes. Only the 64-byte values are
-    // handles: the challenges (32 bytes) stay random.
-    const getRandomValues = crypto.getRandomValues.bind(crypto);
-    const spy = vi
-      .spyOn(crypto, "getRandomValues")
-      .mockImplementation((array) =>
-        array !== null && array.byteLength === 64
-          ? (array as Uint8Array<ArrayBuffer>).fill(7)
-          : getRandomValues(array as Uint8Array<ArrayBuffer>),
-      );
+    const restore = collideHandles();
     try {
-      await t.mutation(api.registration.startRegistration, { userId: "user1" });
+      await t.mutation(api.registration.startRegistrationForExistingUser, {
+        userId: "user1",
+      });
       await expect(
-        t.mutation(api.registration.startRegistration, { userId: "user2" }),
+        t.mutation(api.registration.startRegistrationForExistingUser, {
+          userId: "user2",
+        }),
       ).rejects.toThrow("collides with an existing handle");
     } finally {
-      spy.mockRestore();
+      restore();
     }
-    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
-    expect(handles).toHaveLength(1);
+    expect(await handleRows(t)).toHaveLength(1);
   });
 });
 
-describe("finishRegistration", () => {
+describe("finishRegistrationForNewUser", () => {
+  test("stores the passkey and links the handle to the verified user", async () => {
+    const t = setup();
+    const { credential, userHandle, finish } = await registrationArgs(
+      t,
+      "user1",
+      { startUserId: null, counter: 5 },
+    );
+    const result = await finish();
+    expect(result.success).toBe(true);
+
+    const passkeys = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(passkeys).toHaveLength(1);
+    expect(result).toEqual({ success: true, passkeyId: passkeys[0]._id });
+    expect(passkeys[0].userId).toBe("user1");
+    expect(passkeys[0].counter).toBe(5);
+    expectSameBytes(passkeys[0].credentialId, credential.credentialId);
+
+    const handles = await handleRows(t);
+    expect(handles).toHaveLength(1);
+    expect(handles[0].userId).toBe("user1");
+    expectSameBytes(handles[0].handle, userHandle!);
+  });
+
+  test("returns PROTOCOL_ERROR for an existing-user ceremony", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      startUserId: "user1",
+    });
+    await expectProtocolError(
+      () =>
+        t.mutation(api.registration.finishRegistrationForNewUser, {
+          ...args,
+          newUserId: "user1",
+        }),
+      "the ceremony comes from `existingUser`",
+    );
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+    // The attempt burns the challenge, but the handle has an owner and stays.
+    expect(await t.run((ctx) => ctx.db.query("challenges").collect())).toEqual(
+      [],
+    );
+    expect((await handleRows(t)).map((row) => row.userId)).toEqual(["user1"]);
+  });
+
+  test("throws for an unlinked handle when the user already has one", async () => {
+    const t = setup();
+    // A ceremony that starts as a new user, but that finishes with a user
+    // that already has a handle. The invariant is that this cannot happen.
+    const { finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+    });
+    await t.run((ctx) =>
+      ctx.db.insert("handles", {
+        handle: new Uint8Array(64).fill(9).buffer,
+        userId: "user1",
+      }),
+    );
+    await expect(finish()).rejects.toThrow(
+      "The user already has a different handle.",
+    );
+  });
+
+  test("throws when the handle of the challenge no longer exists", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+    });
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query("handles").collect()) {
+        await ctx.db.delete("handles", row._id);
+      }
+    });
+    await expect(finish()).rejects.toThrow(
+      "The handle of the challenge does not exist.",
+    );
+  });
+
+  test("erases the unlinked handle of an expired challenge", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+    });
+    expireChallenge();
+    await finish();
+    // The ceremony can never complete, thus its handle goes away too.
+    expect(await handleRows(t)).toEqual([]);
+  });
+
+  test.each([
+    { name: "the user is not verified", options: { userVerified: false } },
+    {
+      name: "the relying party ID does not match",
+      options: { authDataRpId: "evil.example.net" },
+    },
+    {
+      name: "the attested credential data is missing",
+      options: { includeCredential: false },
+    },
+  ])(
+    "erases the challenge and the unlinked handle when $name",
+    async ({ options }) => {
+      const t = setup();
+      const { finish } = await registrationArgs(t, "user1", {
+        startUserId: null,
+        ...options,
+      });
+      const result = await finish();
+      expect(result).toEqual({
+        success: false,
+        userError: { error: "PROTOCOL_ERROR" },
+      });
+      // The failure burned the challenge, so the cleanup loop cannot find
+      // the handle later. The mutation must delete the handle itself.
+      expect(await handleRows(t)).toEqual([]);
+      expect(
+        await t.run((ctx) => ctx.db.query("challenges").collect()),
+      ).toEqual([]);
+    },
+  );
+});
+
+describe("finishRegistrationForExistingUser", () => {
   test("stores an ES256 passkey and consumes the challenge", async () => {
     const t = setup();
-    const { credential, args } = await registrationArgs(t, "user1", {
+    const { credential, finish } = await registrationArgs(t, "user1", {
       counter: 5,
     });
-    const result = await t.mutation(api.registration.finishRegistration, args);
+    const result = await finish();
     expect(result.success).toBe(true);
 
     const passkeys = await t.run((ctx) => ctx.db.query("passkeys").collect());
@@ -319,25 +526,12 @@ describe("finishRegistration", () => {
     expect(challenges).toEqual([]);
   });
 
-  test("stores an RS256 passkey with a PKCS#1 public key", async () => {
-    const t = setup();
-    const credential = await generateRS256Credential();
-    const { args } = await registrationArgs(t, "user1", { credential });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result.success).toBe(true);
-
-    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
-    expect(row.algorithm).toBe("RS256");
-    const decoded = decodePKCS1RSAPublicKey(new Uint8Array(row.publicKey));
-    expect(decoded.e).toBe(65537n);
-  });
-
   test("stores the optional name", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       name: "MacBook Touch ID",
     });
-    const result = await t.mutation(api.registration.finishRegistration, args);
+    const result = await finish();
     expect(result.success).toBe(true);
     const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
     expect(row.name).toBe("MacBook Touch ID");
@@ -345,11 +539,8 @@ describe("finishRegistration", () => {
 
   test("stores the transports that the client reports", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
-    const result = await t.mutation(api.registration.finishRegistration, {
-      ...args,
-      transports: ["internal", "hybrid"],
-    });
+    const { finish } = await registrationArgs(t, "user1");
+    const result = await finish({ transports: ["internal", "hybrid"] });
     expect(result.success).toBe(true);
     const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
     expect(row.transports).toEqual(["internal", "hybrid"]);
@@ -357,11 +548,110 @@ describe("finishRegistration", () => {
 
   test("stores no transports when the client reports none", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
-    const result = await t.mutation(api.registration.finishRegistration, args);
+    const { finish } = await registrationArgs(t, "user1");
+    const result = await finish();
     expect(result.success).toBe(true);
     const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
     expect(row).not.toHaveProperty("transports");
+  });
+
+  test("keeps the handle of a user that adds a second passkey", async () => {
+    const t = setup();
+    const first = await registrationArgs(t, "user1", { startUserId: null });
+    await first.finish();
+    const second = await registrationArgs(t, "user1");
+    const result = await second.finish();
+
+    expect(result.success).toBe(true);
+    expectSameBytes(second.userHandle!, first.userHandle!);
+    expect(await handleRows(t)).toHaveLength(1);
+  });
+
+  test("returns PROTOCOL_ERROR for a new-user ceremony", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      startUserId: null,
+    });
+    await expectProtocolError(
+      () =>
+        t.mutation(api.registration.finishRegistrationForExistingUser, {
+          ...args,
+          verifiedUserId: "user1",
+        }),
+      "the ceremony comes from `newUser`",
+    );
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+    // The attempt burns the challenge, and the handle has no owner, thus it
+    // goes away too.
+    expect(await t.run((ctx) => ctx.db.query("challenges").collect())).toEqual(
+      [],
+    );
+    expect(await handleRows(t)).toEqual([]);
+  });
+
+  test("returns PROTOCOL_ERROR for a ceremony of a different user", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user2", {
+      startUserId: "user1",
+    });
+    await expectProtocolError(
+      finish,
+      "created for a different user than the current user",
+    );
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+    // The challenge burns, and the handle of user1 stays.
+    expect(await t.run((ctx) => ctx.db.query("challenges").collect())).toEqual(
+      [],
+    );
+    expect((await handleRows(t)).map((row) => row.userId)).toEqual(["user1"]);
+  });
+
+  test("keeps the linked handle of an expired challenge", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1");
+    expireChallenge();
+    await finish();
+    // The handle belongs to the user, thus it survives the dead ceremony.
+    expect(await handleRows(t)).toHaveLength(1);
+  });
+
+  test("keeps the linked handle when the verification fails", async () => {
+    const t = setup();
+    await register(t, "user1");
+    const { finish } = await registrationArgs(t, "user1", {
+      userVerified: false,
+    });
+    const result = await finish();
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PROTOCOL_ERROR" },
+    });
+    // The handle belongs to user1, so the failed attempt must not remove it.
+    const handles = await handleRows(t);
+    expect(handles).toHaveLength(1);
+    expect(handles[0].userId).toBe("user1");
+  });
+});
+
+// The WebAuthn checks that run before either flow examines the handle. The
+// tests drive them through the existing-user flow: the new-user flow runs
+// the exact same code.
+describe("finishRegistration verification", () => {
+  test("stores an RS256 passkey with a PKCS#1 public key", async () => {
+    const t = setup();
+    const credential = await generateRS256Credential();
+    const { finish } = await registrationArgs(t, "user1", { credential });
+    const result = await finish();
+    expect(result.success).toBe(true);
+
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.algorithm).toBe("RS256");
+    const decoded = decodePKCS1RSAPublicKey(new Uint8Array(row.publicKey));
+    expect(decoded.e).toBe(65537n);
   });
 
   test.each([
@@ -375,15 +665,11 @@ describe("finishRegistration", () => {
     { name: "a transport with a space", transports: ["smart card"] },
   ])("returns PROTOCOL_ERROR for $name", async ({ transports }) => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
+    const { finish } = await registrationArgs(t, "user1");
     // One message covers every rule, thus the values are what the logs
     // carry about this rejection.
     await expectProtocolError(
-      () =>
-        t.mutation(api.registration.finishRegistration, {
-          ...args,
-          transports,
-        }),
+      () => finish({ transports }),
       `The client sent: ${JSON.stringify(transports)}.`,
     );
     expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
@@ -391,87 +677,12 @@ describe("finishRegistration", () => {
     );
   });
 
-  test("links the handle to the verified user in the new-account flow", async () => {
-    const t = setup();
-    const { userHandle, args } = await registrationArgs(t, "user1", {
-      isNewAccountFlow: true,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result.success).toBe(true);
-
-    const handles = await handleRows(t);
-    expect(handles).toHaveLength(1);
-    expect(handles[0].userId).toBe("user1");
-    expectSameBytes(handles[0].handle, userHandle!);
-  });
-
-  test("keeps the handle of a user that adds a second passkey", async () => {
-    const t = setup();
-    const first = await registrationArgs(t, "user1", {
-      isNewAccountFlow: true,
-    });
-    await t.mutation(api.registration.finishRegistration, first.args);
-    const second = await registrationArgs(t, "user1");
-    const result = await t.mutation(
-      api.registration.finishRegistration,
-      second.args,
-    );
-
-    expect(result.success).toBe(true);
-    expectSameBytes(second.userHandle!, first.userHandle!);
-    expect(await handleRows(t)).toHaveLength(1);
-  });
-
-  test("throws for a handle that belongs to a different user", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user2", {
-      startUserId: "user1",
-    });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("The handle belongs to a different user.");
-  });
-
-  test("throws for an unlinked handle when the user already has one", async () => {
-    const t = setup();
-    // A ceremony that starts as a new account, but that finishes with a user
-    // that already has a handle. The invariant is that this cannot happen.
-    const { args } = await registrationArgs(t, "user1", {
-      isNewAccountFlow: true,
-    });
-    await t.run((ctx) =>
-      ctx.db.insert("handles", {
-        handle: new Uint8Array(64).fill(9).buffer,
-        userId: "user1",
-      }),
-    );
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("The user already has a different handle.");
-  });
-
-  test("throws when the handle of the challenge no longer exists", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
-      isNewAccountFlow: true,
-    });
-    await t.run(async (ctx) => {
-      for (const row of await ctx.db.query("handles").collect()) {
-        await ctx.db.delete("handles", row._id);
-      }
-    });
-    await expect(
-      t.mutation(api.registration.finishRegistration, args),
-    ).rejects.toThrow("The handle of the challenge does not exist.");
-  });
-
   test("returns CHALLENGE_EXPIRED for an unknown challenge", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       challenge: toArrayBuffer(crypto.getRandomValues(new Uint8Array(32))),
     });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
+    expect(await finish()).toEqual({
       success: false,
       userError: { error: "CHALLENGE_EXPIRED" },
     });
@@ -479,10 +690,9 @@ describe("finishRegistration", () => {
 
   test("returns CHALLENGE_EXPIRED for an expired challenge and deletes it", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
+    const { finish } = await registrationArgs(t, "user1");
     expireChallenge();
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
+    expect(await finish()).toEqual({
       success: false,
       userError: { error: "CHALLENGE_EXPIRED" },
     });
@@ -492,44 +702,24 @@ describe("finishRegistration", () => {
     expect(challenges).toEqual([]);
   });
 
-  test("erases the unlinked handle of an expired challenge", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
-      isNewAccountFlow: true,
-    });
-    expireChallenge();
-    await t.mutation(api.registration.finishRegistration, args);
-    // The ceremony can never complete, thus its handle goes away too.
-    expect(await handleRows(t)).toEqual([]);
-  });
-
-  test("keeps the linked handle of an expired challenge", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user1");
-    expireChallenge();
-    await t.mutation(api.registration.finishRegistration, args);
-    // The handle belongs to the user, thus it survives the dead ceremony.
-    expect(await handleRows(t)).toHaveLength(1);
-  });
-
   test("returns PROTOCOL_ERROR for an authentication client data type", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       clientDataType: "webauthn.get",
     });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       'a registration ceremony must send "webauthn.create"',
     );
   });
 
   test("returns PROTOCOL_ERROR for an unexpected origin without consuming the challenge", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       origin: "https://evil.example.net",
     });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       'the ceremony ran at the origin "https://evil.example.net"',
     );
     // The origin check happens before the challenge is consumed.
@@ -541,77 +731,54 @@ describe("finishRegistration", () => {
 
   test("returns PROTOCOL_ERROR for a cross-origin ceremony", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", { crossOrigin: true });
+    const { finish } = await registrationArgs(t, "user1", {
+      crossOrigin: true,
+    });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       "the ceremony ran in a cross-origin frame",
     );
   });
 
   test("returns PROTOCOL_ERROR for a relying party ID hash mismatch", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       authDataRpId: "evil.example.net",
     });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       `does not match the expected relying party ID "${RP_ID}"`,
     );
   });
 
   test("returns PROTOCOL_ERROR when the user is not present", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", { userPresent: false });
+    const { finish } = await registrationArgs(t, "user1", {
+      userPresent: false,
+    });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       "no user presence or no user verification",
     );
   });
 
   test("returns PROTOCOL_ERROR when the user is not verified", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       userVerified: false,
     });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       "no user presence or no user verification",
     );
   });
 
-  test("erases the unlinked handle when the user is not verified", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
-      startUserId: null,
-      userVerified: false,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result.success).toBe(false);
-    // The failed attempt burned the challenge. The ceremony can never
-    // complete, thus its unlinked handle goes away too.
-    expect(await handleRows(t)).toEqual([]);
-  });
-
-  test("keeps the linked handle when the user is not verified", async () => {
-    const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
-      userVerified: false,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result.success).toBe(false);
-    // The handle belongs to the user, thus it survives the failed attempt.
-    expect((await handleRows(t)).map((row) => row.userId)).toEqual(["user1"]);
-  });
-
   test("returns PROTOCOL_ERROR when the attested credential data is missing", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", {
+    const { finish } = await registrationArgs(t, "user1", {
       includeCredential: false,
     });
-    await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
-      "carries no attested credential data",
-    );
+    await expectProtocolError(finish, "carries no attested credential data");
   });
 
   test("returns PROTOCOL_ERROR for an unsupported public key algorithm", async () => {
@@ -626,9 +793,9 @@ describe("finishRegistration", () => {
         [-2, new Uint8Array(32)],
       ]),
     );
-    const { args } = await registrationArgs(t, "user1", { credential });
+    const { finish } = await registrationArgs(t, "user1", { credential });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       "the credential uses the COSE key algorithm -8",
     );
   });
@@ -646,9 +813,9 @@ describe("finishRegistration", () => {
         [-3, new Uint8Array(32)],
       ]),
     );
-    const { args } = await registrationArgs(t, "user1", { credential });
+    const { finish } = await registrationArgs(t, "user1", { credential });
     await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
+      finish,
       "the credential uses the elliptic curve 2",
     );
   });
@@ -657,69 +824,25 @@ describe("finishRegistration", () => {
     const t = setup();
     await register(t, "user1");
     const { credential } = await register(t, "user1");
-    // A second ceremony for a new account, with a credential that exists.
+    // A second ceremony for a new user, with a credential that exists.
     // A compliant client cannot cause this.
-    const { args } = await registrationArgs(t, "user2", {
-      isNewAccountFlow: true,
+    const { finish } = await registrationArgs(t, "user2", {
+      startUserId: null,
       credential,
     });
-    await expectProtocolError(
-      () => t.mutation(api.registration.finishRegistration, args),
-      "the credential is already registered",
-    );
+    await expectProtocolError(finish, "the credential is already registered");
     // The attempt burns the challenge, and the unlinked handle of the new
-    // account goes away with it.
+    // user goes away with it.
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
     );
     expect(challenges).toEqual([]);
     expect((await handleRows(t)).map((row) => row.userId)).toEqual(["user1"]);
   });
-
-  test("deletes the unlinked handle when verification fails in the new-account flow", async () => {
-    const t = setup();
-    const { challenge } = await t.mutation(api.registration.startRegistration, {
-      userId: null,
-    });
-    const { args } = await registrationArgs(t, "user1", {
-      challenge,
-      userVerified: false,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "PROTOCOL_ERROR" },
-    });
-    // The failure burned the challenge, so the cleanup loop cannot find the
-    // handle later. The mutation must delete the handle itself.
-    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
-    expect(handles).toEqual([]);
-    const challenges = await t.run((ctx) =>
-      ctx.db.query("challenges").collect(),
-    );
-    expect(challenges).toEqual([]);
-  });
-
-  test("keeps the linked handle when verification fails for an existing user", async () => {
-    const t = setup();
-    await register(t, "user1");
-    const { args } = await registrationArgs(t, "user1", {
-      userVerified: false,
-    });
-    const result = await t.mutation(api.registration.finishRegistration, args);
-    expect(result).toEqual({
-      success: false,
-      userError: { error: "PROTOCOL_ERROR" },
-    });
-    // The handle belongs to user1, so the failed attempt must not remove it.
-    const handles = await t.run((ctx) => ctx.db.query("handles").collect());
-    expect(handles).toHaveLength(1);
-    expect(handles[0].userId).toBe("user1");
-  });
 });
 
-describe("checkRegistration", () => {
-  /** `checkRegistration` takes the finish arguments without the user fields. */
+describe("checkRegistrationForNewUser", () => {
+  /** The check takes the finish arguments without the user fields. */
   function checkArgs({
     expectedRpId,
     expectedOrigin,
@@ -731,9 +854,9 @@ describe("checkRegistration", () => {
 
   test("returns success for a valid attestation and writes nothing", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
+    const { args } = await registrationArgs(t, "user1", { startUserId: null });
     const result = await t.query(
-      api.registration.checkRegistration,
+      api.registration.checkRegistrationForNewUser,
       checkArgs(args),
     );
     expect(result).toEqual({ success: true });
@@ -747,12 +870,24 @@ describe("checkRegistration", () => {
     );
   });
 
+  test("returns PROTOCOL_ERROR for an existing-user ceremony", async () => {
+    const t = setup();
+    const { args } = await registrationArgs(t, "user1", {
+      startUserId: "user1",
+    });
+    await expectProtocolError(
+      () =>
+        t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
+      "the ceremony comes from `existingUser`",
+    );
+  });
+
   test("returns CHALLENGE_EXPIRED for an expired challenge", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
+    const { args } = await registrationArgs(t, "user1", { startUserId: null });
     expireChallenge();
     const result = await t.query(
-      api.registration.checkRegistration,
+      api.registration.checkRegistrationForNewUser,
       checkArgs(args),
     );
     expect(result).toEqual({
@@ -764,10 +899,12 @@ describe("checkRegistration", () => {
   test("returns PROTOCOL_ERROR when the user is not verified", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
+      startUserId: null,
       userVerified: false,
     });
     await expectProtocolError(
-      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      () =>
+        t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
       "no user presence or no user verification",
     );
   });
@@ -775,9 +912,13 @@ describe("checkRegistration", () => {
   test("returns PROTOCOL_ERROR for a duplicate credential ID", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
-    const { args } = await registrationArgs(t, "user2", { credential });
+    const { args } = await registrationArgs(t, "user2", {
+      startUserId: null,
+      credential,
+    });
     await expectProtocolError(
-      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      () =>
+        t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
       "the credential is already registered",
     );
   });
@@ -785,20 +926,22 @@ describe("checkRegistration", () => {
   test("returns PROTOCOL_ERROR for an unexpected origin, like the finish call", async () => {
     const t = setup();
     const { args } = await registrationArgs(t, "user1", {
+      startUserId: null,
       origin: "https://evil.example.net",
     });
     await expectProtocolError(
-      () => t.query(api.registration.checkRegistration, checkArgs(args)),
+      () =>
+        t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
       'the ceremony ran at the origin "https://evil.example.net"',
     );
   });
 
   test("returns PROTOCOL_ERROR for transports that the client made up", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1");
+    const { args } = await registrationArgs(t, "user1", { startUserId: null });
     await expectProtocolError(
       () =>
-        t.query(api.registration.checkRegistration, {
+        t.query(api.registration.checkRegistrationForNewUser, {
           ...checkArgs(args),
           transports: ["smart card"],
         }),
@@ -808,14 +951,16 @@ describe("checkRegistration", () => {
 
   test("a finish with the same arguments succeeds after a successful check", async () => {
     const t = setup();
-    const { args } = await registrationArgs(t, "user1", { startUserId: null });
+    const { args, finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+    });
     const check = await t.query(
-      api.registration.checkRegistration,
+      api.registration.checkRegistrationForNewUser,
       checkArgs(args),
     );
     expect(check).toEqual({ success: true });
-    const finish = await t.mutation(api.registration.finishRegistration, args);
-    expect(finish.success).toBe(true);
+    const result = await finish();
+    expect(result.success).toBe(true);
   });
 });
 
@@ -874,9 +1019,10 @@ describe("deletePasskey", () => {
     const handles = await handleRows(t);
     expect(handles).toHaveLength(1);
     expect(handles[0].userId).toBe("user1");
-    const next = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
+    const next = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
     expectSameBytes(next.userHandle, handle.handle);
   });
 
@@ -958,7 +1104,9 @@ describe("deleteUser", () => {
     const t = setup();
     await register(t, "user1");
     // An in-flight ceremony that adds a passkey to the user.
-    await t.mutation(api.registration.startRegistration, { userId: "user1" });
+    await t.mutation(api.registration.startRegistrationForExistingUser, {
+      userId: "user1",
+    });
 
     await t.mutation(api.registration.deleteUser, { userId: "user1" });
 
@@ -1013,9 +1161,10 @@ describe("deleteUser", () => {
     const [first] = await handleRows(t);
     await t.mutation(api.registration.deleteUser, { userId: "user1" });
 
-    const second = await t.mutation(api.registration.startRegistration, {
-      userId: "user1",
-    });
+    const second = await t.mutation(
+      api.registration.startRegistrationForExistingUser,
+      { userId: "user1" },
+    );
     expect(new Uint8Array(second.userHandle)).not.toEqual(
       new Uint8Array(first.handle),
     );

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -94,7 +94,7 @@ async function registrationArgs(
       startUserId === null
         ? await t.mutation(api.registration.startRegistrationForNewUser, {})
         : await t.mutation(api.registration.startRegistrationForExistingUser, {
-            userId: startUserId,
+            verifiedUserId: startUserId,
           });
     challenge = started.challenge;
     userHandle = started.userHandle;
@@ -211,7 +211,7 @@ describe("startRegistrationForExistingUser", () => {
     const t = setup();
     const { challenge } = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     expect(new Uint8Array(challenge).length).toBe(32);
     const rows = await t.run((ctx) => ctx.db.query("challenges").collect());
@@ -229,7 +229,7 @@ describe("startRegistrationForExistingUser", () => {
     const t = setup();
     const { userHandle } = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     const handles = await handleRows(t);
     expect(handles).toHaveLength(1);
@@ -241,11 +241,11 @@ describe("startRegistrationForExistingUser", () => {
     const t = setup();
     const first = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     const second = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
 
     expectSameBytes(second.userHandle, first.userHandle);
@@ -270,11 +270,11 @@ describe("startRegistrationForExistingUser", () => {
     const t = setup();
     const first = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     const second = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user2" },
+      { verifiedUserId: "user2" },
     );
 
     expect(new Uint8Array(second.userHandle)).not.toEqual(
@@ -291,7 +291,7 @@ describe("startRegistrationForExistingUser", () => {
     );
     const started = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
 
     expect(new Uint8Array(started.userHandle)).not.toEqual(
@@ -310,7 +310,7 @@ describe("startRegistrationForExistingUser", () => {
     await register(t, "user2");
     const { excludeCredentials } = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     const ids = excludeCredentials.map(({ id }) =>
       Array.from(new Uint8Array(id)).join(","),
@@ -325,7 +325,7 @@ describe("startRegistrationForExistingUser", () => {
     await register(t, "user1");
     const { excludeCredentials } = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user2" },
+      { verifiedUserId: "user2" },
     );
     expect(excludeCredentials).toEqual([]);
   });
@@ -336,7 +336,7 @@ describe("startRegistrationForExistingUser", () => {
     const withoutTransports = await register(t, "user1");
     const { excludeCredentials } = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
 
     const byId = new Map(
@@ -360,11 +360,11 @@ describe("startRegistrationForExistingUser", () => {
     const restore = collideHandles();
     try {
       await t.mutation(api.registration.startRegistrationForExistingUser, {
-        userId: "user1",
+        verifiedUserId: "user1",
       });
       await expect(
         t.mutation(api.registration.startRegistrationForExistingUser, {
-          userId: "user2",
+          verifiedUserId: "user2",
         }),
       ).rejects.toThrow("collides with an existing handle");
     } finally {
@@ -1021,7 +1021,7 @@ describe("deletePasskey", () => {
     expect(handles[0].userId).toBe("user1");
     const next = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     expectSameBytes(next.userHandle, handle.handle);
   });
@@ -1105,7 +1105,7 @@ describe("deleteUser", () => {
     await register(t, "user1");
     // An in-flight ceremony that adds a passkey to the user.
     await t.mutation(api.registration.startRegistrationForExistingUser, {
-      userId: "user1",
+      verifiedUserId: "user1",
     });
 
     await t.mutation(api.registration.deleteUser, { userId: "user1" });
@@ -1163,7 +1163,7 @@ describe("deleteUser", () => {
 
     const second = await t.mutation(
       api.registration.startRegistrationForExistingUser,
-      { userId: "user1" },
+      { verifiedUserId: "user1" },
     );
     expect(new Uint8Array(second.userHandle)).not.toEqual(
       new Uint8Array(first.handle),

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -126,7 +126,7 @@ export const startRegistrationForNewUser = mutation({
  * when a signed-in user adds a passkey to their account.
  */
 export const startRegistrationForExistingUser = mutation({
-  args: { userId: v.string() },
+  args: { verifiedUserId: v.string() },
   returns: v.object({
     challenge: v.bytes(),
     userHandle: v.bytes(),
@@ -134,15 +134,15 @@ export const startRegistrationForExistingUser = mutation({
     // to make a second passkey for a credential that the user already has.
     excludeCredentials: v.array(credentialDescriptor),
   }),
-  handler: async (ctx, { userId }) => {
+  handler: async (ctx, { verifiedUserId }) => {
     const existing = await ctx.db
       .query("handles")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .withIndex("by_userId", (q) => q.eq("userId", verifiedUserId))
       .unique();
-    const handle = existing ?? (await insertHandle(ctx, userId));
+    const handle = existing ?? (await insertHandle(ctx, verifiedUserId));
     const passkeys = await ctx.db
       .query("passkeys")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .withIndex("by_userId", (q) => q.eq("userId", verifiedUserId))
       .collect();
     const challenge = await insertRegistrationChallenge(ctx, handle._id);
     return {

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -1,3 +1,70 @@
+/**
+ * The registration ceremonies that make a passkey and store it.
+ *
+ * A ceremony runs in one of two flows, and the component gives each flow
+ * its own pair of functions:
+ *
+ * - The new-user flow (`…ForNewUser`), where the user does not exist yet.
+ *   The ceremony gets a handle with no owner, and the finish step links that
+ *   handle to the user that the caller creates in the same transaction.
+ *
+ * ```
+ *  Client                Provider                         Component
+ *    │                     │                                 │
+ *    │  start the sign-up  │                                 │
+ *    ├────────────────────▶│                                 │
+ *    │                     │  startRegistrationForNewUser()  │
+ *    │                     ├────────────────────────────────▶│     make a handle with no owner
+ *    │                     │◀────────────────────────────────┤
+ *    │◀────────────────────┤                                 │
+ *    │                     │                                 │
+ *    ├─▶ navigator.credentials.create()                      │
+ *    │                     │                                 │
+ *    │  finish the sign-up │                                 │
+ *    ├────────────────────▶│                                 │  ┐  one mutation
+ *    │                     │  checkRegistrationForNewUser()  │  │
+ *    │                     ├────────────────────────────────▶│  │  verify it, write nothing
+ *    │                     │◀────────────────────────────────┤  │
+ *    │                     ├─▶ create the user               │  │
+ *    │                     │  finishRegistrationForNewUser() │  │
+ *    │                     ├────────────────────────────────▶│  │  store the passkey, own the handle
+ *    │                     │◀────────────────────────────────┤  │
+ *    │◀────────────────────┤                                 │  ┘
+ *    │                     │                                 │
+ * ```
+ *
+ * - The existing-user flow (`…ForExistingUser`), where a signed-in user adds
+ *   a passkey. The ceremony reuses the handle of the user, and it excludes
+ *   the passkeys that the user already has.
+ *
+ * ```
+ *  Client                     Provider                                   Component
+ *    │                          │                                           │
+ *    │  start adding a passkey  │                                           │
+ *    ├─────────────────────────▶│                                           │
+ *    │                          │  startRegistrationForExistingUser(userId) │
+ *    │                          ├──────────────────────────────────────────▶│     reuse the handle of the user
+ *    │                          │◀──────────────────────────────────────────┤
+ *    │◀─────────────────────────┤                                           │
+ *    │                          │                                           │
+ *    ├─▶ navigator.credentials.create()                                     │
+ *    │                          │                                           │
+ *    │  finish adding a passkey │                                           │
+ *    ├─────────────────────────▶│                                           │
+ *    │                          │  finishRegistrationForExistingUser()      │
+ *    │                          ├──────────────────────────────────────────▶│     store the passkey
+ *    │                          │◀──────────────────────────────────────────┤
+ *    │◀─────────────────────────┤                                           │
+ *    │                          │                                           │
+ * ```
+ *
+ * The flows never mix: a finish function refuses a ceremony that the other
+ * start function made. The owner of the handle of the ceremony says which
+ * flow started it, thus no extra field is stored.
+ *
+ * @module
+ */
+
 import { Infer, v } from "convex/values";
 import { mutation, MutationCtx, query, QueryCtx } from "./_generated/server.ts";
 import { Doc, Id } from "./_generated/dataModel.ts";
@@ -13,7 +80,6 @@ import { ECDSAPublicKey, p256 } from "../../vendor/oslo/crypto/ecdsa.ts";
 import { RSAPublicKey } from "../../vendor/oslo/crypto/rsa.ts";
 import {
   credentialDescriptor,
-  CredentialDescriptor,
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
@@ -34,66 +100,59 @@ import { scheduleChallengeCleanup } from "./cleanup.ts";
 // Start registration
 //------------------------------------------------------------------------------
 
-// The challenge, the credential IDs, and the user handle travel as raw bytes
-// (Convex `v.bytes()` carries `ArrayBuffer`s end to end). The WebAuthn API
-// in the browser makes and accepts the same bytes, so no base64 conversion
-// is necessary.
-const startRegistrationResult = v.object({
-  challenge: v.bytes(),
-  // The WebAuthn user handle (`user.id`) for the `create()` call.
-  userHandle: v.bytes(),
-  excludeCredentials: v.array(credentialDescriptor),
+/**
+ * Start a registration ceremony for a user that does not exist yet.
+ *
+ * The function makes a handle with no owner, because the user row does not
+ * exist when the ceremony starts. `finishRegistrationForNewUser` links the
+ * handle to the user that the caller creates in the same transaction.
+ */
+export const startRegistrationForNewUser = mutation({
+  args: {},
+  returns: v.object({
+    challenge: v.bytes(),
+    // The WebAuthn user handle (`user.id`) for the `create()` call.
+    userHandle: v.bytes(),
+  }),
+  handler: async (ctx) => {
+    const handle = await insertHandle(ctx, null);
+    const challenge = await insertRegistrationChallenge(ctx, handle._id);
+    return { challenge, userHandle: handle.handle };
+  },
 });
 
 /**
- * Start a registration ceremony.
- *
- * The function stores a one-use `registration` challenge and returns the
- * challenge bytes. The challenge has no identity: it is simply a random
- * string used to avoid replay attacks.
- *
- * The function also returns the `userHandle` for the ceremony:
- * - Give a `userId` when a known user adds a passkey to their account. The
- *   function reuses the handle of the user, or makes one when the user has
- *   none. It also returns the existing credential IDs of the user. This is
- *   used by the authenticator to ensure there isn’t already a passkey that
- *   exists for the user.
- * - Give `null` in the new-account flow (the user row does not exist yet).
- *   The function makes a new handle with no user. `finishRegistration` links
- *   the handle to the verified user.
- *
- * The `userId` argument is required, not optional: the two flows behave
- * differently, so the caller must state which flow it runs. (Compare with
- * `startAuthentication`, where the argument is optional.)
- *
- * TODO(nicolas) Split this into two methods
+ * Start a registration ceremony for a user that already exists, for example
+ * when a signed-in user adds a passkey to their account.
  */
-export const startRegistration = mutation({
-  args: { userId: v.union(v.string(), v.null()) },
-  returns: startRegistrationResult,
+export const startRegistrationForExistingUser = mutation({
+  args: { userId: v.string() },
+  returns: v.object({
+    challenge: v.bytes(),
+    userHandle: v.bytes(),
+    // The user’s existing credential IDs, so the authenticator refuses
+    // to make a second passkey for a credential that the user already has.
+    excludeCredentials: v.array(credentialDescriptor),
+  }),
   handler: async (ctx, { userId }) => {
-    let handle: { _id: Id<"handles">; handle: ArrayBuffer } | null = null;
-    let excludeCredentials: CredentialDescriptor[] = [];
-    if (userId !== null) {
-      // A user has a maximum of one handle: reuse it when it exists.
-      handle = await ctx.db
-        .query("handles")
-        .withIndex("by_userId", (q) => q.eq("userId", userId))
-        .unique();
-      const rows = await ctx.db
-        .query("passkeys")
-        .withIndex("by_userId", (q) => q.eq("userId", userId))
-        .collect();
-      excludeCredentials = rows.map((row) => ({
+    const existing = await ctx.db
+      .query("handles")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+    const handle = existing ?? (await insertHandle(ctx, userId));
+    const passkeys = await ctx.db
+      .query("passkeys")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    const challenge = await insertRegistrationChallenge(ctx, handle._id);
+    return {
+      challenge,
+      userHandle: handle.handle,
+      excludeCredentials: passkeys.map((row) => ({
         id: row.credentialId,
         transports: row.transports,
-      }));
-    }
-    if (handle === null) {
-      handle = await insertHandle(ctx, userId);
-    }
-    const challenge = await insertRegistrationChallenge(ctx, handle._id);
-    return { challenge, userHandle: handle.handle, excludeCredentials };
+      })),
+    };
   },
 });
 
@@ -135,20 +194,34 @@ async function insertRegistrationChallenge(
 }
 
 //------------------------------------------------------------------------------
-// checkRegistration
+// checkRegistrationForNewUser
 //------------------------------------------------------------------------------
 
-// The arguments that the shared verification helper examines.
+// The arguments that the shared verification helpers examine.
 const registrationCheckArgs = {
+  // The expected relying party ID, usually the registrable domain
+  // at which the app is served (for example, "example.com", "subdomain.example.com",
+  // or "localhost"). Only web pages on the same domain (or their subdomains)
+  // will be able to use that passkey.
+  // See https://web.dev/articles/webauthn-rp-id
   expectedRpId: v.string(),
+  // The expected origin of the ceremony (for example, "https://app.example.com").
   expectedOrigin: v.string(),
   attestationObject: v.bytes(),
   clientDataJSON: v.bytes(),
+  // The transports that the browser reported for the new
+  // credential. The value is a hint: a later ceremony sends it back to the
+  // browser, and the verification does not use it.
   transports: v.optional(v.array(v.string())),
 };
 
 const _vRegistrationCheckArgs = v.object(registrationCheckArgs);
 type RegistrationCheckArgs = Infer<typeof _vRegistrationCheckArgs>;
+
+const finishRegistrationArgs = {
+  ...registrationCheckArgs,
+  name: v.optional(v.string()),
+};
 
 const checkRegistrationResult = v.union(
   v.object({ success: v.literal(true) }),
@@ -160,37 +233,33 @@ const checkRegistrationResult = v.union(
 type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
 
 /**
- * Run the verifications of `finishRegistration`, without any write.
+ * Run the verifications of `finishRegistrationForNewUser`, without any
+ * write if the registration can succeed.
  *
  * A transactional sign-up flow calls this query first, before it creates
  * the user. Because this is a query, the runtime enforces that nothing is
  * stored: there is no way to store an unverified credential through it.
  *
- * Guarantee: when `checkRegistration` returns `success: true` inside a
- * mutation, a `finishRegistration` call with the same arguments in the
- * same mutation does not return a `userError`. The two calls run in one
- * transaction, so they see the same rows, and Convex fixes the transaction
- * timestamp, so the challenge TTL check cannot flip between the two calls.
- *
- * The guarantee does not cover throws. This function cannot see the
- * handle-linking invariants of `finishRegistration` (they depend on
- * `verifiedUserId`), so `finishRegistration` can still throw after a
- * successful check, and a throw aborts the transaction.
+ * Guarantee: when `checkRegistrationForNewUser` returns `success: true`
+ * inside a mutation, a `finishRegistrationForNewUser` call with the same
+ * arguments in the same mutation does not return a `userError`.
  */
-export const checkRegistration = query({
+export const checkRegistrationForNewUser = query({
   args: registrationCheckArgs,
   returns: checkRegistrationResult,
   handler: async (ctx, args): Promise<CheckRegistrationResult> => {
-    const verification = await verifyRegistration(ctx, args);
-    if (verification.userError !== null) {
-      return { success: false, userError: verification.userError };
+    const ceremony = await verifyRegistrationAttempt(ctx, args, {
+      kind: "newUser",
+    });
+    if (ceremony.userError !== null) {
+      return { success: false, userError: ceremony.userError };
     }
     return { success: true };
   },
 });
 
 //------------------------------------------------------------------------------
-// Finish registration
+// Finish registration functions
 //------------------------------------------------------------------------------
 
 const finishRegistrationResult = v.union(
@@ -203,154 +272,183 @@ const finishRegistrationResult = v.union(
 type FinishRegistrationResult = Infer<typeof finishRegistrationResult>;
 
 /**
- * Finish a registration ceremony.
+ * Finish a registration ceremony that `startRegistrationForNewUser` started.
  *
- * The app supplies:
- * - `expectedRpId`: the expected relying party ID, usually the registrable domain
- *   at which the app is served (for example, "example.com", "subdomain.example.com",
- *   or "localhost"). Only web pages on the same domain (or their subdomains)
- *   will be able to use that passkey.
- *   See https://web.dev/articles/webauthn-rp-id
- * - `expectedOrigin`: the expected origin of the ceremony (for example,
- *   "https://app.example.com").
- * - `verifiedUserId`: the user that owns the new passkey. This must always be
- *   the user name of the current user (whether it is a user created in the
- *   same transaction, or the currently logged in user).
- * - `name`: an optional label for the credential. This can be automatically
- *   inferred by the client from the authenticator (e.g. “1Password”),
- *   or provided by the user (e.g. “Nicolas’s MacBook Pro”).
- * - `transports`: the transports that the browser reported for the new
- *   credential. The value is a hint: a later ceremony sends it back to the
- *   browser, and the verification does not use it. A value that no
- *   authenticator can report gets `PROTOCOL_ERROR`.
- *
- * The function examines the attestation as
- * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
- * the credential and deletes the challenge.
+ * `newUserId` is the user that the caller creates in the same transaction.
+ * The function links the handle of the ceremony to that user and stores the
+ * credential.
  *
  * Each failure comes back as a `userError`. A client that does not respect
  * the WebAuthn protocol gets `PROTOCOL_ERROR`, and the backend logs say
  * which check failed.
  *
- * A caller that must be sure that this call succeeds before it creates
- * data runs `checkRegistration` first, in the same mutation.
+ * A caller that wants to be sure that this call succeeds before it creates
+ * data can call {@link checkRegistrationForNewUser} first, in the same mutation.
  */
-export const finishRegistration = mutation({
-  args: {
-    ...registrationCheckArgs,
-    verifiedUserId: v.string(),
-    name: v.optional(v.string()),
-    transports: v.optional(v.array(v.string())),
-  },
+export const finishRegistrationForNewUser = mutation({
+  args: { ...finishRegistrationArgs, newUserId: v.string() },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
-    const verification = await verifyRegistration(ctx, args);
-
-    if (verification.userError !== null) {
-      // The challenge burns on each finish attempt, also when the
-      // verification fails. The ceremony can never complete: the unlinked
-      // handle of the ceremony goes away with the challenge.
-      if (verification.challengeRow !== null) {
-        await deleteDeadChallenge(ctx, verification.challengeRow);
-      }
-      return { success: false, userError: verification.userError };
+    const result = await consumeRegistration(ctx, args, { kind: "newUser" });
+    if (result.userError !== null) {
+      return { success: false, userError: result.userError };
     }
-    const challengeRow = verification.challengeRow;
-    // One use only: the consumed challenge is deleted.
-    await ctx.db.delete("challenges", challengeRow._id);
-
-    // Link the handle of the ceremony to the verified user.
-    const handle = await ctx.db.get("handles", challengeRow.handleId);
-    if (handle === null) {
-      throw new Error("The handle of the challenge does not exist.");
-    }
-    if (handle.userId === null) {
-      // The new-account flow: the handle was made before the user existed.
-      const existingHandle = await ctx.db
-        .query("handles")
-        .withIndex("by_userId", (q) => q.eq("userId", args.verifiedUserId))
-        .first();
-      if (existingHandle !== null) {
-        // Invariant: the new-account flow only runs for a brand-new user,
-        // which cannot have a handle already.
-        throw new Error(
-          "Invariant violation: The user already has a different handle. finishRegistration is being called incorrectly.",
-        );
-      }
-      await ctx.db.patch("handles", handle._id, {
-        userId: args.verifiedUserId,
-      });
-    } else if (handle.userId !== args.verifiedUserId) {
+    const existingHandle = await ctx.db
+      .query("handles")
+      .withIndex("by_userId", (q) => q.eq("userId", args.newUserId))
+      .first();
+    if (existingHandle !== null) {
+      // Invariant: the new-user flow only runs for a brand-new user, which
+      // cannot have a handle already.
       throw new Error(
-        "Invariant violation: The handle belongs to a different user. finishRegistration is being called incorrectly.",
+        "Invariant violation: The user already has a different handle. finishRegistrationForNewUser is being called for a user that is not new.",
       );
     }
-
+    await ctx.db.patch("handles", result.handle._id, {
+      userId: args.newUserId,
+    });
     const passkeyId = await ctx.db.insert("passkeys", {
-      userId: args.verifiedUserId,
+      userId: args.newUserId,
       name: args.name,
       transports: args.transports,
-      credentialId: verification.credential.credentialId,
-      algorithm: verification.credential.algorithm,
-      publicKey: verification.credential.publicKey,
-      counter: verification.credential.counter,
+      credentialId: result.credential.credentialId,
+      algorithm: result.credential.algorithm,
+      publicKey: result.credential.publicKey,
+      counter: result.credential.counter,
     });
-
     return { success: true, passkeyId };
   },
 });
 
+/**
+ * Finish a registration ceremony that `startRegistrationForExistingUser`
+ * started.
+ *
+ * `verifiedUserId` is the signed-in user that adds the passkey. The caller
+ * must have authenticated that user. It must be the same user that started
+ * the ceremony.
+ *
+ * The function examines the attestation as
+ * https://webauthn.oslojs.dev/examples/registration shows. Then it stores
+ * the credential.
+ *
+ * Each failure comes back as a `userError`. A client that does not respect
+ * the WebAuthn protocol gets `PROTOCOL_ERROR`, and the backend logs say
+ * which check failed. A ceremony that `startRegistrationForNewUser` started
+ * gets `PROTOCOL_ERROR` too: only `finishRegistrationForNewUser` can finish
+ * it. A ceremony that a different user started gets `PROTOCOL_ERROR` too.
+ */
+export const finishRegistrationForExistingUser = mutation({
+  args: { ...finishRegistrationArgs, verifiedUserId: v.string() },
+  returns: finishRegistrationResult,
+  handler: async (ctx, args): Promise<FinishRegistrationResult> => {
+    const result = await consumeRegistration(ctx, args, {
+      kind: "existingUser",
+      userId: args.verifiedUserId,
+    });
+    if (result.userError !== null) {
+      return { success: false, userError: result.userError };
+    }
+    const passkeyId = await ctx.db.insert("passkeys", {
+      userId: args.verifiedUserId,
+      name: args.name,
+      transports: args.transports,
+      credentialId: result.credential.credentialId,
+      algorithm: result.credential.algorithm,
+      publicKey: result.credential.publicKey,
+      counter: result.credential.counter,
+    });
+    return { success: true, passkeyId };
+  },
+});
+
+/**
+ * Verify a finish step and burn its challenge.
+ *
+ * The challenge is deleted in every case where the lookup found it, also
+ * when the verification fails. On a failure, the unlinked handle of the
+ * ceremony is deleted too.
+ */
+async function consumeRegistration(
+  ctx: MutationCtx,
+  args: RegistrationCheckArgs,
+  flow: RegistrationFlow,
+): Promise<RegistrationCeremony> {
+  const ceremony = await verifyRegistrationAttempt(ctx, args, flow);
+  if (ceremony.userError === null) {
+    await ctx.db.delete("challenges", ceremony.challengeRow._id);
+  } else if (ceremony.challengeRow !== null) {
+    await deleteDeadChallenge(ctx, ceremony.challengeRow);
+  }
+  return ceremony;
+}
+
 //------------------------------------------------------------------------------
 // Verification logic for a registration attempt
 //------------------------------------------------------------------------------
+
+type RegistrationFlow =
+  { kind: "newUser" } | { kind: "existingUser"; userId: string };
 
 type RegistrationChallengeDoc = Extract<
   Doc<"challenges">,
   { kind: "registration" }
 >;
 
-// The result of `verifyRegistration`. On a `userError`, `challengeRow` is
-// the raw challenge row when one exists (live or expired):
-// `finishRegistration` burns it. On success, `challengeRow` is the live row.
-type RegistrationVerification =
+type RegistrationCeremony =
   | {
       userError: FinishRegistrationUserError;
+      // The challenge that the ceremony names, when the lookup found it.
       challengeRow: RegistrationChallengeDoc | null;
     }
   | {
       userError: null;
       challengeRow: RegistrationChallengeDoc;
+      handle: Doc<"handles">;
       credential: VerifiedCredential;
     };
 
-/**
- * The complete verification body of `finishRegistration`, without any
- * write: the client data checks, the challenge lookup with its TTL, the
- * attestation checks, the key extraction, and the duplicate-credential
- * check.
- *
- * The function takes a read-only ctx. `QueryCtx` is structurally satisfied
- * by `MutationCtx`, so both `checkRegistration` (a query) and
- * `finishRegistration` (a mutation) run the exact same code.
- *
- * Failures that the user can correct come back as a `userError`. A client
- * that does not respect the WebAuthn protocol gets `PROTOCOL_ERROR`, and
- * the backend logs say which check failed.
- */
-async function verifyRegistration(
+async function verifyRegistrationAttempt(
   ctx: QueryCtx,
   args: RegistrationCheckArgs,
-): Promise<RegistrationVerification> {
+  flow: RegistrationFlow,
+): Promise<RegistrationCeremony> {
   const lookup = await lookupRegistrationChallenge(ctx, args);
   if (lookup.userError !== null) {
     return lookup;
   }
+
   const verification = await verifyAttestation(ctx, args);
   const { challengeRow } = lookup;
   if (verification.userError !== null) {
     return { userError: verification.userError, challengeRow };
   }
-  return { userError: null, challengeRow, credential: verification.credential };
+
+  const handle = await ctx.db.get("handles", challengeRow.handleId);
+  if (handle === null) {
+    throw new Error("The handle of the challenge does not exist.");
+  }
+
+  const startedBy = handle.userId === null ? "newUser" : "existingUser";
+  if (startedBy !== flow.kind) {
+    console.warn(
+      `Rejected the passkey ceremony: the ceremony comes from \`${startedBy}\`, while the function for ${flow.kind} was called.`,
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow };
+  }
+
+  if (flow.kind === "existingUser" && handle.userId !== flow.userId) {
+    console.warn(
+      "Rejecting registration of a new passkey because the passkey was created for a different user than the current user. This can happen if the user logged in and logged out during the registration process.",
+    );
+    return { userError: { error: "PROTOCOL_ERROR" }, challengeRow };
+  }
+  return {
+    userError: null,
+    challengeRow,
+    handle,
+    credential: verification.credential,
+  };
 }
 
 async function lookupRegistrationChallenge(
@@ -598,6 +696,10 @@ export const listPasskeys = query({
   },
 });
 
+//------------------------------------------------------------------------------
+// Delete passkey
+//------------------------------------------------------------------------------
+
 const deletePasskeyResult = v.union(
   v.object({ success: v.literal(true) }),
   v.object({ success: v.literal(false), userError: deletePasskeyUserError }),
@@ -642,9 +744,9 @@ export const deletePasskey = mutation({
  * holds an old credential stops working (see `deletePasskey`).
  *
  * Caveat: an in-flight registration challenge that points at the handle of
- * the user survives until its TTL. That is safe: `finishRegistration` throws
- * when the handle of the challenge no longer exists, and the cleanup loop
- * erases the challenge after the TTL.
+ * the user survives until its TTL. That is safe: the finish step throws when
+ * the handle of the challenge no longer exists, and the cleanup loop erases
+ * the challenge after the TTL.
  */
 export const deleteUser = mutation({
   args: { userId: v.string() },

--- a/packages/core/src/components/passkey/schema.ts
+++ b/packages/core/src/components/passkey/schema.ts
@@ -38,7 +38,7 @@ export default defineSchema({
   // handle in the auth flows where the user is created transactionally with
   // the passkey registration: the user row does not exist yet when
   // the registration ceremony starts. The handle is created first, and
-  // `finishRegistration` links it to the user.
+  // `finishRegistrationForNewUser` links it to the user.
   handles: defineTable({
     // 64 random bytes (the WebAuthn maximum length for `user.id`).
     handle: v.bytes(),

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -91,7 +91,6 @@ const startSignInResult = v.union(
     challenge: v.bytes(),
     // The WebAuthn user handle (`user.id`) for the `create()` call.
     userHandle: v.bytes(),
-    excludeCredentials: v.array(credentialDescriptor),
     rpId: v.string(),
     rpName: v.string(),
   }),
@@ -258,16 +257,15 @@ export function setupUsernamePasskey<UsersTable extends string>(
               };
             }
 
-            const { challenge, userHandle, excludeCredentials } =
-              await ctx.runMutation(component.registration.startRegistration, {
-                userId: null,
-              });
+            const { challenge, userHandle } = await ctx.runMutation(
+              component.registration.startRegistrationForNewUser,
+              {},
+            );
             return {
               success: true,
               step: "register",
               challenge,
               userHandle,
-              excludeCredentials,
               rpId,
               rpName,
             };
@@ -298,12 +296,13 @@ export function setupUsernamePasskey<UsersTable extends string>(
          *
          * The order of the steps gives that guarantee:
          * 1. Checks that write nothing: the username format, the username
-         *    conflict, and `checkRegistration` (the full WebAuthn
+         *    conflict, and `checkRegistrationForNewUser` (the full WebAuthn
          *    verification as a query). Each failure, correctable or not,
          *    returns a `userError` here, before anything exists.
          * 2. Writes that cannot fail after the checks: `completeSignUp` mints
          *    the user, the account, and the session, `setUsername` stores the
-         *    username, and `finishRegistration` stores the passkey. None of
+         *    username, and `finishRegistrationForNewUser` stores the
+         *    passkey. None of
          *    them can fail after step 1 inside the same transaction, so a
          *    failure throws and rolls everything back.
          */
@@ -333,7 +332,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
 
             // Fail early if the passkey registration fails
             const checkResult = await ctx.runQuery(
-              component.registration.checkRegistration,
+              component.registration.checkRegistrationForNewUser,
               {
                 expectedRpId: rpId,
                 expectedOrigin: origin,
@@ -377,19 +376,20 @@ export function setupUsernamePasskey<UsersTable extends string>(
             // Store the verified credential, link the handle to the new
             // user, and consume the challenge.
             const registrationResult = await ctx.runMutation(
-              component.registration.finishRegistration,
+              component.registration.finishRegistrationForNewUser,
               {
                 expectedRpId: rpId,
                 expectedOrigin: origin,
-                verifiedUserId: tokens.userId,
+                newUserId: tokens.userId,
                 attestationObject: args.attestationObject,
                 clientDataJSON: args.clientDataJSON,
                 transports: args.transports,
               },
             );
             if (!registrationResult.success) {
-              // Not possible: `checkRegistration` succeeded above, in the
-              // same transaction. Throwing rolls everything back.
+              // Not possible: `checkRegistrationForNewUser` succeeded
+              // above, in the same transaction. Throwing rolls everything
+              // back.
               throw new Error(
                 "Unexpected error when storing the passkey: " +
                   registrationResult.userError.error,

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -120,9 +120,9 @@ export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
 const protocolError = v.object({ error: v.literal("PROTOCOL_ERROR") });
 
 /**
- * The user-facing errors for `finishRegistration`. An app can show these
- * errors to the end user. The `error` field is a machine-readable code and
- * the discriminant of the union.
+ * The user-facing errors for the registration finish functions. An app can
+ * show these errors to the end user. The `error` field is a machine-readable
+ * code and the discriminant of the union.
  */
 export const finishRegistrationUserError = v.union(
   // The challenge is unknown, already used, or too old. The user must start

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -68,29 +68,33 @@ export async function register(
   } = {},
 ): Promise<{ credential: TestCredential; passkeyId: string }> {
   const credential = options.credential ?? (await generateES256Credential());
-  const { challenge } = await t.mutation(api.registration.startRegistration, {
-    userId,
-  });
+  const { challenge } = await t.mutation(
+    api.registration.startRegistrationForExistingUser,
+    { userId },
+  );
   const authData = await buildAuthenticatorData({
     rpId: RP_ID,
     counter: options.counter ?? 0,
     credential,
   });
-  const result = await t.mutation(api.registration.finishRegistration, {
-    expectedRpId: RP_ID,
-    expectedOrigin: ORIGIN,
-    verifiedUserId: userId,
-    name: options.name,
-    transports: options.transports,
-    attestationObject: toArrayBuffer(buildAttestationObject(authData)),
-    clientDataJSON: toArrayBuffer(
-      buildClientDataJSON({
-        type: "webauthn.create",
-        challenge,
-        origin: ORIGIN,
-      }),
-    ),
-  });
+  const result = await t.mutation(
+    api.registration.finishRegistrationForExistingUser,
+    {
+      expectedRpId: RP_ID,
+      expectedOrigin: ORIGIN,
+      verifiedUserId: userId,
+      name: options.name,
+      transports: options.transports,
+      attestationObject: toArrayBuffer(buildAttestationObject(authData)),
+      clientDataJSON: toArrayBuffer(
+        buildClientDataJSON({
+          type: "webauthn.create",
+          challenge,
+          origin: ORIGIN,
+        }),
+      ),
+    },
+  );
   if (!result.success) {
     throw new Error(`Test registration failed: ${result.userError.error}`);
   }

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -70,7 +70,7 @@ export async function register(
   const credential = options.credential ?? (await generateES256Credential());
   const { challenge } = await t.mutation(
     api.registration.startRegistrationForExistingUser,
-    { userId },
+    { verifiedUserId: userId },
   );
   const authData = await buildAuthenticatorData({
     rpId: RP_ID,


### PR DESCRIPTION
This PR implements Christian’s proposal in https://github.com/get-convex/convex-auth/pull/460#discussion_r3804459383. 


<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td rowspan="2"><code>startRegistration({ userId: string | null })</code></td>
<td><code>startRegistrationForNewUser({})</code></td>
</tr>
<tr>
<td><code>startRegistrationForExistingUser({ verifiedUserId })</code></td>
</tr>
<tr>
<td rowspan="2"><code>finishRegistration({ verifiedUserId })</code></td>
<td><code>finishRegistrationForNewUser({ newUserId })</code></td>
</tr>
<tr>
<td><code>finishRegistrationForExistingUser({ verifiedUserId })</code></td>
</tr>
</tbody>
</table>

This allows the calling code to be more explicit and avoid issues with flow confusion (we now return `PROTOCOL_ERROR` if finishing a different kind of flow than the one that was started).

We also now return a `PROTOCOL_ERROR` if the existing user flow completes with a different user ID than the one that started it. Previously the code assumed it would imply a developer error, but I realized that it can happen if the user logs out and then logs in with another account mid-flow.