### PR TITLE
Move the test authenticator to a private package

### DIFF
--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -10,15 +10,18 @@ import { convexTest, type TestConvex } from "convex-test";
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { registerCore } from "@convex-dev/auth/providers/testing/core";
+import { registerPasskeyProvider } from "@convex-dev/auth/providers/testing/passkey";
+// The software authenticator is a private package of this repository, not a
+// part of the public API of `@convex-dev/auth`. An app writes an authenticator
+// of its own, or it drives a real one.
 import {
   buildAssertion,
   buildAttestationObject,
   buildAuthenticatorData,
   buildClientDataJSON,
   generateES256Credential,
-  registerPasskeyProvider,
   type TestCredential,
-} from "@convex-dev/auth/providers/testing/passkey";
+} from "@convex-dev/passkey-test-authenticator";
 import { registerUsername } from "@convex-dev/auth/providers/testing/username";
 import { api } from "./_generated/api";
 import schema from "./schema";
@@ -83,11 +86,11 @@ afterEach(() => {
 const as = (t: T, userId: string) => t.withIdentity({ subject: userId });
 
 /** Build the `create()` payloads of a registration ceremony. */
-function attest(
+async function attest(
   challenge: ArrayBuffer,
   credential: TestCredential,
-): Attestation {
-  const authenticatorData = buildAuthenticatorData({
+): Promise<Attestation> {
+  const authenticatorData = await buildAuthenticatorData({
     rpId: RP_ID,
     credential,
   });
@@ -119,7 +122,7 @@ async function signUp(
   const credential = await generateES256Credential();
   const result = await t.mutation(api.auth.finishSignUp, {
     username,
-    ...attest(start.challenge, credential),
+    ...(await attest(start.challenge, credential)),
   });
   if (!result.success) {
     throw new Error(`The sign-up failed: ${result.userError.error}`);
@@ -150,7 +153,7 @@ async function addPasskey(
   const credential = await generateES256Credential();
   const finished = await caller.mutation(
     api.auth.finishAddPasskey,
-    attest(verified.challenge, credential),
+    await attest(verified.challenge, credential),
   );
   if (!finished.success) {
     throw new Error(`The add failed: ${finished.userError.error}`);
@@ -229,7 +232,7 @@ describe("adding a passkey", () => {
     const credential = await generateES256Credential();
     const finished = await caller.mutation(
       api.auth.finishAddPasskey,
-      attest(verified.challenge, credential),
+      await attest(verified.challenge, credential),
     );
     expect(finished).toEqual({ success: true, passkeyId: expect.any(String) });
 
@@ -267,7 +270,7 @@ describe("adding a passkey", () => {
     expect(
       await as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
-        attest(new ArrayBuffer(32), credential),
+        await attest(new ArrayBuffer(32), credential),
       ),
     ).toEqual({ success: false, userError: { error: "CHALLENGE_EXPIRED" } });
   });
@@ -286,7 +289,7 @@ describe("adding a passkey", () => {
     await expect(
       as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
-        attest(start.challenge, credential),
+        await attest(start.challenge, credential),
       ),
     ).rejects.toThrow("The user already has a different handle");
   });
@@ -309,7 +312,7 @@ describe("adding a passkey", () => {
     expect(
       await t.mutation(
         api.auth.finishAddPasskey,
-        attest(new ArrayBuffer(32), await generateES256Credential()),
+        await attest(new ArrayBuffer(32), await generateES256Credential()),
       ),
     ).toEqual(notSignedIn);
   });

--- a/examples/react-passkey/package.json
+++ b/examples/react-passkey/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@convex-dev/batch-worker": "^0.3.0",
+    "@convex-dev/passkey-test-authenticator": "workspace:*",
     "@edge-runtime/vm": "^5.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -154,6 +154,7 @@
     "ora": "^9.4.1"
   },
   "devDependencies": {
+    "@convex-dev/passkey-test-authenticator": "workspace:*",
     "@edge-runtime/vm": "^5.0.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -18,7 +18,6 @@ import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
 import type * as registration from "../registration.js";
 import type * as setup from "../setup.js";
-import type * as testAuthenticator from "../testAuthenticator.js";
 import type * as validation from "../validation.js";
 
 import type {
@@ -39,7 +38,6 @@ const fullApi: ApiFromModules<{
   react: typeof react;
   registration: typeof registration;
   setup: typeof setup;
-  testAuthenticator: typeof testAuthenticator;
   validation: typeof validation;
 }> = anyApi as any;
 

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -2,18 +2,18 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
 import {
-  expectProtocolError,
-  expectSameBytes,
-  setup,
-} from "../passkeyTestSetup.ts";
-import {
   ORIGIN,
   RP_ID,
   buildAssertion,
   generateES256Credential,
   generateRS256Credential,
+} from "@convex-dev/passkey-test-authenticator";
+import {
+  expectProtocolError,
+  expectSameBytes,
   register,
-} from "./testAuthenticator.ts";
+  setup,
+} from "../passkeyTestSetup.ts";
 
 // The component gives no purpose of its own: each app names its own flows.
 const PURPOSE = "test/signIn";

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -4,11 +4,6 @@ import { api } from "./_generated/api.ts";
 import { toArrayBuffer } from "./helpers.ts";
 import { CHALLENGE_TTL_MS } from "./validation.ts";
 import {
-  expectProtocolError,
-  expectSameBytes,
-  setup,
-} from "../passkeyTestSetup.ts";
-import {
   ORIGIN,
   RP_ID,
   buildAttestationObject,
@@ -17,8 +12,13 @@ import {
   encodeCBOR,
   generateES256Credential,
   generateRS256Credential,
+} from "@convex-dev/passkey-test-authenticator";
+import {
+  expectProtocolError,
+  expectSameBytes,
   register,
-} from "./testAuthenticator.ts";
+  setup,
+} from "../passkeyTestSetup.ts";
 
 function handleRows(t: ReturnType<typeof setup>) {
   return t.run((ctx) => ctx.db.query("handles").collect());
@@ -77,7 +77,7 @@ async function registrationArgs(
     challenge = started.challenge;
     userHandle = started.userHandle;
   }
-  const authData = buildAuthenticatorData({
+  const authData = await buildAuthenticatorData({
     rpId: options.authDataRpId ?? RP_ID,
     counter: options.counter ?? 0,
     userPresent: options.userPresent,

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -1,6 +1,17 @@
 import { convexTest, type TestConvex } from "convex-test";
 import { expect, vi } from "vitest";
 import { register as registerBatchWorker } from "@convex-dev/batch-worker/test";
+import {
+  ORIGIN,
+  RP_ID,
+  buildAttestationObject,
+  buildAuthenticatorData,
+  buildClientDataJSON,
+  generateES256Credential,
+  type TestCredential,
+} from "@convex-dev/passkey-test-authenticator";
+import { api } from "./passkey/_generated/api.ts";
+import { toArrayBuffer } from "./passkey/helpers.ts";
 import schema from "./passkey/schema.ts";
 
 export const modules = import.meta.glob("./passkey/**/*.ts");
@@ -43,4 +54,45 @@ export async function expectProtocolError(
   } finally {
     warn.mockRestore();
   }
+}
+
+/** Run a full registration ceremony and return the stored credential. */
+export async function register(
+  t: TestConvex<typeof schema>,
+  userId: string,
+  options: {
+    name?: string;
+    credential?: TestCredential;
+    counter?: number;
+    transports?: string[];
+  } = {},
+): Promise<{ credential: TestCredential; passkeyId: string }> {
+  const credential = options.credential ?? (await generateES256Credential());
+  const { challenge } = await t.mutation(api.registration.startRegistration, {
+    userId,
+  });
+  const authData = await buildAuthenticatorData({
+    rpId: RP_ID,
+    counter: options.counter ?? 0,
+    credential,
+  });
+  const result = await t.mutation(api.registration.finishRegistration, {
+    expectedRpId: RP_ID,
+    expectedOrigin: ORIGIN,
+    verifiedUserId: userId,
+    name: options.name,
+    transports: options.transports,
+    attestationObject: toArrayBuffer(buildAttestationObject(authData)),
+    clientDataJSON: toArrayBuffer(
+      buildClientDataJSON({
+        type: "webauthn.create",
+        challenge,
+        origin: ORIGIN,
+      }),
+    ),
+  });
+  if (!result.success) {
+    throw new Error(`Test registration failed: ${result.userError.error}`);
+  }
+  return { credential, passkeyId: result.passkeyId };
 }

--- a/packages/core/src/components/testing/passkey.ts
+++ b/packages/core/src/components/testing/passkey.ts
@@ -32,8 +32,4 @@ export function registerPasskeyProvider(
   registerBatchWorker(t, `${name}/batchWorker`);
 }
 
-// The software authenticator that the tests of this repo drive. It ships with
-// the other testing helpers so that an app can write its own passkey tests.
-export * from "../passkey/testAuthenticator.ts";
-
 export default { registerPasskeyProvider, schema, modules };

--- a/packages/passkey-test-authenticator/README.md
+++ b/packages/passkey-test-authenticator/README.md
@@ -1,0 +1,11 @@
+# @convex-dev/passkey-test-authenticator
+
+A minimal software WebAuthn authenticator. It builds the payloads of a
+registration or an authentication ceremony (client data, authenticator data,
+attestation objects) and signs assertions with real WebCrypto keys, so that a
+test drives the passkey component with genuine ceremony bytes.
+
+This package is private. It is a development dependency of the packages and the
+example apps of this repository, and it is never published. `@convex-dev/auth`
+does not depend on it, and it does not depend on `@convex-dev/auth`: it knows
+the WebAuthn wire format, not the component.

--- a/packages/passkey-test-authenticator/package.json
+++ b/packages/passkey-test-authenticator/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@convex-dev/passkey-test-authenticator",
+  "version": "0.0.0",
+  "description": "A software WebAuthn authenticator for the tests of this repository",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
+    "@types/node": "^24.12.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/passkey-test-authenticator/src/bytes.test.ts
+++ b/packages/passkey-test-authenticator/src/bytes.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The byte plumbing replaces a vendored library, thus it gets a test of its
+ * own. The ceremony builders are covered by the tests that drive them.
+ */
+import { expect, test } from "vitest";
+import { decodeBase64url, encodeBase64url, toDERSignature } from "./bytes.ts";
+
+/** An ECDSA P-256 signature is `r || s`, 32 bytes each. */
+function p1363(r: Uint8Array, s: Uint8Array): Uint8Array {
+  const out = new Uint8Array(64);
+  out.set(r, 32 - r.length);
+  out.set(s, 64 - s.length);
+  return out;
+}
+
+const filled = (byte: number) => new Uint8Array(32).fill(byte);
+
+test("DER-encodes a signature whose halves need no change", () => {
+  const der = toDERSignature(p1363(filled(0x11), filled(0x22)));
+  expect([...der.slice(0, 4)]).toEqual([0x30, 0x44, 0x02, 0x20]);
+  expect([...der.slice(4, 36)]).toEqual([...filled(0x11)]);
+  expect([...der.slice(36, 38)]).toEqual([0x02, 0x20]);
+  expect([...der.slice(38)]).toEqual([...filled(0x22)]);
+});
+
+test("prefixes a zero byte when the high bit of an integer is set", () => {
+  const der = toDERSignature(p1363(filled(0x80), filled(0x22)));
+  expect([...der.slice(0, 5)]).toEqual([0x30, 0x45, 0x02, 0x21, 0x00]);
+  expect([...der.slice(5, 37)]).toEqual([...filled(0x80)]);
+});
+
+test("strips the leading zero bytes of an integer", () => {
+  const r = new Uint8Array([...new Array(30).fill(0), 0x01, 0x02]);
+  const der = toDERSignature(p1363(r, filled(0x22)));
+  expect([...der.slice(0, 6)]).toEqual([0x30, 0x26, 0x02, 0x02, 0x01, 0x02]);
+});
+
+test("keeps one byte of an integer that is zero", () => {
+  const der = toDERSignature(p1363(filled(0), filled(0x22)));
+  expect([...der.slice(0, 5)]).toEqual([0x30, 0x25, 0x02, 0x01, 0x00]);
+});
+
+test("decodes what it encodes, with or without the padding", () => {
+  const bytes = crypto.getRandomValues(new Uint8Array(31));
+  const base64url = encodeBase64url(bytes);
+  expect(base64url).not.toContain("=");
+  expect([...decodeBase64url(base64url)]).toEqual([...bytes]);
+  expect([...decodeBase64url(`${base64url}==`)]).toEqual([...bytes]);
+});
+
+test("decodes the URL-safe alphabet", () => {
+  // `0xfb 0xff 0xbf` is `+/+/` in base64 and `-_-_` in base64url.
+  expect([...decodeBase64url("-_-_")]).toEqual([0xfb, 0xff, 0xbf]);
+});

--- a/packages/passkey-test-authenticator/src/bytes.ts
+++ b/packages/passkey-test-authenticator/src/bytes.ts
@@ -1,0 +1,60 @@
+/** Byte plumbing that the ceremony builders need. */
+
+/** View a byte array as the `ArrayBuffer` that a Convex argument holds. */
+export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+    ? (bytes.buffer as ArrayBuffer)
+    : (bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer);
+}
+
+/** Encode bytes as base64url without padding, the way WebAuthn does. */
+export function encodeBase64url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Decode a base64url string. A JWK member carries no padding, and `atob`
+ * refuses a partial padding, thus complete the last group first.
+ */
+export function decodeBase64url(text: string): Uint8Array {
+  const base64 = text.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+}
+
+export async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(
+    await crypto.subtle.digest("SHA-256", toArrayBuffer(bytes)),
+  );
+}
+
+/** DER-encode one unsigned integer as an ASN.1 INTEGER. */
+function derInteger(bytes: Uint8Array): number[] {
+  let start = 0;
+  while (start < bytes.length - 1 && bytes[start] === 0) start++;
+  const body = [...bytes.slice(start)];
+  // An ASN.1 INTEGER is signed, thus a leading zero keeps it positive.
+  if ((body[0] & 0x80) !== 0) body.unshift(0);
+  return [0x02, body.length, ...body];
+}
+
+/**
+ * Convert an ECDSA signature from the IEEE P1363 encoding (`r || s`, what
+ * WebCrypto emits) to the DER encoding (what WebAuthn transports).
+ */
+export function toDERSignature(p1363: Uint8Array): Uint8Array {
+  const half = p1363.length / 2;
+  const body = [
+    ...derInteger(p1363.slice(0, half)),
+    ...derInteger(p1363.slice(half)),
+  ];
+  // `r` and `s` are 32 bytes each, thus the body is always shorter than 128
+  // bytes and the length is a single byte.
+  return new Uint8Array([0x30, body.length, ...body]);
+}

--- a/packages/passkey-test-authenticator/src/cbor.ts
+++ b/packages/passkey-test-authenticator/src/cbor.ts
@@ -1,0 +1,39 @@
+/** Just enough CBOR to build COSE keys and attestation objects. */
+
+export type CBORValue =
+  number | string | Uint8Array | Map<number | string, CBORValue>;
+
+function cborHead(majorType: number, value: number): number[] {
+  if (value < 24) {
+    return [(majorType << 5) | value];
+  }
+  if (value < 0x100) {
+    return [(majorType << 5) | 24, value];
+  }
+  if (value < 0x10000) {
+    return [(majorType << 5) | 25, value >> 8, value & 0xff];
+  }
+  throw new Error("Value too large for the test CBOR encoder");
+}
+
+/** Encode a small CBOR value (enough for COSE keys and attestation objects). */
+export function encodeCBOR(value: CBORValue): Uint8Array {
+  const encode = (value: CBORValue): number[] => {
+    if (typeof value === "number") {
+      return value >= 0 ? cborHead(0, value) : cborHead(1, -1 - value);
+    }
+    if (typeof value === "string") {
+      const bytes = new TextEncoder().encode(value);
+      return [...cborHead(3, bytes.length), ...bytes];
+    }
+    if (value instanceof Uint8Array) {
+      return [...cborHead(2, value.length), ...value];
+    }
+    const out = cborHead(5, value.size);
+    for (const [key, entry] of value) {
+      out.push(...encode(key), ...encode(entry));
+    }
+    return out;
+  };
+  return new Uint8Array(encode(value));
+}

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -1,23 +1,25 @@
-import type { TestConvex } from "convex-test";
-import {
-  encodeASN1,
-  ASN1EncodableSequence,
-  ASN1Integer,
-} from "../../vendor/oslo/asn1/index.ts";
-import { bigIntFromBytes } from "../../vendor/oslo/binary/index.ts";
-import { sha256 } from "../../vendor/oslo/crypto/sha2.ts";
-import { decodeBase64urlIgnorePadding } from "../../vendor/oslo/encoding/index.ts";
-import { api } from "./_generated/api.ts";
-import { toArrayBuffer } from "./helpers.ts";
-import type schema from "./schema.ts";
-
 /**
  * A minimal software authenticator for tests. It builds the WebAuthn
  * payloads (client data, authenticator data, attestation objects) and signs
- * assertions with real WebCrypto keys, so the component's parsing and
- * signature verification run against genuine ceremony bytes.
+ * assertions with real WebCrypto keys, so a test runs the parsing and the
+ * signature verification of a relying party against genuine ceremony bytes.
  */
+import {
+  decodeBase64url,
+  encodeBase64url,
+  sha256,
+  toArrayBuffer,
+  toDERSignature,
+} from "./bytes.ts";
+import { encodeCBOR, type CBORValue } from "./cbor.ts";
 
+export { encodeCBOR, type CBORValue };
+
+/**
+ * The relying party that the authenticator uses when a caller names none. An
+ * app under test has a relying party of its own, thus it passes `rpId` and
+ * `origin` to each builder.
+ */
 export const RP_ID = "example.com";
 export const ORIGIN = "https://app.example.com";
 
@@ -26,43 +28,6 @@ export interface TestCredential {
   credentialId: Uint8Array;
   privateKey: CryptoKey;
   cosePublicKey: Uint8Array;
-}
-
-type CBORValue = number | string | Uint8Array | Map<number | string, CBORValue>;
-
-function cborHead(majorType: number, value: number): number[] {
-  if (value < 24) {
-    return [(majorType << 5) | value];
-  }
-  if (value < 0x100) {
-    return [(majorType << 5) | 24, value];
-  }
-  if (value < 0x10000) {
-    return [(majorType << 5) | 25, value >> 8, value & 0xff];
-  }
-  throw new Error("Value too large for the test CBOR encoder");
-}
-
-/** Encode a small CBOR value (enough for COSE keys and attestation objects). */
-export function encodeCBOR(value: CBORValue): Uint8Array {
-  const encode = (value: CBORValue): number[] => {
-    if (typeof value === "number") {
-      return value >= 0 ? cborHead(0, value) : cborHead(1, -1 - value);
-    }
-    if (typeof value === "string") {
-      const bytes = new TextEncoder().encode(value);
-      return [...cborHead(3, bytes.length), ...bytes];
-    }
-    if (value instanceof Uint8Array) {
-      return [...cborHead(2, value.length), ...value];
-    }
-    const out = cborHead(5, value.size);
-    for (const [key, entry] of value) {
-      out.push(...encode(key), ...encode(entry));
-    }
-    return out;
-  };
-  return new Uint8Array(encode(value));
 }
 
 export async function generateES256Credential(): Promise<TestCredential> {
@@ -108,8 +73,8 @@ export async function generateRS256Credential(): Promise<TestCredential> {
     new Map<number, CBORValue>([
       [1, 3], // kty: RSA
       [3, -257], // alg: RS256
-      [-1, decodeBase64urlIgnorePadding(jwk.n!)], // n (256 bytes)
-      [-2, decodeBase64urlIgnorePadding(jwk.e!)], // e (3 bytes)
+      [-1, decodeBase64url(jwk.n!)], // n (256 bytes)
+      [-2, decodeBase64url(jwk.e!)], // e (3 bytes)
     ]),
   );
   return {
@@ -133,21 +98,17 @@ export function buildClientDataJSON({
 }): Uint8Array {
   const bytes =
     challenge instanceof Uint8Array ? challenge : new Uint8Array(challenge);
-  const base64url = btoa(String.fromCharCode(...bytes))
-    .replaceAll("+", "-")
-    .replaceAll("/", "_")
-    .replace(/=+$/, "");
   return new TextEncoder().encode(
     JSON.stringify({
       type,
-      challenge: base64url,
+      challenge: encodeBase64url(bytes),
       origin,
       ...(crossOrigin !== undefined ? { crossOrigin } : {}),
     }),
   );
 }
 
-export function buildAuthenticatorData({
+export async function buildAuthenticatorData({
   rpId,
   userPresent = true,
   userVerified = true,
@@ -160,13 +121,13 @@ export function buildAuthenticatorData({
   counter?: number;
   // When set, the attested credential data block is included (AT flag).
   credential?: Pick<TestCredential, "credentialId" | "cosePublicKey">;
-}): Uint8Array {
+}): Promise<Uint8Array> {
   let flags = 0;
   if (userPresent) flags |= 0x01;
   if (userVerified) flags |= 0x04;
   if (credential !== undefined) flags |= 0x40;
   const parts: number[] = [
-    ...sha256(new TextEncoder().encode(rpId)),
+    ...(await sha256(new TextEncoder().encode(rpId))),
     flags,
     (counter >>> 24) & 0xff,
     (counter >>> 16) & 0xff,
@@ -202,22 +163,18 @@ export async function signAssertion(
 ): Promise<Uint8Array> {
   const message = new Uint8Array(authenticatorData.length + 32);
   message.set(authenticatorData);
-  message.set(sha256(clientDataJSON), authenticatorData.length);
+  message.set(await sha256(clientDataJSON), authenticatorData.length);
   if (credential.algorithm === "ES256") {
     // WebCrypto emits the IEEE P1363 encoding (r || s); WebAuthn transports
-    // the DER (PKIX) encoding, which is what the component expects.
-    const p1363 = new Uint8Array(
-      await crypto.subtle.sign(
-        { name: "ECDSA", hash: "SHA-256" },
-        credential.privateKey,
-        message,
+    // the DER (PKIX) encoding, which is what a relying party expects.
+    return toDERSignature(
+      new Uint8Array(
+        await crypto.subtle.sign(
+          { name: "ECDSA", hash: "SHA-256" },
+          credential.privateKey,
+          message,
+        ),
       ),
-    );
-    return encodeASN1(
-      new ASN1EncodableSequence([
-        new ASN1Integer(bigIntFromBytes(p1363.slice(0, 32))),
-        new ASN1Integer(bigIntFromBytes(p1363.slice(32))),
-      ]),
     );
   }
   return new Uint8Array(
@@ -229,50 +186,7 @@ export async function signAssertion(
   );
 }
 
-type T = TestConvex<typeof schema>;
-
-/** Run a full registration ceremony and return the stored credential. */
-export async function register(
-  t: T,
-  userId: string,
-  options: {
-    name?: string;
-    credential?: TestCredential;
-    counter?: number;
-    transports?: string[];
-  } = {},
-): Promise<{ credential: TestCredential; passkeyId: string }> {
-  const credential = options.credential ?? (await generateES256Credential());
-  const { challenge } = await t.mutation(api.registration.startRegistration, {
-    userId,
-  });
-  const authData = buildAuthenticatorData({
-    rpId: RP_ID,
-    counter: options.counter ?? 0,
-    credential,
-  });
-  const result = await t.mutation(api.registration.finishRegistration, {
-    expectedRpId: RP_ID,
-    expectedOrigin: ORIGIN,
-    verifiedUserId: userId,
-    name: options.name,
-    transports: options.transports,
-    attestationObject: toArrayBuffer(buildAttestationObject(authData)),
-    clientDataJSON: toArrayBuffer(
-      buildClientDataJSON({
-        type: "webauthn.create",
-        challenge,
-        origin: ORIGIN,
-      }),
-    ),
-  });
-  if (!result.success) {
-    throw new Error(`Test registration failed: ${result.userError.error}`);
-  }
-  return { credential, passkeyId: result.passkeyId };
-}
-
-/** Build the assertion arguments for `finishAuthentication`. */
+/** Build the arguments of an authentication ceremony. */
 export async function buildAssertion(
   credential: TestCredential,
   challenge: ArrayBuffer | Uint8Array,
@@ -299,7 +213,7 @@ export async function buildAssertion(
     origin: options.origin ?? ORIGIN,
     crossOrigin: options.crossOrigin,
   });
-  const authenticatorData = buildAuthenticatorData({
+  const authenticatorData = await buildAuthenticatorData({
     rpId: options.rpId ?? RP_ID,
     counter: options.counter ?? 1,
     userPresent: options.userPresent,

--- a/packages/passkey-test-authenticator/tsconfig.json
+++ b/packages/passkey-test-authenticator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    // The package ships as source, thus its relative imports use the
+    // extension of the file on disk (`.ts`). See `packages/core/tsconfig.json`.
+    "module": "Node16",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@convex-dev/batch-worker':
         specifier: ^0.3.0
         version: 0.3.0(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
+      '@convex-dev/passkey-test-authenticator':
+        specifier: workspace:*
+        version: link:../../packages/passkey-test-authenticator
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
@@ -388,6 +391,9 @@ importers:
         specifier: ^9.4.1
         version: 9.4.1
     devDependencies:
+      '@convex-dev/passkey-test-authenticator':
+        specifier: workspace:*
+        version: link:../passkey-test-authenticator
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
@@ -494,6 +500,21 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/passkey-test-authenticator:
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@24.13.2)(jsdom@29.1.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12))
 
   scripts/codegen-host:
     dependencies:


### PR DESCRIPTION
This PR refactors the internal tests so that the test authenticator is no longer exported by the `@convex-dev/auth` package.