### PR TITLE
passkey: validate passkey names

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -75,6 +75,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           expectedOrigin: string;
           expectedRpId: string;
+          name?: string;
           response: {
             clientExtensionResults: {};
             id: string;
@@ -91,7 +92,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
+              | { error: "CHALLENGE_EXPIRED" }
+              | { error: "PROTOCOL_ERROR" }
+              | { error: "INVALID_NAME" };
           },
         Name
       >;
@@ -134,7 +137,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
+              | { error: "CHALLENGE_EXPIRED" }
+              | { error: "PROTOCOL_ERROR" }
+              | { error: "INVALID_NAME" };
           },
         Name
       >;
@@ -162,7 +167,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         | {
             success: false;
             userError:
-              { error: "CHALLENGE_EXPIRED" } | { error: "PROTOCOL_ERROR" };
+              | { error: "CHALLENGE_EXPIRED" }
+              | { error: "PROTOCOL_ERROR" }
+              | { error: "INVALID_NAME" };
           },
         Name
       >;

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -256,13 +256,24 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
         },
       );
       if (!registrationResult.success) {
+        const { userError } = registrationResult;
+        if (userError.error === "INVALID_NAME") {
+          // Not possible: this function passes no `name`, thus the component
+          // stores its default name. The provider does not let an app name a
+          // passkey at registration yet.
+          // TODO(nicolas) Allow the user to provide a custom name when creating a passkey
+          throw new Error(
+            "Unexpected error when storing the passkey: INVALID_NAME",
+            { cause: userError },
+          );
+        }
         // A `PROTOCOL_ERROR` here also covers a registration ceremony that
         // belongs to a different user than the caller, which happens when the
         // caller signs in as a different user after the `verifyAddPasskey`
         // call. `finishRegistrationForExistingUser` compares the owner of the
         // ceremony with `verifiedUserId`, thus this call needs no check of its
         // own. See the same case in `verifyAddPasskey`.
-        return { success: false, userError: registrationResult.userError };
+        return { success: false, userError };
       }
       return { success: true, passkeyId: registrationResult.passkeyId };
     },

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -849,8 +849,9 @@ describe("checkRegistrationForNewUser", () => {
     expectedRpId,
     expectedOrigin,
     response,
+    name,
   }: Awaited<ReturnType<typeof registrationArgs>>["args"]) {
-    return { expectedRpId, expectedOrigin, response };
+    return { expectedRpId, expectedOrigin, response, name };
   }
 
   test("returns success for a valid attestation and writes nothing", async () => {
@@ -968,6 +969,58 @@ describe("checkRegistrationForNewUser", () => {
     expect(check).toEqual({ success: true });
     const result = await finish();
     expect(result.success).toBe(true);
+  });
+
+  test("returns INVALID_NAME for a name that the finish call refuses", async () => {
+    const t = setup();
+    const { args, finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+      name: "   ",
+    });
+    const invalid = { success: false, userError: { error: "INVALID_NAME" } };
+    expect(
+      await t.query(
+        api.registration.checkRegistrationForNewUser,
+        checkArgs(args),
+      ),
+    ).toEqual(invalid);
+    expect(await finish()).toEqual(invalid);
+  });
+});
+
+describe("passkey names at registration", () => {
+  test("refuses a name that the component could not store", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      name: "   ",
+    });
+    expect(await finish()).toEqual({
+      success: false,
+      userError: { error: "INVALID_NAME" },
+    });
+    // The challenge survives, so the same ceremony can be finished again
+    // with a name the component stores.
+    expect(
+      await t.run((ctx) => ctx.db.query("challenges").collect()),
+    ).toHaveLength(1);
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
+  });
+
+  test("refuses a name that the component could not store, for a new user", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+      name: "os\u009dcontrol",
+    });
+    expect(await finish()).toEqual({
+      success: false,
+      userError: { error: "INVALID_NAME" },
+    });
+    expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { api } from "./_generated/api.ts";
 import { toArrayBuffer } from "./helpers.ts";
