### PR TITLE
Add support for pending sign-ins

### DIFF
--- a/examples/nextjs/convex/users.ts
+++ b/examples/nextjs/convex/users.ts
@@ -49,6 +49,8 @@ export const onSignInAnonymous = internalMutation({
     providerAccountId: v.string(),
     profile: v.object({}),
     userId: v.id("users"),
+    // Always sent; empty because this app registers no sign-in requirements.
+    facts: v.object({}),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -62,6 +64,7 @@ export const onSignInPassword = internalMutation({
     providerAccountId: v.string(),
     profile: v.object({ username: v.string() }),
     userId: v.id("users"),
+    facts: v.object({}),
   },
   returns: v.null(),
   handler: async (ctx, args) => {

--- a/packages/core/src/components/core/_generated/component.ts
+++ b/packages/core/src/components/core/_generated/component.ts
@@ -24,11 +24,71 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     public: {
+      continueSignIn: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          accessTokenTtlSeconds?: number;
+          attemptToken: string;
+          onSignInHandle?: string;
+          issuer: string;
+          providerRequirements?: Array<{
+            data?: any;
+            factFields: Array<string>;
+            kind: string;
+          }>;
+          refreshTokenTtlSeconds?: number;
+        },
+        | {
+            status: "session-created";
+            tokens: {
+              accessToken: string;
+              accessTokenExpiresAt: number;
+              refreshToken: string;
+              refreshTokenExpiresAt: number;
+              userId: string;
+            };
+          }
+        | {
+            attemptToken: string;
+            expiresAt: number;
+            requirements: Array<{ data?: any; kind: string }>;
+            status: "pending-requirements";
+            userId: string;
+          }
+        | { status: "expired" },
+        Name
+      >;
+      getAttemptContext: FunctionReference<
+        "query",
+        "internal",
+        { attemptToken: string },
+        {
+          provider: string;
+          providerAccountId: string;
+          userId: string;
+        } | null,
+        Name
+      >;
       getUserIdByAccount: FunctionReference<
         "query",
         "internal",
         { provider: string; providerAccountId: string },
         string | null,
+        Name
+      >;
+      penalizeAttempt: FunctionReference<
+        "mutation",
+        "internal",
+        { attemptToken: string },
+        boolean,
+        Name
+      >;
+      recordAttemptFacts: FunctionReference<
+        "mutation",
+        "internal",
+        { attemptToken: string; facts: any; scope?: "app" | "provider" },
+        boolean,
         Name
       >;
       refresh: FunctionReference<
@@ -57,15 +117,30 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           claims: { profile: any; provider: string; providerAccountId: string };
           issuer: string;
           onSignInHandle?: string;
+          providerRequirements?: Array<{
+            data?: any;
+            factFields: Array<string>;
+            kind: string;
+          }>;
           refreshTokenTtlSeconds?: number;
         },
-        {
-          accessToken: string;
-          accessTokenExpiresAt: number;
-          refreshToken: string;
-          refreshTokenExpiresAt: number;
-          userId: string;
-        },
+        | {
+            status: "session-created";
+            tokens: {
+              accessToken: string;
+              accessTokenExpiresAt: number;
+              refreshToken: string;
+              refreshTokenExpiresAt: number;
+              userId: string;
+            };
+          }
+        | {
+            attemptToken: string;
+            expiresAt: number;
+            requirements: Array<{ data?: any; kind: string }>;
+            status: "pending-requirements";
+            userId: string;
+          },
         Name
       >;
       signOut: FunctionReference<
@@ -84,25 +159,30 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           createUserHandle: string;
           issuer: string;
           onSignInHandle?: string;
+          providerRequirements?: Array<{
+            data?: any;
+            factFields: Array<string>;
+            kind: string;
+          }>;
           refreshTokenTtlSeconds?: number;
         },
-        {
-          accessToken: string;
-          accessTokenExpiresAt: number;
-          refreshToken: string;
-          refreshTokenExpiresAt: number;
-          userId: string;
-        },
-        Name
-      >;
-      signUpWithoutSession: FunctionReference<
-        "mutation",
-        "internal",
-        {
-          claims: { profile: any; provider: string; providerAccountId: string };
-          createUserHandle: string;
-        },
-        { userId: string },
+        | {
+            status: "session-created";
+            tokens: {
+              accessToken: string;
+              accessTokenExpiresAt: number;
+              refreshToken: string;
+              refreshTokenExpiresAt: number;
+              userId: string;
+            };
+          }
+        | {
+            attemptToken: string;
+            expiresAt: number;
+            requirements: Array<{ data?: any; kind: string }>;
+            status: "pending-requirements";
+            userId: string;
+          },
         Name
       >;
     };

--- a/packages/core/src/components/core/core.test.ts
+++ b/packages/core/src/components/core/core.test.ts
@@ -20,13 +20,15 @@ import { api } from "./_generated/api.ts";
 import schema from "./schema.ts";
 import {
   getCreateUserCalls,
+  getEvaluateSignInCalls,
   getOnSignInCalls,
+  resetEvaluateSignInCalls,
   resetUserCallbackCalls,
 } from "./testApp.ts";
 import {
   type AuthClaims,
+  type ProviderSignInOutcome,
   type TokenBundle,
-  USE_USER_ID_AS_ACCOUNT_ID,
 } from "../../lib/types.ts";
 import { sha256Hex } from "../../lib/crypto.ts";
 import { REFRESH_GRACE_MS, SPENT_TOKEN_HORIZON_MS } from "./public.ts";
@@ -71,23 +73,38 @@ function setup() {
 
 type ConvexTestApi = ReturnType<typeof setup>;
 
+/**
+ * Assert a sign-in outcome is `session-created` and unwrap its token bundle. Without
+ * an evaluating callback attached (everything in this suite except the
+ * incomplete-sign-in tests) that is the only outcome the core produces.
+ */
+function expectComplete(outcome: ProviderSignInOutcome): TokenBundle {
+  expect(outcome.status).toBe("session-created");
+  if (outcome.status !== "session-created") throw new Error("unreachable");
+  return outcome.tokens;
+}
+
 /** Establish a brand new identity: the account, its app user, and a session. */
 async function signUp(t: ConvexTestApi, c: AuthClaims) {
-  return await t.mutation(api.public.signUp, {
-    claims: c,
-    createUserHandle: CREATE_USER_HANDLE,
-    onSignInHandle: ON_SIGN_IN_HANDLE,
-    issuer: ISSUER,
-  });
+  return expectComplete(
+    await t.mutation(api.public.signUp, {
+      claims: c,
+      createUserHandle: CREATE_USER_HANDLE,
+      onSignInHandle: ON_SIGN_IN_HANDLE,
+      issuer: ISSUER,
+    }),
+  );
 }
 
 /** Sign a known identity back in, as an app that attached an `onSignIn` does. */
 async function signIn(t: ConvexTestApi, c: AuthClaims) {
-  return await t.mutation(api.public.signIn, {
-    claims: c,
-    onSignInHandle: ON_SIGN_IN_HANDLE,
-    issuer: ISSUER,
-  });
+  return expectComplete(
+    await t.mutation(api.public.signIn, {
+      claims: c,
+      onSignInHandle: ON_SIGN_IN_HANDLE,
+      issuer: ISSUER,
+    }),
+  );
 }
 
 /** Assert a refresh succeeded (a session was minted) and narrow away `null`. */
@@ -172,6 +189,8 @@ describe("signUp", () => {
         providerAccountId: "alice",
         profile: { name: "Alice" },
         userId: "alice",
+        // Always passed, and empty for a sign-in with no requirements.
+        facts: {},
       },
     ]);
   });
@@ -180,11 +199,13 @@ describe("signUp", () => {
     const t = setup();
     resetUserCallbackCalls();
 
-    const bundle = await t.mutation(api.public.signUp, {
-      claims: claims(),
-      createUserHandle: CREATE_USER_HANDLE,
-      issuer: ISSUER,
-    });
+    const bundle = expectComplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        issuer: ISSUER,
+      }),
+    );
 
     expect(bundle.userId).toBe("alice");
     expect(getCreateUserCalls()).toHaveLength(1);
@@ -265,6 +286,7 @@ describe("signIn", () => {
       providerAccountId: "alice",
       profile: { name: "Alice 2.0" },
       userId: "alice",
+      facts: {},
     });
   });
 
