### PR TITLE
passkey: move the wire to WebAuthn JSON

### DIFF
--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -20,10 +20,12 @@ import {
   buildAuthenticatorData,
   buildClientDataJSON,
   generateES256Credential,
+  registrationResponse,
+  toBase64URL,
   type TestCredential,
 } from "@convex-dev/passkey-test-authenticator";
 import { registerUsername } from "@convex-dev/auth/providers/testing/username";
-import { api } from "./_generated/api";
+import { api, components } from "./_generated/api";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -34,26 +36,6 @@ const RP_ID = "localhost";
 const ORIGIN = "http://localhost:5173";
 
 type T = TestConvex<typeof schema>;
-
-type Attestation = {
-  attestationObject: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-};
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength,
-  ) as ArrayBuffer;
-}
-
-/** Assert that two byte buffers hold the same bytes. */
-function expectSameBytes(
-  a: ArrayBuffer | Uint8Array,
-  b: ArrayBuffer | Uint8Array,
-): void {
-  expect(new Uint8Array(a)).toEqual(new Uint8Array(b));
-}
 
 async function setup(): Promise<T> {
   // The core signs JWTs from these env vars. Mint a real RS256 key pair for
@@ -85,29 +67,30 @@ afterEach(() => {
 /** The caller as a signed-in user, the way a real access token identifies one. */
 const as = (t: T, userId: string) => t.withIdentity({ subject: userId });
 
-/** Build the `create()` payloads of a registration ceremony. */
+/** Build the `response` of a `create()` ceremony, spreadable into args. */
 async function attest(
-  challenge: ArrayBuffer,
+  challenge: string,
   credential: TestCredential,
-): Promise<Attestation> {
+): Promise<{ response: ReturnType<typeof registrationResponse> }> {
   const authenticatorData = await buildAuthenticatorData({
     rpId: RP_ID,
     credential,
   });
   return {
-    attestationObject: toArrayBuffer(buildAttestationObject(authenticatorData)),
-    clientDataJSON: toArrayBuffer(
-      buildClientDataJSON({
+    response: registrationResponse({
+      credential,
+      attestationObject: buildAttestationObject(authenticatorData),
+      clientDataJSON: buildClientDataJSON({
         type: "webauthn.create",
         challenge,
         origin: ORIGIN,
       }),
-    ),
+    }),
   };
 }
 
-/** Build the `get()` payloads of an authentication ceremony. */
-const assertWith = (credential: TestCredential, challenge: ArrayBuffer) =>
+/** Build the `response` of a `get()` ceremony, spreadable into args. */
+const assertWith = (credential: TestCredential, challenge: string) =>
   buildAssertion(credential, challenge, { rpId: RP_ID, origin: ORIGIN });
 
 /** Register a new account with its first passkey. */
@@ -122,7 +105,7 @@ async function signUp(
   const credential = await generateES256Credential();
   const result = await t.mutation(api.auth.finishSignUp, {
     username,
-    ...(await attest(start.challenge, credential)),
+    ...(await attest(start.options.challenge, credential)),
   });
   if (!result.success) {
     throw new Error(`The sign-up failed: ${result.userError.error}`);
@@ -143,7 +126,7 @@ async function addPasskey(
   }
   const verified = await caller.mutation(
     api.auth.verifyAddPasskey,
-    await assertWith(authorizeWith, start.challenge),
+    await assertWith(authorizeWith, start.options.challenge),
   );
   if (!verified.success) {
     throw new Error(
@@ -153,7 +136,7 @@ async function addPasskey(
   const credential = await generateES256Credential();
   const finished = await caller.mutation(
     api.auth.finishAddPasskey,
-    await attest(verified.challenge, credential),
+    await attest(verified.options.challenge, credential),
   );
   if (!finished.success) {
     throw new Error(`The add failed: ${finished.userError.error}`);
@@ -177,12 +160,11 @@ describe("listPasskeys", () => {
     expect(forBob.passkeys).toHaveLength(1);
     expect(forAlice.passkeys[0]).toEqual({
       passkeyId: expect.any(String),
-      credentialId: expect.any(ArrayBuffer),
+      credentialId: expect.any(String),
       createdAt: expect.any(Number),
     });
-    expectSameBytes(
-      forBob.passkeys[0].credentialId,
-      bob.credential.credentialId,
+    expect(forBob.passkeys[0].credentialId).toBe(
+      toBase64URL(bob.credential.credentialId),
     );
   });
 
@@ -204,35 +186,34 @@ describe("adding a passkey", () => {
 
     const start = await caller.mutation(api.auth.startAddPasskey, {});
     if (!start.success) throw new Error("The caller is signed in.");
-    expect(start.rpId).toBe(RP_ID);
+    expect(start.options.rpId).toBe(RP_ID);
     // Each passkey of the account can authorize the add.
-    expect(start.allowCredentials).toHaveLength(1);
-    expectSameBytes(
-      start.allowCredentials[0].id,
-      alice.credential.credentialId,
+    expect(start.options.allowCredentials).toHaveLength(1);
+    expect(start.options.allowCredentials[0].id).toBe(
+      toBase64URL(alice.credential.credentialId),
     );
 
     const verified = await caller.mutation(
       api.auth.verifyAddPasskey,
-      await assertWith(alice.credential, start.challenge),
+      await assertWith(alice.credential, start.options.challenge),
     );
     if (!verified.success) throw new Error("The assertion is valid.");
-    expect(verified.rpId).toBe(RP_ID);
+    expect(verified.options.rp.id).toBe(RP_ID);
     // `auth.ts` names no `rpName`, thus the relying party ID stands in for it.
-    expect(verified.rpName).toBe(RP_ID);
-    expect(verified.username).toBe("alice");
+    expect(verified.options.rp.name).toBe(RP_ID);
+    expect(verified.options.user.name).toBe("alice");
+    expect(verified.options.user.displayName).toBe("alice");
     // The authenticator must not make a second credential for a passkey the
     // account already holds.
-    expect(verified.excludeCredentials).toHaveLength(1);
-    expectSameBytes(
-      verified.excludeCredentials[0].id,
-      alice.credential.credentialId,
+    expect(verified.options.excludeCredentials).toHaveLength(1);
+    expect(verified.options.excludeCredentials[0].id).toBe(
+      toBase64URL(alice.credential.credentialId),
     );
 
     const credential = await generateES256Credential();
     const finished = await caller.mutation(
       api.auth.finishAddPasskey,
-      await attest(verified.challenge, credential),
+      await attest(verified.options.challenge, credential),
     );
     expect(finished).toEqual({ success: true, passkeyId: expect.any(String) });
 
@@ -256,9 +237,32 @@ describe("adding a passkey", () => {
     expect(
       await caller.mutation(
         api.auth.verifyAddPasskey,
-        await assertWith(alice.credential, start.challenge),
+        await assertWith(alice.credential, start.options.challenge),
       ),
     ).toEqual({ success: false, userError: { error: "PROTOCOL_ERROR" } });
+  });
+
+  test("refuses to name a passkey for a user without a username", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    await t.run((ctx) =>
+      ctx.runMutation(components.authUsername.public.deleteUsername, {
+        userId: alice.userId,
+      }),
+    );
+    const caller = as(t, alice.userId);
+
+    const start = await caller.mutation(api.auth.startAddPasskey, {});
+    if (!start.success) throw new Error("The caller is signed in.");
+    // The re-authentication succeeds, but the server cannot build the
+    // `user.name` for the new passkey. Only the app can remove a username,
+    // so the failure is an error for the developer, not a `userError`.
+    await expect(
+      caller.mutation(
+        api.auth.verifyAddPasskey,
+        await assertWith(alice.credential, start.options.challenge),
+      ),
+    ).rejects.toThrow("no username");
   });
 
   test("refuses a create() ceremony that no verifyAddPasskey started", async () => {
@@ -270,7 +274,7 @@ describe("adding a passkey", () => {
     expect(
       await as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
-        await attest(new ArrayBuffer(32), credential),
+        await attest(toBase64URL(new ArrayBuffer(32)), credential),
       ),
     ).toEqual({ success: false, userError: { error: "CHALLENGE_EXPIRED" } });
   });
@@ -291,7 +295,7 @@ describe("adding a passkey", () => {
     expect(
       await as(t, alice.userId).mutation(
         api.auth.finishAddPasskey,
-        await attest(start.challenge, credential),
+        await attest(start.options.challenge, credential),
       ),
     ).toEqual({ success: false, userError: { error: "PROTOCOL_ERROR" } });
   });
@@ -308,13 +312,16 @@ describe("adding a passkey", () => {
     expect(
       await t.mutation(
         api.auth.verifyAddPasskey,
-        await assertWith(alice.credential, new ArrayBuffer(32)),
+        await assertWith(alice.credential, toBase64URL(new ArrayBuffer(32))),
       ),
     ).toEqual(notSignedIn);
     expect(
       await t.mutation(
         api.auth.finishAddPasskey,
-        await attest(new ArrayBuffer(32), await generateES256Credential()),
+        await attest(
+          toBase64URL(new ArrayBuffer(32)),
+          await generateES256Credential(),
+        ),
       ),
     ).toEqual(notSignedIn);
   });
@@ -331,28 +338,26 @@ describe("removing a passkey", () => {
       passkeyId: second.passkeyId,
     });
     if (!start.success) throw new Error("The account has two passkeys.");
-    expect(start.rpId).toBe(RP_ID);
+    expect(start.options.rpId).toBe(RP_ID);
     // The passkey that goes away cannot authorize its own removal, thus the
     // browser must not offer it.
-    expect(start.allowCredentials).toHaveLength(1);
-    expectSameBytes(
-      start.allowCredentials[0].id,
-      alice.credential.credentialId,
+    expect(start.options.allowCredentials).toHaveLength(1);
+    expect(start.options.allowCredentials[0].id).toBe(
+      toBase64URL(alice.credential.credentialId),
     );
 
     expect(
       await caller.mutation(api.auth.finishRemovePasskey, {
         passkeyId: second.passkeyId,
-        ...(await assertWith(alice.credential, start.challenge)),
+        ...(await assertWith(alice.credential, start.options.challenge)),
       }),
     ).toEqual({ success: true });
 
     const list = await caller.query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
     expect(list.passkeys).toHaveLength(1);
-    expectSameBytes(
-      list.passkeys[0].credentialId,
-      alice.credential.credentialId,
+    expect(list.passkeys[0].credentialId).toBe(
+      toBase64URL(alice.credential.credentialId),
     );
   });
 
@@ -386,7 +391,7 @@ describe("removing a passkey", () => {
     expect(
       await caller.mutation(api.auth.finishRemovePasskey, {
         passkeyId: second.passkeyId,
-        ...(await assertWith(second.credential, start.challenge)),
+        ...(await assertWith(second.credential, start.options.challenge)),
       }),
     ).toEqual({ success: false, userError: { error: "PROTOCOL_ERROR" } });
 
@@ -409,7 +414,10 @@ describe("removing a passkey", () => {
       passkeyId: second.passkeyId,
     });
     if (!start.success) throw new Error("The account has two passkeys.");
-    const assertion = await assertWith(alice.credential, start.challenge);
+    const assertion = await assertWith(
+      alice.credential,
+      start.options.challenge,
+    );
 
     const list = await caller.query(api.auth.listPasskeys, {});
     if (!list.success) throw new Error("The caller is signed in.");
@@ -466,7 +474,7 @@ describe("removing a passkey", () => {
     expect(
       await caller.mutation(api.auth.finishRemovePasskey, {
         passkeyId: bobList.passkeys[0].passkeyId,
-        ...(await assertWith(alice.credential, start.challenge)),
+        ...(await assertWith(alice.credential, start.options.challenge)),
       }),
     ).toEqual({ success: false, userError: { error: "PASSKEY_NOT_FOUND" } });
 
@@ -492,7 +500,10 @@ describe("removing a passkey", () => {
     expect(
       await t.mutation(api.auth.finishRemovePasskey, {
         passkeyId: second.passkeyId,
-        ...(await assertWith(alice.credential, new ArrayBuffer(32))),
+        ...(await assertWith(
+          alice.credential,
+          toBase64URL(new ArrayBuffer(32)),
+        )),
       }),
     ).toEqual(notSignedIn);
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,19 +100,37 @@
       "types": "./dist/components/password/*.d.ts",
       "default": "./dist/components/password/*.js"
     },
-    "./providers/passkey/client": null,
-    "./providers/passkey/client.js": null,
-    "./providers/passkey/flows": null,
-    "./providers/passkey/flows.js": null,
-    "./providers/passkey/react_impl": null,
-    "./providers/passkey/react_impl.js": null,
-    "./providers/passkey/*.js": {
-      "types": "./dist/components/passkey/*.d.ts",
-      "default": "./dist/components/passkey/*.js"
+    "./providers/passkey/convex.config.js": {
+      "types": "./dist/components/passkey/convex.config.d.ts",
+      "default": "./dist/components/passkey/convex.config.js"
     },
-    "./providers/passkey/*": {
-      "types": "./dist/components/passkey/*.d.ts",
-      "default": "./dist/components/passkey/*.js"
+    "./providers/passkey/convex.config": {
+      "types": "./dist/components/passkey/convex.config.d.ts",
+      "default": "./dist/components/passkey/convex.config.js"
+    },
+    "./providers/passkey/_generated/component.js": {
+      "types": "./dist/components/passkey/_generated/component.d.ts",
+      "default": "./dist/components/passkey/_generated/component.js"
+    },
+    "./providers/passkey/_generated/component": {
+      "types": "./dist/components/passkey/_generated/component.d.ts",
+      "default": "./dist/components/passkey/_generated/component.js"
+    },
+    "./providers/passkey/setup.js": {
+      "types": "./dist/components/passkey/setup.d.ts",
+      "default": "./dist/components/passkey/setup.js"
+    },
+    "./providers/passkey/setup": {
+      "types": "./dist/components/passkey/setup.d.ts",
+      "default": "./dist/components/passkey/setup.js"
+    },
+    "./providers/passkey/react.js": {
+      "types": "./dist/components/passkey/react.d.ts",
+      "default": "./dist/components/passkey/react.js"
+    },
+    "./providers/passkey/react": {
+      "types": "./dist/components/passkey/react.d.ts",
+      "default": "./dist/components/passkey/react.js"
     },
     "./email/*.js": {
       "types": "./dist/components/email/*.d.ts",

--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -9,13 +9,16 @@
  */
 
 import type * as authentication from "../authentication.js";
+import type * as base64url from "../base64url.js";
 import type * as cleanup from "../cleanup.js";
 import type * as client from "../client.js";
+import type * as constants from "../constants.js";
 import type * as flows from "../flows.js";
 import type * as helpers from "../helpers.js";
 import type * as management_add from "../management/add.js";
 import type * as management_list from "../management/list.js";
 import type * as management_remove from "../management/remove.js";
+import type * as options from "../options.js";
 import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
 import type * as react_impl from "../react_impl.js";
@@ -32,13 +35,16 @@ import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
   authentication: typeof authentication;
+  base64url: typeof base64url;
   cleanup: typeof cleanup;
   client: typeof client;
+  constants: typeof constants;
   flows: typeof flows;
   helpers: typeof helpers;
   "management/add": typeof management_add;
   "management/list": typeof management_list;
   "management/remove": typeof management_remove;
+  options: typeof options;
   purposes: typeof purposes;
   react: typeof react;
   react_impl: typeof react_impl;

--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -28,13 +28,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
-          authenticatorData: ArrayBuffer;
-          clientDataJSON: ArrayBuffer;
-          credentialId: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
           purpose: string;
-          signature: ArrayBuffer;
+          response: {
+            clientExtensionResults: {};
+            id: string;
+            rawId: string;
+            response: {
+              authenticatorData: string;
+              clientDataJSON: string;
+              signature: string;
+              userHandle?: string;
+            };
+            type: "public-key";
+          };
         },
         | { passkeyId: string; success: true; userId: string }
         | {
@@ -65,11 +73,19 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "query",
         "internal",
         {
-          attestationObject: ArrayBuffer;
-          clientDataJSON: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
-          transports?: Array<string>;
+          response: {
+            clientExtensionResults: {};
+            id: string;
+            rawId: string;
+            response: {
+              attestationObject: string;
+              clientDataJSON: string;
+              transports?: Array<string>;
+            };
+            type: "public-key";
+          };
         },
         | { success: true }
         | {
@@ -98,12 +114,20 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
-          attestationObject: ArrayBuffer;
-          clientDataJSON: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
           name?: string;
-          transports?: Array<string>;
+          response: {
+            clientExtensionResults: {};
+            id: string;
+            rawId: string;
+            response: {
+              attestationObject: string;
+              clientDataJSON: string;
+              transports?: Array<string>;
+            };
+            type: "public-key";
+          };
           verifiedUserId: string;
         },
         | { passkeyId: string; success: true }
@@ -118,13 +142,21 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
-          attestationObject: ArrayBuffer;
-          clientDataJSON: ArrayBuffer;
           expectedOrigin: string;
           expectedRpId: string;
           name?: string;
           newUserId: string;
-          transports?: Array<string>;
+          response: {
+            clientExtensionResults: {};
+            id: string;
+            rawId: string;
+            response: {
+              attestationObject: string;
+              clientDataJSON: string;
+              transports?: Array<string>;
+            };
+            type: "public-key";
+          };
         },
         | { passkeyId: string; success: true }
         | {
@@ -140,7 +172,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { userId: string },
         Array<{
           createdAt: number;
-          credentialId: ArrayBuffer;
+          credentialId: string;
           name?: string;
           passkeyId: string;
         }>,

--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -4,6 +4,7 @@ import {
   buildAssertion,
   generateES256Credential,
   generateRS256Credential,
+  toBase64URL,
 } from "@convex-dev/passkey-test-authenticator";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
@@ -13,8 +14,8 @@ import {
   setup,
 } from "../passkeyTestSetup.ts";
 import { api } from "./_generated/api.ts";
-import { toArrayBuffer } from "./helpers.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { type WireAuthenticationResponse } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 
 // The component gives no purpose of its own: each app names its own flows.
 const PURPOSE = "test/signIn";
@@ -31,6 +32,19 @@ const EXPECTED = {
 afterEach(() => {
   vi.useRealTimers();
 });
+
+/** Replace fields inside the inner `response` of an assertion envelope. */
+function withInner(
+  assertion: { response: WireAuthenticationResponse },
+  fields: Partial<WireAuthenticationResponse["response"]>,
+) {
+  return {
+    response: {
+      ...assertion.response,
+      response: { ...assertion.response.response, ...fields },
+    },
+  };
+}
 
 describe("startAuthentication", () => {
   test("stores a user-bound challenge and returns the user's credential IDs", async () => {
@@ -229,8 +243,9 @@ describe("finishAuthentication", () => {
       () =>
         t.mutation(api.authentication.finishAuthentication, {
           ...EXPECTED,
-          ...assertion,
-          authenticatorData: new Uint8Array(10).buffer,
+          ...withInner(assertion, {
+            authenticatorData: toBase64URL(new Uint8Array(10)),
+          }),
         }),
       "the authenticator data could not be read",
     );
@@ -248,12 +263,13 @@ describe("finishAuthentication", () => {
       () =>
         t.mutation(api.authentication.finishAuthentication, {
           ...EXPECTED,
-          ...assertion,
-          clientDataJSON: toArrayBuffer(
-            new TextEncoder().encode(
-              JSON.stringify({ type: "webauthn.get", origin: ORIGIN }),
+          ...withInner(assertion, {
+            clientDataJSON: toBase64URL(
+              new TextEncoder().encode(
+                JSON.stringify({ type: "webauthn.get", origin: ORIGIN }),
+              ),
             ),
-          ),
+          }),
         }),
       "the client data JSON carries no challenge",
     );
@@ -439,8 +455,9 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
-      ...assertion,
-      signature: crypto.getRandomValues(new Uint8Array(256)).buffer,
+      ...withInner(assertion, {
+        signature: toBase64URL(crypto.getRandomValues(new Uint8Array(256))),
+      }),
     });
     expect(result).toEqual({
       success: false,
@@ -461,8 +478,7 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
-      ...assertion,
-      signature: new Uint8Array(0).buffer,
+      ...withInner(assertion, { signature: toBase64URL(new Uint8Array(0)) }),
     });
     expect(result).toEqual({
       success: false,
@@ -481,8 +497,7 @@ describe("finishAuthentication", () => {
     const assertion = await buildAssertion(credential, challenge);
     const result = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
-      ...assertion,
-      signature: new Uint8Array(10).buffer,
+      ...withInner(assertion, { signature: toBase64URL(new Uint8Array(10)) }),
     });
     expect(result).toEqual({
       success: false,
@@ -509,8 +524,7 @@ describe("finishAuthentication", () => {
     ]);
     const result = await t.mutation(api.authentication.finishAuthentication, {
       ...EXPECTED,
-      ...assertion,
-      signature: signature.buffer,
+      ...withInner(assertion, { signature: toBase64URL(signature) }),
     });
     expect(result).toEqual({
       success: false,

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -1,8 +1,6 @@
-import type {
-  AuthenticationResponseJSON,
-  AuthenticatorTransportFuture,
-} from "@simplewebauthn/server";
+import type { AuthenticatorTransportFuture } from "@simplewebauthn/server";
 import { verifyAuthenticationResponse } from "@simplewebauthn/server";
+import { vAuthenticationResponseJSON } from "./validation.ts";
 import {
   decodeClientDataJSON,
   isoBase64URL,
@@ -16,6 +14,7 @@ import {
   okOrNull,
   randomChallenge,
   rpIdHashMatches,
+  toArrayBuffer,
 } from "./helpers.ts";
 import {
   credentialDescriptor,
@@ -126,26 +125,28 @@ export const finishAuthentication = mutation({
     purpose: v.string(),
     expectedRpId: v.string(),
     expectedOrigin: v.string(),
-    credentialId: v.bytes(),
-    authenticatorData: v.bytes(),
-    clientDataJSON: v.bytes(),
-    signature: v.bytes(),
+    response: vAuthenticationResponseJSON,
   },
   returns: finishAuthenticationResult,
   handler: async (ctx, args): Promise<FinishAuthenticationResult> => {
     validatePurpose(args.purpose);
+    // `verifyAuthenticationResponse` checks that `id` and `rawId` agree, so
+    // either one can drive the lookup.
+    const credentialId = toArrayBuffer(
+      isoBase64URL.toBuffer(args.response.rawId),
+    );
     const passkey = await ctx.db
       .query("passkeys")
-      .withIndex("by_credentialId", (q) =>
-        q.eq("credentialId", args.credentialId),
-      )
+      .withIndex("by_credentialId", (q) => q.eq("credentialId", credentialId))
       .first();
     if (passkey === null) {
       return { success: false, userError: { error: "UNKNOWN_CREDENTIAL" } };
     }
 
     const authenticatorData = okOrNull(() =>
-      parseAuthenticatorData(new Uint8Array(args.authenticatorData)),
+      parseAuthenticatorData(
+        isoBase64URL.toBuffer(args.response.response.authenticatorData),
+      ),
     );
     if (authenticatorData === null) {
       console.warn(
@@ -183,7 +184,7 @@ export const finishAuthentication = mutation({
     //               callback variant of the `expectedChallenge`
     //               argument of `verifyAuthenticationResponse`.`
     const clientData = okOrNull(() =>
-      decodeClientDataJSON(toBase64URL(args.clientDataJSON)),
+      decodeClientDataJSON(args.response.response.clientDataJSON),
     );
 
     // Here we perform a few checks manually. These checks are also done later by
@@ -279,28 +280,15 @@ export const finishAuthentication = mutation({
       return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
 
-    const credentialId = toBase64URL(args.credentialId);
-    const response: AuthenticationResponseJSON = {
-      id: credentialId,
-      rawId: credentialId,
-      response: {
-        clientDataJSON: toBase64URL(args.clientDataJSON),
-        authenticatorData: toBase64URL(args.authenticatorData),
-        signature: toBase64URL(args.signature),
-      },
-      clientExtensionResults: {},
-      type: "public-key",
-    };
-
     let verification;
     try {
       verification = await verifyAuthenticationResponse({
-        response,
+        response: args.response,
         expectedChallenge: toBase64URL(challengeRow.challenge),
         expectedOrigin: args.expectedOrigin,
         expectedRPID: args.expectedRpId,
         credential: {
-          id: credentialId,
+          id: args.response.rawId,
           publicKey: new Uint8Array(passkey.publicKey),
           // Passkey attestations can carry a counter that can be used by
           // applications to detect duplicated passkeys. The goal is to let

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -130,9 +130,16 @@ export const finishAuthentication = mutation({
   returns: finishAuthenticationResult,
   handler: async (ctx, args): Promise<FinishAuthenticationResult> => {
     validatePurpose(args.purpose);
-    // `verifyAuthenticationResponse` checks that `id` and `rawId` agree, so
-    // either one can drive the lookup.
     const credentialId = toArrayBuffer(
+      // args.response contains the credential ID twice: in `args.response.id`
+      // and `args.response.rawId`. They are identical by definition (and SimpleWebAuthn
+      // checks for their equality), so we can use either one here.
+      // Why do we send the same data twice over our wire format? Because our
+      // wire format matches the `AuthenticationResponseJSON` DOM type
+      // (https://w3c.github.io/webauthn/#dictdef-authenticationresponsejson).
+      // Using the DOM type as the wire format makes the implementation easier both on
+      // the client (argument serialization is simple) and on the server
+      // (SimpleWebAuthn accepts `args.response` directly).
       isoBase64URL.toBuffer(args.response.rawId),
     );
     const passkey = await ctx.db

--- a/packages/core/src/components/passkey/base64url.ts
+++ b/packages/core/src/components/passkey/base64url.ts
@@ -1,0 +1,40 @@
+/**
+ * base64url encoding of the binary fields of the WebAuthn wire.
+ *
+ * @module
+ */
+
+/**
+ * Encode bytes as an unpadded base64url string, the form that every binary
+ * field of the WebAuthn JSON wire takes.
+ */
+export function toBase64URL(bytes: ArrayBuffer): string {
+  let binary = "";
+  for (const byte of new Uint8Array(bytes)) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Decode an unpadded base64url string back to bytes. The browser client
+ * needs it: the WebAuthn API takes the challenge and the credential IDs as
+ * `BufferSource`, while the wire carries them as base64url.
+ */
+export function fromBase64URL(value: string): ArrayBuffer {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  // `atob` needs the padding that the wire leaves out.
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "=",
+  );
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}

--- a/packages/core/src/components/passkey/cleanup.test.ts
+++ b/packages/core/src/components/passkey/cleanup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "./_generated/api.ts";
 import type { Id } from "./_generated/dataModel.ts";
 import { WORKER_NAME } from "./cleanup.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 import { setup } from "../passkeyTestSetup.ts";
 
 const START = new Date("2026-01-01T00:00:00Z").getTime();

--- a/packages/core/src/components/passkey/cleanup.ts
+++ b/packages/core/src/components/passkey/cleanup.ts
@@ -3,7 +3,7 @@ import { defineBatchWorkerValidators, ping } from "@convex-dev/batch-worker";
 import { components, internal } from "./_generated/api.ts";
 import { internalMutation, internalQuery } from "./_generated/server.ts";
 import type { MutationCtx } from "./_generated/server.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 import { deleteDeadChallenge } from "./helpers.ts";
 
 // The name of the batch worker loop that erases expired challenges. Only one

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -1,85 +1,92 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
-  assertionFromCredential,
+  authenticate,
+  authenticateWithAutofill,
   foldClientError,
-  runAuthenticationCeremony,
-  runAutofillAuthenticationCeremony,
-  runRegistrationCeremony,
+  register,
   supportsWebAuthn,
 } from "./client.ts";
+import { fromBase64URL, toBase64URL } from "./base64url.ts";
 
-// The browser WebAuthn surface. jsdom has none, so the tests install a
-// fake `PublicKeyCredential` and `navigator.credentials`.
+// The ceremonies run through `navigator.credentials`, which jsdom has not.
+// The tests stub it and check what the wrappers add on top: the support
+// check, the decoding of the options, the encoding of the response, and
+// the error fold.
 const credentialsCreate = vi.fn();
 const credentialsGet = vi.fn();
 
 class FakePublicKeyCredential {}
 
-// A stand-in for the credential `navigator.credentials.create()` returns.
+const bytes = (text: string) =>
+  Uint8Array.from(text, (character) => character.charCodeAt(0)).buffer;
+
+/**
+ * base64url of a short ASCII string. The ceremonies decode the options they
+ * are given, so the fixtures have to be real base64url.
+ */
+const wire = (text: string) => toBase64URL(bytes(text));
+
+// An attestation credential the way `navigator.credentials.create()`
+// returns one.
 const attestationCredential = {
-  rawId: new ArrayBuffer(8),
+  id: wire("credential-id"),
+  rawId: bytes("credential-id"),
   response: {
-    attestationObject: new ArrayBuffer(1),
-    clientDataJSON: new ArrayBuffer(2),
+    clientDataJSON: bytes("client-data"),
+    attestationObject: bytes("attestation"),
     getTransports: () => ["internal", "hybrid"],
   },
+  type: "public-key",
 };
 
-// A stand-in for the credential `navigator.credentials.get()` returns.
+// An assertion credential the way `navigator.credentials.get()` returns
+// one.
 const assertionCredential = {
-  rawId: new ArrayBuffer(8),
+  id: wire("credential-id"),
+  rawId: bytes("credential-id"),
   response: {
-    authenticatorData: new ArrayBuffer(1),
-    clientDataJSON: new ArrayBuffer(2),
-    signature: new ArrayBuffer(3),
+    clientDataJSON: bytes("client-data"),
+    authenticatorData: bytes("auth-data"),
+    signature: bytes("signature"),
+    userHandle: bytes("user-handle"),
   },
+  type: "public-key",
 };
 
-const registrationOptions = {
-  challenge: new ArrayBuffer(16),
+const creationOptions = {
+  rp: { id: "localhost", name: "Test app" },
+  user: { id: wire("handle"), name: "alice", displayName: "alice" },
+  challenge: wire("challenge"),
+  pubKeyCredParams: [{ alg: -7, type: "public-key" as const }],
+  timeout: 600000,
+  excludeCredentials: [],
+  authenticatorSelection: {
+    residentKey: "required" as const,
+    requireResidentKey: true as const,
+    userVerification: "required" as const,
+  },
+  attestation: "none" as const,
+  extensions: {},
+};
+
+const requestOptions = {
+  challenge: wire("challenge"),
+  timeout: 600000,
   rpId: "localhost",
-  rpName: "Test app",
-  userHandle: new ArrayBuffer(16),
-  userName: "alice",
-  userDisplayName: "Alice",
-  excludeCredentials: [{ id: new ArrayBuffer(4), transports: ["internal"] }],
+  allowCredentials: [],
+  userVerification: "required" as const,
 };
-
-const authenticationOptions = {
-  challenge: new ArrayBuffer(16),
-  rpId: "localhost",
-  allowCredentials: [{ id: new ArrayBuffer(8) }],
-};
-
-const autofillOptions = {
-  challenge: new ArrayBuffer(16),
-  rpId: "localhost",
-};
-
-// `vi.unstubAllGlobals()` does not undo `Object.defineProperty`, so the
-// tests restore the original `navigator.credentials` own property (or its
-// absence) themselves.
-const originalCredentials = Object.getOwnPropertyDescriptor(
-  window.navigator,
-  "credentials",
-);
 
 beforeEach(() => {
   vi.stubGlobal("PublicKeyCredential", FakePublicKeyCredential);
   vi.stubGlobal("isSecureContext", true);
-  Object.defineProperty(window.navigator, "credentials", {
-    value: { create: credentialsCreate, get: credentialsGet },
-    configurable: true,
+  vi.stubGlobal("navigator", {
+    credentials: { create: credentialsCreate, get: credentialsGet },
   });
 });
 
 afterEach(() => {
-  if (originalCredentials === undefined) {
-    delete (window.navigator as { credentials?: unknown }).credentials;
-  } else {
-    Object.defineProperty(window.navigator, "credentials", originalCredentials);
-  }
   vi.unstubAllGlobals();
   credentialsCreate.mockReset();
   credentialsGet.mockReset();
@@ -120,73 +127,60 @@ describe("foldClientError", () => {
   });
 });
 
-describe("runRegistrationCeremony", () => {
-  test("maps the options onto the create() call and returns the attestation", async () => {
+describe("register", () => {
+  test("decodes the options for create() and encodes the response", async () => {
     credentialsCreate.mockResolvedValue(attestationCredential);
 
-    const result = await runRegistrationCeremony(registrationOptions);
+    const result = await register(creationOptions);
 
+    // The wire carries base64url; the WebAuthn API takes bytes. Everything
+    // else reaches the browser as the server built it.
+    const [call] = credentialsCreate.mock.calls[0];
+    expect(call.publicKey.challenge).toEqual(
+      fromBase64URL(creationOptions.challenge),
+    );
+    expect(call.publicKey.user.id).toEqual(
+      fromBase64URL(creationOptions.user.id),
+    );
+    expect(call.publicKey.rp).toEqual(creationOptions.rp);
+    expect(call.publicKey.attestation).toBe("none");
+    expect(call.publicKey.authenticatorSelection).toEqual(
+      creationOptions.authenticatorSelection,
+    );
     expect(result).toEqual({
       success: true,
-      attestation: {
-        attestationObject: attestationCredential.response.attestationObject,
-        clientDataJSON: attestationCredential.response.clientDataJSON,
-        transports: ["internal", "hybrid"],
-      },
-    });
-    expect(credentialsCreate).toHaveBeenCalledWith({
-      signal: undefined,
-      publicKey: {
-        challenge: registrationOptions.challenge,
-        rp: { id: "localhost", name: "Test app" },
-        user: {
-          id: registrationOptions.userHandle,
-          name: "alice",
-          displayName: "Alice",
+      response: {
+        id: wire("credential-id"),
+        rawId: wire("credential-id"),
+        response: {
+          clientDataJSON: wire("client-data"),
+          attestationObject: wire("attestation"),
+          transports: ["internal", "hybrid"],
         },
-        pubKeyCredParams: [
-          { type: "public-key", alg: -7 },
-          { type: "public-key", alg: -257 },
-        ],
-        authenticatorSelection: {
-          residentKey: "required",
-          requireResidentKey: true,
-          userVerification: "required",
-        },
-        attestation: "none",
-        excludeCredentials: [
-          {
-            type: "public-key",
-            id: registrationOptions.excludeCredentials[0].id,
-            transports: ["internal"],
-          },
-        ],
+        clientExtensionResults: {},
+        type: "public-key",
       },
     });
   });
 
-  test("a response without getTransports reports no transports", async () => {
+  test("a browser without getTransports reports no transports", async () => {
     credentialsCreate.mockResolvedValue({
-      rawId: attestationCredential.rawId,
+      ...attestationCredential,
       response: {
-        attestationObject: attestationCredential.response.attestationObject,
-        clientDataJSON: attestationCredential.response.clientDataJSON,
+        clientDataJSON: bytes("client-data"),
+        attestationObject: bytes("attestation"),
       },
     });
-    const result = await runRegistrationCeremony(registrationOptions);
-    expect(result).toEqual({
-      success: true,
-      attestation: {
-        attestationObject: attestationCredential.response.attestationObject,
-        clientDataJSON: attestationCredential.response.clientDataJSON,
-        transports: undefined,
-      },
-    });
+    const result = await register(creationOptions);
+    expect(result.success).toBe(true);
+    expect(result.success && result.response.response).not.toHaveProperty(
+      "transports",
+    );
   });
 
   test("a null credential folds into CEREMONY_ABORTED", async () => {
     credentialsCreate.mockResolvedValue(null);
-    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+    expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
     });
@@ -196,7 +190,7 @@ describe("runRegistrationCeremony", () => {
     credentialsCreate.mockRejectedValue(
       new DOMException("cancelled", "NotAllowedError"),
     );
-    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+    expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
     });
@@ -205,7 +199,7 @@ describe("runRegistrationCeremony", () => {
   test("an unexpected throw folds into OTHER_ERROR with the cause", async () => {
     const cause = new Error("boom");
     credentialsCreate.mockRejectedValue(cause);
-    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+    expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "OTHER_ERROR", cause },
     });
@@ -213,7 +207,7 @@ describe("runRegistrationCeremony", () => {
 
   test("no WebAuthn support folds into WEBAUTHN_UNSUPPORTED", async () => {
     vi.stubGlobal("PublicKeyCredential", undefined);
-    expect(await runRegistrationCeremony(registrationOptions)).toEqual({
+    expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "WEBAUTHN_UNSUPPORTED" },
     });
@@ -221,63 +215,75 @@ describe("runRegistrationCeremony", () => {
   });
 });
 
-describe("runAuthenticationCeremony", () => {
-  test("maps the options onto the get() call and returns the assertion", async () => {
+describe("authenticate", () => {
+  test("decodes the options for get() and encodes the response", async () => {
     credentialsGet.mockResolvedValue(assertionCredential);
 
-    const result = await runAuthenticationCeremony(authenticationOptions);
+    const result = await authenticate({
+      ...requestOptions,
+      allowCredentials: [
+        { id: wire("credential-id"), type: "public-key", transports: ["usb"] },
+      ],
+    });
 
+    const [call] = credentialsGet.mock.calls[0];
+    expect(call.publicKey.challenge).toEqual(
+      fromBase64URL(requestOptions.challenge),
+    );
+    expect(call.publicKey.rpId).toBe(requestOptions.rpId);
+    expect(call.publicKey.userVerification).toBe("required");
+    expect(call.publicKey.allowCredentials).toEqual([
+      {
+        id: fromBase64URL(wire("credential-id")),
+        type: "public-key",
+        transports: ["usb"],
+      },
+    ]);
     expect(result).toEqual({
       success: true,
-      assertion: {
-        // `rawId` carries the credential ID bytes, not the base64url `id`.
-        credentialId: assertionCredential.rawId,
-        authenticatorData: assertionCredential.response.authenticatorData,
-        clientDataJSON: assertionCredential.response.clientDataJSON,
-        signature: assertionCredential.response.signature,
-      },
-    });
-    expect(credentialsGet).toHaveBeenCalledWith({
-      signal: undefined,
-      publicKey: {
-        challenge: authenticationOptions.challenge,
-        rpId: "localhost",
-        allowCredentials: [
-          {
-            type: "public-key",
-            id: authenticationOptions.allowCredentials[0].id,
-            transports: undefined,
-          },
-        ],
-        userVerification: "required",
+      response: {
+        id: wire("credential-id"),
+        rawId: wire("credential-id"),
+        response: {
+          clientDataJSON: wire("client-data"),
+          authenticatorData: wire("auth-data"),
+          signature: wire("signature"),
+          userHandle: wire("user-handle"),
+        },
+        clientExtensionResults: {},
+        type: "public-key",
       },
     });
   });
 
+  test("an assertion without a user handle carries none", async () => {
+    credentialsGet.mockResolvedValue({
+      ...assertionCredential,
+      response: {
+        clientDataJSON: bytes("client-data"),
+        authenticatorData: bytes("auth-data"),
+        signature: bytes("signature"),
+        userHandle: null,
+      },
+    });
+    const result = await authenticate(requestOptions);
+    expect(result.success).toBe(true);
+    expect(result.success && result.response.response).not.toHaveProperty(
+      "userHandle",
+    );
+  });
+
   test("a null credential folds into CEREMONY_ABORTED", async () => {
     credentialsGet.mockResolvedValue(null);
-    expect(await runAuthenticationCeremony(authenticationOptions)).toEqual({
+    expect(await authenticate(requestOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
     });
   });
 
-  test("an aborted signal folds into CEREMONY_ABORTED", async () => {
-    credentialsGet.mockImplementation(({ signal }: { signal?: AbortSignal }) =>
-      Promise.reject(
-        signal?.aborted
-          ? new DOMException("aborted", "AbortError")
-          : new Error("expected an aborted signal"),
-      ),
-    );
-    const controller = new AbortController();
-    controller.abort();
-    expect(
-      await runAuthenticationCeremony({
-        ...authenticationOptions,
-        signal: controller.signal,
-      }),
-    ).toEqual({
+  test("an aborted ceremony folds into CEREMONY_ABORTED", async () => {
+    credentialsGet.mockRejectedValue(new DOMException("aborted", "AbortError"));
+    expect(await authenticate(requestOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
     });
@@ -285,7 +291,7 @@ describe("runAuthenticationCeremony", () => {
 
   test("no WebAuthn support folds into WEBAUTHN_UNSUPPORTED", async () => {
     vi.stubGlobal("PublicKeyCredential", undefined);
-    expect(await runAuthenticationCeremony(authenticationOptions)).toEqual({
+    expect(await authenticate(requestOptions)).toEqual({
       success: false,
       userError: { error: "WEBAUTHN_UNSUPPORTED" },
     });
@@ -293,89 +299,132 @@ describe("runAuthenticationCeremony", () => {
   });
 });
 
-describe("runAutofillAuthenticationCeremony", () => {
+describe("authenticateWithAutofill", () => {
+  // The conditional path calls `navigator.credentials.get` itself, so that
+  // the caller can own the `AbortSignal`; see the comment on the function.
+  const credentialsGet = vi.fn();
+
+  function stubCredentials() {
+    vi.stubGlobal("navigator", { credentials: { get: credentialsGet } });
+  }
+
+  /** A `PublicKeyCredential` the way the browser returns one. */
+  function assertion({ userHandle }: { userHandle: ArrayBuffer | null }) {
+    return {
+      id: wire("credential-id"),
+      rawId: fromBase64URL(wire("credential-id")),
+      response: {
+        clientDataJSON: fromBase64URL(wire("client-data")),
+        authenticatorData: fromBase64URL(wire("auth-data")),
+        signature: fromBase64URL(wire("signature")),
+        userHandle,
+      },
+      type: "public-key",
+    };
+  }
+
+  afterEach(() => {
+    credentialsGet.mockReset();
+  });
+
   test("asks for a conditional request with the caller's signal", async () => {
-    credentialsGet.mockResolvedValue(assertionCredential);
+    stubCredentials();
+    credentialsGet.mockResolvedValue(assertion({ userHandle: null }));
     const controller = new AbortController();
 
-    const result = await runAutofillAuthenticationCeremony(
-      autofillOptions,
-      controller.signal,
+    await authenticateWithAutofill(requestOptions, controller.signal);
+
+    expect(credentialsGet).toHaveBeenCalledTimes(1);
+    const options = credentialsGet.mock.calls[0][0];
+    expect(options.mediation).toBe("conditional");
+    expect(options.signal).toBe(controller.signal);
+    // Conditional mediation requires an empty allow-list.
+    expect(options.publicKey.allowCredentials).toEqual([]);
+    expect(options.publicKey.rpId).toBe(requestOptions.rpId);
+    expect(options.publicKey.timeout).toBe(requestOptions.timeout);
+    expect(options.publicKey.userVerification).toBe("required");
+    expect(toBase64URL(options.publicKey.challenge)).toBe(
+      requestOptions.challenge,
+    );
+  });
+
+  test("puts the assertion into the wire shape", async () => {
+    stubCredentials();
+    credentialsGet.mockResolvedValue(
+      assertion({ userHandle: fromBase64URL(wire("user-handle")) }),
     );
 
-    expect(result).toEqual({
+    expect(
+      await authenticateWithAutofill(
+        requestOptions,
+        new AbortController().signal,
+      ),
+    ).toEqual({
       success: true,
-      assertion: {
-        credentialId: assertionCredential.rawId,
-        authenticatorData: assertionCredential.response.authenticatorData,
-        clientDataJSON: assertionCredential.response.clientDataJSON,
-        signature: assertionCredential.response.signature,
-      },
-    });
-    expect(credentialsGet).toHaveBeenCalledWith({
-      mediation: "conditional",
-      signal: controller.signal,
-      publicKey: {
-        challenge: autofillOptions.challenge,
-        rpId: "localhost",
-        // Conditional mediation requires an empty allow-list.
-        allowCredentials: [],
-        userVerification: "required",
+      response: {
+        id: wire("credential-id"),
+        rawId: wire("credential-id"),
+        response: {
+          clientDataJSON: wire("client-data"),
+          authenticatorData: wire("auth-data"),
+          signature: wire("signature"),
+          userHandle: wire("user-handle"),
+        },
+        clientExtensionResults: {},
+        type: "public-key",
       },
     });
   });
 
-  test("a null credential folds into CEREMONY_ABORTED", async () => {
-    credentialsGet.mockResolvedValue(null);
+  test("a discoverable assertion without a user handle carries none", async () => {
+    stubCredentials();
+    credentialsGet.mockResolvedValue(assertion({ userHandle: null }));
+
+    const result = await authenticateWithAutofill(
+      requestOptions,
+      new AbortController().signal,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.response.response).not.toHaveProperty(
+      "userHandle",
+    );
+  });
+
+  test("an abort folds into CEREMONY_ABORTED", async () => {
+    stubCredentials();
+    credentialsGet.mockRejectedValue(new DOMException("aborted", "AbortError"));
+
     expect(
-      await runAutofillAuthenticationCeremony(
-        autofillOptions,
+      await authenticateWithAutofill(
+        requestOptions,
         new AbortController().signal,
       ),
     ).toEqual({ success: false, userError: { error: "CEREMONY_ABORTED" } });
   });
 
-  test("an aborted signal folds into CEREMONY_ABORTED", async () => {
-    credentialsGet.mockImplementation(({ signal }: { signal: AbortSignal }) =>
-      Promise.reject(
-        signal.aborted
-          ? new DOMException("aborted", "AbortError")
-          : new Error("expected an aborted signal"),
-      ),
-    );
-    const controller = new AbortController();
-    controller.abort();
+  test("a null credential folds into CEREMONY_ABORTED", async () => {
+    stubCredentials();
+    credentialsGet.mockResolvedValue(null);
+
     expect(
-      await runAutofillAuthenticationCeremony(
-        autofillOptions,
-        controller.signal,
+      await authenticateWithAutofill(
+        requestOptions,
+        new AbortController().signal,
       ),
     ).toEqual({ success: false, userError: { error: "CEREMONY_ABORTED" } });
   });
 
   test("no WebAuthn support folds into WEBAUTHN_UNSUPPORTED", async () => {
+    stubCredentials();
     vi.stubGlobal("PublicKeyCredential", undefined);
+
     expect(
-      await runAutofillAuthenticationCeremony(
-        autofillOptions,
+      await authenticateWithAutofill(
+        requestOptions,
         new AbortController().signal,
       ),
     ).toEqual({ success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } });
     expect(credentialsGet).not.toHaveBeenCalled();
-  });
-});
-
-describe("assertionFromCredential", () => {
-  test("uses rawId and the assertion response fields", () => {
-    expect(
-      assertionFromCredential(
-        assertionCredential as unknown as PublicKeyCredential,
-      ),
-    ).toEqual({
-      credentialId: assertionCredential.rawId,
-      authenticatorData: assertionCredential.response.authenticatorData,
-      clientDataJSON: assertionCredential.response.clientDataJSON,
-      signature: assertionCredential.response.signature,
-    });
   });
 });

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -22,7 +22,22 @@
  * @module
  */
 
-import type { CredentialDescriptor } from "./validation.ts";
+import type {
+  WireAuthenticationResponse,
+  WireCreationOptions,
+  WireRegistrationResponse,
+  WireRequestOptions,
+} from "./validation.ts";
+import { fromBase64URL, toBase64URL } from "./base64url.ts";
+
+// Apps and custom flows read the wire shapes from here: they are the exact
+// shapes of the provider's mutations.
+export type {
+  WireAuthenticationResponse,
+  WireCreationOptions,
+  WireRegistrationResponse,
+  WireRequestOptions,
+} from "./validation.ts";
 
 /**
  * The failures the browser side produces (the server never returns these):
@@ -53,43 +68,19 @@ export type PasskeyClientFailure = {
 };
 
 /**
- * The output of a registration ceremony: the fields a finish mutation needs
- * to verify the new passkey (see `finishSignUp` in the username + passkey
- * recipe).
- */
-export type PasskeyAttestation = {
-  attestationObject: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  // Older browsers have no `getTransports`. Then the server stores no
-  // transports for this credential.
-  transports?: string[];
-};
-
-/**
- * The output of an authentication ceremony: the fields a finish mutation
- * needs to verify the signature (see `finishSignIn` in the username +
- * passkey recipe).
- */
-export type PasskeyAssertion = {
-  credentialId: ArrayBuffer;
-  authenticatorData: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  signature: ArrayBuffer;
-};
-
-/**
- * The result of {@link runRegistrationCeremony}: the attestation to send to
- * the finish mutation, or a user-facing `userError`.
+ * The result of {@link register}: the response to send to the finish
+ * mutation, or a user-facing `userError`.
  */
 export type PasskeyRegistrationResult =
-  { success: true; attestation: PasskeyAttestation } | PasskeyClientFailure;
+  { success: true; response: WireRegistrationResponse } | PasskeyClientFailure;
 
 /**
- * The result of {@link runAuthenticationCeremony}: the assertion to send to
- * the finish mutation, or a user-facing `userError`.
+ * The result of {@link authenticate}: the response to send to the finish
+ * mutation, or a user-facing `userError`.
  */
 export type PasskeyAuthenticationResult =
-  { success: true; assertion: PasskeyAssertion } | PasskeyClientFailure;
+  | { success: true; response: WireAuthenticationResponse }
+  | PasskeyClientFailure;
 
 /**
  * Whether this browser can run WebAuthn ceremonies on this page. The
@@ -104,170 +95,159 @@ export function supportsWebAuthn(): boolean {
   );
 }
 
-function isCeremonyAborted(cause: unknown): boolean {
-  // `NotAllowedError` is what the browser throws when the user dismisses
-  // the dialog, when the ceremony times out, and when the page is not
-  // allowed to run one. `AbortError` is what an `AbortSignal` produces.
-  // A `null` credential is handled separately.
-  return (
-    cause instanceof DOMException &&
-    (cause.name === "NotAllowedError" || cause.name === "AbortError")
-  );
-}
-
 /**
  * Fold a thrown value into the {@link PasskeyClientError} shape, so callers
  * handle every failure through one `userError` switch. Useful for custom
  * flows that call `navigator.credentials` or a mutation themselves.
  */
 export function foldClientError(cause: unknown): PasskeyClientError {
-  if (isCeremonyAborted(cause)) {
+  // `NotAllowedError` is what the browser throws when the user dismisses
+  // the dialog, when the ceremony times out, and when the page is not
+  // allowed to run one. `AbortError` is what an `AbortSignal` produces.
+  // A `null` credential is handled separately.
+  if (
+    cause instanceof DOMException &&
+    (cause.name === "NotAllowedError" || cause.name === "AbortError")
+  ) {
     return { error: "CEREMONY_ABORTED" };
   }
   return { error: "OTHER_ERROR", cause };
 }
 
 /**
- * Turn the credential descriptors from the server into the WebAuthn shape
- * of `allowCredentials` and `excludeCredentials`.
+ * Turn the JSON credential descriptors of the wire into the DOM shape of
+ * `allowCredentials` and `excludeCredentials`.
  */
-function credentialDescriptors(
-  credentials: CredentialDescriptor[],
+function descriptorsFromJSON(
+  descriptors: WireRequestOptions["allowCredentials"],
 ): PublicKeyCredentialDescriptor[] {
-  return credentials.map(({ id, transports }) => ({
-    type: "public-key",
-    id,
-    // The database stores a string array, we’re converting here
-    // to the narrower DOM type ("internal" | "hybrid" | "usb" | "nfc" | … )
+  return descriptors.map(({ id, type, transports }) => ({
+    id: fromBase64URL(id),
+    type,
+    // The wire keeps `transports` as free-form strings, because the
+    // WebAuthn spec lets new transports appear; the DOM type does not.
     transports: transports as AuthenticatorTransport[] | undefined,
   }));
 }
 
 /**
- * Turn an assertion credential from `navigator.credentials.get()` into a
- * {@link PasskeyAssertion}. Useful for custom flows that run the `get()`
- * call themselves, for example with conditional mediation.
+ * Turn the creation options of the wire into the DOM shape that
+ * `navigator.credentials.create()` takes: every binary field is base64url
+ * on the wire and a `BufferSource` in the API.
  */
-export function assertionFromCredential(
-  credential: PublicKeyCredential,
-): PasskeyAssertion {
-  const response = credential.response as AuthenticatorAssertionResponse;
+function creationOptionsFromJSON(
+  options: WireCreationOptions,
+): PublicKeyCredentialCreationOptions {
   return {
-    // `rawId` carries the credential ID bytes; `credential.id` is the
-    // base64url form and must not be sent.
-    credentialId: credential.rawId,
-    authenticatorData: response.authenticatorData,
-    clientDataJSON: response.clientDataJSON,
-    signature: response.signature,
+    rp: options.rp,
+    user: {
+      id: fromBase64URL(options.user.id),
+      name: options.user.name,
+      displayName: options.user.displayName,
+    },
+    challenge: fromBase64URL(options.challenge),
+    pubKeyCredParams: options.pubKeyCredParams,
+    timeout: options.timeout,
+    excludeCredentials: descriptorsFromJSON(options.excludeCredentials),
+    authenticatorSelection: options.authenticatorSelection,
+    attestation: options.attestation,
+    extensions: options.extensions,
+  };
+}
+
+/** Turn the request options of the wire into the DOM shape that
+ * `navigator.credentials.get()` takes (see
+ * {@link creationOptionsFromJSON}). */
+function requestOptionsFromJSON(
+  options: WireRequestOptions,
+): PublicKeyCredentialRequestOptions {
+  return {
+    challenge: fromBase64URL(options.challenge),
+    timeout: options.timeout,
+    rpId: options.rpId,
+    allowCredentials: descriptorsFromJSON(options.allowCredentials),
+    userVerification: options.userVerification,
   };
 }
 
 /**
- * Run a modal registration ceremony (`navigator.credentials.create()`).
- *
- * The `challenge`, `userHandle`, and `excludeCredentials` come from a start
- * mutation. The `userName` and `userDisplayName` are what the browser shows
- * for the new passkey in its passkey manager; the flow chooses them (for
- * example, the username the user typed).
- *
- * The created passkey is discoverable (required for autofill) and requires
- * user verification, which is what the server-side verification demands.
- *
- * @param options.signal Abort the ceremony (folds into `CEREMONY_ABORTED`).
+ * Put an attestation credential from a `create()` call into the wire
+ * shape.
  */
-export async function runRegistrationCeremony(options: {
-  challenge: ArrayBuffer;
-  rpId: string;
-  rpName: string;
-  userHandle: ArrayBuffer;
-  userName: string;
-  userDisplayName: string;
-  excludeCredentials: CredentialDescriptor[];
-  signal?: AbortSignal;
-}): Promise<PasskeyRegistrationResult> {
+function attestationToJSON(
+  credential: PublicKeyCredential,
+): WireRegistrationResponse {
+  const response = credential.response as AuthenticatorAttestationResponse;
+  // Older browsers have no `getTransports`. Then the server stores no
+  // transports for this credential.
+  const transports =
+    typeof response.getTransports === "function"
+      ? response.getTransports()
+      : undefined;
+  return {
+    id: credential.id,
+    rawId: toBase64URL(credential.rawId),
+    response: {
+      clientDataJSON: toBase64URL(response.clientDataJSON),
+      attestationObject: toBase64URL(response.attestationObject),
+      ...(transports !== undefined ? { transports } : {}),
+    },
+    // The options request no extensions, so there is nothing to report.
+    clientExtensionResults: {},
+    type: "public-key",
+  };
+}
+
+/**
+ * Run a modal registration ceremony (a WebAuthn `create()` call).
+ *
+ * `options` comes from a start mutation, ready for the browser: this
+ * function only decodes its binary fields.
+ */
+export async function register(
+  options: WireCreationOptions,
+): Promise<PasskeyRegistrationResult> {
   if (!supportsWebAuthn()) {
     return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
   try {
     const credential = (await navigator.credentials.create({
-      signal: options.signal,
-      publicKey: {
-        challenge: options.challenge,
-        rp: { id: options.rpId, name: options.rpName },
-        user: {
-          id: options.userHandle,
-          name: options.userName,
-          displayName: options.userDisplayName,
-        },
-        // Exactly the algorithms the server accepts (ES256 and RS256; see
-        // the verification in `registration.ts`).
-        pubKeyCredParams: [
-          { type: "public-key", alg: -7 }, // ES256
-          { type: "public-key", alg: -257 }, // RS256
-        ],
-        authenticatorSelection: {
-          residentKey: "required",
-          requireResidentKey: true,
-          userVerification: "required",
-        },
-        attestation: "none",
-        excludeCredentials: credentialDescriptors(options.excludeCredentials),
-      },
+      publicKey: creationOptionsFromJSON(options),
     })) as PublicKeyCredential | null; // navigator.credentials.get is typed as returning `Credential | null`, but with these arguments it returns a PublicKeyCredential
     if (credential === null) {
       return { success: false, userError: { error: "CEREMONY_ABORTED" } };
     }
-    const response = credential.response as AuthenticatorAttestationResponse;
-    return {
-      success: true,
-      attestation: {
-        attestationObject: response.attestationObject,
-        clientDataJSON: response.clientDataJSON,
-        // Older browsers have no `getTransports`. Then the server stores
-        // no transports for this credential.
-        transports:
-          typeof response.getTransports === "function"
-            ? response.getTransports()
-            : undefined,
-      },
-    };
+    return { success: true, response: attestationToJSON(credential) };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }
 }
 
 /**
- * Run a modal authentication ceremony (`navigator.credentials.get()`).
+ * Run a modal authentication ceremony (a WebAuthn `get()` call).
  *
- * The `challenge` and `allowCredentials` come from a start mutation. An
- * empty `allowCredentials` lets the user pick any passkey of this relying
- * party; the picked passkey then identifies the account.
+ * `options` comes from a start mutation, ready for the browser: this
+ * function only decodes its binary fields.
  *
- * @param options.signal Abort the ceremony (folds into `CEREMONY_ABORTED`).
+ * For the conditional-mediation flow, which stays pending until the user
+ * picks a passkey in the autocompletion list of an
+ * `<input autoComplete="… webauthn">`, use
+ * {@link authenticateWithAutofill}.
  */
-export async function runAuthenticationCeremony(options: {
-  challenge: ArrayBuffer;
-  rpId: string;
-  allowCredentials: CredentialDescriptor[];
-  signal?: AbortSignal;
-}): Promise<PasskeyAuthenticationResult> {
+export async function authenticate(
+  options: WireRequestOptions,
+): Promise<PasskeyAuthenticationResult> {
   if (!supportsWebAuthn()) {
     return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
   try {
     const credential = (await navigator.credentials.get({
-      signal: options.signal,
-      publicKey: {
-        challenge: options.challenge,
-        rpId: options.rpId,
-        allowCredentials: credentialDescriptors(options.allowCredentials),
-        userVerification: "required",
-      },
+      publicKey: requestOptionsFromJSON(options),
     })) as PublicKeyCredential | null; // navigator.credentials.get is typed as returning `Credential | null`, but with these arguments it returns a PublicKeyCredential
     if (credential === null) {
       return { success: false, userError: { error: "CEREMONY_ABORTED" } };
     }
-    return { success: true, assertion: assertionFromCredential(credential) };
+    return { success: true, response: assertionToJSON(credential) };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }
@@ -281,33 +261,60 @@ export async function runAuthenticationCeremony(options: {
  * `signal` aborts it. This is required because the caller is expected to
  * periodically recreate a new ceremony (because every ceremony has a timeout).
  */
-export async function runAutofillAuthenticationCeremony(
-  options: { challenge: ArrayBuffer; rpId: string },
+export async function authenticateWithAutofill(
+  options: WireRequestOptions,
   signal: AbortSignal,
 ): Promise<PasskeyAuthenticationResult> {
   if (!supportsWebAuthn()) {
     return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
   try {
-    const credential = (await navigator.credentials.get({
+    const credential = await navigator.credentials.get({
       mediation: "conditional",
       signal,
       publicKey: {
-        challenge: options.challenge,
+        challenge: fromBase64URL(options.challenge),
+        timeout: options.timeout,
         rpId: options.rpId,
         // Conditional mediation requires an empty allow-list: the passkey
         // the user picks in the autocompletion list identifies the account.
         allowCredentials: [],
-        userVerification: "required",
+        userVerification: options.userVerification,
       },
-    })) as PublicKeyCredential | null; // navigator.credentials.get is typed as returning `Credential | null`, but with these arguments it returns a PublicKeyCredential
+    });
     if (credential === null) {
       // The spec lets `get()` resolve with `null`. No assertion means no
       // ceremony, which is the same outcome for a caller as an abort.
       return { success: false, userError: { error: "CEREMONY_ABORTED" } };
     }
-    return { success: true, assertion: assertionFromCredential(credential) };
+    return {
+      success: true,
+      response: assertionToJSON(credential as PublicKeyCredential),
+    };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }
+}
+
+/**
+ * Put an assertion credential from a `get()` call into the wire shape.
+ */
+function assertionToJSON(
+  credential: PublicKeyCredential,
+): WireAuthenticationResponse {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: toBase64URL(credential.rawId),
+    response: {
+      clientDataJSON: toBase64URL(response.clientDataJSON),
+      authenticatorData: toBase64URL(response.authenticatorData),
+      signature: toBase64URL(response.signature),
+      ...(response.userHandle !== null
+        ? { userHandle: toBase64URL(response.userHandle) }
+        : {}),
+    },
+    clientExtensionResults: {},
+    type: "public-key",
+  };
 }

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -224,7 +224,8 @@ export async function register(
 }
 
 /**
- * Run a modal authentication ceremony (a WebAuthn `get()` call).
+ * Run a modal authentication ceremony
+ * (a WebAuthn `navigator.credentials.get()` call).
  *
  * `options` comes from a start mutation, ready for the browser: this
  * function only decodes its binary fields.
@@ -297,7 +298,8 @@ export async function authenticateWithAutofill(
 }
 
 /**
- * Put an assertion credential from a `get()` call into the wire shape.
+ * Put an assertion credential from a `navigator.credentials.get()`
+ * call into the wire shape.
  */
 function assertionToJSON(
   credential: PublicKeyCredential,

--- a/packages/core/src/components/passkey/constants.ts
+++ b/packages/core/src/components/passkey/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * The constants of the passkey provider that both sides of the wire read.
+ *
+ * They live apart from `validation.ts` so that the browser bundle of
+ * `react.tsx` does not retain the validators for them: a `v.object(...)`
+ * initializer is not provably pure, so a bundler keeps every validator of a
+ * module that a client imports one value from.
+ *
+ * @module
+ */
+
+// How long a stored challenge stays valid. The WebAuthn spec recommends
+// ceremony timeouts of 5–10 minutes to leave room for user interaction
+// (PIN entry, cross-device flows); we match the upper bound. Expiring
+// challenges bounds the window for replay of an intercepted challenge.
+// https://www.w3.org/TR/webauthn-3/#sctn-timeout-recommended-range
+export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+// The COSE signature algorithms this provider accepts, as IANA identifiers
+// (https://www.iana.org/assignments/cose/cose.xhtml#algorithms). The same
+// list is offered to the authenticator in the server-built
+// `pubKeyCredParams` and enforced when the attestation is verified, so the
+// two can never disagree. `@simplewebauthn/server` also verifies Ed25519
+// (-8); adding it here is the only change needed to accept it.
+export const SUPPORTED_ALGORITHM_IDS = [
+  -7, // ES256
+  -257, // RS256
+];

--- a/packages/core/src/components/passkey/flows.ts
+++ b/packages/core/src/components/passkey/flows.ts
@@ -14,8 +14,8 @@ import type {
   TokenBundle,
 } from "../../lib/types.ts";
 import {
-  runAuthenticationCeremony,
-  runRegistrationCeremony,
+  authenticate,
+  register,
   supportsWebAuthn,
   type PasskeyClientError,
   type PasskeyClientFailure,
@@ -26,6 +26,10 @@ import type {
   StartAutofillSignInResult,
   StartSignInResult,
 } from "./setup.ts";
+import type {
+  WireAuthenticationResponse,
+  WireRegistrationResponse,
+} from "./validation.ts";
 
 type StartSignInMutation = FunctionReference<
   "mutation",
@@ -44,24 +48,14 @@ type StartAutofillSignInMutation = FunctionReference<
 type FinishSignUpMutation = FunctionReference<
   "mutation",
   "public",
-  {
-    username: string;
-    attestationObject: ArrayBuffer;
-    clientDataJSON: ArrayBuffer;
-    transports?: string[];
-  },
+  { username: string; response: WireRegistrationResponse },
   ClientView<FinishSignUpResult>
 >;
 
 type FinishSignInMutation = FunctionReference<
   "mutation",
   "public",
-  {
-    credentialId: ArrayBuffer;
-    authenticatorData: ArrayBuffer;
-    clientDataJSON: ArrayBuffer;
-    signature: ArrayBuffer;
-  },
+  { response: WireAuthenticationResponse },
   ClientView<FinishSignInResult>
 >;
 
@@ -132,25 +126,16 @@ export async function runSignInOrSignUpFlow(
   }
 
   if (start.step === "register") {
-    const ceremony = await runRegistrationCeremony({
-      challenge: start.challenge,
-      rpId: start.rpId,
-      rpName: start.rpName,
-      // The handle comes from the server: the app user id cannot be
-      // used, because the user row does not exist yet.
-      userHandle: start.userHandle,
-      userName: username,
-      userDisplayName: username,
-      // A sign-up ceremony makes the first passkey of a brand-new
-      // user, so there are no credentials to exclude.
-      excludeCredentials: [],
-    });
+    // TODO(nicolas) Consider not showing the registration UI immediately,
+    // but instead showing a screen that tells the user they have no account
+    // and suggest creating one.
+    const ceremony = await register(start.options);
     if (!ceremony.success) {
       return ceremony;
     }
     const result = await signInApi.mutation(api.finishSignUp, {
       username,
-      ...ceremony.attestation,
+      response: ceremony.response,
     });
     if (!result.success) {
       return result;
@@ -159,15 +144,13 @@ export async function runSignInOrSignUpFlow(
     return { ...result, flow: "signUp" };
   }
 
-  const ceremony = await runAuthenticationCeremony({
-    challenge: start.challenge,
-    rpId: start.rpId,
-    allowCredentials: start.allowCredentials,
-  });
+  const ceremony = await authenticate(start.options);
   if (!ceremony.success) {
     return ceremony;
   }
-  const result = await signInApi.mutation(api.finishSignIn, ceremony.assertion);
+  const result = await signInApi.mutation(api.finishSignIn, {
+    response: ceremony.response,
+  });
   if (!result.success) {
     return result;
   }

--- a/packages/core/src/components/passkey/flows.ts
+++ b/packages/core/src/components/passkey/flows.ts
@@ -55,6 +55,7 @@ type FinishSignUpMutation = FunctionReference<
 type FinishSignInMutation = FunctionReference<
   "mutation",
   "public",
+  // TODO(nicolas) Consider changing the name of the argument to `credential`
   { response: WireAuthenticationResponse },
   ClientView<FinishSignInResult>
 >;

--- a/packages/core/src/components/passkey/helpers.test.ts
+++ b/packages/core/src/components/passkey/helpers.test.ts
@@ -6,7 +6,7 @@ import {
   randomHandle,
   toArrayBuffer,
 } from "./helpers.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 import { expectSameBytes, setup } from "../passkeyTestSetup.ts";
 import { MutationCtx } from "./_generated/server.ts";
 import { Id } from "./_generated/dataModel.ts";

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -1,7 +1,7 @@
 import { isoUint8Array, toHash } from "@simplewebauthn/server/helpers";
 import { Doc, Id } from "./_generated/dataModel.ts";
 import { MutationCtx, QueryCtx } from "./_generated/server.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 
 /**
  * Run `read` and return its value. Return `null` when it throws.

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -33,18 +33,24 @@ import { getAuthUserId } from "../../core/userId.ts";
 import { ADD_PASSKEY_PURPOSE } from "../purposes.ts";
 import type { UsernamePasskeyConfig } from "../setup.ts";
 import {
-  credentialDescriptor,
   finishAuthenticationUserError,
   finishRegistrationUserError,
   notSignedInUserError,
+  vAuthenticationResponseJSON,
+  vPublicKeyCredentialCreationOptionsJSON,
+  vPublicKeyCredentialRequestOptionsJSON,
+  vRegistrationResponseJSON,
 } from "../validation.ts";
+import {
+  buildAuthenticationOptions,
+  buildRegistrationOptions,
+} from "../options.ts";
 
 const startAddPasskeyResult = v.union(
   v.object({
     success: v.literal(true),
-    challenge: v.bytes(),
-    allowCredentials: v.array(credentialDescriptor),
-    rpId: v.string(),
+    // Ready for the re-authentication `get()` call.
+    options: vPublicKeyCredentialRequestOptionsJSON,
   }),
   v.object({ success: v.literal(false), userError: notSignedInUserError }),
 );
@@ -54,16 +60,7 @@ export type StartAddPasskeyResult = Infer<typeof startAddPasskeyResult>;
 const verifyAddPasskeyResult = v.union(
   v.object({
     success: v.literal(true),
-    challenge: v.bytes(),
-    // The WebAuthn user handle (`user.id`) for the `create()` call.
-    userHandle: v.bytes(),
-    excludeCredentials: v.array(credentialDescriptor),
-    rpId: v.string(),
-    rpName: v.string(),
-    // The WebAuthn `user.name` and `user.displayName` for the `create()`
-    // call. `null` when the app removed the username of the user; then the
-    // client chooses what to show.
-    username: v.union(v.string(), v.null()),
+    options: vPublicKeyCredentialCreationOptionsJSON,
   }),
   v.object({
     success: v.literal(false),
@@ -104,7 +101,14 @@ export function startAddPasskey(config: UsernamePasskeyConfig) {
           "The signed-in user has no passkey. They can’t add a new passkey, because we can’t ask them to reauthenticate.",
         );
       }
-      return { success: true, challenge, allowCredentials, rpId: config.rpId };
+      return {
+        success: true,
+        options: buildAuthenticationOptions({
+          rpId: config.rpId,
+          challenge,
+          allowCredentials,
+        }),
+      };
     },
   });
 }
@@ -112,10 +116,7 @@ export function startAddPasskey(config: UsernamePasskeyConfig) {
 export function verifyAddPasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
-      credentialId: v.bytes(),
-      authenticatorData: v.bytes(),
-      clientDataJSON: v.bytes(),
-      signature: v.bytes(),
+      response: vAuthenticationResponseJSON,
     },
     returns: verifyAddPasskeyResult,
     handler: async (ctx, args): Promise<VerifyAddPasskeyResult> => {
@@ -130,10 +131,7 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
           purpose: ADD_PASSKEY_PURPOSE,
           expectedRpId: config.rpId,
           expectedOrigin: config.origin,
-          credentialId: args.credentialId,
-          authenticatorData: args.authenticatorData,
-          clientDataJSON: args.clientDataJSON,
-          signature: args.signature,
+          response: args.response,
         },
       );
       if (!authenticationResult.success) {
@@ -163,14 +161,29 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
         config.usernameComponent.public.getUsername,
         { userId },
       );
+      if (username === null) {
+        // WebAuthn requires `user.name` and `user.displayName`, and the
+        // browser keeps them in its passkey manager for the life of the
+        // passkey. Only the app can remove a username, so this is an app
+        // state the flow cannot serve, not a user error. Throwing rolls
+        // back the registration challenge.
+        throw new Error(
+          "The signed-in user has no username. Give them a username before they add a passkey.",
+        );
+      }
       return {
         success: true,
-        challenge,
-        userHandle,
-        excludeCredentials,
-        rpId: config.rpId,
-        rpName: config.rpName,
-        username,
+        options: buildRegistrationOptions({
+          rpId: config.rpId,
+          rpName: config.rpName,
+          challenge,
+          userHandle,
+          // What the browser shows for the new passkey in its passkey
+          // manager.
+          userName: username,
+          userDisplayName: username,
+          excludeCredentials,
+        }),
       };
     },
   });
@@ -179,9 +192,7 @@ export function verifyAddPasskey(config: UsernamePasskeyConfig) {
 export function finishAddPasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
-      attestationObject: v.bytes(),
-      clientDataJSON: v.bytes(),
-      transports: v.optional(v.array(v.string())),
+      response: vRegistrationResponseJSON,
     },
     returns: finishAddPasskeyResult,
     handler: async (ctx, args): Promise<FinishAddPasskeyResult> => {
@@ -196,9 +207,7 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
           expectedRpId: config.rpId,
           expectedOrigin: config.origin,
           verifiedUserId: userId,
-          attestationObject: args.attestationObject,
-          clientDataJSON: args.clientDataJSON,
-          transports: args.transports,
+          response: args.response,
         },
       );
       if (!registrationResult.success) {

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -49,7 +49,7 @@ import {
 const startAddPasskeyResult = v.union(
   v.object({
     success: v.literal(true),
-    // Ready for the re-authentication `get()` call.
+    // Ready for the re-authentication `navigator.credentials.get()` call.
     options: vPublicKeyCredentialRequestOptionsJSON,
   }),
   v.object({ success: v.literal(false), userError: notSignedInUserError }),

--- a/packages/core/src/components/passkey/management/list.ts
+++ b/packages/core/src/components/passkey/management/list.ts
@@ -16,7 +16,7 @@ import { notSignedInUserError } from "../validation.ts";
 const passkeyMetadata = v.object({
   passkeyId: v.string(),
   name: v.optional(v.string()),
-  credentialId: v.bytes(),
+  credentialId: v.string(), // as base64url
   createdAt: v.number(),
 });
 

--- a/packages/core/src/components/passkey/management/remove.ts
+++ b/packages/core/src/components/passkey/management/remove.ts
@@ -27,12 +27,15 @@ import { Infer, v } from "convex/values";
 import { getAuthUserId } from "../../core/userId.ts";
 import { REMOVE_PASSKEY_PURPOSE } from "../purposes.ts";
 import type { UsernamePasskeyConfig } from "../setup.ts";
+import { toBase64URL } from "../base64url.ts";
 import {
-  credentialDescriptor,
   deletePasskeyUserError,
   finishAuthenticationUserError,
   notSignedInUserError,
+  vAuthenticationResponseJSON,
+  vPublicKeyCredentialRequestOptionsJSON,
 } from "../validation.ts";
+import { buildAuthenticationOptions } from "../options.ts";
 
 /**
  * The user-facing error when the user tries to remove their only passkey.
@@ -49,9 +52,9 @@ const lastPasskeyUserError = v.object({ error: v.literal("LAST_PASSKEY") });
 const startRemovePasskeyResult = v.union(
   v.object({
     success: v.literal(true),
-    challenge: v.bytes(),
-    allowCredentials: v.array(credentialDescriptor),
-    rpId: v.string(),
+    // Ready for the authorization `get()` call. The `allowCredentials`
+    // list excludes the passkey that goes away.
+    options: vPublicKeyCredentialRequestOptionsJSON,
   }),
   v.object({
     success: v.literal(false),
@@ -78,16 +81,6 @@ const finishRemovePasskeyResult = v.union(
 );
 
 export type FinishRemovePasskeyResult = Infer<typeof finishRemovePasskeyResult>;
-
-/** Tell if two credential IDs hold the same bytes. */
-function sameBytes(a: ArrayBuffer, b: ArrayBuffer): boolean {
-  if (a.byteLength !== b.byteLength) {
-    return false;
-  }
-  const left = new Uint8Array(a);
-  const right = new Uint8Array(b);
-  return left.every((byte, index) => byte === right[index]);
-}
 
 export function startRemovePasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
@@ -123,14 +116,18 @@ export function startRemovePasskey(config: UsernamePasskeyConfig) {
       );
       return {
         success: true,
-        challenge,
-        // The filter helps the user only: the browser then does not offer
-        // the passkey that goes away. `finishRemovePasskey` refuses such an
-        // assertion again, and that check is the enforcement.
-        allowCredentials: allowCredentials.filter(
-          (candidate) => !sameBytes(candidate.id, target.credentialId),
-        ),
-        rpId: config.rpId,
+        options: buildAuthenticationOptions({
+          rpId: config.rpId,
+          challenge,
+          // The filter helps the user only: the browser then does not offer
+          // the passkey that goes away. `finishRemovePasskey` refuses such
+          // an assertion again, and that check is the enforcement.
+          // (`listPasskeys` returns base64url credential IDs, the component
+          // start function returns bytes.)
+          allowCredentials: allowCredentials.filter(
+            (candidate) => toBase64URL(candidate.id) !== target.credentialId,
+          ),
+        }),
       };
     },
   });
@@ -140,10 +137,7 @@ export function finishRemovePasskey(config: UsernamePasskeyConfig) {
   return mutationGeneric({
     args: {
       passkeyId: v.string(),
-      credentialId: v.bytes(),
-      authenticatorData: v.bytes(),
-      clientDataJSON: v.bytes(),
-      signature: v.bytes(),
+      response: vAuthenticationResponseJSON,
     },
     returns: finishRemovePasskeyResult,
     handler: async (ctx, args): Promise<FinishRemovePasskeyResult> => {
@@ -158,10 +152,7 @@ export function finishRemovePasskey(config: UsernamePasskeyConfig) {
           purpose: REMOVE_PASSKEY_PURPOSE,
           expectedRpId: config.rpId,
           expectedOrigin: config.origin,
-          credentialId: args.credentialId,
-          authenticatorData: args.authenticatorData,
-          clientDataJSON: args.clientDataJSON,
-          signature: args.signature,
+          response: args.response,
         },
       );
       if (!authenticationResult.success) {

--- a/packages/core/src/components/passkey/management/remove.ts
+++ b/packages/core/src/components/passkey/management/remove.ts
@@ -52,8 +52,8 @@ const lastPasskeyUserError = v.object({ error: v.literal("LAST_PASSKEY") });
 const startRemovePasskeyResult = v.union(
   v.object({
     success: v.literal(true),
-    // Ready for the authorization `get()` call. The `allowCredentials`
-    // list excludes the passkey that goes away.
+    // Ready for the authorization `navigator.credentials.get()` call.
+    // The `allowCredentials` list excludes the passkey that goes away.
     options: vPublicKeyCredentialRequestOptionsJSON,
   }),
   v.object({

--- a/packages/core/src/components/passkey/options.test.ts
+++ b/packages/core/src/components/passkey/options.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "vitest";
+import { isoBase64URL } from "@simplewebauthn/server/helpers";
+import { toBase64URL } from "./base64url.ts";
+import {
+  buildAuthenticationOptions,
+  buildRegistrationOptions,
+} from "./options.ts";
+import { CHALLENGE_TTL_MS, SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
+
+const RP_ID = "example.com";
+const RP_NAME = "Example";
+
+function bytes(...values: number[]): ArrayBuffer {
+  return Uint8Array.from(values).buffer;
+}
+
+describe("toBase64URL", () => {
+  // The provider assembles its options objects without
+  // `@simplewebauthn/server`, which would pull the X.509 and ASN.1 stack
+  // into the app-side bundle for one encode. These cases hold the
+  // replacement to the encoding of the library.
+  test("matches the encoder of the library", () => {
+    for (let length = 0; length < 130; length += 1) {
+      const buffer = new Uint8Array(length);
+      for (let index = 0; index < length; index += 1) {
+        // A fixed pattern that covers every byte value.
+        buffer[index] = (index * 7 + length) % 256;
+      }
+      expect(toBase64URL(buffer.buffer)).toBe(isoBase64URL.fromBuffer(buffer));
+    }
+  });
+
+  test("emits no padding and none of the characters base64 reserves", () => {
+    // 0xFB 0xFF encodes to "+/8=" in base64, which is the case that tells
+    // the two alphabets apart.
+    expect(toBase64URL(bytes(0xfb, 0xff))).toBe("-_8");
+  });
+
+  test("encodes an empty buffer as an empty string", () => {
+    expect(toBase64URL(new ArrayBuffer(0))).toBe("");
+  });
+});
+
+describe("buildRegistrationOptions", () => {
+  const build = (
+    overrides: Partial<Parameters<typeof buildRegistrationOptions>[0]> = {},
+  ) =>
+    buildRegistrationOptions({
+      rpId: RP_ID,
+      rpName: RP_NAME,
+      challenge: bytes(1, 2, 3),
+      userHandle: bytes(4, 5, 6),
+      userName: "ada",
+      userDisplayName: "Ada",
+      excludeCredentials: [],
+      ...overrides,
+    });
+
+  test("encodes the challenge and the user handle as base64url", () => {
+    const options = build();
+    expect(options.challenge).toBe(toBase64URL(bytes(1, 2, 3)));
+    expect(options.user).toEqual({
+      id: toBase64URL(bytes(4, 5, 6)),
+      name: "ada",
+      displayName: "Ada",
+    });
+    expect(options.rp).toEqual({ id: RP_ID, name: RP_NAME });
+  });
+
+  test("offers exactly the algorithms the verification enforces", () => {
+    expect(build().pubKeyCredParams).toEqual(
+      SUPPORTED_ALGORITHM_IDS.map((alg) => ({ alg, type: "public-key" })),
+    );
+  });
+
+  test("asks for a discoverable credential and user verification", () => {
+    const options = build();
+    expect(options.authenticatorSelection).toEqual({
+      residentKey: "required",
+      requireResidentKey: true,
+      userVerification: "required",
+    });
+    expect(options.attestation).toBe("none");
+  });
+
+  test("requests no extensions", () => {
+    // The wire validator refuses any other extension.
+    expect(build().extensions).toEqual({});
+  });
+
+  test("gives the browser less time than the challenge has to live", () => {
+    // The challenge starts ageing when the start mutation stores it, which
+    // is before the browser starts its own countdown. A ceremony that the
+    // browser still accepts must never come back as `CHALLENGE_EXPIRED`.
+    expect(build().timeout).toBeLessThan(CHALLENGE_TTL_MS);
+  });
+
+  test("turns the excluded credentials into JSON descriptors", () => {
+    const options = build({
+      excludeCredentials: [
+        { id: bytes(7, 8), transports: ["usb", "internal"] },
+        { id: bytes(9), transports: undefined },
+      ],
+    });
+    expect(options.excludeCredentials).toEqual([
+      {
+        id: toBase64URL(bytes(7, 8)),
+        type: "public-key",
+        transports: ["usb", "internal"],
+      },
+      { id: toBase64URL(bytes(9)), type: "public-key" },
+    ]);
+    // An absent `transports` is absent, not `undefined`: the wire validator
+    // marks it optional, and Convex refuses a key whose value is undefined
+    // only after it drops it, which hides the difference in tests.
+    expect("transports" in options.excludeCredentials[1]).toBe(false);
+  });
+});
+
+describe("buildAuthenticationOptions", () => {
+  test("builds a discoverable-credential request from an empty list", () => {
+    const options = buildAuthenticationOptions({
+      rpId: RP_ID,
+      challenge: bytes(1, 2, 3),
+      allowCredentials: [],
+    });
+    expect(options).toEqual({
+      challenge: toBase64URL(bytes(1, 2, 3)),
+      timeout: options.timeout,
+      rpId: RP_ID,
+      allowCredentials: [],
+      userVerification: "required",
+    });
+    expect(options.timeout).toBeLessThan(CHALLENGE_TTL_MS);
+  });
+
+  test("turns the allowed credentials into JSON descriptors", () => {
+    const options = buildAuthenticationOptions({
+      rpId: RP_ID,
+      challenge: bytes(1),
+      allowCredentials: [{ id: bytes(7, 8), transports: ["hybrid"] }],
+    });
+    expect(options.allowCredentials).toEqual([
+      {
+        id: toBase64URL(bytes(7, 8)),
+        type: "public-key",
+        transports: ["hybrid"],
+      },
+    ]);
+  });
+});

--- a/packages/core/src/components/passkey/options.ts
+++ b/packages/core/src/components/passkey/options.ts
@@ -1,0 +1,123 @@
+/**
+ * Assembly of the WebAuthn options objects that the start mutations of the
+ * provider return.
+ *
+ * These helpers pin the settings of this provider and build the exact wire
+ * shape of the validators in `validation.ts`. The objects are plain data:
+ * every binary field is base64url, and every other field is a constant of
+ * this provider or a value that a component start function supplied.
+ *
+ * `generateRegistrationOptions` / `generateAuthenticationOptions` of
+ * `@simplewebauthn/server` build the same objects, but this module does not
+ * use them. It is app-side code, which an app bundles into its own Convex
+ * deployment, and the library entry points pull in the X.509 and ASN.1
+ * stack (~390 KB minified). With the challenge and the user handle supplied
+ * by the component, the library adds nothing here but the base64url
+ * encoding that `base64url.ts` does in ten lines.
+ *
+ * @module
+ */
+import { toBase64URL } from "./base64url.ts";
+import { CHALLENGE_TTL_MS, SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
+import type {
+  CredentialDescriptor,
+  WireCreationOptions,
+  WireRequestOptions,
+} from "./validation.ts";
+
+// The `timeout` hint for the browser (browsers clamp the value to their own
+// maximum). It stays under the lifetime of the stored challenge, so the
+// browser gives up on a ceremony before its challenge expires: a user who
+// takes too long gets the browser's own "cancelled" failure rather than a
+// `CHALLENGE_EXPIRED` from the server.
+const CEREMONY_TIMEOUT_MS = CHALLENGE_TTL_MS - 60 * 1000;
+
+// The settings this provider pins. They are stated here once, and the
+// `v.literal(...)` fields of the wire validators in `validation.ts` hold
+// them to it.
+//
+// The created passkey is discoverable, which autofill requires, and
+// requires user verification, which the server-side verification demands.
+const AUTHENTICATOR_SELECTION = {
+  residentKey: "required",
+  requireResidentKey: true,
+  userVerification: "required",
+} as const satisfies WireCreationOptions["authenticatorSelection"];
+
+/**
+ * Turn the credential descriptors of a component start function into the
+ * JSON descriptors of the wire.
+ */
+function descriptorsJSON(
+  credentials: CredentialDescriptor[],
+): WireRequestOptions["allowCredentials"] {
+  return credentials.map(({ id, transports }) => ({
+    id: toBase64URL(id),
+    type: "public-key" as const,
+    // The component stores the transports as free-form strings, because
+    // the WebAuthn spec lets new ones appear.
+    ...(transports !== undefined ? { transports } : {}),
+  }));
+}
+
+/**
+ * Build the `PublicKeyCredentialCreationOptionsJSON` for a registration
+ * ceremony from the output of a component start function.
+ *
+ * `userName` and `userDisplayName` are what the browser shows for the new
+ * passkey in its passkey manager.
+ */
+export function buildRegistrationOptions(args: {
+  rpId: string;
+  rpName: string;
+  challenge: ArrayBuffer;
+  userHandle: ArrayBuffer;
+  userName: string;
+  userDisplayName: string;
+  excludeCredentials: CredentialDescriptor[];
+}): WireCreationOptions {
+  return {
+    rp: { id: args.rpId, name: args.rpName },
+    user: {
+      id: toBase64URL(args.userHandle),
+      name: args.userName,
+      displayName: args.userDisplayName,
+    },
+    challenge: toBase64URL(args.challenge),
+    // The same list the attestation verification enforces, so the two can
+    // never disagree.
+    pubKeyCredParams: SUPPORTED_ALGORITHM_IDS.map((alg) => ({
+      alg,
+      type: "public-key" as const,
+    })),
+    timeout: CEREMONY_TIMEOUT_MS,
+    excludeCredentials: descriptorsJSON(args.excludeCredentials),
+    authenticatorSelection: AUTHENTICATOR_SELECTION,
+    attestation: "none",
+    // This provider requests no extensions. `credProps` would be the one
+    // worth asking for, and its answer is constant-true under
+    // `residentKey: "required"`.
+    extensions: {},
+  };
+}
+
+/**
+ * Build the `PublicKeyCredentialRequestOptionsJSON` for an authentication
+ * ceremony from the output of the component's `startAuthentication`.
+ *
+ * An empty `allowCredentials` list means a discoverable-credential
+ * ceremony: the passkey the user picks identifies the account.
+ */
+export function buildAuthenticationOptions(args: {
+  rpId: string;
+  challenge: ArrayBuffer;
+  allowCredentials: CredentialDescriptor[];
+}): WireRequestOptions {
+  return {
+    challenge: toBase64URL(args.challenge),
+    timeout: CEREMONY_TIMEOUT_MS,
+    rpId: args.rpId,
+    allowCredentials: descriptorsJSON(args.allowCredentials),
+    userVerification: "required",
+  };
+}

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -16,6 +16,8 @@ import {
 } from "./react.tsx";
 import { usePasskeyAutofill, usePasskeyCeremonySlot } from "./react_impl.tsx";
 
+import { fromBase64URL, toBase64URL } from "./base64url.ts";
+
 const noopAutofill = {
   pauseAutofillFlow: () => {},
   resumeAutofillFlow: () => {},
@@ -127,6 +129,15 @@ function stubCredentials() {
  * conditional-mediation request until the user picks a passkey. */
 const pendingForever = () => new Promise<never>(() => {});
 
+const bytes = (text: string) =>
+  Uint8Array.from(text, (character) => character.charCodeAt(0)).buffer;
+
+/**
+ * The wire form of a short ASCII string: canonical base64url, so that a
+ * value decoded from it encodes back to exactly the same string.
+ */
+const wire = (text: string) => toBase64URL(bytes(text));
+
 class FakePublicKeyCredential {
   static isConditionalMediationAvailable = async () => true;
 }
@@ -141,54 +152,107 @@ const bundle: TokenBundle = {
   userId: "user-1",
 };
 
+// The options objects the start mutations return, ready for the browser.
+const creationOptions = {
+  rp: { id: "localhost", name: "Test app" },
+  user: { id: "handle-1", name: "alice", displayName: "alice" },
+  challenge: "challenge-1",
+  pubKeyCredParams: [{ alg: -7, type: "public-key" as const }],
+  timeout: 600000,
+  excludeCredentials: [],
+  authenticatorSelection: {
+    residentKey: "required" as const,
+    requireResidentKey: true as const,
+    userVerification: "required" as const,
+  },
+  attestation: "none" as const,
+  extensions: {},
+};
+
+const requestOptions = {
+  challenge: "challenge-1",
+  timeout: 600000,
+  rpId: "localhost",
+  allowCredentials: [
+    { id: "cred-1", type: "public-key" as const, transports: ["internal"] },
+  ],
+  userVerification: "required" as const,
+};
+
+// A stand-in for the credential `navigator.credentials.get()` returns, for
+// the modal and the conditional path alike. It encodes back to
+// `wireAuthenticationResponse`.
+const conditionalCredential = {
+  id: wire("cred-1"),
+  rawId: bytes("cred-1"),
+  response: {
+    clientDataJSON: bytes("client-data"),
+    authenticatorData: bytes("auth-data"),
+    signature: bytes("signature"),
+    userHandle: bytes("handle-1"),
+  },
+  type: "public-key",
+};
+
 const registerStart = {
   success: true,
   step: "register",
-  challenge: new ArrayBuffer(16),
-  userHandle: new ArrayBuffer(16),
-  rpId: "localhost",
-  rpName: "Test app",
+  options: creationOptions,
 };
 
 const authenticateStart = {
   success: true,
   step: "authenticate",
-  challenge: new ArrayBuffer(16),
-  allowCredentials: [{ id: new ArrayBuffer(8), transports: ["internal"] }],
-  rpId: "localhost",
+  options: requestOptions,
 };
 
-// What an autofill start mutation returns for a conditional request.
-const requestOptions = { challenge: new ArrayBuffer(16), rpId: "localhost" };
-
 // A stand-in for the credential `navigator.credentials.create()` returns.
+// It encodes back to `wireRegistrationResponse`.
 const attestationCredential = {
-  rawId: new ArrayBuffer(8),
+  id: wire("cred-1"),
+  rawId: bytes("cred-1"),
   response: {
-    attestationObject: new ArrayBuffer(1),
-    clientDataJSON: new ArrayBuffer(2),
+    clientDataJSON: bytes("client-data"),
+    attestationObject: bytes("attestation"),
     getTransports: () => ["internal", "hybrid"],
   },
+  type: "public-key",
 };
 
 // A stand-in for an older browser, whose attestation response has no
 // `getTransports` method.
 const attestationCredentialWithoutTransports = {
-  rawId: new ArrayBuffer(8),
+  ...attestationCredential,
   response: {
-    attestationObject: new ArrayBuffer(1),
-    clientDataJSON: new ArrayBuffer(2),
+    clientDataJSON: bytes("client-data"),
+    attestationObject: bytes("attestation"),
   },
 };
 
-// A stand-in for the credential `navigator.credentials.get()` returns.
-const assertionCredential = {
-  rawId: new ArrayBuffer(8),
+// The wire forms of the two responses, as the finish mutations receive them.
+const wireRegistrationResponse = {
+  id: wire("cred-1"),
+  rawId: wire("cred-1"),
   response: {
-    authenticatorData: new ArrayBuffer(1),
-    clientDataJSON: new ArrayBuffer(2),
-    signature: new ArrayBuffer(3),
+    clientDataJSON: wire("client-data"),
+    attestationObject: wire("attestation"),
+    transports: ["internal", "hybrid"],
   },
+  clientExtensionResults: {},
+  type: "public-key",
+};
+
+const wireAuthenticationResponse = {
+  id: wire("cred-1"),
+  rawId: wire("cred-1"),
+  response: {
+    clientDataJSON: wire("client-data"),
+    authenticatorData: wire("auth-data"),
+    signature: wire("signature"),
+    userHandle: wire("handle-1"),
+  },
+  clientExtensionResults: {},
+  type: "public-key",
 };
 
 beforeEach(() => {
@@ -253,11 +317,23 @@ describe("useUsernamePasskeySignIn signIn", () => {
     });
 
     expect(mutations.startSignIn).toHaveBeenCalledWith({ username: "alice" });
+    // The server-built options reach the browser with their binary fields
+    // decoded and everything else untouched.
+    const [createCall] = ceremonyCreate.mock.calls[0] as [
+      { publicKey: PublicKeyCredentialCreationOptions },
+    ];
+    expect(createCall.publicKey.challenge).toEqual(
+      fromBase64URL(creationOptions.challenge),
+    );
+    expect(createCall.publicKey.user.id).toEqual(
+      fromBase64URL(creationOptions.user.id),
+    );
+    expect(createCall.publicKey.rp).toEqual(creationOptions.rp);
+    expect(createCall.publicKey.attestation).toBe("none");
+    // The response reaches the finish mutation in the wire shape.
     expect(mutations.finishSignUp).toHaveBeenCalledWith({
       username: "alice",
-      attestationObject: attestationCredential.response.attestationObject,
-      clientDataJSON: attestationCredential.response.clientDataJSON,
-      transports: ["internal", "hybrid"],
+      response: wireRegistrationResponse,
     });
     expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
     expect(result.current.auth.isAuthenticated).toBe(true);
@@ -278,14 +354,14 @@ describe("useUsernamePasskeySignIn signIn", () => {
 
     expect(returned.success).toBe(true);
     const [args] = mutations.finishSignUp.mock.calls[0] as [
-      { transports?: string[] },
+      { response: { response: { transports?: string[] } } },
     ];
-    expect(args.transports).toBe(undefined);
+    expect(args.response.response).not.toHaveProperty("transports");
   });
 
   test("sign-in success runs the authentication ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(authenticateStart);
-    ceremonyGet.mockResolvedValue(assertionCredential);
+    ceremonyGet.mockResolvedValue(conditionalCredential);
     mutations.finishSignIn.mockResolvedValue({
       success: true,
       tokens: bundle,
@@ -299,22 +375,21 @@ describe("useUsernamePasskeySignIn signIn", () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
 
-    const [request] = ceremonyGet.mock.calls[0] as [
+    const [getCall] = ceremonyGet.mock.calls[0] as [
       { publicKey: PublicKeyCredentialRequestOptions },
     ];
-    expect(request.publicKey.allowCredentials).toEqual([
-      {
-        type: "public-key",
-        id: authenticateStart.allowCredentials[0].id,
-        transports: ["internal"],
-      },
-    ]);
-    // `rawId` carries the credential ID bytes, not the base64url `id`.
+    expect(getCall.publicKey.challenge).toEqual(
+      fromBase64URL(requestOptions.challenge),
+    );
+    expect(getCall.publicKey.rpId).toBe(requestOptions.rpId);
+    expect(getCall.publicKey.allowCredentials).toEqual(
+      requestOptions.allowCredentials.map((descriptor) => ({
+        ...descriptor,
+        id: fromBase64URL(descriptor.id),
+      })),
+    );
     expect(mutations.finishSignIn).toHaveBeenCalledWith({
-      credentialId: assertionCredential.rawId,
-      authenticatorData: assertionCredential.response.authenticatorData,
-      clientDataJSON: assertionCredential.response.clientDataJSON,
-      signature: assertionCredential.response.signature,
+      response: wireAuthenticationResponse,
     });
     expect(returned).toEqual({
       success: true,
@@ -403,7 +478,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
     // The first call still completes normally.
     let firstResult!: UsernamePasskeySignInResult;
     await act(async () => {
-      resolveCeremony(assertionCredential);
+      resolveCeremony(conditionalCredential);
       firstResult = await first;
     });
     expect(firstResult).toEqual({
@@ -425,7 +500,9 @@ describe("useUsernamePasskeySignIn signIn", () => {
   });
 
   test("signIn keeps one identity while the autofill status changes", async () => {
-    mutations.startAutofillSignIn.mockResolvedValue(requestOptions);
+    mutations.startAutofillSignIn.mockResolvedValue({
+      options: requestOptions,
+    });
     conditionalGet.mockImplementation(pendingForever);
     const { result, unmount } = renderPasskey();
     // Captured before the loop reports anything, so the assertion below
@@ -460,8 +537,10 @@ describe("useUsernamePasskeySignIn autofill", () => {
   });
 
   test("a picked passkey signs the user in: waiting → signedIn", async () => {
-    mutations.startAutofillSignIn.mockResolvedValue(requestOptions);
-    conditionalGet.mockResolvedValue(assertionCredential);
+    mutations.startAutofillSignIn.mockResolvedValue({
+      options: requestOptions,
+    });
+    conditionalGet.mockResolvedValue(conditionalCredential);
     mutations.finishSignIn.mockResolvedValue({
       success: true,
       tokens: bundle,
@@ -479,10 +558,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
     expect(call.signal).toBeInstanceOf(AbortSignal);
     expect(call.publicKey.rpId).toBe(requestOptions.rpId);
     expect(mutations.finishSignIn).toHaveBeenCalledWith({
-      credentialId: assertionCredential.rawId,
-      authenticatorData: assertionCredential.response.authenticatorData,
-      clientDataJSON: assertionCredential.response.clientDataJSON,
-      signature: assertionCredential.response.signature,
+      response: wireAuthenticationResponse,
     });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.passkey.autofill.lastError).toBe(null);
@@ -492,8 +568,10 @@ describe("useUsernamePasskeySignIn autofill", () => {
   });
 
   test("a success after a failed assertion clears lastError", async () => {
-    mutations.startAutofillSignIn.mockResolvedValue(requestOptions);
-    conditionalGet.mockResolvedValue(assertionCredential);
+    mutations.startAutofillSignIn.mockResolvedValue({
+      options: requestOptions,
+    });
+    conditionalGet.mockResolvedValue(conditionalCredential);
     // The first assertion fails on the server; the loop retries with a
     // fresh challenge and the second one succeeds.
     mutations.finishSignIn
@@ -521,7 +599,9 @@ describe("useUsernamePasskeySignIn autofill", () => {
   });
 
   test("signIn pauses the pending autofill request and resumes it after", async () => {
-    mutations.startAutofillSignIn.mockResolvedValue(requestOptions);
+    mutations.startAutofillSignIn.mockResolvedValue({
+      options: requestOptions,
+    });
     // The conditional (autofill) request stays pending until aborted; the
     // modal ceremony resolves. A modal ceremony while a conditional
     // request is still pending would displace it (the slot enforces this),
@@ -536,7 +616,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
       // ceremony started. The signal latches, thus this holds whether the
       // pause landed while the request was pending or still starting.
       expect(conditionalSignal?.aborted).toBe(true);
-      return Promise.resolve(assertionCredential);
+      return Promise.resolve(conditionalCredential);
     });
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     mutations.finishSignIn.mockResolvedValue({
@@ -676,8 +756,8 @@ describe("usePasskeyCeremonySlot", () => {
 });
 
 describe("usePasskeyAutofill", () => {
-  test("hands the picked assertion to onAssertion and reports success", async () => {
-    conditionalGet.mockResolvedValue(assertionCredential);
+  test("hands the picked response to onAssertion and reports success", async () => {
+    conditionalGet.mockResolvedValue(conditionalCredential);
     const start = vi.fn(async () => requestOptions);
     const onAssertion = vi.fn(async () => ({ success: true as const }));
     const { result, unmount } = renderHook(() =>
@@ -687,19 +767,14 @@ describe("usePasskeyAutofill", () => {
     await waitFor(() => expect(result.current.status).toBe("signedIn"));
     expect(result.current.available).toBe(true);
     expect(result.current.lastError).toBe(null);
-    expect(onAssertion).toHaveBeenCalledWith({
-      credentialId: assertionCredential.rawId,
-      authenticatorData: assertionCredential.response.authenticatorData,
-      clientDataJSON: assertionCredential.response.clientDataJSON,
-      signature: assertionCredential.response.signature,
-    });
+    expect(onAssertion).toHaveBeenCalledWith(wireAuthenticationResponse);
 
     unmount();
     await act(async () => {});
   });
 
   test("stops after three failed assertions in a row", async () => {
-    conditionalGet.mockResolvedValue(assertionCredential);
+    conditionalGet.mockResolvedValue(conditionalCredential);
     const start = vi.fn(async () => requestOptions);
     const flowError = { error: "VERIFICATION_FAILED" as const };
     const onAssertion = vi.fn(async () => ({

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -28,7 +28,15 @@ import {
   type AlreadyPendingFailure,
 } from "./react_impl.tsx";
 
-export type { PasskeyClientError } from "./client.ts";
+// Apps read the wire shapes and the browser-side failure shapes from here.
+export type {
+  PasskeyClientError,
+  PasskeyClientFailure,
+  WireAuthenticationResponse,
+  WireCreationOptions,
+  WireRegistrationResponse,
+  WireRequestOptions,
+} from "./client.ts";
 export type {
   UsernamePasskeyApi,
   UsernamePasskeyAutofillError,
@@ -110,13 +118,14 @@ export function useUsernamePasskeySignIn(
   ctxRef.current = { convex, api: usernamePasskeyApi, signInApi, setSession };
 
   const autofill = usePasskeyAutofill<UsernamePasskeyAutofillError>({
-    start: () => {
+    start: async () => {
       const { convex, api } = ctxRef.current;
-      return convex.mutation(api.startAutofillSignIn, {});
+      const { options } = await convex.mutation(api.startAutofillSignIn, {});
+      return options;
     },
-    onAssertion: async (assertion) => {
+    onAssertion: async (response) => {
       const { api, signInApi, setSession } = ctxRef.current;
-      const result = await signInApi.mutation(api.finishSignIn, assertion);
+      const result = await signInApi.mutation(api.finishSignIn, { response });
       if (!result.success) {
         return result;
       }

--- a/packages/core/src/components/passkey/react_impl.tsx
+++ b/packages/core/src/components/passkey/react_impl.tsx
@@ -10,14 +10,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  authenticateWithAutofill,
   foldClientError,
-  runAutofillAuthenticationCeremony,
   supportsWebAuthn,
-  type PasskeyAssertion,
   type PasskeyClientError,
   type PasskeyClientFailure,
+  type WireRequestOptions,
 } from "./client.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
+import type { WireAuthenticationResponse } from "./validation.ts";
 
 //------------------------------------------------------------------------------
 // Autofill
@@ -110,11 +111,11 @@ export function usePasskeyAutofill<E = never>(options: {
    */
   enabled?: boolean;
   /**
-   * Mint a fresh challenge for a conditional-mediation request, usually
-   * through the start mutation of the flow (the `startAutofillSignIn`
-   * mutation of a passkey recipe).
+   * Mint fresh options (with a fresh challenge) for a
+   * conditional-mediation request, usually through the start mutation of
+   * the flow (the `startAutofillSignIn` mutation of a passkey recipe).
    */
-  start: () => Promise<{ challenge: ArrayBuffer; rpId: string }>;
+  start: () => Promise<WireRequestOptions>;
   /**
    * Handle the assertion of the passkey the user picked, usually by
    * sending it to the flow's finish mutation. Return `success: false` with
@@ -122,7 +123,7 @@ export function usePasskeyAutofill<E = never>(options: {
    * a small cap); return `success: true` to end the flow as `"signedIn"`.
    */
   onAssertion: (
-    assertion: PasskeyAssertion,
+    response: WireAuthenticationResponse,
   ) => Promise<{ success: true } | { success: false; userError: E }>;
 }) {
   // The implementation flows from the following constraints:
@@ -278,7 +279,7 @@ export function usePasskeyAutofill<E = never>(options: {
           AUTOFILL_REFRESH_MS,
         );
 
-        const result = await runAutofillAuthenticationCeremony(
+        const result = await authenticateWithAutofill(
           requestOptions,
           controller.signal,
         );
@@ -315,7 +316,7 @@ export function usePasskeyAutofill<E = never>(options: {
         setStatus("signingIn");
         let outcome;
         try {
-          outcome = await optionsRef.current.onAssertion(result.assertion);
+          outcome = await optionsRef.current.onAssertion(result.response);
         } catch (cause) {
           if (!alive) {
             return;

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.ts";
 import { toArrayBuffer } from "./helpers.ts";
-import { CHALLENGE_TTL_MS } from "./validation.ts";
+import { CHALLENGE_TTL_MS } from "./constants.ts";
 import {
   ORIGIN,
   RP_ID,
@@ -11,6 +11,8 @@ import {
   encodeCBOR,
   generateES256Credential,
   generateRS256Credential,
+  registrationResponse,
+  toBase64URL,
 } from "@convex-dev/passkey-test-authenticator";
 import {
   expectProtocolError,
@@ -105,30 +107,31 @@ async function registrationArgs(
     userVerified: options.userVerified,
     credential: options.includeCredential === false ? undefined : credential,
   });
-  const args = {
+  const buildArgs = (extra: { transports?: string[] } = {}) => ({
     expectedRpId: RP_ID,
     expectedOrigin: ORIGIN,
     name: options.name,
-    attestationObject: toArrayBuffer(buildAttestationObject(authData)),
-    clientDataJSON: toArrayBuffer(
-      buildClientDataJSON({
+    response: registrationResponse({
+      credential,
+      attestationObject: buildAttestationObject(authData),
+      clientDataJSON: buildClientDataJSON({
         type: options.clientDataType ?? "webauthn.create",
         challenge,
         origin: options.origin ?? ORIGIN,
         crossOrigin: options.crossOrigin,
       }),
-    ),
-  };
+      transports: extra.transports,
+    }),
+  });
+  const args = buildArgs();
   const finish = (extra: { transports?: string[] } = {}) =>
     startUserId === null
       ? t.mutation(api.registration.finishRegistrationForNewUser, {
-          ...args,
-          ...extra,
+          ...buildArgs(extra),
           newUserId: userId,
         })
       : t.mutation(api.registration.finishRegistrationForExistingUser, {
-          ...args,
-          ...extra,
+          ...buildArgs(extra),
           verifiedUserId: userId,
         });
   return { credential, userHandle, args, finish };
@@ -784,11 +787,17 @@ describe("finishRegistration verification", () => {
         t.mutation(api.registration.finishRegistrationForExistingUser, {
           ...args,
           verifiedUserId: "user1",
-          clientDataJSON: toArrayBuffer(
-            new TextEncoder().encode(
-              JSON.stringify({ type: "webauthn.create", origin: ORIGIN }),
-            ),
-          ),
+          response: {
+            ...args.response,
+            response: {
+              ...args.response.response,
+              clientDataJSON: toBase64URL(
+                new TextEncoder().encode(
+                  JSON.stringify({ type: "webauthn.create", origin: ORIGIN }),
+                ),
+              ),
+            },
+          },
         }),
       "the client data JSON carries no challenge",
     );
@@ -839,10 +848,9 @@ describe("checkRegistrationForNewUser", () => {
   function checkArgs({
     expectedRpId,
     expectedOrigin,
-    attestationObject,
-    clientDataJSON,
+    response,
   }: Awaited<ReturnType<typeof registrationArgs>>["args"]) {
-    return { expectedRpId, expectedOrigin, attestationObject, clientDataJSON };
+    return { expectedRpId, expectedOrigin, response };
   }
 
   test("returns success for a valid attestation and writes nothing", async () => {
@@ -936,7 +944,13 @@ describe("checkRegistrationForNewUser", () => {
       () =>
         t.query(api.registration.checkRegistrationForNewUser, {
           ...checkArgs(args),
-          transports: ["smart card"],
+          response: {
+            ...args.response,
+            response: {
+              ...args.response.response,
+              transports: ["smart card"],
+            },
+          },
         }),
       'The client sent: ["smart card"].',
     );
@@ -978,7 +992,7 @@ describe("listPasskeys", () => {
     expect(result).toHaveLength(1);
     expect(result[0].passkeyId).toBe(passkeyId);
     expect(result[0].name).toBe("MacBook");
-    expectSameBytes(result[0].credentialId, credential.credentialId);
+    expect(result[0].credentialId).toBe(toBase64URL(credential.credentialId));
     expect(typeof result[0].createdAt).toBe("number");
     // The key material never leaves the component.
     expect(result[0]).not.toHaveProperty("publicKey");

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -69,10 +69,7 @@ import { Infer, v } from "convex/values";
 import { mutation, MutationCtx, query, QueryCtx } from "./_generated/server.ts";
 import { Doc, Id } from "./_generated/dataModel.ts";
 import { verifyRegistrationResponse } from "@simplewebauthn/server";
-import type {
-  AuthenticatorTransportFuture,
-  RegistrationResponseJSON,
-} from "@simplewebauthn/server";
+import type { RegistrationResponseJSON } from "@simplewebauthn/server";
 import {
   decodeAttestationObject,
   decodeClientDataJSON,
@@ -81,12 +78,13 @@ import {
 } from "@simplewebauthn/server/helpers";
 import {
   credentialDescriptor,
+  vRegistrationResponseJSON,
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
   transportsAreValid,
-  SUPPORTED_ALGORITHM_IDS,
 } from "./validation.ts";
+import { SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
 import {
   deleteDeadChallenge,
   findChallenge,
@@ -215,12 +213,7 @@ const registrationCheckArgs = {
   expectedRpId: v.string(),
   // The expected origin of the ceremony (for example, "https://app.example.com").
   expectedOrigin: v.string(),
-  attestationObject: v.bytes(),
-  clientDataJSON: v.bytes(),
-  // The transports that the browser reported for the new
-  // credential. The value is a hint: a later ceremony sends it back to the
-  // browser, and the verification does not use it.
-  transports: v.optional(v.array(v.string())),
+  response: vRegistrationResponseJSON,
 };
 
 const _vRegistrationCheckArgs = v.object(registrationCheckArgs);
@@ -318,7 +311,7 @@ export const finishRegistrationForNewUser = mutation({
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.newUserId,
       name: args.name,
-      transports: args.transports,
+      transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
       counter: result.credential.counter,
@@ -358,7 +351,7 @@ export const finishRegistrationForExistingUser = mutation({
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.verifiedUserId,
       name: args.name,
-      transports: args.transports,
+      transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
       counter: result.credential.counter,
@@ -473,14 +466,15 @@ async function lookupRegistrationChallenge(
     challengeRow: null,
   } as const;
 
-  if (!transportsAreValid(args.transports)) {
+  const { transports } = args.response.response;
+  if (!transportsAreValid(transports)) {
     console.warn(
-      `Rejected the passkey ceremony: the client reported transports that seem invalid. The client sent: ${JSON.stringify(args.transports).slice(0, 200)}.`,
+      `Rejected the passkey ceremony: the client reported transports that seem invalid. The client sent: ${JSON.stringify(transports).slice(0, 200)}.`,
     );
     return PROTOCOL_ERROR;
   }
   const clientData = okOrNull(() =>
-    decodeClientDataJSON(toBase64URL(args.clientDataJSON)),
+    decodeClientDataJSON(args.response.response.clientDataJSON),
   );
   if (clientData === null) {
     console.warn(
@@ -559,14 +553,13 @@ async function verifyAttestation(
 > {
   const PROTOCOL_ERROR = { userError: { error: "PROTOCOL_ERROR" } } as const;
 
-  // The wire carries raw ceremony bytes, not the WebAuthn JSON envelope, so
-  // the envelope is rebuilt here. `verifyRegistrationResponse` wants `id`
-  // and `rawId`, which the client never sends: they are read back out of
-  // the attested credential data, the same place the verification itself
-  // takes the authoritative credential ID from.
-  const attestationBytes = new Uint8Array(args.attestationObject);
+  // `verifyRegistrationResponse` runs all of these checks again.
+  // We still perform them manually so that we can log error messages
+  // that are more helpful.
   const authenticatorData = okOrNull(() => {
-    const attestation = decodeAttestationObject(attestationBytes);
+    const attestation = decodeAttestationObject(
+      isoBase64URL.toBuffer(args.response.response.attestationObject),
+    );
     return parseAuthenticatorData(attestation.get("authData"));
   });
   if (authenticatorData === null) {
@@ -601,24 +594,14 @@ async function verifyAttestation(
     );
     return PROTOCOL_ERROR;
   }
-  const credentialId = isoBase64URL.fromBuffer(authenticatorData.credentialID);
-
-  const response: RegistrationResponseJSON = {
-    id: credentialId,
-    rawId: credentialId,
-    response: {
-      clientDataJSON: toBase64URL(args.clientDataJSON),
-      attestationObject: toBase64URL(args.attestationObject),
-      transports: args.transports as AuthenticatorTransportFuture[] | undefined,
-    },
-    clientExtensionResults: {},
-    type: "public-key",
-  };
 
   let verification;
   try {
     verification = await verifyRegistrationResponse({
-      response,
+      // The wire type keeps `transports` as free-form strings, because the
+      // WebAuthn spec lets new transports appear; the library type does
+      // not. The verification does not read the transports.
+      response: args.response as RegistrationResponseJSON,
       expectedChallenge: toBase64URL(challengeRow.challenge),
       expectedOrigin: args.expectedOrigin,
       expectedRPID: args.expectedRpId,
@@ -688,7 +671,7 @@ export const listPasskeys = query({
     v.object({
       passkeyId: v.string(),
       name: v.optional(v.string()),
-      credentialId: v.bytes(),
+      credentialId: v.string(),
       createdAt: v.number(),
     }),
   ),
@@ -700,7 +683,7 @@ export const listPasskeys = query({
     return rows.map((row) => ({
       passkeyId: row._id,
       name: row.name,
-      credentialId: row.credentialId,
+      credentialId: toBase64URL(row.credentialId),
       createdAt: row._creationTime,
     }));
   },

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -13,10 +13,17 @@ import {
   validateUsernameFormat,
 } from "../username/validation.ts";
 import {
-  credentialDescriptor,
   finishAuthenticationUserError,
   finishRegistrationUserError,
+  vAuthenticationResponseJSON,
+  vPublicKeyCredentialCreationOptionsJSON,
+  vPublicKeyCredentialRequestOptionsJSON,
+  vRegistrationResponseJSON,
 } from "./validation.ts";
+import {
+  buildAuthenticationOptions,
+  buildRegistrationOptions,
+} from "./options.ts";
 import {
   finishAddPasskey,
   startAddPasskey,
@@ -80,19 +87,13 @@ const startSignInResult = v.union(
   v.object({
     success: v.literal(true),
     step: v.literal("authenticate"),
-    challenge: v.bytes(),
-    allowCredentials: v.array(credentialDescriptor),
-    rpId: v.string(),
+    options: vPublicKeyCredentialRequestOptionsJSON,
   }),
   // The username is free: register a new account with a new passkey.
   v.object({
     success: v.literal(true),
     step: v.literal("register"),
-    challenge: v.bytes(),
-    // The WebAuthn user handle (`user.id`) for the `create()` call.
-    userHandle: v.bytes(),
-    rpId: v.string(),
-    rpName: v.string(),
+    options: vPublicKeyCredentialCreationOptionsJSON,
   }),
   v.object({ success: v.literal(false), userError: setUsernameUserError }),
 );
@@ -104,8 +105,7 @@ const startSignInResult = v.union(
 export type StartSignInResult = Infer<typeof startSignInResult>;
 
 const startAutofillSignInResult = v.object({
-  challenge: v.bytes(),
-  rpId: v.string(),
+  options: vPublicKeyCredentialRequestOptionsJSON,
 });
 
 /**
@@ -251,9 +251,11 @@ export function setupUsernamePasskey<UsersTable extends string>(
               return {
                 success: true,
                 step: "authenticate",
-                challenge,
-                allowCredentials,
-                rpId,
+                options: buildAuthenticationOptions({
+                  rpId,
+                  challenge,
+                  allowCredentials,
+                }),
               };
             }
 
@@ -264,10 +266,19 @@ export function setupUsernamePasskey<UsersTable extends string>(
             return {
               success: true,
               step: "register",
-              challenge,
-              userHandle,
-              rpId,
-              rpName,
+              options: buildRegistrationOptions({
+                rpId,
+                rpName,
+                challenge,
+                userHandle,
+                // What the browser shows for the new passkey in its passkey manager.
+                // TODO(nicolas) Think of how we could allow the app to customize this
+                userName: username,
+                userDisplayName: username,
+                // A sign-up ceremony makes the first passkey of a brand-new
+                // user, so there are no credentials to exclude.
+                excludeCredentials: [],
+              }),
             };
           },
         }),
@@ -285,7 +296,13 @@ export function setupUsernamePasskey<UsersTable extends string>(
               component.authentication.startAuthentication,
               { purpose: SIGN_IN_PURPOSE },
             );
-            return { challenge, rpId };
+            return {
+              options: buildAuthenticationOptions({
+                rpId,
+                challenge,
+                allowCredentials: [],
+              }),
+            };
           },
         }),
 
@@ -309,9 +326,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
         finishSignUp: authMutation({
           args: {
             username: v.string(),
-            attestationObject: v.bytes(),
-            clientDataJSON: v.bytes(),
-            transports: v.optional(v.array(v.string())),
+            response: vRegistrationResponseJSON,
           },
           returns: finishSignUpResult,
           handler: async (ctx, args): Promise<FinishSignUpResult> => {
@@ -336,9 +351,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               {
                 expectedRpId: rpId,
                 expectedOrigin: origin,
-                attestationObject: args.attestationObject,
-                clientDataJSON: args.clientDataJSON,
-                transports: args.transports,
+                response: args.response,
               },
             );
             if (!checkResult.success) {
@@ -381,9 +394,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 expectedRpId: rpId,
                 expectedOrigin: origin,
                 newUserId: tokens.userId,
-                attestationObject: args.attestationObject,
-                clientDataJSON: args.clientDataJSON,
-                transports: args.transports,
+                response: args.response,
               },
             );
             if (!registrationResult.success) {
@@ -416,10 +427,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
          */
         finishSignIn: authMutation({
           args: {
-            credentialId: v.bytes(),
-            authenticatorData: v.bytes(),
-            clientDataJSON: v.bytes(),
-            signature: v.bytes(),
+            response: vAuthenticationResponseJSON,
           },
           returns: finishSignInResult,
           handler: async (ctx, args): Promise<FinishSignInResult> => {
@@ -429,10 +437,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 purpose: SIGN_IN_PURPOSE,
                 expectedRpId: rpId,
                 expectedOrigin: origin,
-                credentialId: args.credentialId,
-                authenticatorData: args.authenticatorData,
-                clientDataJSON: args.clientDataJSON,
-                signature: args.signature,
+                response: args.response,
               },
             );
             if (!authenticationResult.success) {

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -110,7 +110,7 @@ const startAutofillSignInResult = v.object({
 
 /**
  * The result of `startAutofillSignIn`: an unbound challenge for a
- * conditional-mediation (passkey autofill) `get()` call.
+ * conditional-mediation (passkey autofill) `navigator.credentials.get()` call.
  */
 export type StartAutofillSignInResult = Infer<typeof startAutofillSignInResult>;
 

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -1,21 +1,10 @@
 import { Infer, v } from "convex/values";
-
-// How long a stored challenge stays valid. The WebAuthn spec recommends
-// ceremony timeouts of 5–10 minutes to leave room for user interaction
-// (PIN entry, cross-device flows); we match the upper bound. Expiring
-// challenges bounds the window for replay of an intercepted challenge.
-// https://www.w3.org/TR/webauthn-3/#sctn-timeout-recommended-range
-export const CHALLENGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-// The COSE signature algorithms this provider accepts, as IANA identifiers
-// (https://www.iana.org/assignments/cose/cose.xhtml#algorithms). This list
-// is enforced when the attestation is verified. The client offers its own
-// `pubKeyCredParams` literal in `react.tsx`, so keep the two lists in sync
-// by hand. `@simplewebauthn/server` also verifies Ed25519 (-8).
-export const SUPPORTED_ALGORITHM_IDS = [
-  -7, // ES256
-  -257, // RS256
-];
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from "@simplewebauthn/server";
 
 /**
  * Constants used for some basic best-effort validation of the
@@ -110,6 +99,160 @@ export const credentialDescriptor = v.object({
   transports: v.optional(v.array(v.string())),
 });
 export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
+
+//------------------------------------------------------------------------------
+// The WebAuthn JSON wire format
+//------------------------------------------------------------------------------
+//
+// The wire between the client and the provider carries the spec's JSON
+// shapes (https://w3c.github.io/webauthn/#dictdef-registrationresponsejson
+// and friends): base64url strings for the binary fields, options assembled
+// on the server by `options.ts`, and responses fed to
+// `verifyRegistrationResponse` / `verifyAuthenticationResponse` unchanged.
+//
+// The validators are exact: they list every field the server produces or
+// reads, and nothing else. A client must prune the convenience fields that
+// `@simplewebauthn/browser` adds to a response (`publicKey`,
+// `publicKeyAlgorithm`, `authenticatorData`, `authenticatorAttachment`)
+// before it calls a mutation; the React hooks do that pruning.
+
+/**
+ * A library type with every `transports` list widened to plain strings.
+ * The wire keeps the transports open because the WebAuthn spec lets new
+ * transports appear, and the component stores them as free-form strings.
+ * Used only by the `_…Matches` pins below.
+ */
+type OpenTransports<T> = T extends readonly (infer E)[]
+  ? OpenTransports<E>[]
+  : T extends object
+    ? {
+        [K in keyof T]: K extends "transports"
+          ? string[]
+          : OpenTransports<T[K]>;
+      }
+    : T;
+
+/** Require `A` to be assignable to `B` (used as a compile-time pin). */
+type Extends<A extends B, B> = A;
+
+/** The JSON form of {@link credentialDescriptor}, for the options objects. */
+const credentialDescriptorJSON = v.object({
+  id: v.string(),
+  type: v.literal("public-key"),
+  transports: v.optional(v.array(v.string())),
+});
+
+/**
+ * The `PublicKeyCredentialCreationOptionsJSON` that the start mutations of a
+ * registration ceremony return. Pass it to the WebAuthn `create()` call
+ * (for example through `startRegistration` of `@simplewebauthn/browser`).
+ *
+ * The shape is exactly what `generateRegistrationOptions` produces with the
+ * settings of this provider: `attestation: "none"`, a discoverable
+ * credential with required user verification, and no extensions.
+ */
+export const vPublicKeyCredentialCreationOptionsJSON = v.object({
+  rp: v.object({ id: v.string(), name: v.string() }),
+  user: v.object({
+    id: v.string(),
+    name: v.string(),
+    displayName: v.string(),
+  }),
+  challenge: v.string(),
+  pubKeyCredParams: v.array(
+    v.object({ alg: v.number(), type: v.literal("public-key") }),
+  ),
+  timeout: v.number(),
+  excludeCredentials: v.array(credentialDescriptorJSON),
+  authenticatorSelection: v.object({
+    residentKey: v.literal("required"),
+    requireResidentKey: v.literal(true),
+    userVerification: v.literal("required"),
+  }),
+  attestation: v.literal("none"),
+  extensions: v.object({}),
+});
+export type WireCreationOptions = Infer<
+  typeof vPublicKeyCredentialCreationOptionsJSON
+>;
+type _CreationOptionsMatch = Extends<
+  WireCreationOptions,
+  OpenTransports<PublicKeyCredentialCreationOptionsJSON>
+>;
+
+/**
+ * The `PublicKeyCredentialRequestOptionsJSON` that the start mutations of an
+ * authentication ceremony return. Pass it to the WebAuthn `get()` call (for
+ * example through `startAuthentication` of `@simplewebauthn/browser`).
+ *
+ * An empty `allowCredentials` list means a discoverable-credential ceremony:
+ * the passkey the user picks identifies the account.
+ */
+export const vPublicKeyCredentialRequestOptionsJSON = v.object({
+  challenge: v.string(),
+  timeout: v.number(),
+  rpId: v.string(),
+  allowCredentials: v.array(credentialDescriptorJSON),
+  userVerification: v.literal("required"),
+});
+export type WireRequestOptions = Infer<
+  typeof vPublicKeyCredentialRequestOptionsJSON
+>;
+type _RequestOptionsMatch = Extends<
+  WireRequestOptions,
+  OpenTransports<PublicKeyCredentialRequestOptionsJSON>
+>;
+
+/**
+ * The `RegistrationResponseJSON` that the finish mutations of a registration
+ * ceremony take, without the convenience fields that duplicate data from the
+ * attestation object (`publicKey`, `publicKeyAlgorithm`,
+ * `authenticatorData`, `authenticatorAttachment`).
+ *
+ * `clientExtensionResults` must be empty because the options request no
+ * extensions.
+ */
+export const vRegistrationResponseJSON = v.object({
+  id: v.string(),
+  rawId: v.string(),
+  response: v.object({
+    clientDataJSON: v.string(),
+    attestationObject: v.string(),
+    transports: v.optional(v.array(v.string())),
+  }),
+  clientExtensionResults: v.object({}),
+  type: v.literal("public-key"),
+});
+export type WireRegistrationResponse = Infer<typeof vRegistrationResponseJSON>;
+type _RegistrationResponseMatch = Extends<
+  WireRegistrationResponse,
+  OpenTransports<RegistrationResponseJSON>
+>;
+
+/**
+ * The `AuthenticationResponseJSON` that the finish mutations of an
+ * authentication ceremony take. `clientExtensionResults` must be empty
+ * because the options request no extensions.
+ */
+export const vAuthenticationResponseJSON = v.object({
+  id: v.string(),
+  rawId: v.string(),
+  response: v.object({
+    clientDataJSON: v.string(),
+    authenticatorData: v.string(),
+    signature: v.string(),
+    userHandle: v.optional(v.string()),
+  }),
+  clientExtensionResults: v.object({}),
+  type: v.literal("public-key"),
+});
+export type WireAuthenticationResponse = Infer<
+  typeof vAuthenticationResponseJSON
+>;
+type _AuthenticationResponseMatch = Extends<
+  WireAuthenticationResponse,
+  AuthenticationResponseJSON
+>;
 
 /**
  * The client broke the WebAuthn protocol: an unexpected origin, an

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -182,7 +182,7 @@ type _CreationOptionsMatch = Extends<
 
 /**
  * The `PublicKeyCredentialRequestOptionsJSON` that the start mutations of an
- * authentication ceremony return. Pass it to the WebAuthn `get()` call (for
+ * authentication ceremony return. Pass it to the WebAuthn `navigator.credentials.get()` call (for
  * example through `startAuthentication` of `@simplewebauthn/browser`).
  *
  * An empty `allowCredentials` list means a discoverable-credential ceremony:

--- a/packages/core/src/components/passkeyTestSetup.ts
+++ b/packages/core/src/components/passkeyTestSetup.ts
@@ -8,10 +8,10 @@ import {
   buildAuthenticatorData,
   buildClientDataJSON,
   generateES256Credential,
+  registrationResponse,
   type TestCredential,
 } from "@convex-dev/passkey-test-authenticator";
 import { api } from "./passkey/_generated/api.ts";
-import { toArrayBuffer } from "./passkey/helpers.ts";
 import schema from "./passkey/schema.ts";
 
 export const modules = import.meta.glob("./passkey/**/*.ts");
@@ -84,15 +84,16 @@ export async function register(
       expectedOrigin: ORIGIN,
       verifiedUserId: userId,
       name: options.name,
-      transports: options.transports,
-      attestationObject: toArrayBuffer(buildAttestationObject(authData)),
-      clientDataJSON: toArrayBuffer(
-        buildClientDataJSON({
+      response: registrationResponse({
+        credential,
+        attestationObject: buildAttestationObject(authData),
+        clientDataJSON: buildClientDataJSON({
           type: "webauthn.create",
           challenge,
           origin: ORIGIN,
         }),
-      ),
+        transports: options.transports,
+      }),
     },
   );
   if (!result.success) {

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -8,12 +8,48 @@ import {
   decodeBase64url,
   encodeBase64url,
   sha256,
-  toArrayBuffer,
   toDERSignature,
 } from "./bytes.ts";
 import { encodeCBOR, type CBORValue } from "./cbor.ts";
 
 export { encodeCBOR, type CBORValue };
+
+/**
+ * The `RegistrationResponseJSON` wire envelope of a `create()` call, pruned
+ * to the fields that the exact validators of a relying party accept.
+ */
+export type RegistrationResponseEnvelope = {
+  id: string;
+  rawId: string;
+  response: {
+    clientDataJSON: string;
+    attestationObject: string;
+    transports?: string[];
+  };
+  clientExtensionResults: Record<string, never>;
+  type: "public-key";
+};
+
+/** The `AuthenticationResponseJSON` wire envelope of a `get()` call. */
+export type AuthenticationResponseEnvelope = {
+  id: string;
+  rawId: string;
+  response: {
+    clientDataJSON: string;
+    authenticatorData: string;
+    signature: string;
+    userHandle?: string;
+  };
+  clientExtensionResults: Record<string, never>;
+  type: "public-key";
+};
+
+/** Encode ceremony bytes the way the JSON wire carries them. */
+export function toBase64URL(bytes: Uint8Array | ArrayBuffer): string {
+  return encodeBase64url(
+    bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes),
+  );
+}
 
 /**
  * The relying party that the authenticator uses when a caller names none. An
@@ -92,16 +128,17 @@ export function buildClientDataJSON({
   crossOrigin,
 }: {
   type: "webauthn.create" | "webauthn.get";
-  challenge: ArrayBuffer | Uint8Array;
+  // Raw challenge bytes, or the base64url string of an options object.
+  challenge: ArrayBuffer | Uint8Array | string;
   origin: string;
   crossOrigin?: boolean;
 }): Uint8Array {
-  const bytes =
-    challenge instanceof Uint8Array ? challenge : new Uint8Array(challenge);
+  const base64url =
+    typeof challenge === "string" ? challenge : toBase64URL(challenge);
   return new TextEncoder().encode(
     JSON.stringify({
       type,
-      challenge: encodeBase64url(bytes),
+      challenge: base64url,
       origin,
       ...(crossOrigin !== undefined ? { crossOrigin } : {}),
     }),
@@ -186,10 +223,32 @@ export async function signAssertion(
   );
 }
 
-/** Build the arguments of an authentication ceremony. */
+export function registrationResponse(options: {
+  credential: Pick<TestCredential, "credentialId">;
+  attestationObject: Uint8Array;
+  clientDataJSON: Uint8Array;
+  transports?: string[];
+}): RegistrationResponseEnvelope {
+  const id = toBase64URL(options.credential.credentialId);
+  return {
+    id,
+    rawId: id,
+    response: {
+      clientDataJSON: toBase64URL(options.clientDataJSON),
+      attestationObject: toBase64URL(options.attestationObject),
+      ...(options.transports !== undefined
+        ? { transports: options.transports }
+        : {}),
+    },
+    clientExtensionResults: {},
+    type: "public-key",
+  };
+}
+
+/** Build the `response` argument of an authentication finish mutation. */
 export async function buildAssertion(
   credential: TestCredential,
-  challenge: ArrayBuffer | Uint8Array,
+  challenge: ArrayBuffer | Uint8Array | string,
   options: {
     type?: "webauthn.create" | "webauthn.get";
     origin?: string;
@@ -201,12 +260,7 @@ export async function buildAssertion(
     // Sign with a different key than `credential` (an invalid signature).
     signWith?: TestCredential;
   } = {},
-): Promise<{
-  credentialId: ArrayBuffer;
-  authenticatorData: ArrayBuffer;
-  clientDataJSON: ArrayBuffer;
-  signature: ArrayBuffer;
-}> {
+): Promise<{ response: AuthenticationResponseEnvelope }> {
   const clientDataJSON = buildClientDataJSON({
     type: options.type ?? "webauthn.get",
     challenge,
@@ -224,10 +278,20 @@ export async function buildAssertion(
     authenticatorData,
     clientDataJSON,
   );
+  const id = toBase64URL(credential.credentialId);
   return {
-    credentialId: toArrayBuffer(credential.credentialId),
-    authenticatorData: toArrayBuffer(authenticatorData),
-    clientDataJSON: toArrayBuffer(clientDataJSON),
-    signature: toArrayBuffer(signature),
+    // Wrapped in `{ response }`, so tests can spread the result into the
+    // arguments of a finish mutation.
+    response: {
+      id,
+      rawId: id,
+      response: {
+        clientDataJSON: toBase64URL(clientDataJSON),
+        authenticatorData: toBase64URL(authenticatorData),
+        signature: toBase64URL(signature),
+      },
+      clientExtensionResults: {},
+      type: "public-key",
+    },
   };
 }

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -30,7 +30,7 @@ export type RegistrationResponseEnvelope = {
   type: "public-key";
 };
 
-/** The `AuthenticationResponseJSON` wire envelope of a `get()` call. */
+/** The `AuthenticationResponseJSON` wire envelope of a `navigator.credentials.get()` call. */
 export type AuthenticationResponseEnvelope = {
   id: string;
   rawId: string;


### PR DESCRIPTION
This changes the format of the argument/return values used by the passkey component and provider. Instead of using `v.bytes()`, we now use objects similar to [`RegistrationResponseJSON`](https://w3c.github.io/webauthn/#dictdef-registrationresponsejson).

This will make it easier to switch to using SimpleWebAuthn everywhere, because it will allow us to use these request/response structures directly instead of converting to/from our custom wire format.

Nothing in this wire format is proprietary to SimpleWebAuthn, so if we ever wanted to change the underlying implementation in the future we wouldn’t need any breaking change.