### PR TITLE
Support sign-in requirements in the password provider and its client

### DIFF
--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { ReactNode } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { AuthClient } from "../../browser/sessionManager.ts";
@@ -8,18 +14,25 @@ import type { TokenBundle } from "../../lib/types.ts";
 import { AuthProvider, useAuth } from "../../react/client.tsx";
 import { useAuthToken } from "../../react/index.tsx";
 import { stubSignInApi } from "../../react/testSignInApi.ts";
+import type { FunctionReference } from "convex/server";
+import type {
+  ClientView,
+  SignInIncomplete,
+  SignInSuccess,
+} from "../../lib/types.ts";
+import type { SignInResult, SignUpResult } from "./setup.ts";
 import {
+  Credentials,
+  renderRequirements,
   SignInWithPasswordResult,
   SignUpWithPasswordResult,
+  useRequirementsFlow,
   useSignInWithPassword,
   useSignUpWithPassword,
+  type RequirementFlowContext,
 } from "./react.tsx";
 
 type Result = SignInWithPasswordResult | SignUpWithPasswordResult;
-type Flow = {
-  run: (c: typeof credentials) => Promise<Result>;
-  pending: boolean;
-};
 
 // The hooks run their action through the injected `AuthSignInApi`, so the test
 // substitutes a signInApi rather than mocking `convex/react`.