@@ -274,10 +296,12 @@ describe("signIn", () => {
     resetUserCallbackCalls();
 
     // No `onSignInHandle` is what an app that left `onSignIn` out sends.
-    const bundle = await t.mutation(api.public.signIn, {
-      claims: claims(),
-      issuer: ISSUER,
-    });
+    const bundle = expectComplete(
+      await t.mutation(api.public.signIn, {
+        claims: claims(),
+        issuer: ISSUER,
+      }),
+    );
 
     expect(bundle.userId).toBe("alice");
     expect(getOnSignInCalls()).toHaveLength(0);
@@ -296,89 +320,6 @@ describe("signIn", () => {
       async (ctx) => (await ctx.db.query("sessions").collect()).length,
     );
     expect(sessions).toBe(0);
-  });
-});
-
-describe("signUpWithoutSession", () => {
-  test("creates the user and the account, but no session", async () => {
-    const t = setup();
-    resetUserCallbackCalls();
-
-    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
-      claims: claims(),
-      createUserHandle: CREATE_USER_HANDLE,
-    });
-
-    // The app's createUser echoes the providerAccountId as the user id.
-    expect(userId).toBe("alice");
-    expect(getCreateUserCalls()).toHaveLength(1);
-    // No sign-in happened, so onSignIn does not run.
-    expect(getOnSignInCalls()).toHaveLength(0);
-
-    // The account exists, but no session was minted.
-    const counts = await t.run(async (ctx) => ({
-      accounts: (await ctx.db.query("accounts").collect()).length,
-      sessions: (await ctx.db.query("sessions").collect()).length,
-    }));
-    expect(counts).toEqual({ accounts: 1, sessions: 0 });
-  });
-
-  test("a later signIn resolves the same user and mints a session", async () => {
-    const t = setup();
-    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
-      claims: claims(),
-      createUserHandle: CREATE_USER_HANDLE,
-    });
-
-    const bundle = await signIn(t, claims());
-    expect(bundle.userId).toBe(userId);
-
-    // The sign-in reused the account that signUpWithoutSession made.
-    const counts = await t.run(async (ctx) => ({
-      accounts: (await ctx.db.query("accounts").collect()).length,
-      sessions: (await ctx.db.query("sessions").collect()).length,
-    }));
-    expect(counts).toEqual({ accounts: 1, sessions: 1 });
-  });
-
-  test("keys the account by the minted user id with USE_USER_ID_AS_ACCOUNT_ID", async () => {
-    const t = setup();
-    const { userId } = await t.mutation(api.public.signUpWithoutSession, {
-      claims: claims({
-        providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
-        profile: { email: "alice@example.com" },
-      }),
-      createUserHandle: CREATE_USER_HANDLE,
-    });
-
-    // The account's identifier is the user id the app minted, so a later
-    // sign-in that passes the user id resolves the same user.
-    const bundle = await signIn(t, claims({ providerAccountId: userId }));
-    expect(bundle.userId).toBe(userId);
-
-    const accounts = await t.run(
-      async (ctx) => await ctx.db.query("accounts").collect(),
-    );
-    expect(accounts).toHaveLength(1);
-    expect(accounts[0].providerAccountId).toBe(userId);
-  });
-
-  test("refuses an identity that already has an account", async () => {
-    const t = setup();
-    await signUp(t, claims());
-
-    // Like signUp: a second app user for the same identity is never minted.
-    await expect(
-      t.mutation(api.public.signUpWithoutSession, {
-        claims: claims(),
-        createUserHandle: CREATE_USER_HANDLE,
-      }),
-    ).rejects.toThrow(/already\s+exists/i);
-
-    const accounts = await t.run(
-      async (ctx) => (await ctx.db.query("accounts").collect()).length,
-    );
-    expect(accounts).toBe(1);
   });
 });
 
