### PR TITLE
Give sign-in results a `status` discriminant

### DIFF
--- a/examples/nextjs/app/signin/page.tsx
+++ b/examples/nextjs/app/signin/page.tsx
@@ -30,7 +30,7 @@ export default function SignIn() {
           e.preventDefault();
           setError(null);
           const result = await signIn({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             router.push("/");
             return;
           }

--- a/examples/nextjs/app/signup/page.tsx
+++ b/examples/nextjs/app/signup/page.tsx
@@ -27,7 +27,7 @@ export default function SignUp() {
           e.preventDefault();
           setError(null);
           const result = await signUp({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             router.push("/");
             return;
           }

--- a/examples/react-minimal/convex/auth.test.ts
+++ b/examples/react-minimal/convex/auth.test.ts
@@ -39,10 +39,10 @@ describe("anonymous sign in", () => {
   test("returns a token bundle in the shared sign-in envelope", async () => {
     const t = await setup();
     const result = await t.mutation(api.auth.signInAnonymous, {});
-    // Every provider returns the same `{ success, tokens }` envelope. Fixing
+    // Every provider returns the same `{ status, tokens }` envelope. Fixing
     // where the bundle sits is what lets the SSR auth proxy find the refresh
     // token and move it into an httpOnly cookie.
-    expect(result.success).toBe(true);
+    expect(result.status).toBe("complete");
     const { tokens } = result;
     expect(tokens.userId).not.toBe(null);
     expect(tokens.accessToken).not.toBe(null);

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -38,7 +38,7 @@ export function LogIn() {
         e.preventDefault();
         setError(null);
         const result = await signIn({ username });
-        if (result.success) {
+        if (result.status === "complete") {
           return;
         }
         setError(errorMessage(result.userError));
@@ -74,7 +74,7 @@ export function LogIn() {
 
 function errorMessage(
   userError:
-    | Extract<PasskeySignInResult, { success: false }>["userError"]
+    | Extract<PasskeySignInResult, { status: "error" }>["userError"]
     | PasskeyAutofillError,
 ): string {
   switch (userError.error) {

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -54,14 +54,14 @@ const signIn = (
 
 type PasswordResult =
   Awaited<ReturnType<typeof signUp>> | Awaited<ReturnType<typeof signIn>>;
-type PasswordSuccess = Extract<PasswordResult, { success: true }>;
+type PasswordSuccess = Extract<PasswordResult, { status: "complete" }>;
 
 describe("setupUsernamePassword", () => {
   test("signs up a new user and returns a session", async () => {
     const t = await setup();
     const result = await signUp(t, "alice", PASSWORD);
     expect(result).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -77,7 +77,7 @@ describe("setupUsernamePassword", () => {
     const up = await signUp(t, "alice", PASSWORD);
     const inResult = await signIn(t, "alice", PASSWORD);
     expect(up).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -87,7 +87,7 @@ describe("setupUsernamePassword", () => {
       },
     });
     expect(inResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -106,8 +106,8 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const alice = await signUp(t, "alice", PASSWORD);
     const bob = await signUp(t, "bob", "different horse battery staple");
-    expect(alice).toMatchObject({ success: true });
-    expect(bob).toMatchObject({ success: true });
+    expect(alice).toMatchObject({ status: "complete" });
+    expect(bob).toMatchObject({ status: "complete" });
     expect((bob as PasswordSuccess).tokens.userId).not.toBe(
       (alice as PasswordSuccess).tokens.userId,
     );
@@ -128,7 +128,7 @@ describe("setupUsernamePassword", () => {
     await signUp(t, "alice", PASSWORD);
     const result = await signIn(t, "alice", "wrong horse battery staple");
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "INVALID_CREDENTIALS" },
     });
   });
@@ -137,7 +137,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const result = await signIn(t, "nobody", PASSWORD);
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USER_NOT_FOUND" },
     });
   });
@@ -147,7 +147,7 @@ describe("setupUsernamePassword", () => {
     await signUp(t, "alice", PASSWORD);
     const result = await signUp(t, "alice", PASSWORD);
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TAKEN" },
     });
   });
@@ -156,7 +156,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "Alice", PASSWORD);
     expect(up).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -169,7 +169,7 @@ describe("setupUsernamePassword", () => {
     // A different casing is treated as the same account for both sign-in...
     const inResult = await signIn(t, "ALICE", PASSWORD);
     expect(inResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -185,7 +185,7 @@ describe("setupUsernamePassword", () => {
     // ...and the taken-username check.
     const dup = await signUp(t, "alice", PASSWORD);
     expect(dup).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TAKEN" },
     });
   });
@@ -194,7 +194,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "", PASSWORD);
     expect(up).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TOO_SHORT", minimumLength: 1 },
     });
   });
@@ -214,14 +214,14 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "alice", "short");
     expect(up).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
     });
 
     // No account was created, so a later sign-up with a valid password works.
     const retry = await signUp(t, "alice", PASSWORD);
     expect(retry).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -17,7 +17,7 @@ export function LogIn() {
           e.preventDefault();
           setError(null);
           const result = await signIn({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             return;
           }
           setError(() => {

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -17,7 +17,7 @@ export function SignUp() {
           e.preventDefault();
           setError(null);
           const result = await signUp({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             return;
           }
           setError(() => {

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -74,7 +74,7 @@ export function setupAnonymous<UsersTable extends string>(
               providerAccountId: anonymousId,
               profile: {},
             });
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
       };

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -180,7 +180,10 @@ describe("usePasskey signIn", () => {
   test("sign-up success runs the registration ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(registerStart);
     credentialsCreate.mockResolvedValue(attestationCredential);
-    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
+    mutations.finishSignUp.mockResolvedValue({
+      status: "complete",
+      tokens: bundle,
+    });
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
@@ -196,7 +199,11 @@ describe("usePasskey signIn", () => {
       clientDataJSON: attestationCredential.response.clientDataJSON,
       transports: ["internal", "hybrid"],
     });
-    expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
+    expect(returned).toEqual({
+      status: "complete",
+      tokens: bundle,
+      flow: "signUp",
+    });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("access-1");
   });
@@ -204,7 +211,10 @@ describe("usePasskey signIn", () => {
   test("sends no transports when the browser has no getTransports", async () => {
     mutations.startSignIn.mockResolvedValue(registerStart);
     credentialsCreate.mockResolvedValue(attestationCredentialWithoutTransports);
-    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
+    mutations.finishSignUp.mockResolvedValue({
+      status: "complete",
+      tokens: bundle,
+    });
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
@@ -213,7 +223,7 @@ describe("usePasskey signIn", () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
 
-    expect(returned.success).toBe(true);
+    expect(returned.status).toBe("complete");
     const [args] = mutations.finishSignUp.mock.calls[0] as [
       { transports?: string[] },
     ];
@@ -224,7 +234,7 @@ describe("usePasskey signIn", () => {
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     credentialsGet.mockResolvedValue(assertionCredential);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -254,7 +264,7 @@ describe("usePasskey signIn", () => {
       signature: assertionCredential.response.signature,
     });
     expect(returned).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",
@@ -276,7 +286,10 @@ describe("usePasskey signIn", () => {
       returned = await result.current.passkey.signIn({ username: "no" });
     });
 
-    expect(returned).toEqual(failure);
+    expect(returned).toEqual({
+      status: "error",
+      userError: failure.userError,
+    });
     expect(credentialsCreate).not.toHaveBeenCalled();
     expect(credentialsGet).not.toHaveBeenCalled();
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -296,7 +309,7 @@ describe("usePasskey signIn", () => {
     });
 
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "CEREMONY_ABORTED" },
     });
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -312,7 +325,7 @@ describe("usePasskey signIn", () => {
       }),
     );
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -332,7 +345,7 @@ describe("usePasskey signIn", () => {
       second = await result.current.passkey.signIn({ username: "alice" });
     });
     expect(second).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "CEREMONY_ABORTED" },
     });
     expect(mutations.startSignIn).toHaveBeenCalledTimes(1);
@@ -344,7 +357,7 @@ describe("usePasskey signIn", () => {
       firstResult = await first;
     });
     expect(firstResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",
@@ -418,7 +431,7 @@ describe("usePasskey autofill", () => {
     });
     credentialsGet.mockResolvedValue(assertionCredential);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -450,11 +463,11 @@ describe("usePasskey autofill", () => {
     // fresh challenge and the second one succeeds.
     mutations.finishSignIn
       .mockResolvedValueOnce({
-        success: false,
+        status: "error",
         userError: { error: "VERIFICATION_FAILED" },
       })
       .mockResolvedValueOnce({
-        success: true,
+        status: "complete",
         tokens: bundle,
         username: "alice",
       });
@@ -503,7 +516,7 @@ describe("usePasskey autofill", () => {
     );
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -521,7 +534,7 @@ describe("usePasskey autofill", () => {
     // The modal flow paused the autofill request before its ceremony...
     expect(conditionalAborts).toEqual(["PAUSE"]);
     expect(returned).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -107,7 +107,7 @@ export type PasskeyApi = {
  *   callers that want to inspect or log it.
  */
 type ClientFailure = {
-  success: false;
+  status: "error";
   userError:
     | { error: "CEREMONY_ABORTED" }
     | { error: "WEBAUTHN_UNSUPPORTED" }
@@ -121,15 +121,20 @@ type ClientFailure = {
  * created a new account, `"signIn"` when it authenticated an existing one.
  */
 export type PasskeySignInResult =
-  | (Extract<ClientView<FinishSignUpResult>, { success: true }> & {
+  | (Extract<ClientView<FinishSignUpResult>, { status: "complete" }> & {
       flow: "signUp";
     })
-  | (Extract<ClientView<FinishSignInResult>, { success: true }> & {
+  | (Extract<ClientView<FinishSignInResult>, { status: "complete" }> & {
       flow: "signIn";
     })
-  | Extract<ClientView<FinishSignUpResult>, { success: false }>
-  | Extract<ClientView<FinishSignInResult>, { success: false }>
-  | Extract<StartSignInResult, { success: false }>
+  | Extract<ClientView<FinishSignUpResult>, { status: "error" }>
+  | Extract<ClientView<FinishSignInResult>, { status: "error" }>
+  // `startSignIn` reports which ceremony to run rather than a sign-in, so it
+  // keeps its own `success` shape; its failure is folded in as an error arm.
+  | {
+      status: "error";
+      userError: Extract<StartSignInResult, { success: false }>["userError"];
+    }
   | ClientFailure;
 
 /**
@@ -139,7 +144,7 @@ export type PasskeySignInResult =
  * shape, so callers handle every failure through the one `error` switch.
  */
 export type PasskeyAutofillError =
-  | Extract<FinishSignInResult, { success: false }>["userError"]
+  | Extract<FinishSignInResult, { status: "error" }>["userError"]
   | ClientFailure["userError"];
 
 /**
@@ -378,7 +383,7 @@ async function runAuthenticationCeremony(
  *       onSubmit={async (e) => {
  *         e.preventDefault();
  *         const result = await signIn({ username });
- *         if (!result.success) {
+ *         if (result.status !== "complete") {
  *           // map result.userError to a message
  *         }
  *       }}
@@ -454,7 +459,7 @@ export function usePasskey(
       // autofill pause/resume protocol, and the browser rejects a second
       // modal ceremony anyway.
       if (pendingRef.current) {
-        return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+        return { status: "error", userError: { error: "CEREMONY_ABORTED" } };
       }
       pendingRef.current = true;
       setPending(true);
@@ -467,7 +472,7 @@ export function usePasskey(
       try {
         if (!supportsWebAuthn()) {
           return {
-            success: false,
+            status: "error",
             userError: { error: "WEBAUTHN_UNSUPPORTED" },
           };
         }
@@ -478,19 +483,22 @@ export function usePasskey(
           username,
         });
         if (!start.success) {
-          return start;
+          return { status: "error", userError: start.userError };
         }
 
         if (start.step === "register") {
           const args = await runRegistrationCeremony(username, start);
           if (args === null) {
-            return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+            return {
+              status: "error",
+              userError: { error: "CEREMONY_ABORTED" },
+            };
           }
           const result = await signInApi.mutation(
             passkeyApi.finishSignUp,
             args,
           );
-          if (!result.success) {
+          if (result.status !== "complete") {
             return result;
           }
           await setSession(result.tokens);
@@ -499,16 +507,16 @@ export function usePasskey(
 
         const args = await runAuthenticationCeremony(start);
         if (args === null) {
-          return { success: false, userError: { error: "CEREMONY_ABORTED" } };
+          return { status: "error", userError: { error: "CEREMONY_ABORTED" } };
         }
         const result = await signInApi.mutation(passkeyApi.finishSignIn, args);
-        if (!result.success) {
+        if (result.status !== "complete") {
           return result;
         }
         await setSession(result.tokens);
         return { ...result, flow: "signIn" };
       } catch (cause) {
-        return { success: false, userError: foldClientError(cause) };
+        return { status: "error", userError: foldClientError(cause) };
       } finally {
         autofillHandle?.resume();
         // Reset even when something throws.
@@ -697,7 +705,7 @@ export function usePasskey(
             passkeyApi.finishSignIn,
             assertionArgs(credential),
           );
-          if (result.success) {
+          if (result.status === "complete") {
             // Residual race with the modal flow: when the user resolves
             // the autofill assertion just before the modal flow pauses us,
             // and the modal ceremony also completes, `setSession` runs
@@ -773,16 +781,15 @@ export function usePasskey(
     /**
      * Runs the identifier-first passkey flow for the given username.
      *
-     * Returns an object with a `success` boolean flag.
+     * Returns an object discriminated by `status`.
      *
-     * If it is `true` the sign-in (or the account creation) was successful
-     * and the client will establish an authenticated session with the
-     * Convex backend server. The `flow` field tells which one it was:
-     * `"signUp"` created a new account, `"signIn"` authenticated an
-     * existing one.
+     * On `"complete"` the sign-in (or the account creation) worked and the
+     * client will establish an authenticated session with the Convex
+     * backend server. The `flow` field tells which one it was: `"signUp"`
+     * created a new account, `"signIn"` authenticated an existing one.
      *
-     * If it is `false` the returned object will have a `userError` field
-     * with additional details about why sign-in failed.
+     * On `"error"` the returned object has a `userError` field with
+     * additional details about why sign-in failed.
      */
     signIn,
     /** `true` while a `signIn` attempt is running. */

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -102,7 +102,7 @@ export type StartAutofillSignInResult = Infer<typeof startAutofillSignInResult>;
 const finishSignUpResult = v.union(
   vSignInSuccess,
   v.object({
-    success: v.literal(false),
+    status: v.literal("error"),
     userError: v.union(finishRegistrationUserError, setUsernameUserError),
   }),
 );
@@ -115,14 +115,14 @@ const finishSignUpResult = v.union(
 export type FinishSignUpResult = Infer<typeof finishSignUpResult>;
 
 const finishSignInResult = v.union(
+  // This provider widens the shared success arm with the account's username,
+  // for display. It is `null` when the app removed the user's username.
   v.object({
     ...vSignInSuccess.fields,
-    // The username of the account, for display. `null` when the app
-    // removed the username of the user.
     username: v.union(v.string(), v.null()),
   }),
   v.object({
-    success: v.literal(false),
+    status: v.literal("error"),
     userError: finishAuthenticationUserError,
   }),
 );
@@ -294,7 +294,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             const { username } = args;
             const usernameError = validateUsernameFormat(username);
             if (usernameError !== null) {
-              return { success: false, userError: usernameError };
+              return { status: "error", userError: usernameError };
             }
 
             // Fail early if the username is taken
@@ -303,7 +303,10 @@ export function setupUsernamePasskey<UsersTable extends string>(
               { username },
             );
             if (existing !== null) {
-              return { success: false, userError: { error: "USERNAME_TAKEN" } };
+              return {
+                status: "error",
+                userError: { error: "USERNAME_TAKEN" },
+              };
             }
 
             // Fail early if the passkey registration fails
@@ -317,7 +320,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               },
             );
             if (!checkResult.success) {
-              return { success: false, userError: checkResult.userError };
+              return { status: "error", userError: checkResult.userError };
             }
 
             // Create the account + app user (via the app's createUser) and
@@ -371,7 +374,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               );
             }
 
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
 
@@ -411,7 +414,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             );
             if (!authenticationResult.success) {
               return {
-                success: false,
+                status: "error",
                 userError: authenticationResult.userError,
               };
             }
@@ -426,7 +429,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               providerAccountId: userId,
               profile: { username },
             });
-            return { success: true, tokens, username };
+            return { status: "complete", tokens, username };
           },
         }),
       };

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -82,7 +82,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
   });
 
   test("success adopts the session and returns the result", async () => {
-    runMutation.mockResolvedValue({ success: true, tokens: bundle });
+    runMutation.mockResolvedValue({ status: "complete", tokens: bundle });
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -93,13 +93,13 @@ describe.each(flows)("$name", ({ useFlow }) => {
     });
 
     expect(runMutation).toHaveBeenCalledWith(credentials);
-    expect(returned).toEqual({ success: true, tokens: bundle });
+    expect(returned).toEqual({ status: "complete", tokens: bundle });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("access-1");
   });
 
   test("user error is returned without adopting a session", async () => {
-    const failure = { success: false, userError: { error: "USER_NOT_FOUND" } };
+    const failure = { status: "error", userError: { error: "USER_NOT_FOUND" } };
     runMutation.mockResolvedValue(failure);
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
@@ -125,7 +125,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     });
 
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "OTHER_ERROR", cause },
     });
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -149,7 +149,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     await waitFor(() => expect(result.current.flow.pending).toBe(true));
 
     await act(async () => {
-      resolveMutation!({ success: true, tokens: bundle });
+      resolveMutation!({ status: "complete", tokens: bundle });
       await pending;
     });
     expect(result.current.flow.pending).toBe(false);

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -59,7 +59,7 @@ type SignUpWithPasswordMutation = FunctionReference<
  * on `cause` for callers that want to inspect or log it.
  */
 type UnexpectedFailure = {
-  success: false;
+  status: "error";
   userError: { error: "OTHER_ERROR"; cause: unknown };
 };
 
@@ -81,7 +81,7 @@ export type SignUpWithPasswordResult =
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signIn`, check the `success` flag on the return value to see
+ * After calling `signIn`, check the `status` field on the return value to see
  * whether the sign-in was successful or if you need to handle an error.
  *
  * ```tsx
@@ -95,7 +95,7 @@ export type SignUpWithPasswordResult =
  *       onSubmit={async (e) => {
  *         e.preventDefault();
  *         const result = await signIn({ username, password });
- *         if (!result.success) {
+ *         if (result.status !== "complete") {
  *           // map result.userError to a message
  *         }
  *       }}
@@ -116,12 +116,12 @@ export function useSignInWithPassword(
     /**
      * Passes up the given crendentials to perform a username/password sign in.
      *
-     * Returns an object with a `success` boolean flag.
+     * Returns an object with a `status` discriminant.
      *
-     * If it is `true` the sign-in was successful and the client will establish
+     * `"complete"` means the sign-in succeeded and the client will establish
      * an authenticated session with the Convex backend server.
      *
-     * If it is `false` the returned object will have a `userError` field with
+     * `"error"` means the returned object has a `userError` field with
      * additional details about why sign-in failed.
      */
     signIn: run,
@@ -140,7 +140,7 @@ export function useSignInWithPassword(
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signUp`, check the `success` flag on the return value to see
+ * After calling `signUp`, check the `status` field on the return value to see
  * whether the sign-up was successful or if you need to handle an error.
  *
  * ```tsx
@@ -163,12 +163,12 @@ export function useSignUpWithPassword(
     /**
      * Passes up the given crendentials to perform a username/password sign up.
      *
-     * Returns an object with a `success` boolean flag.
+     * Returns an object with a `status` discriminant.
      *
-     * If it is `true` the sign-up was successful and the client will establish
+     * `"complete"` means the sign-up succeeded and the client will establish
      * an authenticated session with the Convex backend server.
      *
-     * If it is `false` the returned object will have a `userError` field with
+     * `"error"` means the returned object has a `userError` field with
      * additional details about why sign-up failed.
      */
     signUp: run,
@@ -197,7 +197,7 @@ function usePasswordFlow<
       setPending(true);
       try {
         const result = await signInApi.mutation(mutation, credentials);
-        if (result.success) {
+        if (result.status === "complete") {
           await setSession(result.tokens);
         }
         return result;
@@ -206,7 +206,10 @@ function usePasswordFlow<
         // the same discriminated result as `OTHER_ERROR`, preserving the thrown
         // value on `cause`, so the caller handles it alongside every other
         // failure and can still inspect or log the original error if it wants.
-        return { success: false, userError: { error: "OTHER_ERROR", cause } };
+        return {
+          status: "error",
+          userError: { error: "OTHER_ERROR", cause },
+        };
       } finally {
         // Reset even when the mutation throws.
         setPending(false);

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -2,6 +2,8 @@ import { Infer, v } from "convex/values";
 import {
   vSignInSuccess,
   USE_USER_ID_AS_ACCOUNT_ID,
+  type SignInError,
+  type SignInSuccess,
   type UserCallbacks,
 } from "../../lib/types.ts";
 import type { AuthCore } from "../core/setup.ts";
@@ -37,15 +39,19 @@ export type UsernamePasswordOptions = {
   usernameComponent: UsernameComponentApi;
 };
 
+/** This provider's correctable-failure vocabularies. */
+const signInUserError = v.union(
+  verifyPasswordUserError,
+  v.object({ error: v.literal("USER_NOT_FOUND") }),
+);
+const signUpUserError = v.union(setPasswordUserError, setUsernameUserError);
+
+type SignInUserError = Infer<typeof signInUserError>;
+type SignUpUserError = Infer<typeof signUpUserError>;
+
 const signInResult = v.union(
   vSignInSuccess,
-  v.object({
-    success: v.literal(false),
-    userError: v.union(
-      verifyPasswordUserError,
-      v.object({ error: v.literal("USER_NOT_FOUND") }),
-    ),
-  }),
+  v.object({ status: v.literal("error"), userError: signInUserError }),
 );
 
 /**
@@ -53,14 +59,11 @@ const signInResult = v.union(
  *
  * On success the minted session tokens, otherwise a user-facing `userError`.
  */
-export type SignInResult = Infer<typeof signInResult>;
+export type SignInResult = SignInSuccess | SignInError<SignInUserError>;
 
 const signUpResult = v.union(
   vSignInSuccess,
-  v.object({
-    success: v.literal(false),
-    userError: v.union(setPasswordUserError, setUsernameUserError),
-  }),
+  v.object({ status: v.literal("error"), userError: signUpUserError }),
 );
 
 /**
@@ -68,7 +71,7 @@ const signUpResult = v.union(
  *
  * On success the minted session tokens, otherwise a user-facing `userError`.
  */
-export type SignUpResult = Infer<typeof signUpResult>;
+export type SignUpResult = SignInSuccess | SignInError<SignUpUserError>;
 
 /**
  * The simplest password recipe: every account is a `(username, password)` pair,
@@ -134,11 +137,11 @@ export function setupUsernamePassword<UsersTable extends string>(
             // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
             const usernameError = validateUsernameFormat(username);
             if (usernameError !== null) {
-              return { success: false, userError: usernameError };
+              return { status: "error", userError: usernameError };
             }
             const userError = validateNewPassword(password);
             if (userError !== null) {
-              return { success: false, userError };
+              return { status: "error", userError };
             }
 
             const existing = await ctx.runQuery(
@@ -146,7 +149,10 @@ export function setupUsernamePassword<UsersTable extends string>(
               { username },
             );
             if (existing !== null) {
-              return { success: false, userError: { error: "USERNAME_TAKEN" } };
+              return {
+                status: "error",
+                userError: { error: "USERNAME_TAKEN" },
+              };
             }
 
             // Create the account + app user (via the app's createUser) and
@@ -200,7 +206,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               );
             }
 
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
 
@@ -224,7 +230,7 @@ export function setupUsernamePassword<UsersTable extends string>(
             );
             if (userId === null) {
               return {
-                success: false,
+                status: "error",
                 userError: { error: "USER_NOT_FOUND" },
               };
             }
@@ -234,7 +240,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               { userId, password },
             );
             if (!verifyResult.success) {
-              return { success: false, userError: verifyResult.userError };
+              return { status: "error", userError: verifyResult.userError };
             }
 
             // The username resolved to a user id and its password verified, so
@@ -244,7 +250,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               providerAccountId: userId,
               profile: { username },
             });
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
       };

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,7 +1,3 @@
-import { FunctionReference } from "convex/server";
-
-import { GenericId, Infer, v } from "convex/values";
-
 /**
  * Shared contracts that cross a module boundary within Convex Auth. That includes
  * validators (and their inferred types) for what the core's session functions
@@ -13,7 +9,13 @@ import { GenericId, Infer, v } from "convex/values";
  * This module deliberately depends on nothing else in the package, which is what
  * lets both the server and the browser halves import from it without either
  * reaching into the other's tree.
+ *
+ * @module
  */
+
+import { FunctionReference } from "convex/server";
+
+import { GenericId, Infer, v } from "convex/values";
 
 /**
  * The session a successful sign-in (or refresh) mints: a short-lived access
@@ -30,21 +32,19 @@ export const vTokenBundle = v.object({
 
 export type TokenBundle = Infer<typeof vTokenBundle>;
 
-/**
- * The success arm of every provider's sign-in result.
- *
- * Providers compose this into their result union rather than declaring the
- * success arm themselves. Fixing where the minted bundle sits is what lets the
- * SSR auth proxy find the refresh token without knowing which provider produced
- * the response, and lets it reject a shape it doesn't recognize instead of
- * forwarding tokens to the browser.
- */
+/** The success arm, `complete`: a session was minted. */
 export const vSignInSuccess = v.object({
-  success: v.literal(true),
+  status: v.literal("complete"),
   tokens: vTokenBundle,
 });
 
 export type SignInSuccess = Infer<typeof vSignInSuccess>;
+
+/** The error arm: a correctable, provider-specific failure. */
+export type SignInError<UserError> = {
+  status: "error";
+  userError: UserError;
+};
 
 /**
  * The token bundle that an SSR route hands back to the client. It is a slimmed

--- a/packages/core/src/server/signInProxy.test.ts
+++ b/packages/core/src/server/signInProxy.test.ts
@@ -75,14 +75,17 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("token interception", () => {
   test("moves the refresh token into an httpOnly cookie and slims the body", async () => {
-    upstream({ status: "success", value: { success: true, tokens: bundle() } });
+    upstream({
+      status: "success",
+      value: { status: "complete", tokens: bundle() },
+    });
 
     const response = await handler(call(envelope()));
     expect(response.status).toBe(200);
 
     const body = await response.json();
     // The envelope survives; only the refresh half of the bundle is removed.
-    expect(body.value.success).toBe(true);
+    expect(body.value.status).toBe("complete");
     expect(body.value.tokens).toEqual({
       accessToken: "access-1",
       accessTokenExpiresAt: 1_000,
@@ -101,7 +104,7 @@ describe("token interception", () => {
     // tokens. The refresh token is the only thing the proxy removes.
     upstream({
       status: "success",
-      value: { success: true, tokens: bundle(), username: "alice" },
+      value: { status: "complete", tokens: bundle(), username: "alice" },
     });
 
     const body = await (await handler(call(envelope()))).json();
@@ -112,13 +115,13 @@ describe("token interception", () => {
   test("passes a failure arm through untouched and writes no cookies", async () => {
     upstream({
       status: "success",
-      value: { success: false, userError: { error: "INVALID_CREDENTIALS" } },
+      value: { status: "error", userError: { error: "INVALID_CREDENTIALS" } },
     });
 
     const response = await handler(call(envelope()));
     const body = await response.json();
     expect(body.value).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "INVALID_CREDENTIALS" },
     });
     // A failed sign-in is a successful call: the transport says 200 and the
@@ -139,6 +142,22 @@ describe("token interception", () => {
     const response = await handler(call(envelope()));
     expect(response.status).toBe(500);
     expect(await response.text()).toContain("did not return a sign-in result");
+  });
+
+  test("fails closed on an unknown arm that carries tokens", async () => {
+    // The arms are matched by name, so a shape the proxy does not know is
+    // refused even though it looks like a failure. Classifying "not a
+    // success" as a failure would forward this verbatim — tokens included,
+    // since only the success path strips them.
+    upstream({
+      status: "success",
+      value: { success: false, tokens: bundle() },
+    });
+
+    const response = await handler(call(envelope()));
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain("did not return a sign-in result");
+    expect(setCookies(response)).toBe("");
   });
 
   test("fails closed when an exposed function returns an unrecognized shape", async () => {
@@ -216,7 +235,7 @@ describe("forwarding", () => {
   test("forwards args in the caller's encoding, and the caller's auth header", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
 
     await handler(
@@ -241,7 +260,7 @@ describe("forwarding", () => {
   test("routes each endpoint to its counterpart on the deployment", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
     await handler(call(envelope(), { kind: "mutation" }));
     expect(fetchSpy.mock.calls[0][0]).toBe(`${CONVEX_URL}/api/mutation`);
@@ -250,7 +269,7 @@ describe("forwarding", () => {
   test("never forwards the browser's cookies to the deployment", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
     await handler(
       call(envelope(), {
@@ -266,7 +285,7 @@ describe("forwarding", () => {
   test("forwards server log lines so a proxied call logs like a direct one", async () => {
     upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
       logLines: ["from the function's console.log"],
     });
     const body = await (await handler(call(envelope()))).json();
@@ -335,7 +354,7 @@ describe("ConvexHttpClient wire contract", () => {
       return new Response(
         JSON.stringify({
           status: "success",
-          value: { success: true, tokens: bundle() },
+          value: { status: "complete", tokens: bundle() },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
@@ -354,7 +373,7 @@ describe("ConvexHttpClient wire contract", () => {
 
     // The client parsed the proxy's reply, and the refresh token is gone.
     expect(result).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: "access-1",
         accessTokenExpiresAt: 1_000,

--- a/packages/core/src/server/signInProxy.ts
+++ b/packages/core/src/server/signInProxy.ts
@@ -30,6 +30,7 @@ import {
 } from "convex/server";
 import {
   makeSlimBundle,
+  type SignInError,
   type SignInSuccess,
   type TokenBundle,
 } from "../lib/types.ts";
@@ -42,15 +43,17 @@ import { forbiddenOriginResponse, isTrustedOrigin } from "./origin.ts";
 /**
  * A sign-in function exposed through the proxy.
  *
- * Any public mutation or action returning the shared {@link SignInSuccess}
- * envelope. Args are typed loosely because the proxy never inspects them; it
- * forwards the caller's encoded args untouched.
+ * Any public mutation or action returning the shared sign-in envelope — its
+ * arms, spelled out from the same declarations providers compose their
+ * results from, so this and {@link classifyResult} cannot drift apart. Args
+ * are typed loosely because the proxy never inspects them; it forwards the
+ * caller's encoded args untouched.
  */
 export type ExposedSignInFn = FunctionReference<
   "mutation" | "action",
   "public",
   DefaultFunctionArgs,
-  SignInSuccess | { success: false }
+  SignInSuccess | SignInError<unknown>
 >;
 
 /** Configuration for {@link convexProxyHandler}. */
@@ -132,10 +135,13 @@ function isEncodedTokenBundle(value: unknown): value is TokenBundle {
 }
 
 /**
- * Classify a sign-in function's return value.
+ * Classify a sign-in function's return value by its `status` discriminant.
  *
  * `null` means "not the envelope this proxy knows how to handle", which the
- * caller turns into a 500 rather than forwarding.
+ * caller turns into a 500 rather than forwarding. Every arm is matched by
+ * name, so an unrecognized shape fails closed here instead of being waved
+ * through as "not a success" — which is how a future arm carrying a token
+ * could otherwise reach the browser unstripped.
  */
 function classifyResult(
   value: unknown,
@@ -144,11 +150,16 @@ function classifyResult(
     return null;
   }
   const result = value as Record<string, unknown>;
-  if (result.success === false) return { kind: "failure" };
-  if (result.success !== true) return null;
-  return isEncodedTokenBundle(result.tokens)
-    ? { kind: "success", tokens: result.tokens }
-    : null;
+  switch (result.status) {
+    case "error":
+      return { kind: "failure" };
+    case "complete":
+      return isEncodedTokenBundle(result.tokens)
+        ? { kind: "success", tokens: result.tokens }
+        : null;
+    default:
+      return null;
+  }
 }
 
 /** A plain-text error. `ConvexHttpClient` throws its body as an `Error`. */


### PR DESCRIPTION
The results shape shifts from `{success: boolean, ...}` to  
`{status: "complete" | "error", ...}` (and will include `"incomplete"`  
in an upcoming PR).