@@ -37,27 +50,45 @@ const bundle: TokenBundle = {
 
 const credentials = { username: "alice", password: "hunter2" };
 
-// The stub signInApi ignores the reference, so any value will do.
-const mutation = {} as never;
+// The stub signInApi ignores the reference values; only their declared types
+// matter, driving the hooks' inference the way an app without sign-in
+// requirements would (the plain two-arm result unions).
+const signInMutation = {} as FunctionReference<
+  "mutation",
+  "public",
+  Credentials,
+  ClientView<SignInResult>
+>;
+const signUpMutation = {} as FunctionReference<
+  "mutation",
+  "public",
+  Credentials,
+  ClientView<SignUpResult>
+>;
 
 const flows = [
   {
     name: "useSignInWithPassword",
     useFlow: () => {
-      const { signIn, pending } = useSignInWithPassword(mutation);
-      return { run: signIn, pending };
+      const { signIn, pending } = useSignInWithPassword(signInMutation);
+      return { run: signIn as (c: Credentials) => Promise<Result>, pending };
     },
   },
   {
     name: "useSignUpWithPassword",
     useFlow: () => {
-      const { signUp, pending } = useSignUpWithPassword(mutation);
-      return { run: signUp, pending };
+      const { signUp, pending } = useSignUpWithPassword(signUpMutation);
+      return { run: signUp as (c: Credentials) => Promise<Result>, pending };
     },
   },
 ];
 
-function renderFlow(useFlow: () => Flow) {
+function renderFlow<
+  F extends {
+    run: (c: typeof credentials) => Promise<unknown>;
+    pending: boolean;
+  },
+>(useFlow: () => F) {
   const client = new AuthClient({
     mode: "spa",
     authApi: { refreshSession: async () => null, signOut: async () => {} },
@@ -99,7 +130,10 @@ describe.each(flows)("$name", ({ useFlow }) => {
   });
 
   test("user error is returned without adopting a session", async () => {
-    const failure = { status: "error", userError: { error: "USER_NOT_FOUND" } };
+    const failure = {
+      status: "error",
+      userError: { error: "USER_NOT_FOUND" },
+    };
     runMutation.mockResolvedValue(failure);
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
@@ -164,5 +198,364 @@ describe.each(flows)("$name", ({ useFlow }) => {
       await result.current.flow.run(credentials);
     });
     expect(result.current.flow.pending).toBe(false);
+  });
+});
+
+// --- Incomplete sign-ins (requirements) --------------------------------------
+
+/** The closed requirement union an app with requirements would see through
+ * its generated api types. */
+type TestRequirement = { kind: "test:verify"; data: { hint: string } };
+
+const reqSignInMutation = {} as FunctionReference<
+  "mutation",
+  "public",
+  Credentials,
+  ClientView<
+    | SignInSuccess
+    | SignInIncomplete<TestRequirement>
+    | { status: "error"; userError: { error: "USER_NOT_FOUND" } }
+  >
+>;
+
+const reqContinueMutation = {} as FunctionReference<
+  "mutation",
+  "public",
+  { attemptToken: string },
+  ClientView<
+    | SignInSuccess
+    | SignInIncomplete<TestRequirement>
+    | { status: "error"; userError: { error: "ATTEMPT_EXPIRED" } }
+  >
+>;
+
+const incompleteResult = {
+  status: "incomplete",
+  requirements: [{ kind: "test:verify", data: { hint: "prove it" } }],
+  attemptToken: "attempt-1",
+  expiresAt: 4102444800000,
+};
+
+describe("incomplete sign-ins", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runMutation.mockReset();
+  });
+
+  function renderRequirementsFlow(withContinue = true) {
+    return renderFlow(() => {
+      const { signIn, pending } = useSignInWithPassword(
+        reqSignInMutation,
+        withContinue ? reqContinueMutation : undefined,
+      );
+      return { run: signIn, pending };
+    });
+  }
+
+  test("an incomplete result withholds the session and continueWith resumes it", async () => {
+    runMutation
+      .mockResolvedValueOnce(incompleteResult)
+      .mockResolvedValueOnce({ status: "complete", tokens: bundle });
+    const { result } = renderRequirementsFlow();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: Awaited<ReturnType<typeof result.current.flow.run>>;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+
+    expect(returned.status).toBe("incomplete");
+    if (returned.status !== "incomplete") {
+      throw new Error("expected an incomplete result");
+    }
+    expect(returned.requirements).toEqual(incompleteResult.requirements);
+    // No session was adopted for the incomplete round.
+    expect(result.current.auth.isAuthenticated).toBe(false);
+    const { continueWith } = returned;
+
+    let next!: Awaited<ReturnType<typeof continueWith>>;
+    await act(async () => {
+      next = await continueWith();
+    });
+    expect(runMutation).toHaveBeenLastCalledWith({
+      attemptToken: "attempt-1",
+    });
+    expect(next).toEqual({ status: "complete", tokens: bundle });
+    expect(result.current.auth.isAuthenticated).toBe(true);
+  });
+
+  test("a still-incomplete continuation is augmented again (multi-round)", async () => {
+    runMutation
+      .mockResolvedValueOnce(incompleteResult)
+      .mockResolvedValueOnce(incompleteResult)
+      .mockResolvedValueOnce({ status: "complete", tokens: bundle });
+    const { result } = renderRequirementsFlow();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let first!: Awaited<ReturnType<typeof result.current.flow.run>>;
+    await act(async () => {
+      first = await result.current.flow.run(credentials);
+    });
+    if (first.status !== "incomplete") {
+      throw new Error("expected an incomplete result");
+    }
+    const firstIncomplete = first;
+
+    let second!: Awaited<ReturnType<typeof firstIncomplete.continueWith>>;
+    await act(async () => {
+      second = await firstIncomplete.continueWith();
+    });
+    if (second.status !== "incomplete") {
+      throw new Error("expected a second incomplete result");
+    }
+    const secondIncomplete = second;
+
+    let third!: Awaited<ReturnType<typeof secondIncomplete.continueWith>>;
+    await act(async () => {
+      third = await secondIncomplete.continueWith();
+    });
+    expect(third).toEqual({ status: "complete", tokens: bundle });
+  });
+
+  test("ATTEMPT_EXPIRED from the continue mutation passes through", async () => {
+    const expired = {
+      status: "error",
+      userError: { error: "ATTEMPT_EXPIRED" },
+    };
+    runMutation
+      .mockResolvedValueOnce(incompleteResult)
+      .mockResolvedValueOnce(expired);
+    const { result } = renderRequirementsFlow();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: Awaited<ReturnType<typeof result.current.flow.run>>;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+    if (returned.status !== "incomplete") {
+      throw new Error("expected an incomplete result");
+    }
+    const { continueWith } = returned;
+
+    let next!: Awaited<ReturnType<typeof continueWith>>;
+    await act(async () => {
+      next = await continueWith();
+    });
+    expect(next).toEqual(expired);
+    expect(result.current.auth.isAuthenticated).toBe(false);
+  });
+
+  test("a thrown continue mutation folds into OTHER_ERROR", async () => {
+    const cause = new Error("network blip");
+    runMutation
+      .mockResolvedValueOnce(incompleteResult)
+      .mockRejectedValueOnce(cause);
+    const { result } = renderRequirementsFlow();
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: Awaited<ReturnType<typeof result.current.flow.run>>;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+    if (returned.status !== "incomplete") {
+      throw new Error("expected an incomplete result");
+    }
+    const { continueWith } = returned;
+
+    let next!: Awaited<ReturnType<typeof continueWith>>;
+    await act(async () => {
+      next = await continueWith();
+    });
+    expect(next).toEqual({
+      status: "error",
+      userError: { error: "OTHER_ERROR", cause },
+    });
+  });
+
+  test("continueWith without a configured continue mutation throws a setup error", async () => {
+    runMutation.mockResolvedValueOnce(incompleteResult);
+    const { result } = renderRequirementsFlow(false);
+    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
+
+    let returned!: Awaited<ReturnType<typeof result.current.flow.run>>;
+    await act(async () => {
+      returned = await result.current.flow.run(credentials);
+    });
+    if (returned.status !== "incomplete") {
+      throw new Error("expected an incomplete result");
+    }
+    await expect(returned.continueWith()).rejects.toThrow(/continue mutation/);
+  });
+});
+
+// --- Requirements-flow helpers ------------------------------------------------
+
+describe("useRequirementsFlow", () => {
+  const requirement = { kind: "test:verify" as const, data: { hint: "2+2" } };
+
+  function incompleteWith(continueWith: () => Promise<unknown>) {
+    return {
+      status: "incomplete" as const,
+      requirements: [requirement],
+      attemptToken: "attempt-1",
+      expiresAt: 4102444800000,
+      continueWith,
+    };
+  }
+
+  test("adopts a still-incomplete round, then reports completion", async () => {
+    const nextRequirement = { kind: "test:other" as const, data: {} };
+    const secondRound = {
+      status: "incomplete" as const,
+      requirements: [nextRequirement],
+      attemptToken: "attempt-1",
+      expiresAt: 4102444800000,
+      continueWith: vi
+        .fn()
+        .mockResolvedValue({ status: "complete", tokens: {} }),
+    };
+    const onExpired = vi.fn();
+    const { result } = renderHook(() =>
+      useRequirementsFlow(
+        incompleteWith(vi.fn().mockResolvedValue(secondRound)),
+        { onExpired },
+      ),
+    );
+    expect(result.current.requirements).toEqual([requirement]);
+    expect(result.current.attemptToken).toBe("attempt-1");
+
+    let status!: Awaited<ReturnType<typeof result.current.continueSignIn>>;
+    await act(async () => {
+      status = await result.current.continueSignIn();
+    });
+    expect(status).toBe("incomplete");
+    // The fresh round was adopted: requirements and continueWith swap over.
+    expect(result.current.requirements).toEqual([nextRequirement]);
+
+    await act(async () => {
+      status = await result.current.continueSignIn();
+    });
+    expect(status).toBe("complete");
+    expect(secondRound.continueWith).toHaveBeenCalled();
+    expect(onExpired).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  test("an expired attempt reports expired and calls onExpired", async () => {
+    const onExpired = vi.fn();
+    const { result } = renderHook(() =>
+      useRequirementsFlow(
+        incompleteWith(
+          vi.fn().mockResolvedValue({
+            status: "error",
+            userError: { error: "ATTEMPT_EXPIRED" },
+          }),
+        ),
+        { onExpired },
+      ),
+    );
+
+    let status!: Awaited<ReturnType<typeof result.current.continueSignIn>>;
+    await act(async () => {
+      status = await result.current.continueSignIn();
+    });
+    expect(status).toBe("expired");
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unexpected failure lands in the error state and clears on retry", async () => {
+    const cause = new Error("network blip");
+    const failure = {
+      status: "error",
+      userError: { error: "OTHER_ERROR", cause },
+    };
+    const continueWith = vi
+      .fn()
+      .mockResolvedValueOnce(failure)
+      .mockResolvedValueOnce({ status: "complete", tokens: {} });
+    const onExpired = vi.fn();
+    const { result } = renderHook(() =>
+      useRequirementsFlow(incompleteWith(continueWith), { onExpired }),
+    );
+
+    let status!: Awaited<ReturnType<typeof result.current.continueSignIn>>;
+    await act(async () => {
+      status = await result.current.continueSignIn();
+    });
+    expect(status).toBe("error");
+    expect(result.current.error).toEqual({ error: "OTHER_ERROR", cause });
+    expect(onExpired).not.toHaveBeenCalled();
+
+    await act(async () => {
+      status = await result.current.continueSignIn();
+    });
+    expect(status).toBe("complete");
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("renderRequirements", () => {
+  const context: RequirementFlowContext = {
+    attemptToken: "attempt-1",
+    expiresAt: 0,
+    continueSignIn: async () => "complete" as const,
+    expire: () => {},
+  };
+  type Req =
+    | { kind: "test:verify"; data: { hint: string } }
+    | { kind: "test:other"; data: Record<string, never> };
+
+  test("dispatches each requirement to its kind's handler with the context", () => {
+    const requirements: Req[] = [
+      { kind: "test:verify", data: { hint: "2+2" } },
+      { kind: "test:other", data: {} },
+    ];
+    render(
+      <>
+        {renderRequirements(requirements, context, {
+          "test:verify": (req, ctx) => (
+            <p>
+              challenge {req.data.hint} for {ctx.attemptToken}
+            </p>
+          ),
+          "test:other": () => <p>other step</p>,
+        })}
+      </>,
+    );
+    screen.getByText("challenge 2+2 for attempt-1");
+    screen.getByText("other step");
+  });
+
+  test("an unknown kind (version skew) falls back", () => {
+    // A backend that registered a kind this build predates: the closed
+    // union is a compile-time promise, so simulate the skew with a cast.
+    const requirements = [
+      { kind: "future:kind", data: {} },
+    ] as unknown as Req[];
+    render(
+      <>
+        {renderRequirements(requirements, context, {
+          "test:verify": () => <p>never rendered</p>,
+          "test:other": () => <p>never rendered</p>,
+          fallback: (req) => <p>unsupported: {req.kind}</p>,
+        })}
+      </>,
+    );
+    screen.getByText("unsupported: future:kind");
+  });
+
+  test("an unknown kind without a fallback renders nothing", () => {
+    const requirements = [
+      { kind: "future:kind", data: {} },
+    ] as unknown as Req[];
+    const { container } = render(
+      <>
+        {renderRequirements(requirements, context, {
+          "test:verify": () => <p>never rendered</p>,
+          "test:other": () => <p>never rendered</p>,
+        })}
+      </>,
+    );
+    expect(container.textContent).toBe("");
   });
 });

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -13,41 +13,74 @@
  * Each hook returns a function for sending up the credentials and a `pending`
  * value that is flipped to `true` while the credentials are being validated.
  *
+ * When the backend registered sign-in requirements, a flow may resolve to an
+ * *incomplete* result: the credentials verified, but the app requires more
+ * (a second factor, say) before signing the user in. The result carries the
+ * outstanding `requirements` for the UI to walk the user through and a
+ * `continueWith` callback that resumes the flow — call it after the
+ * requirement's verification endpoint has succeeded, and it resolves like
+ * the original call: to a complete session, another incomplete result, or a
+ * failure. Multi-round flows need nothing special; every round looks the
+ * same.
+ *
  * @module
  */
 "use client";
 
 import { FunctionReference } from "convex/server";
-import { useCallback, useState } from "react";
-import type { ClientView } from "../../lib/types.ts";
+import { Fragment, useCallback, useState, type ReactNode } from "react";
+import type { ClientView, SignInRequirement } from "../../lib/types.ts";
 import { useAuthActions, useAuthSignInApi } from "../../react/index.tsx";
-import type { SignInResult, SignUpResult } from "./setup.ts";
+import type {
+  ContinueSignInWithPasswordResult,
+  SignInResult,
+  SignUpResult,
+} from "./setup.ts";
+import type { SignInRequirements } from "../../lib/requirements.ts";
 
 /** The `(username, password)` pair both flows accept. */
 export type Credentials = { username: string; password: string };
 
 /**
- * The `signInWithPassword` mutation the app re-exports from its `setupCore`.
+ * The `signInWithPassword` mutation the app re-exports from its auth setup.
  *
  * Its return value is the access-only {@link ClientView}, which is what both
  * session models have in common. Hand it to `setSession`, the only supported
  * consumer.
+ *
+ * This is the *bound* on what the hooks accept: generated references narrow
+ * the incomplete arm's `requirements` to the app's registered requirement
+ * kinds, and the hooks are generic over the actual reference so those types
+ * flow through to the caller.
  */
 type SignInWithPasswordMutation = FunctionReference<
   "mutation",
   "public",
   Credentials,
-  ClientView<SignInResult>
+  ClientView<SignInResult<SignInRequirements>>
 >;
 
 /**
- * The `signUpWithPassword` mutation the app re-exports from its `setupCore`.
+ * The `signUpWithPassword` mutation the app re-exports from its auth setup;
+ * see {@link SignInWithPasswordMutation} on narrowing.
  */
 type SignUpWithPasswordMutation = FunctionReference<
   "mutation",
   "public",
   Credentials,
-  ClientView<SignUpResult>
+  ClientView<SignUpResult<SignInRequirements>>
+>;
+
+/**
+ * The `continueSignInWithPassword` mutation the app re-exports when it
+ * registered sign-in requirements; see {@link SignInWithPasswordMutation} on
+ * narrowing.
+ */
+type ContinueSignInWithPasswordMutation = FunctionReference<
+  "mutation",
+  "public",
+  { attemptToken: string },
+  ClientView<ContinueSignInWithPasswordResult<SignInRequirements>>
 >;
 
 /**
@@ -63,13 +96,43 @@ type UnexpectedFailure = {
   userError: { error: "OTHER_ERROR"; cause: unknown };
 };
 
+/**
+ * Augment the incomplete arm of a server result with `continueWith`, leaving
+ * every other arm untouched. `ContinueResult` is the server result of the
+ * continue mutation, whose incomplete arm is augmented the same way — so a
+ * multi-round flow types the same at every round.
+ */
+type WithContinue<Result, ContinueResult> = Result extends {
+  status: "incomplete";
+}
+  ? Result & {
+      /**
+       * Resume this sign-in, after satisfying (some of) the requirements:
+       * re-evaluates server-side and resolves like the original call — to a
+       * complete session, another incomplete result, or a failure
+       * (`ATTEMPT_EXPIRED` once the attempt is gone; start over then).
+       */
+      continueWith: () => Promise<PasswordFlowResult<ContinueResult>>;
+    }
+  : Result;
+
+/**
+ * A flow result as returned to the app: the server result with the
+ * incomplete arm augmented with `continueWith` and the failure arms widened
+ * with the client-produced {@link UnexpectedFailure}.
+ */
+export type PasswordFlowResult<Result, ContinueResult = Result> =
+  WithContinue<Result, ContinueResult> | UnexpectedFailure;
+
 /** The result of the `signIn` callback from {@link useSignInWithPassword}. */
-export type SignInWithPasswordResult =
-  ClientView<SignInResult> | UnexpectedFailure;
+export type SignInWithPasswordResult = PasswordFlowResult<
+  ClientView<SignInResult>
+>;
 
 /** The result of the `signUp` callback from {@link useSignUpWithPassword}. */
-export type SignUpWithPasswordResult =
-  ClientView<SignUpResult> | UnexpectedFailure;
+export type SignUpWithPasswordResult = PasswordFlowResult<
+  ClientView<SignUpResult>
+>;
 
 /**
  * Client for the password provider's sign-in flow: wire the backend's
@@ -81,8 +144,8 @@ export type SignUpWithPasswordResult =
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signIn`, check the `status` field on the return value to see
- * whether the sign-in was successful or if you need to handle an error.
+ * After calling `signIn`, switch on the `status` field of the return value
+ * to see whether the sign-in succeeded, needs more from the user, or failed.
  *
  * ```tsx
  * import { useSignInWithPassword } from "@convex-dev/auth/providers/password/react";
@@ -106,23 +169,53 @@ export type SignUpWithPasswordResult =
  * }
  * ```
  *
+ * When the backend registered sign-in requirements, pass the app's
+ * `continueSignInWithPassword` reference too, and handle the incomplete
+ * result:
+ *
+ * ```tsx
+ * const { signIn, pending } = useSignInWithPassword(
+ *   api.auth.signInWithPassword,
+ *   api.auth.continueSignInWithPassword,
+ * );
+ * // ...
+ * const result = await signIn({ username, password });
+ * if (result.status === "incomplete") {
+ *   // walk the user through result.requirements, then:
+ *   const next = await result.continueWith();
+ * }
+ * ```
+ *
  * @param signInMutation The app's `signInWithPassword` mutation reference.
+ * @param continueMutation The app's `continueSignInWithPassword` mutation
+ *   reference; required to resume incomplete sign-ins.
  */
-export function useSignInWithPassword(
-  signInMutation: SignInWithPasswordMutation,
+export function useSignInWithPassword<
+  Result extends SignInWithPasswordMutation["_returnType"],
+  ContinueResult extends ContinueSignInWithPasswordMutation["_returnType"] =
+    never,
+>(
+  signInMutation: FunctionReference<"mutation", "public", Credentials, Result>,
+  continueMutation?: FunctionReference<
+    "mutation",
+    "public",
+    { attemptToken: string },
+    ContinueResult
+  >,
 ) {
-  const { run, pending } = usePasswordFlow(signInMutation);
+  const { run, pending } = usePasswordFlow(signInMutation, continueMutation);
   return {
     /**
      * Passes up the given crendentials to perform a username/password sign in.
      *
-     * Returns an object with a `status` discriminant.
+     * Returns an object discriminated by `status`.
      *
-     * `"complete"` means the sign-in succeeded and the client will establish
+     * On `"complete"` the sign-in worked and the client will establish
      * an authenticated session with the Convex backend server.
      *
-     * `"error"` means the returned object has a `userError` field with
-     * additional details about why sign-in failed.
+     * On `"incomplete"` requirements are outstanding: walk the user through
+     * `requirements`, then resume via `continueWith`. On `"error"` the
+     * object has a `userError` field detailing why sign-in failed.
      */
     signIn: run,
     /** `true` if the sign-in attempt is being validated. */
@@ -140,8 +233,8 @@ export function useSignInWithPassword(
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signUp`, check the `status` field on the return value to see
- * whether the sign-up was successful or if you need to handle an error.
+ * After calling `signUp`, switch on the `status` field of the return value
+ * to see whether the sign-up succeeded, needs more from the user, or failed.
  *
  * ```tsx
  * import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
@@ -154,22 +247,35 @@ export function useSignInWithPassword(
  * ```
  *
  * @param signUpMutation The backend's `signUpWithPassword` mutation reference.
+ * @param continueMutation The app's `continueSignInWithPassword` mutation
+ *   reference; required to resume incomplete sign-ups.
  */
-export function useSignUpWithPassword(
-  signUpMutation: SignUpWithPasswordMutation,
+export function useSignUpWithPassword<
+  Result extends SignUpWithPasswordMutation["_returnType"],
+  ContinueResult extends ContinueSignInWithPasswordMutation["_returnType"] =
+    never,
+>(
+  signUpMutation: FunctionReference<"mutation", "public", Credentials, Result>,
+  continueMutation?: FunctionReference<
+    "mutation",
+    "public",
+    { attemptToken: string },
+    ContinueResult
+  >,
 ) {
-  const { run, pending } = usePasswordFlow(signUpMutation);
+  const { run, pending } = usePasswordFlow(signUpMutation, continueMutation);
   return {
     /**
      * Passes up the given crendentials to perform a username/password sign up.
      *
-     * Returns an object with a `status` discriminant.
+     * Returns an object discriminated by `status`.
      *
-     * `"complete"` means the sign-up succeeded and the client will establish
+     * On `"complete"` the sign-up worked and the client will establish
      * an authenticated session with the Convex backend server.
      *
-     * `"error"` means the returned object has a `userError` field with
-     * additional details about why sign-up failed.
+     * On `"incomplete"` requirements are outstanding: walk the user through
+     * `requirements`, then resume via `continueWith`. On `"error"` the
+     * object has a `userError` field detailing why sign-up failed.
      */
     signUp: run,
     /** `true` if the sign-up attempt is being validated. */
@@ -177,46 +283,299 @@ export function useSignUpWithPassword(
   };
 }
 
+/** The loose structural shape the flow internals work against; the precise
+ * types are re-applied on the hook's public signature. */
+type AnyServerResult =
+  | { status: "complete"; tokens: Parameters<SetSession>[0] }
+  | {
+      status: "incomplete";
+      requirements: unknown[];
+      attemptToken: string;
+      expiresAt: number;
+      continueWith?: () => Promise<AnyServerResult>;
+    }
+  | { status: "error"; userError: unknown };
+
+type SetSession = ReturnType<typeof useAuthActions>["setSession"];
+
 /**
  * Shared internals for sign-in and sign-up: run the mutation, adopt the
- * session on success, and track in-flight state. The two flows are
- * structurally identical and differ only in the mutation they call and the
- * name they expose the callback under.
+ * session on success, augment an incomplete result with `continueWith`, and
+ * track in-flight state. The two flows are structurally identical and differ
+ * only in the mutation they call and the name they expose the callback
+ * under.
  */
 function usePasswordFlow<
-  Result extends ClientView<SignInResult> | ClientView<SignUpResult>,
->(mutation: FunctionReference<"mutation", "public", Credentials, Result>) {
+  Result extends ClientView<
+    SignInResult<SignInRequirements> | SignUpResult<SignInRequirements>
+  >,
+  ContinueResult extends ClientView<
+    ContinueSignInWithPasswordResult<SignInRequirements>
+  > = never,
+>(
+  mutation: FunctionReference<"mutation", "public", Credentials, Result>,
+  continueMutation?: FunctionReference<
+    "mutation",
+    "public",
+    { attemptToken: string },
+    ContinueResult
+  >,
+) {
   const { setSession } = useAuthActions();
   // Running through the signInApi rather than `useAction` is what lets these hooks
   // serve both session models. See {@link useAuthSignInApi}.
   const signInApi = useAuthSignInApi();
   const [pending, setPending] = useState(false);
 
+  const handle = useCallback(
+    async (result: AnyServerResult): Promise<AnyServerResult> => {
+      if (result.status === "complete") {
+        await setSession(result.tokens);
+        return result;
+      }
+      if (result.status !== "incomplete") return result;
+
+      // Requirements are outstanding: hand the caller the same result with
+      // `continueWith` folded into it. Continuing funnels back through this
+      // handler, so a multi-round flow needs no special handling anywhere.
+      const continueWith = async (): Promise<AnyServerResult> => {
+        if (continueMutation === undefined) {
+          throw new Error(
+            "The sign-in reported outstanding requirements but the hook was " +
+              "given no continue mutation. Pass the app's " +
+              "`continueSignInWithPassword` reference as the hook's second " +
+              "argument.",
+          );
+        }
+        try {
+          const next = await signInApi.mutation(continueMutation, {
+            attemptToken: result.attemptToken,
+          });
+          return await handle(next as AnyServerResult);
+        } catch (cause) {
+          return {
+            status: "error",
+            userError: { error: "OTHER_ERROR", cause },
+          };
+        }
+      };
+      return { ...result, continueWith };
+    },
+    [signInApi, continueMutation, setSession],
+  );
+
   const run = useCallback(
-    async (credentials: Credentials): Promise<Result | UnexpectedFailure> => {
+    async (
+      credentials: Credentials,
+    ): Promise<PasswordFlowResult<Result, ContinueResult>> => {
       setPending(true);
       try {
         const result = await signInApi.mutation(mutation, credentials);
-        if (result.status === "complete") {
-          await setSession(result.tokens);
-        }
-        return result;
+        return (await handle(result as AnyServerResult)) as PasswordFlowResult<
+          Result,
+          ContinueResult
+        >;
       } catch (cause) {
         // The mutation threw instead of resolving to a `userError`. Fold it into
         // the same discriminated result as `OTHER_ERROR`, preserving the thrown
         // value on `cause`, so the caller handles it alongside every other
         // failure and can still inspect or log the original error if it wants.
-        return {
-          status: "error",
-          userError: { error: "OTHER_ERROR", cause },
-        };
+        return { status: "error", userError: { error: "OTHER_ERROR", cause } };
       } finally {
         // Reset even when the mutation throws.
         setPending(false);
       }
     },
-    [signInApi, mutation, setSession],
+    [signInApi, mutation, handle],
   );
 
   return { run, pending };
+}
+
+// --- Requirements flow --------------------------------------------------------
+//
+// TODO: dowski - Everything below is password-flavored only through its type
+// bounds (the shape of this provider's continue mutation); the mechanics are
+// provider-agnostic. Once another provider supports sign-in requirements,
+// consider moving these to a shared module parameterized over the provider's
+// continue mutation.
+
+/**
+ * The incomplete result of any of this provider's flows, derived from the
+ * app's `continueSignInWithPassword` reference alone — the incomplete arm is
+ * structurally identical across sign-in, sign-up, and continuation, so one
+ * reference names them all:
+ *
+ * ```ts
+ * type Incomplete = PasswordIncomplete<
+ *   typeof api.auth.continueSignInWithPassword
+ * >;
+ * ```
+ *
+ * This is the type to park in state when a flow comes back incomplete, and
+ * what {@link useRequirementsFlow} takes over from there.
+ */
+export type PasswordIncomplete<
+  Continue extends ContinueSignInWithPasswordMutation,
+> = Extract<
+  PasswordFlowResult<Continue["_returnType"]>,
+  { status: "incomplete" }
+>;
+
+/**
+ * What one {@link useRequirementsFlow} continuation round resolved to:
+ * `complete` (a session was established; the app's auth state flips),
+ * `incomplete` (requirements remain — the hook adopted the fresh round),
+ * `expired` (the attempt is gone; `onExpired` was called), or `error` (the
+ * mutation failed unexpectedly; see the hook's `error` state).
+ */
+export type ContinueSignInStatus =
+  "complete" | "incomplete" | "expired" | "error";
+
+/**
+ * What a requirement handler (or a capability-authored requirement
+ * component) receives alongside the requirement itself: the attempt's
+ * bearer token to present to verification endpoints, and the two flow
+ * signals — resume the sign-in, or report the attempt gone.
+ *
+ * The object {@link useRequirementsFlow} returns satisfies this shape, so
+ * apps pass it straight through to {@link renderRequirements}.
+ */
+export type RequirementFlowContext = {
+  /** The parked attempt's bearer token, for verification endpoints. */
+  attemptToken: string;
+  /** When the attempt expires (epoch ms). Continuing never extends it. */
+  expiresAt: number;
+  /**
+   * Re-run evaluation, after verification endpoints have recorded their
+   * facts. Resolves to what the round produced; on `incomplete` the flow
+   * has already adopted the fresh requirements.
+   */
+  continueSignIn: () => Promise<ContinueSignInStatus>;
+  /**
+   * Report the attempt gone — e.g. a verification endpoint returned its
+   * "expired" arm. Routes to the flow's `onExpired`.
+   */
+  expire: () => void;
+};
+
+/**
+ * Per-kind requirement renderers, keyed by the closed requirement union the
+ * generated api types carry. The record must name **every** registered
+ * kind — registering a new requirement on the backend fails the build here
+ * with a missing-property error until the UI handles it. The optional
+ * `fallback` is the runtime backstop for version skew (a stale client
+ * bundle against a backend that registered a kind this build predates);
+ * requirement kinds are namespaced (`app:…`), so `fallback` can never
+ * collide with one.
+ */
+export type RequirementHandlers<Req extends { kind: string }> = {
+  [K in Req["kind"]]: (
+    requirement: Extract<Req, { kind: K }>,
+    context: RequirementFlowContext,
+  ) => ReactNode;
+} & {
+  fallback?: (
+    requirement: SignInRequirement,
+    context: RequirementFlowContext,
+  ) => ReactNode;
+};
+
+/**
+ * Render each outstanding requirement through its kind's handler (see
+ * {@link RequirementHandlers}). Headless: it owns the dispatch and the
+ * exhaustiveness, not the form around it.
+ *
+ * ```tsx
+ * {renderRequirements(flow.requirements, flow, {
+ *   "mathFactor:problem": (req, ctx) => <MathChallenge context={ctx} />,
+ *   fallback: (req) => <p>Can't satisfy: {req.kind}</p>,
+ * })}
+ * ```
+ */
+export function renderRequirements<Req extends { kind: string }>(
+  requirements: readonly Req[],
+  context: RequirementFlowContext,
+  handlers: RequirementHandlers<Req>,
+): ReactNode {
+  const byKind = handlers as Record<
+    string,
+    | ((requirement: never, context: RequirementFlowContext) => ReactNode)
+    | undefined
+  >;
+  return requirements.map((requirement) => {
+    const handler = byKind[requirement.kind] ?? handlers.fallback;
+    return (
+      <Fragment key={requirement.kind}>
+        {handler === undefined ? null : handler(requirement as never, context)}
+      </Fragment>
+    );
+  });
+}
+
+/**
+ * Own the requirements phase of a sign-in: hold the current incomplete
+ * round, re-run evaluation via its `continueWith`, adopt the next round
+ * when requirements remain, and fold the terminal arms into two signals —
+ * `onExpired` when the attempt is gone (restart from the credentials form)
+ * and the `error` state for unexpected failures.
+ *
+ * The returned object satisfies {@link RequirementFlowContext}, so it goes
+ * straight into {@link renderRequirements} and capability components. A
+ * completed continuation needs no handling here: `usePasswordFlow` already
+ * adopted the session, and the app's authenticated state flips on its own.
+ */
+export function useRequirementsFlow<
+  Incomplete extends {
+    status: "incomplete";
+    requirements: readonly { kind: string }[];
+    attemptToken: string;
+    expiresAt: number;
+    continueWith: () => Promise<unknown>;
+  },
+>(initial: Incomplete, options: { onExpired: () => void }) {
+  const { onExpired } = options;
+  const [current, setCurrent] = useState(initial);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<UnexpectedFailure["userError"] | null>(
+    null,
+  );
+
+  const continueSignIn =
+    useCallback(async (): Promise<ContinueSignInStatus> => {
+      setPending(true);
+      setError(null);
+      try {
+        const next = (await current.continueWith()) as AnyServerResult;
+        if (next.status === "complete") return "complete";
+        if (next.status === "incomplete") {
+          // The rounds of one flow all share the incomplete shape, so the
+          // fresh round (requirements and continueWith included) slots in.
+          setCurrent(next as unknown as Incomplete);
+          return "incomplete";
+        }
+        const userError = next.userError as { error: string };
+        if (userError.error === "ATTEMPT_EXPIRED") {
+          onExpired();
+          return "expired";
+        }
+        setError(next.userError as UnexpectedFailure["userError"]);
+        return "error";
+      } finally {
+        setPending(false);
+      }
+    }, [current, onExpired]);
+
+  return {
+    /** The still-outstanding requirements of the current round. */
+    requirements: current.requirements as Incomplete["requirements"],
+    attemptToken: current.attemptToken,
+    expiresAt: current.expiresAt,
+    continueSignIn,
+    expire: onExpired,
+    /** `true` while a continuation round is in flight. */
+    pending,
+    /** The last continuation's unexpected failure, cleared on the next one. */
+    error,
+  };
 }

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -1,11 +1,21 @@
-import { Infer, v } from "convex/values";
+import { Infer, v, type Validator } from "convex/values";
+import type { RegisteredMutation } from "convex/server";
 import {
+  vAttemptExpiredError,
   vSignInSuccess,
   USE_USER_ID_AS_ACCOUNT_ID,
+  type ProviderSignInOutcome,
   type SignInError,
+  type SignInIncomplete,
   type SignInSuccess,
   type UserCallbacks,
 } from "../../lib/types.ts";
+import {
+  requirementValidators,
+  type RequirementOf,
+  type SignInFactsOf,
+  type SignInRequirements,
+} from "../../lib/requirements.ts";
 import type { AuthCore } from "../core/setup.ts";
 import type { ComponentApi } from "./_generated/component.ts";
 import type { ComponentApi as UsernameComponentApi } from "../username/_generated/component.ts";
@@ -22,10 +32,15 @@ import {
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "password";
 
+/** The profile shape this provider sends to the app's user callbacks. */
+type PasswordProfile = { username: string };
+
 /**
  * Options for {@link setupUsernamePassword}.
  */
-export type UsernamePasswordOptions = {
+export type UsernamePasswordOptions<
+  R extends SignInRequirements | undefined = undefined,
+> = {
   /**
    * The mounted password component (`components.authPasswordProvider`). The
    * recipe drives its `setPassword` / `verifyPassword` mutations.
@@ -37,6 +52,19 @@ export type UsernamePasswordOptions = {
    * at sign-up and reads it back at sign-in.
    */
   usernameComponent: UsernameComponentApi;
+  /**
+   * The app's sign-in requirements for this provider: an array of
+   * `requirement(...)` declarations (see `@convex-dev/auth/lib/requirements`).
+   *
+   * Registering requirements switches the provider into evaluating mode: the
+   * `onSignIn` callback becomes required, runs as the sign-in *evaluator* on
+   * every round, and may leave a sign-in `incomplete`. The sign-in and
+   * sign-up results gain an incomplete arm carrying the outstanding
+   * requirements and an `attemptToken`, and the setup exports an additional
+   * `continueSignInWithPassword` mutation that resumes a parked sign-in once
+   * requirements have been satisfied.
+   */
+  signInRequirements?: R;
 };
 
 /** This provider's correctable-failure vocabularies. */
@@ -49,29 +77,124 @@ const signUpUserError = v.union(setPasswordUserError, setUsernameUserError);
 type SignInUserError = Infer<typeof signInUserError>;
 type SignUpUserError = Infer<typeof signUpUserError>;
 
-const signInResult = v.union(
-  vSignInSuccess,
-  v.object({ status: v.literal("error"), userError: signInUserError }),
-);
+/**
+ * The incomplete arm of this provider's results, present only when sign-in
+ * requirements were registered — so an app that registered none never has to
+ * narrow an arm that cannot occur. `R` closes the requirement `kind` union.
+ */
+type Incomplete<R extends SignInRequirements | undefined> =
+  R extends SignInRequirements ? SignInIncomplete<RequirementOf<R>> : never;
 
 /**
  * The result of `signInWithPassword`.
  *
  * On success the minted session tokens, otherwise a user-facing `userError`.
+ * When the provider registered sign-in requirements (`R`), the union gains
+ * the incomplete arm: the credentials verified but requirements are
+ * outstanding, and the sign-in is continued via `continueSignInWithPassword`.
  */
-export type SignInResult = SignInSuccess | SignInError<SignInUserError>;
-
-const signUpResult = v.union(
-  vSignInSuccess,
-  v.object({ status: v.literal("error"), userError: signUpUserError }),
-);
+export type SignInResult<R extends SignInRequirements | undefined = undefined> =
+  SignInSuccess | Incomplete<R> | SignInError<SignInUserError>;
 
 /**
  * The result of `signUpWithPassword`.
  *
  * On success the minted session tokens, otherwise a user-facing `userError`.
+ * When the provider registered sign-in requirements (`R`), the union gains
+ * the incomplete arm — the account was created (signing in later re-prompts
+ * for what is still outstanding), but no session exists yet.
  */
-export type SignUpResult = SignInSuccess | SignInError<SignUpUserError>;
+export type SignUpResult<R extends SignInRequirements | undefined = undefined> =
+  SignInSuccess | Incomplete<R> | SignInError<SignUpUserError>;
+
+/**
+ * The result of `continueSignInWithPassword`: the sign-in completed, is
+ * still incomplete, or the attempt is gone (`ATTEMPT_EXPIRED` — unknown
+ * token, lapsed TTL, or exhausted continuation budget) and the user should
+ * sign in again from scratch.
+ */
+export type ContinueSignInWithPasswordResult<R extends SignInRequirements> =
+  | SignInSuccess
+  | Incomplete<R>
+  | SignInError<Infer<typeof vAttemptExpiredError>>;
+
+/**
+ * The app user id an outcome refers to, whether or not a session was created.
+ * The user exists either way — creation is eager, and only the session is
+ * withheld — so the credentials are stored on both arms.
+ */
+function outcomeUserId(outcome: ProviderSignInOutcome): string {
+  return outcome.status === "session-created"
+    ? outcome.tokens.userId
+    : outcome.userId;
+}
+
+/**
+ * Convert a core outcome into the arms returned to clients: `session-created`
+ * becomes the success arm, `pending-requirements` the incomplete arm with the
+ * server-only `userId` stripped. Built field by field rather than forwarded,
+ * since only the differing `status` values keep the outcome from satisfying
+ * the client arm structurally.
+ */
+function clientResult(
+  outcome: ProviderSignInOutcome,
+): SignInSuccess | SignInIncomplete {
+  return outcome.status === "session-created"
+    ? { status: "complete", tokens: outcome.tokens }
+    : {
+        status: "incomplete",
+        requirements: outcome.requirements,
+        attemptToken: outcome.attemptToken,
+        expiresAt: outcome.expiresAt,
+      };
+}
+
+/**
+ * The user callbacks this provider's `attachUserCallbacks` takes, typed from
+ * the registered requirement specs: with none registered the facts bag and
+ * the requirement union are the open ones, and `onSignIn` is the plain
+ * per-sign-in hook it has always been.
+ */
+export type PasswordUserCallbacks<
+  UsersTable extends string,
+  R extends SignInRequirements | undefined,
+> = UserCallbacks<
+  "password",
+  PasswordProfile,
+  UsersTable,
+  SignInFactsOf<R>,
+  RequirementOf<R>
+>;
+
+/**
+ * The public functions {@link setupUsernamePassword} produces for the app to
+ * export, declared as explicit `RegisteredMutation` aliases so Convex's api
+ * codegen preserves the precise arg/result types — including the closed
+ * requirement union — all the way into the browser's `api` types.
+ * `continueSignInWithPassword` exists (at runtime and in the type) only when
+ * sign-in requirements were registered.
+ */
+export type PasswordApi<R extends SignInRequirements | undefined = undefined> =
+  {
+    signUpWithPassword: RegisteredMutation<
+      "public",
+      { username: string; password: string },
+      Promise<SignUpResult<R>>
+    >;
+    signInWithPassword: RegisteredMutation<
+      "public",
+      { username: string; password: string },
+      Promise<SignInResult<R>>
+    >;
+  } & (R extends SignInRequirements
+    ? {
+        continueSignInWithPassword: RegisteredMutation<
+          "public",
+          { attemptToken: string },
+          Promise<ContinueSignInWithPasswordResult<R>>
+        >;
+      }
+    : Record<never, never>);
 
 /**
  * The simplest password recipe: every account is a `(username, password)` pair,
@@ -91,47 +214,127 @@ export type SignUpResult = SignInSuccess | SignInError<SignUpUserError>;
  * The app re-exports the returned `signUpWithPassword` / `signInWithPassword`
  * mutations so its clients can call them.
  *
+ * To gate sign-ins behind additional requirements (a second factor, a
+ * CAPTCHA, …), register them via `signInRequirements` and attach an
+ * evaluating `onSignIn`:
+ *
+ * ```ts
+ * export const {
+ *   signUpWithPassword,
+ *   signInWithPassword,
+ *   continueSignInWithPassword,
+ * } = setupUsernamePassword(core, {
+ *   component: components.authPasswordProvider,
+ *   usernameComponent: components.authUsername,
+ *   signInRequirements: [mathFactor.requirement],
+ * }).attachUserCallbacks({
+ *   createUser: internal.users.createUser,
+ *   onSignIn: internal.users.evaluateSignIn,
+ * });
+ * ```
+ *
+ * The compile-time check on the evaluating `onSignIn` is covariant-only: it
+ * catches a callback emitting an undeclared requirement kind or payload,
+ * while a callback that *misses* a declared kind is caught at runtime by the
+ * validators derived from the same specs.
+ *
  * Account resolution (username → app user id) is owned by the username
  * component: the recipe stores the username there at sign-up, and reads the
  * user id back from it at sign-in. The password component itself stores only
  * `{ userId, passwordHash }` and knows nothing about usernames.
  */
-export function setupUsernamePassword<UsersTable extends string>(
-  core: AuthCore<UsersTable>,
-  options: UsernamePasswordOptions,
-) {
-  const { component, usernameComponent } = options;
+export function setupUsernamePassword<
+  UsersTable extends string,
+  const R extends SignInRequirements | undefined = undefined,
+>(core: AuthCore<UsersTable>, options: UsernamePasswordOptions<R>) {
+  const { component, usernameComponent, signInRequirements } = options;
 
   return {
     /**
-     * Supply the app's user callbacks (see {@link UserCallbacks} for how their
-     * args must be declared) and get this provider's functions to export.
+     * Supply the app's user callbacks (see {@link PasswordUserCallbacks} for
+     * how their args must be declared) and get this provider's functions to
+     * export.
      */
-    attachUserCallbacks({
-      createUser,
-      onSignIn,
-    }: UserCallbacks<"password", { username: string }, UsersTable>) {
+    attachUserCallbacks(
+      callbacks: PasswordUserCallbacks<UsersTable, R>,
+    ): PasswordApi<R> {
+      const { createUser, onSignIn } = callbacks as UserCallbacks<
+        "password",
+        PasswordProfile,
+        UsersTable
+      >;
       const { authMutation } = core.bindProvider({
         name: PROVIDER_NAME,
         createUser,
         onSignIn,
+        requirements: signInRequirements,
       });
+      // The validator helper's conditional arms only resolve for a
+      // non-generic type, and `R` is still a type parameter here. The runtime
+      // arms are exact either way — the incomplete arm is built only when
+      // requirements were registered — and the closed requirement union
+      // reaches clients through `PasswordApi<R>` below.
+      const requirements: SignInRequirements | undefined = signInRequirements;
 
-      return {
+      // The arms every result of this provider shares. The incomplete arm is
+      // present only when requirements were registered, and is deferred to
+      // `requirementValidators` so the union it carries is the one the app's
+      // `onSignIn` is validated against, and so that function's duplicate-kind
+      // and duplicate-fact-field checks run on this path too.
+      const sharedArms: Validator<unknown, "required", string>[] =
+        requirements === undefined
+          ? [vSignInSuccess]
+          : [
+              vSignInSuccess,
+              v.object({
+                status: v.literal("incomplete"),
+                requirements: v.array(
+                  requirementValidators(requirements).vRequirement,
+                ),
+                attemptToken: v.string(),
+                expiresAt: v.number(),
+              }),
+            ];
+
+      /**
+       * One result union, at the width the handlers work in: the requirement
+       * *kinds* stay open here — the closed union is applied once, at
+       * {@link PasswordApi} — but are enforced at runtime by `sharedArms`.
+       */
+      const resultOf = <UserError>(
+        userError: Validator<UserError, "required", string>,
+      ) =>
+        v.union(
+          ...sharedArms,
+          v.object({ status: v.literal("error"), userError }),
+        ) as unknown as Validator<
+          SignInSuccess | SignInIncomplete | SignInError<UserError>,
+          "required",
+          string
+        >;
+
+      const api = {
         /**
-         * Create a new account: reject a taken username or an invalid password,
-         * otherwise create the user + session and store the username and the
-         * password.
+         * Create a new account: reject a taken username or an invalid
+         * password, otherwise create the user, store the credentials, and
+         * either mint the session or report the outstanding requirements.
+         *
+         * The credentials are stored on an incomplete outcome too: the user
+         * and account exist (creation is eager; only the session is
+         * withheld), and an abandoned sign-up heals by signing *in* — the
+         * evaluator re-runs and re-prompts for what is still outstanding.
          */
         signUpWithPassword: authMutation({
           args: { username: v.string(), password: v.string() },
-          returns: signUpResult,
+          returns: resultOf(signUpUserError),
           handler: async (
             ctx,
             { username, password },
-          ): Promise<SignUpResult> => {
+          ): Promise<
+            SignInSuccess | SignInIncomplete | SignInError<SignUpUserError>
+          > => {
             // Validate the username and the password *before* creating
-            // anything, so invalid input never mints a session.
+            // anything, so invalid input never mints a user.
             // (`setUsername` and `setPassword` do the same checks again, but by
             // then the account would already exist.)
             // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
@@ -155,33 +358,19 @@ export function setupUsernamePassword<UsersTable extends string>(
               };
             }
 
-            // Create the account + app user (via the app's createUser) and
-            // mint the session. Password accounts are keyed by the app user id,
-            // which does not exist before this call mints it, hence the
-            // placeholder; sign-in passes the user id itself. `profile.username`
-            // keeps the original casing for display.
-            //
-            // TODO(nicolas) The app's user callbacks should not receive a
-            // provider account ID for the password provider at all: the value
-            // is an internal key ("" at sign-up, the user id afterwards) with
-            // no meaning to the app. We will probably improve this when
-            // providers support typesafe profiles.
             const outcome = await ctx.convexAuth.completeSignUp({
               providerAccountId: USE_USER_ID_AS_ACCOUNT_ID,
               profile: { username },
             });
-            if (outcome.status !== "session-created") {
-              // Unreachable: this provider registers no requirements, so the
-              // core has nothing to withhold the session for.
-              throw new Error(
-                "Password sign-up came back without a session: " +
-                  outcome.status,
-              );
-            }
+            // The credentials are stored on the incomplete arm too: the
+            // account exists either way (creation is eager; only the session
+            // is withheld) and must be able to finish this sign-in and make
+            // later ones.
+            const userId = outcomeUserId(outcome);
 
             const setUsernameResult = await ctx.runMutation(
               usernameComponent.public.setUsername,
-              { userId: outcome.tokens.userId, username },
+              { userId, username },
             );
             if (!setUsernameResult.success) {
               // Unexpected: we validated the username above, and this handler
@@ -198,7 +387,7 @@ export function setupUsernamePassword<UsersTable extends string>(
             const setResult = await ctx.runMutation(
               component.public.setPassword,
               {
-                userId: outcome.tokens.userId,
+                userId,
                 password,
               },
             );
@@ -214,24 +403,23 @@ export function setupUsernamePassword<UsersTable extends string>(
               );
             }
 
-            return { status: "complete", tokens: outcome.tokens };
+            return clientResult(outcome);
           },
         }),
 
         /**
-         * Verify an existing account's password and, on success, mint a session.
-         * Returns `USER_NOT_FOUND` when the username has no account and
-         * `INVALID_CREDENTIALS` when the password is wrong, so callers can tell
-         * the two apart. (Account existence is already observable via sign-up's
-         * `USERNAME_TAKEN`, so distinguishing them here leaks nothing new.)
+         * Verify an existing account's password and, on success, either mint
+         * a session or report the outstanding requirements.
          */
         signInWithPassword: authMutation({
           args: { username: v.string(), password: v.string() },
-          returns: signInResult,
+          returns: resultOf(signInUserError),
           handler: async (
             ctx,
             { username, password },
-          ): Promise<SignInResult> => {
+          ): Promise<
+            SignInSuccess | SignInIncomplete | SignInError<SignInUserError>
+          > => {
             const userId = await ctx.runQuery(
               usernameComponent.public.getUserIdByUsername,
               { username },
@@ -258,17 +446,50 @@ export function setupUsernamePassword<UsersTable extends string>(
               providerAccountId: userId,
               profile: { username },
             });
-            if (outcome.status !== "session-created") {
-              // Unreachable: see the note in `signUpWithPassword`.
-              throw new Error(
-                "Password sign-in came back without a session: " +
-                  outcome.status,
-              );
-            }
-            return { status: "complete", tokens: outcome.tokens };
+            return clientResult(outcome);
           },
         }),
+
+        /**
+         * Resume a parked sign-in once requirements have been satisfied
+         * (verification endpoints have recorded their facts): re-evaluate
+         * and either mint the session or report what is still outstanding.
+         *
+         * The password is *not* re-verified here — the attempt token
+         * (random, stored hashed, short-lived, and budgeted) is the
+         * continuation credential. `ATTEMPT_EXPIRED` means the attempt is
+         * gone and the user should sign in from scratch.
+         *
+         * Spread in only when requirements were registered, matching what
+         * {@link PasswordApi} declares. Without them no sign-in is ever
+         * parked, so an always-`ATTEMPT_EXPIRED` public mutation would be
+         * surface with nothing behind it.
+         */
+        ...(requirements === undefined
+          ? undefined
+          : {
+              continueSignInWithPassword: authMutation({
+                args: { attemptToken: v.string() },
+                returns: resultOf(vAttemptExpiredError),
+                handler: async (ctx, { attemptToken }) => {
+                  const outcome = await ctx.convexAuth.continueSignIn({
+                    attemptToken,
+                  });
+                  if (outcome.status === "expired") {
+                    // The one user-correctable condition the core raises
+                    // rather than this provider: every other `userError` is
+                    // raised before the core is asked for a session.
+                    return {
+                      status: "error" as const,
+                      userError: { error: "ATTEMPT_EXPIRED" as const },
+                    };
+                  }
+                  return clientResult(outcome);
+                },
+              }),
+            }),
       };
+      return api as unknown as PasswordApi<R>;
     },
   };
 }


### PR DESCRIPTION
`setupUsernamePassword` takes `signInRequirements` and threads the specs
through: to `bindProvider`, which checks an evaluator is attached; to the
result validators, which gain the incomplete arm; and to `PasswordApi<R>`,
whose hand-written `RegisteredMutation` aliases are what carry the closed
requirement union through Convex's api codegen into the browser. Sign-up
stores the credentials on the incomplete arm too — the account exists either
way and has to be able to finish this sign-in and make later ones.

`continueSignInWithPassword` resumes a parked attempt. It exists only when
requirements were registered, in the api object as well as in the type:
without them nothing is ever parked, so mounting it would be public surface
that can only ever answer `ATTEMPT_EXPIRED`.

On the client, `useSignInWithPassword`/`useSignUpWithPassword` become generic
over the app's result types, so the closed union survives into the caller,
and take the continue mutation as a second argument. An incomplete result
comes back carrying `continueWith`, which re-enters the same handler — so
every round of a multi-round flow has the same shape.

`useRequirementsFlow` and `renderRequirements` own the loop above that: hold
the current round, call the capability's own verification endpoint with the
attempt token, continue, and adopt the next round. `renderRequirements` maps
each `kind` to a renderer, with a `fallback` for a kind the client does not
know yet — the server can start sending one before the client ships. These
are provider-agnostic and should move to a shared module once a second
provider grows requirements.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>