@@ -655,12 +596,14 @@ describe("token lifetime configuration", () => {
   test("honors a custom access-token TTL on sign-up", async () => {
     const t = setup();
     const before = Date.now();
-    const bundle = await t.mutation(api.public.signUp, {
-      claims: claims(),
-      createUserHandle: CREATE_USER_HANDLE,
-      issuer: ISSUER,
-      accessTokenTtlSeconds: 300, // 5 minutes
-    });
+    const bundle = expectComplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        issuer: ISSUER,
+        accessTokenTtlSeconds: 300, // 5 minutes
+      }),
+    );
     // The JWT `exp` is floored to the second, so allow a small window.
     expect(bundle.accessTokenExpiresAt).toBeGreaterThanOrEqual(
       before + 300_000 - 1000,
@@ -676,12 +619,14 @@ describe("token lifetime configuration", () => {
     const oneHourMs = oneHourSeconds * 1000;
 
     const before = Date.now();
-    const bundle = await t.mutation(api.public.signUp, {
-      claims: claims(),
-      createUserHandle: CREATE_USER_HANDLE,
-      issuer: ISSUER,
-      refreshTokenTtlSeconds: oneHourSeconds,
-    });
+    const bundle = expectComplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        issuer: ISSUER,
+        refreshTokenTtlSeconds: oneHourSeconds,
+      }),
+    );
     expect(bundle.refreshTokenExpiresAt).toBeGreaterThanOrEqual(
       before + oneHourMs,
     );
@@ -747,5 +692,434 @@ describe("getUserIdByAccount", () => {
       providerAccountId: "alice",
     });
     expect(other).toBeNull();
+  });
+});
+
+// --- Incomplete sign-ins (requirements) --------------------------------------
+
+const EVALUATE_HANDLE = "testApp:evaluateSignIn";
+const COMPLETING_EVALUATE_HANDLE = "testApp:evaluateSignInAlwaysComplete";
+const THROWING_EVALUATE_HANDLE = "testApp:evaluateSignInThatThrows";
+
+/** Sign up with the evaluating callback attached (requirements mode). */
+async function signUpEvaluated(
+  t: ReturnType<typeof setup>,
+  c: AuthClaims,
+  handle: string = EVALUATE_HANDLE,
+) {
+  return await t.mutation(api.public.signUp, {
+    claims: c,
+    createUserHandle: CREATE_USER_HANDLE,
+    onSignInHandle: handle,
+    issuer: ISSUER,
+  });
+}
+
+/** Sign a known identity back in with the evaluating callback attached. */
+async function signInEvaluated(
+  t: ReturnType<typeof setup>,
+  c: AuthClaims,
+  handle: string = EVALUATE_HANDLE,
+) {
+  return await t.mutation(api.public.signIn, {
+    claims: c,
+    onSignInHandle: handle,
+    issuer: ISSUER,
+  });
+}
+
+/** Narrow an outcome to its incomplete arm. */
+function expectIncomplete(outcome: ProviderSignInOutcome) {
+  expect(outcome.status).toBe("pending-requirements");
+  if (outcome.status !== "pending-requirements") throw new Error("unreachable");
+  return outcome;
+}
+
+async function attemptRows(t: ReturnType<typeof setup>) {
+  return await t.run(
+    async (ctx) => await ctx.db.query("pendingSignInAttempts").collect(),
+  );
+}
+
+describe("incomplete sign-ins", () => {
+  test("an accepting evaluator completes the sign-up and sees empty facts", async () => {
+    const t = setup();
+    resetEvaluateSignInCalls();
+
+    const outcome = await signUpEvaluated(
+      t,
+      claims(),
+      COMPLETING_EVALUATE_HANDLE,
+    );
+
+    const bundle = expectComplete(outcome);
+    expect(bundle.userId).toBe("alice");
+    expect(getEvaluateSignInCalls()).toEqual([
+      {
+        provider: "password",
+        providerAccountId: "alice",
+        profile: { name: "Alice" },
+        userId: "alice",
+        facts: {},
+      },
+    ]);
+    expect(await attemptRows(t)).toHaveLength(0);
+  });
+
+  test("a demanding evaluator parks the sign-up: user + account exist, session withheld", async () => {
+    const t = setup();
+
+    const outcome = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    expect(outcome.requirements).toEqual([
+      { kind: "test:verify", data: { hint: "prove it" } },
+    ]);
+    expect(outcome.attemptToken).toBeTruthy();
+    expect(outcome.expiresAt).toBeGreaterThan(Date.now());
+    expect(outcome.userId).toBe("alice");
+
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+      attempts: (await ctx.db.query("pendingSignInAttempts").collect()).length,
+    }));
+    // Eager creation: the account exists; only the session is withheld.
+    expect(counts).toEqual({ accounts: 1, sessions: 0, attempts: 1 });
+
+    // The raw token is never stored.
+    const [attempt] = await attemptRows(t);
+    expect(attempt.attemptTokenHash).not.toBe(outcome.attemptToken);
+  });
+
+  test("an evaluator that throws on sign-up rolls back the user it just created", async () => {
+    const t = setup();
+
+    await expect(
+      signUpEvaluated(t, claims(), THROWING_EVALUATE_HANDLE),
+    ).rejects.toThrow(/no sign-ins for you/);
+
+    const counts = await t.run(async (ctx) => ({
+      accounts: (await ctx.db.query("accounts").collect()).length,
+      sessions: (await ctx.db.query("sessions").collect()).length,
+      attempts: (await ctx.db.query("pendingSignInAttempts").collect()).length,
+    }));
+    expect(counts).toEqual({ accounts: 0, sessions: 0, attempts: 0 });
+  });
+
+  test("continueSignIn stays incomplete until the fact is recorded, then completes", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    // Nothing verified yet: still incomplete, budget burned.
+    const stillIncomplete = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(stillIncomplete.status).toBe("pending-requirements");
+    const [afterFirst] = await attemptRows(t);
+    expect(afterFirst.continueCount).toBe(1);
+    // Continuing never extends the attempt's lifetime.
+    expect(afterFirst.expiresAt).toBe(parked.expiresAt);
+
+    // A verification endpoint records the fact...
+    const recorded = await t.mutation(api.public.recordAttemptFacts, {
+      attemptToken: parked.attemptToken,
+      facts: { verified: true },
+    });
+    expect(recorded).toBe(true);
+
+    // ...and the next round completes: attempt gone, session minted.
+    resetEvaluateSignInCalls();
+    const done = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(done.status).toBe("session-created");
+    if (done.status !== "session-created") throw new Error("unreachable");
+    expect(done.tokens.userId).toBe("alice");
+    expect(getEvaluateSignInCalls()[0].facts).toEqual({ verified: true });
+
+    const counts = await t.run(async (ctx) => ({
+      sessions: (await ctx.db.query("sessions").collect()).length,
+      attempts: (await ctx.db.query("pendingSignInAttempts").collect()).length,
+    }));
+    expect(counts).toEqual({ sessions: 1, attempts: 0 });
+  });
+
+  test("an unknown attempt token reports expired", async () => {
+    const t = setup();
+    const outcome = await t.mutation(api.public.continueSignIn, {
+      attemptToken: "no-such-token",
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(outcome).toEqual({ status: "expired" });
+  });
+
+  test("an attempt past its TTL reports expired and is deleted", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    await t.run(async (ctx) => {
+      const [attempt] = await ctx.db.query("pendingSignInAttempts").collect();
+      await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+        expiresAt: Date.now() - 1,
+      });
+    });
+
+    const outcome = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(outcome).toEqual({ status: "expired" });
+    expect(await attemptRows(t)).toHaveLength(0);
+  });
+
+  test("an attempt over its continuation cap reports expired and is deleted", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    await t.run(async (ctx) => {
+      const [attempt] = await ctx.db.query("pendingSignInAttempts").collect();
+      await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+        continueCount: 10,
+      });
+    });
+
+    const outcome = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(outcome).toEqual({ status: "expired" });
+    expect(await attemptRows(t)).toHaveLength(0);
+  });
+
+  test("a fresh sign-in supersedes the pending attempt and resets its facts", async () => {
+    const t = setup();
+    const first = expectIncomplete(await signUpEvaluated(t, claims()));
+    await t.mutation(api.public.recordAttemptFacts, {
+      attemptToken: first.attemptToken,
+      facts: { verified: true },
+    });
+
+    // A second device signs in fresh (the account now exists): the pending
+    // attempt is replaced wholesale — facts reset, so the factor must be
+    // re-proven — and the first device's token dies with it.
+    const second = expectIncomplete(
+      await signInEvaluated(t, claims({ providerAccountId: "alice" })),
+    );
+    expect(second.attemptToken).not.toBe(first.attemptToken);
+
+    const rows = await attemptRows(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].facts).toEqual({});
+    expect(rows[0].continueCount).toBe(0);
+
+    const firstContinued = await t.mutation(api.public.continueSignIn, {
+      attemptToken: first.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(firstContinued).toEqual({ status: "expired" });
+  });
+
+  test("a fresh completing sign-in deletes the pending attempt", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    const outcome = await signInEvaluated(
+      t,
+      claims(),
+      COMPLETING_EVALUATE_HANDLE,
+    );
+    expectComplete(outcome);
+    expect(await attemptRows(t)).toHaveLength(0);
+
+    const continued = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: EVALUATE_HANDLE,
+      issuer: ISSUER,
+    });
+    expect(continued).toEqual({ status: "expired" });
+  });
+
+  test("getAttemptContext resolves the subject of a live attempt only", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    const context = await t.query(api.public.getAttemptContext, {
+      attemptToken: parked.attemptToken,
+    });
+    expect(context).toEqual({
+      provider: "password",
+      providerAccountId: "alice",
+      userId: "alice",
+    });
+
+    expect(
+      await t.query(api.public.getAttemptContext, {
+        attemptToken: "no-such-token",
+      }),
+    ).toBeNull();
+  });
+
+  test("penalizeAttempt burns budget and deletes the attempt at the cap", async () => {
+    const t = setup();
+    const parked = expectIncomplete(await signUpEvaluated(t, claims()));
+
+    expect(
+      await t.mutation(api.public.penalizeAttempt, {
+        attemptToken: parked.attemptToken,
+      }),
+    ).toBe(true);
+    const [row] = await attemptRows(t);
+    expect(row.continueCount).toBe(1);
+
+    await t.run(async (ctx) => {
+      const [attempt] = await ctx.db.query("pendingSignInAttempts").collect();
+      await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+        continueCount: 9,
+      });
+    });
+    // This failure exhausts the cap: the attempt dies.
+    expect(
+      await t.mutation(api.public.penalizeAttempt, {
+        attemptToken: parked.attemptToken,
+      }),
+    ).toBe(false);
+    expect(await attemptRows(t)).toHaveLength(0);
+  });
+
+  test("recordAttemptFacts reports a dead attempt instead of resurrecting it", async () => {
+    const t = setup();
+    expect(
+      await t.mutation(api.public.recordAttemptFacts, {
+        attemptToken: "no-such-token",
+        facts: { verified: true },
+      }),
+    ).toBe(false);
+  });
+
+  test("provider requirements are checked even with no app onSignIn attached", async () => {
+    // Before the callback paths were unified, a provider that registered its
+    // own requirement while the app attached no `onSignIn` fell down the
+    // notify-only path and had its requirement silently dropped.
+    const t = setup();
+    const providerRequirements = [
+      {
+        kind: "emailValidation",
+        data: { address: "a…@example.com" },
+        factFields: ["emailVerified"],
+      },
+    ];
+
+    const parked = expectIncomplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        providerRequirements,
+        issuer: ISSUER,
+      }),
+    );
+    expect(parked.requirements).toEqual([
+      { kind: "emailValidation", data: { address: "a…@example.com" } },
+    ]);
+
+    await t.mutation(api.public.recordAttemptFacts, {
+      attemptToken: parked.attemptToken,
+      facts: { emailVerified: true },
+      scope: "provider",
+    });
+    const done = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      providerRequirements,
+      issuer: ISSUER,
+    });
+    expect(done.status).toBe("session-created");
+  });
+
+  test("provider requirements gate completion until their provider facts exist", async () => {
+    const t = setup();
+    resetEvaluateSignInCalls();
+    const providerRequirements = [
+      {
+        kind: "emailValidation",
+        data: { address: "a…@example.com" },
+        factFields: ["emailVerified"],
+      },
+    ];
+
+    // The app's evaluator accepts, but the provider requirement is
+    // outstanding, so the sign-up parks.
+    const parked = expectIncomplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims(),
+        createUserHandle: CREATE_USER_HANDLE,
+        onSignInHandle: COMPLETING_EVALUATE_HANDLE,
+        providerRequirements,
+        issuer: ISSUER,
+      }),
+    );
+    expect(parked.requirements).toEqual([
+      { kind: "emailValidation", data: { address: "a…@example.com" } },
+    ]);
+
+    // Recording the fact under the *app* scope must not satisfy it...
+    await t.mutation(api.public.recordAttemptFacts, {
+      attemptToken: parked.attemptToken,
+      facts: { emailVerified: true },
+      scope: "app",
+    });
+    const still = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: COMPLETING_EVALUATE_HANDLE,
+      providerRequirements,
+      issuer: ISSUER,
+    });
+    expect(still.status).toBe("pending-requirements");
+
+    // ...but the provider scope does. The app's evaluator never sees the
+    // provider bag (its facts stay what the app scope accumulated).
+    await t.mutation(api.public.recordAttemptFacts, {
+      attemptToken: parked.attemptToken,
+      facts: { emailVerified: true },
+      scope: "provider",
+    });
+    resetEvaluateSignInCalls();
+    const done = await t.mutation(api.public.continueSignIn, {
+      attemptToken: parked.attemptToken,
+      onSignInHandle: COMPLETING_EVALUATE_HANDLE,
+      providerRequirements,
+      issuer: ISSUER,
+    });
+    expect(done.status).toBe("session-created");
+    expect(getEvaluateSignInCalls()[0].facts).toEqual({ emailVerified: true });
+  });
+
+  test("USE_USER_ID_AS_ACCOUNT_ID sign-ups key the attempt by the resolved user id", async () => {
+    const t = setup();
+    const parked = expectIncomplete(
+      await t.mutation(api.public.signUp, {
+        claims: claims({ providerAccountId: "" }),
+        // Mints the user id from the profile ("Alice"): the empty placeholder
+        // account id must never leak into the attempt or the evaluator.
+        createUserHandle: "testApp:createUserFromProfileName",
+        onSignInHandle: EVALUATE_HANDLE,
+        issuer: ISSUER,
+      }),
+    );
+    expect(parked.userId).toBe("Alice");
+    const context = await t.query(api.public.getAttemptContext, {
+      attemptToken: parked.attemptToken,
+    });
+    expect(context).toEqual({
+      provider: "password",
+      providerAccountId: "Alice",
+      userId: "Alice",
+    });
   });
 });