+import { MAX_PASSKEY_NAME_LENGTH } from "./validation.ts";
 import { CHALLENGE_TTL_MS } from "./constants.ts";
 import {
   ORIGIN,
@@ -989,20 +990,32 @@ describe("checkRegistrationForNewUser", () => {
 });
 
 describe("passkey names at registration", () => {
+  const invalidNames = {
+    "only whitespace": "   ",
+    "a C1 control": "os\u009dcontrol",
+    "a line feed": "two\nlines",
+    "a right-to-left override": "Mac\u202eBook",
+    "a zero-width space": "Mac\u200bBook",
+    "a byte order mark": "Mac\ufeffBook",
+    "51 code points": "a".repeat(MAX_PASSKEY_NAME_LENGTH + 1),
+    "51 astral code points": "😀".repeat(MAX_PASSKEY_NAME_LENGTH + 1),
+  };
+
   test("refuses a name that the component could not store", async () => {
     const t = setup();
-    const { finish } = await registrationArgs(t, "user1", {
-      name: "   ",
-    });
-    expect(await finish()).toEqual({
-      success: false,
-      userError: { error: "INVALID_NAME" },
-    });
-    // The challenge survives, so the same ceremony can be finished again
-    // with a name the component stores.
+    let userId = 0;
+    for (const [description, name] of Object.entries(invalidNames)) {
+      const { finish } = await registrationArgs(t, `user${userId++}`, { name });
+      expect(await finish(), description).toEqual({
+        success: false,
+        userError: { error: "INVALID_NAME" },
+      });
+    }
+    // The challenges survive, so the same ceremonies can be finished again
+    // with names the component stores.
     expect(
       await t.run((ctx) => ctx.db.query("challenges").collect()),
-    ).toHaveLength(1);
+    ).toHaveLength(Object.keys(invalidNames).length);
     expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
       [],
     );
@@ -1021,6 +1034,28 @@ describe("passkey names at registration", () => {
     expect(await t.run((ctx) => ctx.db.query("passkeys").collect())).toEqual(
       [],
     );
+  });
+
+  test("stores a name that is at the limit or that needs a joiner", async () => {
+    const t = setup();
+    // The limit counts code points, thus an astral character counts as one.
+    const accepted = [
+      "a".repeat(MAX_PASSKEY_NAME_LENGTH),
+      "😀".repeat(MAX_PASSKEY_NAME_LENGTH),
+      // A zero-width joiner is necessary for some scripts and for emoji
+      // sequences, thus it stays permitted.
+      "family\u{1f468}\u200d\u{1f469}\u200d\u{1f466}",
+    ];
+    let userId = 0;
+    for (const name of accepted) {
+      const { finish } = await registrationArgs(t, `user${userId++}`, { name });
+      expect(await finish(), name).toMatchObject({ success: true });
+    }
+    expect(
+      await t.run(async (ctx) =>
+        (await ctx.db.query("passkeys").collect()).map((row) => row.name),
+      ),
+    ).toEqual(accepted);
   });
 });
 

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -252,8 +252,6 @@ export const checkRegistrationForNewUser = query({
   args: finishRegistrationArgs,
   returns: checkRegistrationResult,
   handler: async (ctx, args): Promise<CheckRegistrationResult> => {
-    // The same check as in `finishRegistrationForNewUser`, so that the
-    // guarantee above holds for the `name` argument too.
     if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
       return { success: false, userError: { error: "INVALID_NAME" } };
     }
@@ -298,9 +296,6 @@ export const finishRegistrationForNewUser = mutation({
   args: { ...finishRegistrationArgs, newUserId: v.string() },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
-    // Before the ceremony is consumed: a name the component cannot store
-    // must not burn the challenge of a ceremony that could otherwise run
-    // again with a name that it can.
     if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
       return { success: false, userError: { error: "INVALID_NAME" } };
     }
@@ -355,7 +350,6 @@ export const finishRegistrationForExistingUser = mutation({
   args: { ...finishRegistrationArgs, verifiedUserId: v.string() },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
-    // See the note in `finishRegistrationForNewUser`.
     if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
       return { success: false, userError: { error: "INVALID_NAME" } };
     }

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -81,6 +81,8 @@ import {
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
+  invalidNameUserError,
+  passkeyNameIsValid,
   transportsAreValid,
 } from "./validation.ts";
 import { SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
@@ -220,6 +222,8 @@ type RegistrationCheckArgs = Infer<typeof _vRegistrationCheckArgs>;
 
 const finishRegistrationArgs = {
   ...registrationCheckArgs,
+  // The name of the passkey, for display in a settings list. See
+  // {@link passkeyNameIsValid}.
   name: v.optional(v.string()),
 };
 
@@ -227,7 +231,7 @@ const checkRegistrationResult = v.union(
   v.object({ success: v.literal(true) }),
   v.object({
     success: v.literal(false),
-    userError: finishRegistrationUserError,
+    userError: v.union(finishRegistrationUserError, invalidNameUserError),
   }),
 );
 type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
@@ -245,9 +249,14 @@ type CheckRegistrationResult = Infer<typeof checkRegistrationResult>;
  * arguments in the same mutation does not return a `userError`.
  */
 export const checkRegistrationForNewUser = query({
-  args: registrationCheckArgs,
+  args: finishRegistrationArgs,
   returns: checkRegistrationResult,
   handler: async (ctx, args): Promise<CheckRegistrationResult> => {
+    // The same check as in `finishRegistrationForNewUser`, so that the
+    // guarantee above holds for the `name` argument too.
+    if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
+      return { success: false, userError: { error: "INVALID_NAME" } };
+    }
     const ceremony = await verifyRegistrationAttempt(ctx, args, {
       kind: "newUser",
     });
@@ -266,7 +275,7 @@ const finishRegistrationResult = v.union(
   v.object({ success: v.literal(true), passkeyId: v.string() }),
   v.object({
     success: v.literal(false),
-    userError: finishRegistrationUserError,
+    userError: v.union(finishRegistrationUserError, invalidNameUserError),
   }),
 );
 type FinishRegistrationResult = Infer<typeof finishRegistrationResult>;
@@ -289,6 +298,12 @@ export const finishRegistrationForNewUser = mutation({
   args: { ...finishRegistrationArgs, newUserId: v.string() },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
+    // Before the ceremony is consumed: a name the component cannot store
+    // must not burn the challenge of a ceremony that could otherwise run
+    // again with a name that it can.
+    if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
+      return { success: false, userError: { error: "INVALID_NAME" } };
+    }
     const result = await consumeRegistration(ctx, args, { kind: "newUser" });
     if (result.userError !== null) {
       return { success: false, userError: result.userError };
@@ -340,6 +355,10 @@ export const finishRegistrationForExistingUser = mutation({
   args: { ...finishRegistrationArgs, verifiedUserId: v.string() },
   returns: finishRegistrationResult,
   handler: async (ctx, args): Promise<FinishRegistrationResult> => {
+    // See the note in `finishRegistrationForNewUser`.
+    if (args.name !== undefined && !passkeyNameIsValid(args.name)) {
+      return { success: false, userError: { error: "INVALID_NAME" } };
+    }
     const result = await consumeRegistration(ctx, args, {
       kind: "existingUser",
       userId: args.verifiedUserId,

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -355,7 +355,17 @@ export function setupUsernamePasskey<UsersTable extends string>(
               },
             );
             if (!checkResult.success) {
-              return { success: false, userError: checkResult.userError };
+              const { userError } = checkResult;
+              if (userError.error === "INVALID_NAME") {
+                // Not possible: this function passes no `name`, thus the
+                // component stores its default name. See the same case in
+                // `finishAddPasskey`.
+                throw new Error(
+                  "Unexpected error when storing the passkey: INVALID_NAME",
+                  { cause: userError },
+                );
+              }
+              return { success: false, userError };
             }
 
             // Create the account + app user (via the app's createUser) and

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -310,11 +310,25 @@ export type FinishAuthenticationUserError = Infer<
 export const MAX_PASSKEY_NAME_LENGTH = 50;
 
 /**
+ * Characters that make the text direction or the position of the subsequent
+ * characters different, and characters that show nothing. An attacker uses
+ * them to show a name that is not the name that the component stores, or to
+ * make a name disappear from the settings list. The list is the list of the
+ * username validator.
+ *
+ * The list does not contain the zero-width joiner (U+200D) and the
+ * zero-width non-joiner (U+200C). These two characters are necessary to
+ * write some scripts correctly, and also to write emoji sequences.
+ */
+const BIDI_AND_INVISIBLE_CONTROLS =
+  /[\u061c\u200b\u200e\u200f\u202a-\u202e\u2066-\u2069\ufeff]/u;
+
+/**
  * Examine a passkey name before the component stores it.
  *
  * The component only refuses what no real label is: an empty or
- * whitespace-only string, control characters, or a length over
- * {@link MAX_PASSKEY_NAME_LENGTH} code points.
+ * whitespace-only string, control characters, characters that spoof how the
+ * name shows, or a length over {@link MAX_PASSKEY_NAME_LENGTH} code points.
  */
 export function passkeyNameIsValid(name: string): boolean {
   return (
@@ -323,13 +337,14 @@ export function passkeyNameIsValid(name: string): boolean {
     // `\p{Cc}` is the whole Unicode control category: the C0 range and
     // DEL, and the C1 range (U+0080-U+009F), which a paste from a legacy
     // encoding can carry.
-    !/\p{Cc}/u.test(name)
+    !/\p{Cc}/u.test(name) &&
+    !BIDI_AND_INVISIBLE_CONTROLS.test(name)
   );
 }
 
 /**
- * The name is empty, too long, or contains control characters. See
- * {@link passkeyNameIsValid}.
+ * The name is empty, too long, or contains characters that the component
+ * refuses. See {@link passkeyNameIsValid}.
  */
 export const invalidNameUserError = v.object({
   error: v.literal("INVALID_NAME"),

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -303,6 +303,39 @@ export type FinishAuthenticationUserError = Infer<
 >;
 
 /**
+ * The largest length of a passkey name, in Unicode code points. A name is a
+ * short label in a settings list ("MacBook Touch ID"); the limit stops a
+ * client from writing large data to the row.
+ */
+export const MAX_PASSKEY_NAME_LENGTH = 50;
+
+/**
+ * Examine a passkey name before the component stores it.
+ *
+ * The component only refuses what no real label is: an empty or
+ * whitespace-only string, control characters, or a length over
+ * {@link MAX_PASSKEY_NAME_LENGTH} code points.
+ */
+export function passkeyNameIsValid(name: string): boolean {
+  return (
+    name.trim().length > 0 &&
+    [...name].length <= MAX_PASSKEY_NAME_LENGTH &&
+    // `\p{Cc}` is the whole Unicode control category: the C0 range and
+    // DEL, and the C1 range (U+0080-U+009F), which a paste from a legacy
+    // encoding can carry.
+    !/\p{Cc}/u.test(name)
+  );
+}
+
+/**
+ * The name is empty, too long, or contains control characters. See
+ * {@link passkeyNameIsValid}.
+ */
+export const invalidNameUserError = v.object({
+  error: v.literal("INVALID_NAME"),
+});
+
+/**
  * The user-facing errors for `deletePasskey`. An app can show these errors
  * to the end user.
  */


### PR DESCRIPTION
This is the first PR of a stack that will allow passkeys to have names, so that they are easier for users to identify.

The `passkeys` table already has a `name` field (that so far we are never setting). Since we will allow users to set values, we need some basic amount of validation to ensure users don’t abuse it to store the entire [Bee Movie script](https://knowyourmeme.com/memes/bee-movie-script-according-to-all-known-laws-of-aviation).