--- a/packages/core/src/components/core/public.ts
+++ b/packages/core/src/components/core/public.ts
@@ -14,6 +14,14 @@ import {
   vTokenBundle,
   type TokenBundle,
   USE_USER_ID_AS_ACCOUNT_ID,
+  vProviderSignInOutcome,
+  type ProviderSignInOutcome,
+  vProviderContinueOutcome,
+  type ProviderContinueOutcome,
+  vProviderRequirement,
+  type ProviderRequirement,
+  type SignInRequirement,
+  vAttemptContext,
 } from "../../lib/types.ts";
 import { signJwt, generateRefreshToken } from "./crypto.ts";
 import { sha256Hex } from "../../lib/crypto.ts";
@@ -37,6 +45,13 @@ export const REFRESH_GRACE_MS = 30 * 1000; // 30 seconds
 // reuse-detection horizon: past it the row is gone and a replayed token reads
 // as unknown, which revokes nothing but also grants nothing.
 export const SPENT_TOKEN_HORIZON_MS = 60 * 60 * 1000; // 1 hour
+// How long a parked incomplete sign-in stays continuable. Long enough for a
+// user to answer a challenge, short enough that parked sign-ins don't linger.
+const ATTEMPT_TTL_MS = 10 * 60 * 1000; // 10 minutes
+// How many times a single attempt may be continued (or penalized) before it
+// is discarded — a brute-force/looping guard (e.g. guessing a second-factor
+// challenge).
+const MAX_CONTINUE_COUNT = 10;
 
 // The issuer (CONVEX_SITE_URL) is passed in by the app rather than read here:
 // inside a component the system var arrives prefixed with the mount's
@@ -274,7 +289,6 @@ function asUserId(userId: string): GenericId<string> {
  * session needs: the account id and its app user id. The claims are passed to
  * the `createUser` callback.
  *
- * Both `signUp` and the sessionless `signUpWithoutSession` build on this.
  */
 async function createAccount(
   ctx: MutationCtx,
@@ -336,24 +350,189 @@ async function createAccount(
   return { accountId, userId };
 }
 
+// --- Sign-in attempts (incomplete sign-ins) ---------------------------------
+
+/** Look up the (at most one) pending attempt for a provider identity. */
+function attemptByIdentity(
+  ctx: QueryCtx,
+  provider: string,
+  providerAccountId: string,
+): Promise<Doc<"pendingSignInAttempts"> | null> {
+  return ctx.db
+    .query("pendingSignInAttempts")
+    .withIndex("by_provider_account", (q) =>
+      q.eq("provider", provider).eq("providerAccountId", providerAccountId),
+    )
+    .unique();
+}
+
 /**
- * Run the app's sign-in callback, if it attached one. Every sign-in goes
- * through here, a first one included, so per-sign-in work in the app has a
- * single home.
+ * Load the live attempt a bearer token names, or `null` — deleting the row —
+ * when the token is unknown, the attempt has expired, or it is over its
+ * continuation cap. Shared by {@link continueSignIn} and the fact primitives
+ * below so every touch applies the same hygiene.
  */
-async function notifySignIn(
+async function liveAttemptByToken(
   ctx: MutationCtx,
-  claims: AuthClaims,
+  attemptToken: string,
+): Promise<Doc<"pendingSignInAttempts"> | null> {
+  const attemptTokenHash = await sha256Hex(attemptToken);
+  const attempt = await ctx.db
+    .query("pendingSignInAttempts")
+    .withIndex("by_token_hash", (q) =>
+      q.eq("attemptTokenHash", attemptTokenHash),
+    )
+    .unique();
+  if (attempt === null) return null;
+  if (
+    attempt.expiresAt < Date.now() ||
+    attempt.continueCount >= MAX_CONTINUE_COUNT
+  ) {
+    await ctx.db.delete("pendingSignInAttempts", attempt._id);
+    return null;
+  }
+  return attempt;
+}
+
+/**
+ * Run one round of sign-in evaluation and collect the outstanding
+ * requirements.
+ *
+ * Two checks compose, in a fixed order:
+ *
+ *  1. *Provider-registered* requirements (injected by the provider's setup
+ *     from its config options) are checked by the framework itself: one is
+ *     outstanding until every one of its `factFields` is present in the
+ *     attempt's provider-scoped facts bag.
+ *  2. The app's `onSignIn` callback, when one is attached, judges the
+ *     sign-in against the app-scoped facts bag and returns its verdict. An
+ *     app with no requirements returns `null` every time, which is how a
+ *     plain per-sign-in hook and a full evaluator are the same callback.
+ *
+ * The two facts bags are disjoint on purpose: the app's callback never sees
+ * provider facts, so its strictly-validated `facts` arg can't be broken by
+ * fields it never declared. A provider-registered requirement is therefore
+ * checked even when the app attached no callback at all.
+ *
+ * The callback runs on *every* round — first sign-in, returning sign-in, and
+ * each continuation — and is deliberately blind to which round this is: it
+ * judges `(user, profile, facts)` and nothing else. `providerAccountId` is
+ * always the *resolved* id (the attempt's key), never a sign-up placeholder.
+ */
+async function evaluateSignIn(
+  ctx: MutationCtx,
+  identity: { provider: string; providerAccountId: string; profile: unknown },
   userId: string,
-  onSignInHandle: string | undefined,
-): Promise<void> {
-  if (onSignInHandle === undefined) return;
-  await ctx.runMutation(onSignInHandle as OnSignInFunctionHandle, {
-    provider: claims.provider,
-    providerAccountId: claims.providerAccountId,
-    profile: claims.profile,
+  facts: Record<string, unknown>,
+  providerFacts: Record<string, unknown>,
+  onSignInHandle: OnSignInFunctionHandle | undefined,
+  providerRequirements: ProviderRequirement[],
+): Promise<SignInRequirement[]> {
+  const outstanding = providerRequirements
+    .filter(
+      (requirement) =>
+        !requirement.factFields.every(
+          (field) => providerFacts[field] !== undefined,
+        ),
+    )
+    .map((requirement) => ({
+      kind: requirement.kind,
+      data: requirement.data,
+    }));
+  if (onSignInHandle === undefined) return outstanding;
+  const verdict = await ctx.runMutation(onSignInHandle, {
+    provider: identity.provider,
+    providerAccountId: identity.providerAccountId,
+    profile: identity.profile,
     userId: asUserId(userId),
+    facts,
   });
+  return [...outstanding, ...(verdict === null ? [] : verdict.requirements)];
+}
+
+/**
+ * Finish a *fresh* (non-continuation) sign-in round: evaluate with empty
+ * facts bags, then either mint the session or park the sign-in as an attempt.
+ *
+ * Any pending attempt for the identity is superseded either way: a fresh
+ * sign-in that completes deletes it, and one that stays incomplete replaces
+ * it wholesale — new token, facts reset (a fresh sign-in re-proves its
+ * factors, the conservative default), continuation budget restored. That
+ * also means a second device signing in invalidates the first device's
+ * attempt token.
+ */
+async function finishSignIn(
+  ctx: MutationCtx,
+  opts: {
+    identity: {
+      provider: string;
+      providerAccountId: string;
+      profile: unknown;
+    };
+    accountId: Id<"accounts">;
+    userId: string;
+    onSignInHandle: OnSignInFunctionHandle | undefined;
+    providerRequirements: ProviderRequirement[];
+    issuer: string;
+    ttl: TtlConfig;
+  },
+): Promise<ProviderSignInOutcome> {
+  const { identity, userId } = opts;
+  const pending = await attemptByIdentity(
+    ctx,
+    identity.provider,
+    identity.providerAccountId,
+  );
+  const requirements = await evaluateSignIn(
+    ctx,
+    identity,
+    userId,
+    {},
+    {},
+    opts.onSignInHandle,
+    opts.providerRequirements,
+  );
+
+  if (requirements.length === 0) {
+    if (pending !== null) {
+      await ctx.db.delete("pendingSignInAttempts", pending._id);
+    }
+    const tokens = await issueSession(
+      ctx,
+      opts.accountId,
+      userId,
+      opts.issuer,
+      opts.ttl,
+    );
+    return { status: "session-created", tokens };
+  }
+
+  const attemptToken = generateRefreshToken();
+  const attempt = {
+    provider: identity.provider,
+    providerAccountId: identity.providerAccountId,
+    profile: identity.profile,
+    // Filled in by `recordAttemptFacts` as verification endpoints succeed; a
+    // fresh sign-in always starts with empty bags.
+    facts: {},
+    providerFacts: {},
+    userId,
+    attemptTokenHash: await sha256Hex(attemptToken),
+    expiresAt: Date.now() + ATTEMPT_TTL_MS,
+    continueCount: 0,
+  };
+  if (pending !== null) {
+    await ctx.db.patch("pendingSignInAttempts", pending._id, attempt);
+  } else {
+    await ctx.db.insert("pendingSignInAttempts", attempt);
+  }
+  return {
+    status: "pending-requirements",
+    requirements,
+    attemptToken,
+    expiresAt: attempt.expiresAt,
+    userId,
+  };
 }
 
 // --- Component API ------------------------------------------------------------
@@ -371,6 +550,13 @@ async function notifySignIn(
  * other sign-in. An `onSignIn` that throws therefore rolls back the user
  * `createUser` just made, since both are subtransactions of this one.
  *
+ * The sign-in may come back `pending-requirements` when requirements are outstanding —
+ * the app's `onSignIn` asked for more, or a provider-registered requirement
+ * is unmet. The user and account are created eagerly either way, and only the
+ * session is withheld, which makes abandoned incomplete sign-ups
+ * self-healing: signing *in* later resolves the same user and re-prompts,
+ * instead of failing or minting a duplicate.
+ *
  * The JWT accessToken in the return value is issued with `issuer` as its
  * `iss`. Token lifetimes default to 1m (access) and 30d (refresh) unless
  * `accessTokenTtlSeconds` / `refreshTokenTtlSeconds` are supplied (the app
@@ -384,20 +570,39 @@ export const signUp = mutation({
     claims: vAuthClaims,
     createUserHandle: v.string(),
     onSignInHandle: v.optional(v.string()),
+    providerRequirements: v.optional(v.array(vProviderRequirement)),
     issuer: v.string(),
     accessTokenTtlSeconds: v.optional(v.number()),
     refreshTokenTtlSeconds: v.optional(v.number()),
   },
-  returns: vTokenBundle,
-  handler: async (ctx, args): Promise<TokenBundle> => {
+  returns: vProviderSignInOutcome,
+  handler: async (ctx, args): Promise<ProviderSignInOutcome> => {
     const ttl = resolveTtlConfig(args);
     const { accountId, userId } = await createAccount(
       ctx,
       args.claims,
       args.createUserHandle as CreateUserFunctionHandle,
     );
-    await notifySignIn(ctx, args.claims, userId, args.onSignInHandle);
-    return await issueSession(ctx, accountId, userId, args.issuer, ttl);
+    return await finishSignIn(ctx, {
+      identity: {
+        provider: args.claims.provider,
+        // The resolved key, which for USE_USER_ID_AS_ACCOUNT_ID providers is
+        // the user id `createUser` just minted — evaluation always sees (and
+        // attempts are always keyed by) the resolved id, never the sign-up
+        // placeholder.
+        providerAccountId:
+          args.claims.providerAccountId === USE_USER_ID_AS_ACCOUNT_ID
+            ? userId
+            : args.claims.providerAccountId,
+        profile: args.claims.profile,
+      },
+      accountId,
+      userId,
+      onSignInHandle: args.onSignInHandle as OnSignInFunctionHandle | undefined,
+      providerRequirements: args.providerRequirements ?? [],
+      issuer: args.issuer,
+      ttl,
+    });
   },
 });
 
@@ -415,18 +620,24 @@ export const signUp = mutation({
  * `accessTokenTtlSeconds` / `refreshTokenTtlSeconds` are supplied (the app
  * sets these once via `setupCore`).
  *
+ * The sign-in may come back `pending-requirements` when requirements are outstanding:
+ * no session is minted, the sign-in is parked as an attempt, and the returned
+ * `attemptToken` continues it via {@link continueSignIn}. An identity has at
+ * most one live attempt — a fresh sign-in supersedes it.
+ *
  * Throws when the identity has no account.
  */
 export const signIn = mutation({
   args: {
     claims: vAuthClaims,
     onSignInHandle: v.optional(v.string()),
+    providerRequirements: v.optional(v.array(vProviderRequirement)),
     issuer: v.string(),
     accessTokenTtlSeconds: v.optional(v.number()),
     refreshTokenTtlSeconds: v.optional(v.number()),
   },
-  returns: vTokenBundle,
-  handler: async (ctx, args): Promise<TokenBundle> => {
+  returns: vProviderSignInOutcome,
+  handler: async (ctx, args): Promise<ProviderSignInOutcome> => {
     const ttl = resolveTtlConfig(args);
     const { claims } = args;
     const account = await accountByIdentity(
@@ -441,44 +652,213 @@ export const signIn = mutation({
           `A first sign-in for an identity must go through signUp.`,
       );
     }
-    await notifySignIn(ctx, claims, account.userId, args.onSignInHandle);
-    return await issueSession(
-      ctx,
-      account._id,
-      account.userId,
-      args.issuer,
+    return await finishSignIn(ctx, {
+      identity: {
+        provider: claims.provider,
+        providerAccountId: claims.providerAccountId,
+        profile: claims.profile,
+      },
+      accountId: account._id,
+      userId: account.userId,
+      onSignInHandle: args.onSignInHandle as OnSignInFunctionHandle | undefined,
+      providerRequirements: args.providerRequirements ?? [],
+      issuer: args.issuer,
       ttl,
-    );
+    });
   },
 });
 
 /**
- * Create the account and the app user for a provider's verified identity
- * claims, without minting a session.
+ * Continue a parked sign-in attempt, re-running evaluation against the facts
+ * verification endpoints have recorded since the last round.
  *
- * Providers use this (via the `signUpWithoutSession` helper the core hands
- * them) when the user must complete a step before the first sign-in — for
- * example, an email validation. Account creation follows the same rules as
- * `signUp` (the app's `createUser` mutation mints the user,
- * `USE_USER_ID_AS_ACCOUNT_ID` keys the account by the minted user id, and an
- * identity that already has an account is refused), but no session is minted
- * and `onSignIn` does not run: the user cannot make authenticated calls until
- * a later `signIn` succeeds.
+ * When nothing is outstanding anymore the attempt is deleted and a session
+ * minted; otherwise the attempt burns one unit of continuation budget and
+ * reports the remaining requirements (its token and expiry are unchanged —
+ * continuing never extends an attempt's lifetime). Returns `expired` —
+ * deleting the row where one exists — for an unknown token, an attempt past
+ * its lifetime, or one over its continuation cap; the caller should restart
+ * the sign-in from scratch.
+ *
+ * The attempt token is the continuation credential: random, stored only as a
+ * hash, short-lived, and budgeted. Providers do not re-verify their own
+ * factor (the password, say) on continuation.
  */
-export const signUpWithoutSession = mutation({
+export const continueSignIn = mutation({
   args: {
-    claims: vAuthClaims,
-    createUserHandle: v.string(),
+    attemptToken: v.string(),
+    onSignInHandle: v.optional(v.string()),
+    providerRequirements: v.optional(v.array(vProviderRequirement)),
+    issuer: v.string(),
+    accessTokenTtlSeconds: v.optional(v.number()),
+    refreshTokenTtlSeconds: v.optional(v.number()),
   },
-  returns: v.object({ userId: v.string() }),
-  handler: async (ctx, args): Promise<{ userId: string }> => {
-    // TODO: This API is kind of awkward. We might want to reconsider it before the GA v2 release.
-    const { userId } = await createAccount(
+  returns: vProviderContinueOutcome,
+  handler: async (ctx, args): Promise<ProviderContinueOutcome> => {
+    const ttl = resolveTtlConfig(args);
+    const attempt = await liveAttemptByToken(ctx, args.attemptToken);
+    if (attempt === null) return { status: "expired" };
+
+    const requirements = await evaluateSignIn(
       ctx,
-      args.claims,
-      args.createUserHandle as CreateUserFunctionHandle,
+      {
+        provider: attempt.provider,
+        providerAccountId: attempt.providerAccountId,
+        profile: attempt.profile,
+      },
+      attempt.userId,
+      (attempt.facts ?? {}) as Record<string, unknown>,
+      (attempt.providerFacts ?? {}) as Record<string, unknown>,
+      args.onSignInHandle as OnSignInFunctionHandle | undefined,
+      args.providerRequirements ?? [],
     );
-    return { userId };
+
+    if (requirements.length === 0) {
+      await ctx.db.delete("pendingSignInAttempts", attempt._id);
+      const account = await accountByIdentity(
+        ctx,
+        attempt.provider,
+        attempt.providerAccountId,
+      );
+      if (account === null) {
+        // Accounts are created eagerly before any attempt is parked, so a
+        // missing one means the account was deleted mid-flow.
+        throw new Error(
+          `Invariant violation: no account for provider = ${JSON.stringify(attempt.provider)} ` +
+            `and provider account ID = ${JSON.stringify(attempt.providerAccountId)} ` +
+            `behind a live sign-in attempt`,
+        );
+      }
+      const tokens = await issueSession(
+        ctx,
+        account._id,
+        attempt.userId,
+        args.issuer,
+        ttl,
+      );
+      return { status: "session-created", tokens };
+    }
+
+    await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+      continueCount: attempt.continueCount + 1,
+    });
+    return {
+      status: "pending-requirements",
+      requirements,
+      attemptToken: args.attemptToken,
+      expiresAt: attempt.expiresAt,
+      userId: attempt.userId,
+    };
+  },
+});
+
+// --- Verification-fact primitives --------------------------------------------
+//
+// The building blocks for endpoints that *verify* a requirement server-side
+// (a second factor, a CAPTCHA, an email link) and record the proof as a fact
+// on the pending attempt. Like every function here they are
+// component-internal — callable from app/provider server code, never from
+// clients — so the only path to a recorded fact runs through whatever
+// verification the calling endpoint performed. The shape of such an endpoint:
+//
+//   1. `getAttemptContext` — resolve the attempt's *subject* and verify
+//      against it (never against caller-supplied identity).
+//   2. On success: `recordAttemptFacts` — the evaluator sees the fact on the
+//      next round and stops demanding the requirement.
+//   3. On failure: `penalizeAttempt` — a failed verification must burn
+//      continuation budget, or the endpoint is an unmetered guessing oracle.
+
+/**
+ * Resolve a live attempt's subject: which provider identity is mid-sign-in
+ * and which user the flow is anchored to. Returns `null` for an unknown,
+ * expired or over-cap token (surface that as "start over").
+ *
+ * A query, so it cannot lazily delete a dead attempt the way mutating
+ * touches do — the row is simply treated as gone.
+ */
+export const getAttemptContext = query({
+  args: { attemptToken: v.string() },
+  returns: v.union(vAttemptContext, v.null()),
+  handler: async (ctx, args) => {
+    const attemptTokenHash = await sha256Hex(args.attemptToken);
+    const attempt = await ctx.db
+      .query("pendingSignInAttempts")
+      .withIndex("by_token_hash", (q) =>
+        q.eq("attemptTokenHash", attemptTokenHash),
+      )
+      .unique();
+    if (
+      attempt === null ||
+      attempt.expiresAt < Date.now() ||
+      attempt.continueCount >= MAX_CONTINUE_COUNT
+    ) {
+      return null;
+    }
+    return {
+      provider: attempt.provider,
+      providerAccountId: attempt.providerAccountId,
+      userId: attempt.userId,
+    };
+  },
+});
+
+/**
+ * Record verification facts on a pending attempt (shallow merge, later
+ * writes win). This is the *only* write path into the trusted facts bags —
+ * there is no client-writable channel into either. `scope` picks the bag:
+ * `"app"` (the default) is what the app's evaluator reads; `"provider"`
+ * backs provider-registered requirements and stays invisible to the app.
+ * Returns `false` when the attempt is gone (unknown/expired/over-cap) — the
+ * verification succeeded but there is nothing left to record it on, so the
+ * caller should surface "start over".
+ */
+export const recordAttemptFacts = mutation({
+  args: {
+    attemptToken: v.string(),
+    facts: v.any(),
+    scope: v.optional(v.union(v.literal("app"), v.literal("provider"))),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args): Promise<boolean> => {
+    const attempt = await liveAttemptByToken(ctx, args.attemptToken);
+    if (attempt === null) return false;
+    const scope = args.scope ?? "app";
+    if (scope === "provider") {
+      await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+        providerFacts: {
+          ...(attempt.providerFacts ?? {}),
+          ...(args.facts ?? {}),
+        },
+      });
+    } else {
+      await ctx.db.patch("pendingSignInAttempts", attempt._id, {
+        facts: { ...(attempt.facts ?? {}), ...(args.facts ?? {}) },
+      });
+    }
+    return true;
+  },
+});
+
+/**
+ * Meter a *failed* verification against the attempt's continuation cap.
+ * Successes are self-limiting (there are only so many facts to record);
+ * failures are the brute-force surface, and only reach the core through this
+ * call. Returns `false` when the attempt was already gone or this failure
+ * exhausted the cap (the row is deleted either way it dies).
+ */
+export const penalizeAttempt = mutation({
+  args: { attemptToken: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args): Promise<boolean> => {
+    const attempt = await liveAttemptByToken(ctx, args.attemptToken);
+    if (attempt === null) return false;
+    const continueCount = attempt.continueCount + 1;
+    if (continueCount >= MAX_CONTINUE_COUNT) {
+      await ctx.db.delete("pendingSignInAttempts", attempt._id);
+      return false;
+    }
+    await ctx.db.patch("pendingSignInAttempts", attempt._id, { continueCount });
+    return true;
   },
 });
 

--- a/packages/core/src/components/core/schema.ts
+++ b/packages/core/src/components/core/schema.ts
@@ -43,4 +43,33 @@ export default defineSchema({
   })
     .index("by_hash", ["hash"])
     .index("by_session", ["sessionId"]),
+  // One row per *parked* incomplete sign-in: the app's evaluating `onSignIn`
+  // returned outstanding requirements, so the session is withheld and the
+  // sign-in waits here to be continued. The user and account already exist
+  // (creation is eager); the attempt only remembers what evaluation needs to
+  // re-run. At most one live attempt exists per (provider, providerAccountId)
+  // — a fresh sign-in supersedes it. The raw attempt token is never stored,
+  // only its SHA-256 hash.
+  pendingSignInAttempts: defineTable({
+    provider: v.string(),
+    // The *resolved* provider account id (for providers keyed by the app user
+    // id, that user id — never the sign-up placeholder).
+    providerAccountId: v.string(),
+    profile: v.any(),
+    // Server-verified facts the app's evaluator sees, recorded only via
+    // `recordAttemptFacts` (scope "app"). Never client-writable.
+    facts: v.optional(v.any()),
+    // Facts backing provider-registered requirements, checked by the
+    // framework itself and invisible to the app's evaluator (scope
+    // "provider").
+    providerFacts: v.optional(v.any()),
+    userId: v.string(),
+    attemptTokenHash: v.string(),
+    expiresAt: v.number(),
+    // How many times this attempt has been continued or penalized; the cap
+    // is the brute-force guard on requirement verification.
+    continueCount: v.number(),
+  })
+    .index("by_token_hash", ["attemptTokenHash"])
+    .index("by_provider_account", ["provider", "providerAccountId"]),
 });

--- a/packages/core/src/components/core/setup.ts
+++ b/packages/core/src/components/core/setup.ts
@@ -18,6 +18,7 @@ import {
   type TokenBundle,
   type ConvexAuthCtx,
   type UserCallbacks,
+  type ProviderSignInOutcome,
 } from "../../lib/types.ts";
 
 /**
@@ -295,6 +296,26 @@ export function setupCore<UsersTable extends string = "users">(options: {
 
     // The helpers close over the live ctx; both mutation and action ctxs
     // expose the compatible `runMutation`/`runQuery` these need.
+    // The component reports an *outcome* now: a session was created, or
+    // requirements are outstanding and the sign-in is parked. Nothing
+    // registers requirements yet — no provider passes `providerRequirements`
+    // and no app callback can return a verdict a provider would understand —
+    // so the helpers keep their bundle-returning signature and treat the
+    // parked arm as the invariant violation it would be.
+    //
+    // TODO: the next change hands providers the outcome itself, along with
+    // the helpers that continue a parked attempt, and this unwrapping goes
+    // away.
+    const expectSession = (outcome: ProviderSignInOutcome): TokenBundle => {
+      if (outcome.status !== "session-created") {
+        throw new Error(
+          `Invariant violation: provider "${name}" registers no sign-in ` +
+            "requirements, but the sign-in was parked as incomplete.",
+        );
+      }
+      return outcome.tokens;
+    };
+
     const makeHelpers = (
       ctx:
         | GenericActionCtx<GenericDataModel>
@@ -304,50 +325,38 @@ export function setupCore<UsersTable extends string = "users">(options: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<TokenBundle> => {
-        return await ctx.runMutation(component.public.signUp, {
-          claims: {
-            provider: name,
-            providerAccountId: args.providerAccountId,
-            profile: args.profile,
-          },
-          createUserHandle: await createFunctionHandle(createUser),
-          onSignInHandle: await onSignInHandle(),
-          issuer: issuer(),
-          accessTokenTtlSeconds,
-          refreshTokenTtlSeconds,
-        });
+        return expectSession(
+          await ctx.runMutation(component.public.signUp, {
+            claims: {
+              provider: name,
+              providerAccountId: args.providerAccountId,
+              profile: args.profile,
+            },
+            createUserHandle: await createFunctionHandle(createUser),
+            onSignInHandle: await onSignInHandle(),
+            issuer: issuer(),
+            accessTokenTtlSeconds,
+            refreshTokenTtlSeconds,
+          }),
+        );
       },
       completeSignIn: async (args: {
         providerAccountId: string;
         profile: Profile;
       }): Promise<TokenBundle> => {
-        return await ctx.runMutation(component.public.signIn, {
-          claims: {
-            provider: name,
-            providerAccountId: args.providerAccountId,
-            profile: args.profile,
-          },
-          onSignInHandle: await onSignInHandle(),
-          issuer: issuer(),
-          accessTokenTtlSeconds,
-          refreshTokenTtlSeconds,
-        });
-      },
-      // Creates the app user + account without a session, for providers where
-      // the user must complete a step (e.g. an email validation) before the
-      // first sign-in.
-      signUpWithoutSession: async (args: {
-        providerAccountId: string;
-        profile: Profile;
-      }): Promise<{ userId: string }> => {
-        return await ctx.runMutation(component.public.signUpWithoutSession, {
-          claims: {
-            provider: name,
-            providerAccountId: args.providerAccountId,
-            profile: args.profile,
-          },
-          createUserHandle: await createFunctionHandle(createUser),
-        });
+        return expectSession(
+          await ctx.runMutation(component.public.signIn, {
+            claims: {
+              provider: name,
+              providerAccountId: args.providerAccountId,
+              profile: args.profile,
+            },
+            onSignInHandle: await onSignInHandle(),
+            issuer: issuer(),
+            accessTokenTtlSeconds,
+            refreshTokenTtlSeconds,
+          }),
+        );
       },
       resolveUserId: async (
         providerAccountId: string,

--- a/packages/core/src/components/core/testApp.ts
+++ b/packages/core/src/components/core/testApp.ts
@@ -69,3 +69,90 @@ export const onSignInThatThrows = internalMutation({
     throw new Error("no sign-ins for you");
   },
 });
+
+/**
+ * The shape of an evaluating `onSignIn` call, mirroring what the core sends
+ * to `evaluateSignInHandle` (test-only).
+ */
+export const vEvaluateSignIn = v.object({
+  ...vOnSignIn.fields,
+  facts: v.any(),
+});
+type EvaluateSignInCall = Infer<typeof vEvaluateSignIn>;
+const evaluateSignInCalls: EvaluateSignInCall[] = [];
+
+/** Read the recorded evaluator calls (test-only). */
+export function getEvaluateSignInCalls(): readonly EvaluateSignInCall[] {
+  return evaluateSignInCalls;
+}
+
+/** Clear the recorded evaluator calls (test-only). */
+export function resetEvaluateSignInCalls(): void {
+  evaluateSignInCalls.length = 0;
+}
+
+const vTestVerdict = v.union(
+  v.null(),
+  v.object({
+    status: v.literal("requirements-needed"),
+    requirements: v.array(
+      v.object({ kind: v.string(), data: v.optional(v.any()) }),
+    ),
+  }),
+);
+
+/**
+ * Stand-in for an app's evaluating `onSignIn`: demands the `verified` fact,
+ * accepting the sign-in only once a verification endpoint has recorded it.
+ */
+export const evaluateSignIn = internalMutation({
+  args: vEvaluateSignIn,
+  returns: vTestVerdict,
+  handler: async (_ctx, args) => {
+    evaluateSignInCalls.push({ ...args });
+    const facts = args.facts as Record<string, unknown>;
+    if (facts.verified === undefined) {
+      return {
+        status: "requirements-needed" as const,
+        requirements: [{ kind: "test:verify", data: { hint: "prove it" } }],
+      };
+    }
+    return null;
+  },
+});
+
+/** An evaluator that accepts every sign-in outright (test-only). */
+export const evaluateSignInAlwaysComplete = internalMutation({
+  args: vEvaluateSignIn,
+  returns: vTestVerdict,
+  handler: async (_ctx, args) => {
+    evaluateSignInCalls.push({ ...args });
+    return null;
+  },
+});
+
+/**
+ * An evaluator that always throws, for asserting that a rejected first
+ * sign-in rolls back everything the same call created (test-only).
+ */
+export const evaluateSignInThatThrows = internalMutation({
+  args: vEvaluateSignIn,
+  returns: vTestVerdict,
+  handler: async () => {
+    throw new Error("no sign-ins for you");
+  },
+});
+
+/**
+ * A `createUser` that mints the user id from the profile instead of echoing
+ * the provider account id — what the `USE_USER_ID_AS_ACCOUNT_ID` tests need,
+ * since there the incoming account id is the empty placeholder (test-only).
+ */
+export const createUserFromProfileName = internalMutation({
+  args: vCreateUser,
+  returns: v.string(),
+  handler: async (_ctx, args) => {
+    createUserCalls.push({ ...args });
+    return (args.profile as { name: string }).name;
+  },
+});

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -32,6 +32,20 @@ export const vTokenBundle = v.object({
 
 export type TokenBundle = Infer<typeof vTokenBundle>;
 
+/**
+ * One pending sign-in requirement as it crosses the wire: its registered
+ * `kind` plus the payload the server sends down with it (a CAPTCHA
+ * challenge, a label to display, …).
+ *
+ * The core treats requirements as opaque payloads of this shape.
+ */
+export const vSignInRequirement = v.object({
+  kind: v.string(),
+  data: v.optional(v.any()),
+});
+
+export type SignInRequirement = Infer<typeof vSignInRequirement>;
+
 /** The success arm, `complete`: a session was minted. */
 export const vSignInSuccess = v.object({
   status: v.literal("complete"),
@@ -40,11 +54,102 @@ export const vSignInSuccess = v.object({
 
 export type SignInSuccess = Infer<typeof vSignInSuccess>;
 
+/**
+ * The incomplete arm: the credentials verified, but sign-in requirements
+ * remain outstanding. `attemptToken` resumes the parked sign-in.
+ *
+ * The server-side counterpart is {@link ProviderSignInOutcome}'s
+ * `pending-requirements` arm, which additionally carries a server-only
+ * `userId`.
+ */
+export type SignInIncomplete<Req = SignInRequirement> = {
+  status: "incomplete";
+  requirements: Req[];
+  attemptToken: string;
+  expiresAt: number;
+};
+
 /** The error arm: a correctable, provider-specific failure. */
 export type SignInError<UserError> = {
   status: "error";
   userError: UserError;
 };
+
+/**
+ * The verdict an evaluating `onSignIn` callback returns: `null` accepts the
+ * sign-in (a session is minted), `requirements-needed` withholds the session
+ * and surfaces the still-outstanding requirements to the client.
+ *
+ * The value reads as the directive it is — it *asks* the core for the
+ * requirements it names. What the core then reports to provider code is
+ * {@link ProviderSignInOutcome}'s `pending-requirements` arm.
+ */
+export type OnSignInVerdict = null | {
+  status: "requirements-needed";
+  requirements: SignInRequirement[];
+};
+
+/**
+ * A *provider-registered* requirement, injected by a provider's setup
+ * function based on its config options (as opposed to the app-registered
+ * requirements the `onSignIn` evaluator judges). The framework itself checks
+ * it: the requirement is outstanding until every field in `factFields` is
+ * present in the attempt's provider-scoped facts bag, which provider-owned
+ * verification endpoints populate via `recordAttemptFacts(..., "provider")`.
+ * Invisible to the app's `onSignIn`.
+ */
+export const vProviderRequirement = v.object({
+  kind: v.string(),
+  data: v.optional(v.any()),
+  factFields: v.array(v.string()),
+});
+
+export type ProviderRequirement = Infer<typeof vProviderRequirement>;
+
+/**
+ * The outcome of a sign-in as the core component reports it to provider
+ * code: `session-created` with the minted tokens, or `pending-requirements`
+ * with the outstanding requirements and the attempt token that continues it.
+ *
+ * These values deliberately differ from the `complete`/`incomplete` the
+ * client arms use ({@link SignInSuccess}, {@link SignInIncomplete}). Both
+ * layers discriminate on `status`, so distinct vocabularies are what stop a
+ * server-side outcome — which carries the server-only `userId` — from
+ * satisfying a client arm structurally and reaching the browser unstripped.
+ * They also read as what they are: a statement about the *session*, not about
+ * the shape of a reply.
+ *
+ * The `pending-requirements` arm is always stateful: the sign-in is parked as
+ * an attempt row and `attemptToken` is the credential that resumes it (until
+ * `expiresAt`). `userId` is server-only — the user exists even though the
+ * sign-in is incomplete (user creation is eager; only the session is
+ * withheld) — and providers strip it before returning results to clients.
+ */
+export const vProviderSignInOutcome = v.union(
+  v.object({ status: v.literal("session-created"), tokens: vTokenBundle }),
+  v.object({
+    status: v.literal("pending-requirements"),
+    requirements: v.array(vSignInRequirement),
+    attemptToken: v.string(),
+    expiresAt: v.number(),
+    userId: v.string(),
+  }),
+);
+
+export type ProviderSignInOutcome = Infer<typeof vProviderSignInOutcome>;
+
+/**
+ * The outcome of continuing a parked sign-in attempt: the sign-in outcomes
+ * plus `expired` for an attempt that is gone — an unknown token, a lapsed
+ * TTL, or an exhausted continuation budget, deliberately indistinguishable
+ * from one another.
+ */
+export const vProviderContinueOutcome = v.union(
+  ...vProviderSignInOutcome.members,
+  v.object({ status: v.literal("expired") }),
+);
+
+export type ProviderContinueOutcome = Infer<typeof vProviderContinueOutcome>;
 
 /**
  * The token bundle that an SSR route hands back to the client. It is a slimmed
@@ -182,6 +287,8 @@ export const vOnSignIn = v.object({
   providerAccountId: v.string(),
   profile: v.any(),
   userId: v.string(),
+  // Always sent, and always empty for an app with no sign-in requirements.
+  facts: v.any(),
 });
 
 /**
@@ -226,18 +333,31 @@ export type CreateUserFn<
 
 /**
  * The type of an app defined sign-in mutation: an optional hook that runs on
- * *every* sign-in.
+ * *every* sign-in — the first one (right after {@link CreateUserFn} has
+ * minted the user) and every one after it, including each continuation of a
+ * sign-in that is waiting on requirements.
  *
- * That includes the first one, where it runs immediately after
- * {@link CreateUserFn} has minted the user. So per-sign-in work (a last-seen
- * timestamp, an audit row, syncing the user record from the latest `profile`,
- * which the core does not store) belongs here and nowhere else.
+ * It is the app's sign-in *evaluator*, and it is deliberately blind to which
+ * round it is: it judges `(user, profile, facts)` and nothing else. Per
+ * sign-in work (a last-seen timestamp, an audit row, syncing the user record
+ * from the latest `profile`, which the core does not store) belongs here and
+ * nowhere else.
  *
- * The core resolves the account to its app user first, so `userId` is always
- * present and there is nothing to return. Declare `returns: v.null()` and
- * return `null`, or leave the callback out entirely. Throw a `ConvexError` to
- * reject the sign in, which on a first sign-in rolls back the user the create
- * callback just made.
+ * Return `null` to accept the sign-in and have a session minted — an app with
+ * no sign-in requirements returns `null` unconditionally, so `returns:
+ * v.null()` is the whole contract. With requirements registered, return a
+ * `requirements-needed` verdict listing what is still outstanding: the session
+ * is withheld, but the user and account already exist (creation is eager)
+ * and, unlike a throw, the verdict *commits* the callback's writes. Throwing
+ * a `ConvexError` remains the hard rejection and, on a first sign-in, rolls
+ * back the user the create callback just made.
+ *
+ * `facts` is the accumulated, server-verified evidence for this sign-in. It
+ * is always passed and always empty for an app with no requirements (declare
+ * `facts: v.object({})`).
+ *
+ * `providerAccountId` is always the *resolved* account id, never a provider's
+ * internal sign-up placeholder.
  *
  * Like {@link CreateUserFn}, the args must be declared with the provider's
  * exact literal types, and one mutation per provider (delegating to a plain
@@ -255,8 +375,9 @@ export type OnSignInFn<
     providerAccountId: string;
     profile: Profile;
     userId: GenericId<UsersTable>;
+    facts: Record<string, unknown>;
   },
-  null
+  null | { status: "requirements-needed"; requirements: SignInRequirement[] }
 >;
 
 /**
@@ -272,6 +393,22 @@ export type UserCallbacks<
   createUser: CreateUserFn<Provider, Profile, UsersTable>;
   onSignIn?: OnSignInFn<Provider, Profile, UsersTable>;
 };
+
+/**
+ * The subject of a parked sign-in attempt, as verification endpoints resolve
+ * it from an attempt token.
+ *
+ * Endpoints must verify factors against this subject — never against a
+ * caller-supplied identity — so "confirm the factor" cannot become "confirm
+ * as anyone".
+ */
+export const vAttemptContext = v.object({
+  provider: v.string(),
+  providerAccountId: v.string(),
+  userId: v.string(),
+});
+
+export type AttemptContext = Infer<typeof vAttemptContext>;
 
 /**
  * The helpers that `authMutation`/`authAction` inject onto `ctx` for a
@@ -312,20 +449,6 @@ export type BoundAuthHelpers<Profile> = {
     providerAccountId: string;
     profile: Profile;
   }): Promise<TokenBundle>;
-  /**
-   * Create the account and the app user for a verified identity, but do not
-   * mint a session.
-   *
-   * Call this when the user must complete a step (for example, an email
-   * validation) before the first sign-in. Account creation follows the same
-   * rules as `completeSignUp`: the app's `createUser` mints the user, and an
-   * identity that already has an account is refused. `onSignIn` does not run.
-   * The provider signs the user in later with `completeSignIn`.
-   */
-  signUpWithoutSession(args: {
-    providerAccountId: string;
-    profile: Profile;
-  }): Promise<{ userId: string }>;
   /**
    * Look up the app user id for a given `providerAccountId`.
    *

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -58,10 +58,7 @@ const FAKE_BUNDLE: TokenBundle = {
   userId: "user-1",
 };
 
-/**
- * A fake core whose builders inject fake {@link BoundAuthHelpers}.
- * `signUpWithoutSession` is never reached by redemption.
- */
+/** A fake core whose builders inject fake {@link BoundAuthHelpers}. */
 const FAKE_CORE = {
   bindProvider: <Provider extends string, Profile>({
     name,
@@ -90,9 +87,6 @@ const FAKE_CORE = {
       completeSignUp: record("signUp"),
       completeSignIn: record("signIn"),
       resolveUserId: async () => resolvedUserId.value,
-      signUpWithoutSession: async () => {
-        throw new Error("signUpWithoutSession is not used by redemption");
-      },
     };
     const authMutation: AuthMutationBuilder<Profile> = (fn) =>
       mutationGeneric({


### PR DESCRIPTION
A sign-in can now end without a session. When evaluation reports outstanding
requirements, the attempt is parked in a new `pendingSignInAttempts` row and
the caller gets `pending-requirements` with a token that resumes it; the user
and account already exist, since creation is eager and only the session is
withheld.

`signUp`/`signIn` return that outcome instead of a bare bundle, and four
functions work the parked attempt: `continueSignIn` re-evaluates it,
`getAttemptContext` resolves its subject so a verification endpoint checks a
factor against *that* user rather than a caller-supplied identity,
`recordAttemptFacts` records what an endpoint proved, and `penalizeAttempt`
burns budget on a failed check so the endpoint isn't an unmetered guessing
oracle. Attempts expire after ten minutes or ten continuations, whichever
comes first, and a fresh sign-in supersedes a pending one for the same
account. Only the SHA-256 hash of the attempt token is stored.

Requirements stay an open `{ kind, data? }` vocabulary here; closing it is
the next change. Two bags of facts, not one: the app's evaluator sees only
`facts`, while `providerFacts` backs requirements a provider registers and
the framework checks itself, so a provider cannot break the app's strictly
validated `facts` argument.

`signUpWithoutSession` goes away — it existed for exactly this situation and
had no callers outside tests.

`ctx.convexAuth.completeSignUp`/`completeSignIn` keep returning a bundle for
now, unwrapping the outcome behind a temporary assertion: nothing registers
requirements yet, so the parked arm is unreachable. That keeps every provider
untouched here; the next change hands them the outcome itself.

One breaking change for apps: the core always sends `facts` to `onSignIn`, so
an existing callback must declare it (`facts: v.object({})` for an app with
no requirements) or argument validation rejects the call.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>