### PR TITLE
Add an example gating sign-in on a second factor

### DIFF
--- a/.github/workflows/convex-codegen.yml
+++ b/.github/workflows/convex-codegen.yml
@@ -49,6 +49,7 @@ jobs:
             examples/react-google
             examples/react-github
             examples/react-password
+            examples/react-password-requirements
             examples/react-passkey
             examples/nextjs
           )

--- a/examples/react-password-requirements/.gitignore
+++ b/examples/react-password-requirements/.gitignore
@@ -1,0 +1,2 @@
+
+.env.local

--- a/examples/react-password-requirements/README.md
+++ b/examples/react-password-requirements/README.md
@@ -1,0 +1,76 @@
+# react-password-requirements example
+
+A copy of the `react-password` example whose evaluating `onSignIn` callback
+_suspends_ sign-ins with requirements instead of always completing them. It
+demos a fake second factor (`mathFactor:problem`): solving a small math
+problem gates _every_ session mint, sign-up included. The verified
+credentials are parked in a server-side sign-in attempt; the client answers
+against the factor's own endpoints, which record the proof as a **fact** on
+the attempt, then resumes via `continueSignInWithPassword` (the hooks'
+`continueWith`).
+
+## The typed requirement registry
+
+The framework treats requirements as opaque `{ kind: string, data?: any }`
+payloads until an app closes the vocabulary by passing a plain array of
+`requirement(...)` declarations (from `@convex-dev/auth/lib/requirements`)
+to the provider setup's `signInRequirements` option. Each requirement
+declares its `kind`, the `data` payload the server sends down with it, and
+the `facts` recorded once server-side verification succeeds. This example
+registers the array on `setupUsernamePassword` (`convex/auth.ts`), and it
+threads through the whole stack:
+
+- The evaluating callback (`convex/users.ts`) derives its `facts` and
+  `returns` validators from the same specs via `requirementValidators`, so
+  declaration and enforcement can't drift — a verdict emitting an
+  unregistered kind fails validation at runtime and, via
+  `attachUserCallbacks`, the build.
+- The generated `api` types carry the closed requirement union, so the
+  client's per-kind handlers record (`renderRequirements`) is
+  exhaustiveness-checked — registering a new kind breaks the build until
+  the UI handles it (see `src/routes/requirementsStep.tsx`).
+
+The example's other interesting pieces:
+
+- `convex/lib/mathFactor.ts` — the second factor packaged as a pluggable
+  capability (a stand-in for a real TOTP or passkey verifier). Its setup
+  value provides its table (mounted in `schema.ts`), its challenge/verify
+  endpoint handlers (mounted in `auth.ts`), and its requirement spec — so
+  registering `mathFactor:problem` proves the thing that satisfies it is
+  actually installed. Verification happens out-of-band from the sign-in
+  flow, against the factor's own endpoints, and success is recorded as a
+  `mathVerified` **fact** on the sign-in attempt through the core's
+  `recordAttemptFacts` primitive — reachable only from server code, so a
+  recorded fact proves the verifying code actually ran. Failed answers are
+  metered against the attempt's continuation cap (`penalizeAttempt`), and
+  verification binds to the attempt's subject (`getAttemptContext`), never
+  to caller-supplied identity. A fresh sign-in starts with an empty facts
+  bag and must re-prove the factor.
+- `convex/users.ts` — the evaluator that judges `(user, profile, facts)` and
+  returns a verdict. It's a pure judge: the math gate is a presence check on
+  the facts bag; it never evaluates or records anything itself.
+- `src/routes/requirementsStep.tsx` — the requirements UI both the log-in
+  and sign-up pages share, built on the framework's `useRequirementsFlow`
+  (owns the continue/adopt/expire state machine) and `renderRequirements`
+  (typed per-kind dispatch): the app only supplies the math input and the
+  copy.
+
+Because the user, account and credentials are created _eagerly_ (only the
+session is withheld), an abandoned incomplete sign-up self-heals: signing
+_in_ later resolves the same user and re-prompts for what's still
+outstanding — and re-signing-up reports the taken username.
+
+## Generate code / run
+
+Run the example from its own directory.
+
+```bash
+cd examples/react-password-requirements
+npx convex dev --once    # provisions a deployment, generates convex/_generated
+npx @convex-dev/auth     # sets AUTH_PRIVATE_KEY + AUTH_JWKS on the deployment
+npm run dev              # start the Vite frontend
+```
+
+## Test usage
+
+The tests defined in the example are run along with `pnpm test` in the repo root.

--- a/examples/react-password-requirements/convex/_generated/api.d.ts
+++ b/examples/react-password-requirements/convex/_generated/api.d.ts
@@ -1,0 +1,59 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as auth from "../auth.js";
+import type * as currentUser from "../currentUser.js";
+import type * as lib_mathFactor from "../lib/mathFactor.js";
+import type * as users from "../users.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
+  currentUser: typeof currentUser;
+  "lib/mathFactor": typeof lib_mathFactor;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  auth: import("@convex-dev/auth/core/_generated/component.js").ComponentApi<"auth">;
+  authPasswordProvider: import("@convex-dev/auth/providers/password/_generated/component.js").ComponentApi<"authPasswordProvider">;
+  authUsername: import("@convex-dev/auth/username/_generated/component.js").ComponentApi<"authUsername">;
+};

--- a/examples/react-password-requirements/convex/_generated/api.js
+++ b/examples/react-password-requirements/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/examples/react-password-requirements/convex/_generated/dataModel.d.ts
+++ b/examples/react-password-requirements/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/examples/react-password-requirements/convex/_generated/server.d.ts
+++ b/examples/react-password-requirements/convex/_generated/server.d.ts
@@ -1,0 +1,156 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_JWKS: string;
+  readonly AUTH_PRIVATE_KEY: string;
+};
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/examples/react-password-requirements/convex/_generated/server.js
+++ b/examples/react-password-requirements/convex/_generated/server.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/examples/react-password-requirements/convex/auth.config.ts
+++ b/examples/react-password-requirements/convex/auth.config.ts
@@ -1,0 +1,13 @@
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      type: "customJwt",
+      applicationID: "convex",
+      issuer: process.env.CONVEX_SITE_URL!,
+      jwks: `${process.env.CONVEX_SITE_URL}/auth/.well-known/jwks.json`,
+      algorithm: "RS256",
+    },
+  ],
+} satisfies AuthConfig;

--- a/examples/react-password-requirements/convex/auth.ts
+++ b/examples/react-password-requirements/convex/auth.ts
@@ -1,0 +1,61 @@
+import { components, internal } from "./_generated/api";
+import { mutation } from "./_generated/server";
+import { setupCore } from "@convex-dev/auth/core/setup";
+import { setupUsernamePassword } from "@convex-dev/auth/providers/password/setup";
+import { v } from "convex/values";
+import { mathFactor } from "./lib/mathFactor";
+
+const core = setupCore({ component: components.auth });
+export const { signOut, refreshSession, isAuthenticated } = core;
+
+export const {
+  signUpWithPassword,
+  signInWithPassword,
+  continueSignInWithPassword,
+} = setupUsernamePassword(core, {
+  component: components.authPasswordProvider,
+  usernameComponent: components.authUsername,
+  // The app's closed requirement vocabulary. It threads through the stack:
+  // the evaluating callback's hand-written validators (users.ts) must mirror
+  // it (checked at compile time by `attachUserCallbacks` and at runtime by
+  // the validators derived from it), and the generated client types carry
+  // the closed requirement union.
+  //
+  // The spec is only obtainable from the capability's setup: registering the
+  // kind proves the thing that satisfies it is installed.
+  signInRequirements: [mathFactor.requirement],
+}).attachUserCallbacks({
+  createUser: internal.users.createUser,
+  onSignIn: internal.users.evaluateSignIn,
+});
+
+// The math factor's own endpoints, mounted by the app. This is the whole
+// integration story for a verified requirement: the factor verifies
+// server-side and records its fact through the core's app-only primitives
+// (`recordAttemptFacts` / `penalizeAttempt`), the app's evaluator just
+// checks the fact's presence, and the client drives these when the
+// requirement shows up. A provider could equally expose endpoints like
+// these from its own API (e.g. a password `confirm` for re-authentication).
+
+export const getMathChallenge = mutation({
+  args: { attemptToken: v.string() },
+  returns: v.union(
+    v.object({ status: v.literal("challenge"), question: v.string() }),
+    v.object({ status: v.literal("expired") }),
+  ),
+  handler: (ctx, args) =>
+    mathFactor.getChallenge(ctx, components.auth, args.attemptToken),
+});
+
+export const verifyMathAnswer = mutation({
+  args: { attemptToken: v.string(), answer: v.number() },
+  returns: v.object({
+    status: v.union(
+      v.literal("verified"),
+      v.literal("incorrect"),
+      v.literal("expired"),
+    ),
+  }),
+  handler: (ctx, args) =>
+    mathFactor.verify(ctx, components.auth, args.attemptToken, args.answer),
+});

--- a/examples/react-password-requirements/convex/convex.config.ts
+++ b/examples/react-password-requirements/convex/convex.config.ts
@@ -1,0 +1,24 @@
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import auth from "@convex-dev/auth/core/convex.config.js";
+import passwordProvider from "@convex-dev/auth/providers/password/convex.config.js";
+import username from "@convex-dev/auth/username/convex.config.js";
+
+const app = defineApp({
+  env: {
+    AUTH_PRIVATE_KEY: v.string(),
+    AUTH_JWKS: v.string(),
+  },
+});
+
+app.use(auth, {
+  httpPrefix: "/auth",
+  env: {
+    AUTH_PRIVATE_KEY: app.env.AUTH_PRIVATE_KEY,
+    AUTH_JWKS: app.env.AUTH_JWKS,
+  },
+});
+app.use(passwordProvider);
+app.use(username);
+
+export default app;

--- a/examples/react-password-requirements/convex/currentUser.ts
+++ b/examples/react-password-requirements/convex/currentUser.ts
@@ -1,0 +1,24 @@
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+/**
+ * The currently signed-in user, or null.
+ *
+ * Demonstrates an authenticated query.
+ */
+export const loggedInUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      return null;
+    }
+    const userId = identity.subject as Id<"users">;
+    const user = await ctx.db.get("users", userId);
+    if (user === null) {
+      return null;
+    }
+
+    return { id: user._id, username: user.username };
+  },
+});

--- a/examples/react-password-requirements/convex/lib/mathFactor.ts
+++ b/examples/react-password-requirements/convex/lib/mathFactor.ts
@@ -1,0 +1,155 @@
+/**
+ * A fake second factor packaged as a pluggable capability (a stand-in for a
+ * real TOTP or passkey verifier). It owns everything about itself:
+ *
+ *  - its table (`tables`, which the app spreads into its schema),
+ *  - challenge issuance and verification (`getChallenge` / `verify`, which
+ *    the app mounts as public endpoints — see auth.ts),
+ *  - and its requirement spec (`requirement`).
+ *
+ * The spec is only obtainable by calling {@link setupMathFactor}, so an app
+ * that registers `mathFactor:problem` in its sign-in requirements
+ * necessarily holds the setup value that mounts the table and the endpoints
+ * — "requirable ⟹ available" by construction.
+ *
+ * The factor is verified out-of-band from the sign-in flow: the app's
+ * `onSignIn` evaluator only ever emits the requirement (when the
+ * `mathVerified` fact is absent) and never evaluates anything. The client
+ * drives this factor's own endpoints — fetch the challenge, submit the
+ * answer — and on success `verify` records the fact through the core's
+ * `recordAttemptFacts` primitive, which only server code can reach. The
+ * next sign-in round sees the fact and stops demanding the requirement.
+ * Failed answers are metered against the attempt's continuation cap via
+ * `penalizeAttempt`, so the endpoint isn't a free guessing oracle.
+ */
+import {
+  type DataModelFromSchemaDefinition,
+  defineSchema,
+  defineTable,
+  type GenericMutationCtx,
+} from "convex/server";
+import { v } from "convex/values";
+import { requirement } from "@convex-dev/auth/lib/requirements";
+import type { ComponentApi } from "@convex-dev/auth/core/setup";
+
+const tables = {
+  // The outstanding challenge per user. Created when the client first asks
+  // for it, reused while unanswered, deleted when answered correctly (at
+  // which point the recorded `mathVerified` fact takes over as the proof).
+  mathChallenges: defineTable({
+    userId: v.string(),
+    question: v.string(),
+    answer: v.number(),
+  }).index("by_userId", ["userId"]),
+};
+
+// Only for typing the endpoint handlers' ctx against the factor's own
+// table; the app mounts `tables` into its real schema, whose ctx is
+// assignable to this one.
+const _ownSchema = defineSchema(tables);
+type MathFactorCtx = GenericMutationCtx<
+  DataModelFromSchemaDefinition<typeof _ownSchema>
+>;
+
+export type MathFactor = ReturnType<typeof setupMathFactor>;
+
+/** The app's one instance, consumed by schema.ts (tables), users.ts (the
+ * requirement it emits), and auth.ts (the spec + mounted endpoints). A real
+ * capability would be a package and the app would instantiate it in its own
+ * module instead. */
+export const mathFactor = setupMathFactor();
+
+export function setupMathFactor(options?: { maxOperand?: number }) {
+  const maxOperand = options?.maxOperand ?? 9;
+
+  /** The live challenge for a user, creating one on first ask. */
+  async function challengeFor(ctx: MathFactorCtx, userId: string) {
+    const existing = await ctx.db
+      .query("mathChallenges")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+    if (existing !== null) return existing;
+    const a = 1 + Math.floor(Math.random() * maxOperand);
+    const b = 1 + Math.floor(Math.random() * maxOperand);
+    const id = await ctx.db.insert("mathChallenges", {
+      userId,
+      question: `${a} + ${b}`,
+      answer: a + b,
+    });
+    return (await ctx.db.get("mathChallenges", id))!;
+  }
+
+  /** Resolve the attempt's subject; the factor needs an anchored user. */
+  async function subjectUserId(
+    ctx: MathFactorCtx,
+    core: ComponentApi,
+    attemptToken: string,
+  ): Promise<string | null> {
+    const context = await ctx.runQuery(core.public.getAttemptContext, {
+      attemptToken,
+    });
+    return context?.userId ?? null;
+  }
+
+  return {
+    requirement: requirement("mathFactor:problem", {
+      // The requirement itself carries no payload: the client fetches the
+      // challenge from the factor's own endpoint, and the answer travels to
+      // the endpoint too — never through the sign-in flow.
+      data: v.object({}),
+      facts: { mathVerified: v.object({ verifiedAt: v.number() }) },
+    }),
+    tables,
+    /**
+     * Handler for the app's challenge endpoint: the caller presents the
+     * attempt token, and the factor issues (or repeats) the challenge for
+     * the user that attempt is anchored to.
+     */
+    async getChallenge(
+      ctx: MathFactorCtx,
+      core: ComponentApi,
+      attemptToken: string,
+    ): Promise<
+      { status: "challenge"; question: string } | { status: "expired" }
+    > {
+      const userId = await subjectUserId(ctx, core, attemptToken);
+      if (userId === null) return { status: "expired" };
+      const challenge = await challengeFor(ctx, userId);
+      return { status: "challenge", question: challenge.question };
+    },
+    /**
+     * Handler for the app's verification endpoint. A correct answer
+     * consumes the challenge and records the `mathVerified` fact on the
+     * attempt (the sign-in's next round sees it and stops demanding the
+     * requirement); a wrong answer is metered against the attempt's
+     * continuation cap.
+     */
+    async verify(
+      ctx: MathFactorCtx,
+      core: ComponentApi,
+      attemptToken: string,
+      answer: number,
+    ): Promise<{ status: "verified" | "incorrect" | "expired" }> {
+      const userId = await subjectUserId(ctx, core, attemptToken);
+      if (userId === null) return { status: "expired" };
+      const challenge = await ctx.db
+        .query("mathChallenges")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .unique();
+      if (challenge !== null && answer === challenge.answer) {
+        await ctx.db.delete("mathChallenges", challenge._id);
+        const recorded = await ctx.runMutation(core.public.recordAttemptFacts, {
+          attemptToken,
+          facts: { mathVerified: { verifiedAt: Date.now() } },
+        });
+        return { status: recorded ? "verified" : "expired" };
+      }
+      // Wrong (or premature) answer: burn continuation budget so guessing
+      // is bounded, and report whether the attempt survived.
+      const alive = await ctx.runMutation(core.public.penalizeAttempt, {
+        attemptToken,
+      });
+      return { status: alive ? "incorrect" : "expired" };
+    },
+  };
+}

--- a/examples/react-password-requirements/convex/requirements.test.ts
+++ b/examples/react-password-requirements/convex/requirements.test.ts
@@ -1,0 +1,335 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+import { api } from "./_generated/api.js";
+import { registerCore } from "@convex-dev/auth/providers/testing/core";
+import { registerPasswordProvider } from "@convex-dev/auth/providers/testing/password";
+import { registerUsername } from "@convex-dev/auth/providers/testing/username";
+import schema from "./schema.js";
+
+const modules = import.meta.glob("./**/*.ts");
+
+const PASSWORD = "correct horse battery staple"; // 28 chars, valid
+
+async function setup() {
+  // The core signs JWTs from these env vars (see core/public.ts). Mint a real
+  // RS256 key pair for each test and stub the env so Vitest can reset it.
+  const { publicKey, privateKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const pkcs8 = await exportPKCS8(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+
+  vi.stubEnv("CONVEX_SITE_URL", "https://example.convex.site");
+  vi.stubEnv("AUTH_PRIVATE_KEY", btoa(pkcs8));
+  vi.stubEnv(
+    "AUTH_JWKS",
+    JSON.stringify({
+      keys: [{ ...publicJwk, kid: "test-key", alg: "RS256", use: "sig" }],
+    }),
+  );
+
+  const t = convexTest(schema, modules);
+  registerCore(t);
+  registerPasswordProvider(t);
+  registerUsername(t);
+  return t;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+type T = Awaited<ReturnType<typeof setup>>;
+
+const signUp = (t: T, username: string, password: string) =>
+  t.mutation(api.auth.signUpWithPassword, { username, password });
+
+const signIn = (t: T, username: string, password: string) =>
+  t.mutation(api.auth.signInWithPassword, { username, password });
+
+const continueSignIn = (t: T, attemptToken: string) =>
+  t.mutation(api.auth.continueSignInWithPassword, { attemptToken });
+
+// The math factor's own endpoints: the client fetches the challenge and
+// submits the answer here, out-of-band from the sign-in flow.
+const getMathChallenge = (t: T, attemptToken: string) =>
+  t.mutation(api.auth.getMathChallenge, { attemptToken });
+
+const verifyMathAnswer = (t: T, attemptToken: string, answer: number) =>
+  t.mutation(api.auth.verifyMathAnswer, { attemptToken, answer });
+
+type AnyResult =
+  | Awaited<ReturnType<typeof signUp>>
+  | Awaited<ReturnType<typeof signIn>>
+  | Awaited<ReturnType<typeof continueSignIn>>;
+
+/** Narrow a result to its incomplete arm, failing the test on a mismatch. */
+function expectIncomplete(result: AnyResult) {
+  if (result.status !== "incomplete") {
+    throw new Error(`expected an incomplete result: ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+/** Narrow a result to its success arm, failing the test on a mismatch. */
+function expectComplete(result: AnyResult) {
+  if (result.status !== "complete") {
+    throw new Error(`expected a complete result: ${JSON.stringify(result)}`);
+  }
+  return result.tokens;
+}
+
+/** Narrow a status-discriminated result, failing the test on a mismatch. */
+function expectStatus<R extends { status: string }, S extends R["status"]>(
+  result: R,
+  status: S,
+): Extract<R, { status: S }> {
+  expect(result.status).toBe(status);
+  return result as Extract<R, { status: S }>;
+}
+
+/** Fetch the attempt's current math challenge and compute the answer. */
+async function solveMath(t: T, attemptToken: string): Promise<number> {
+  const challenge = expectStatus(
+    await getMathChallenge(t, attemptToken),
+    "challenge",
+  );
+  const [a, b] = challenge.question.split(" + ").map(Number);
+  return a + b;
+}
+
+/** Drive the math factor to verified for an attempt. */
+async function passMathFactor(t: T, attemptToken: string): Promise<void> {
+  const answer = await solveMath(t, attemptToken);
+  expect(await verifyMathAnswer(t, attemptToken, answer)).toEqual({
+    status: "verified",
+  });
+}
+
+const completeTokens = {
+  accessToken: expect.any(String),
+  accessTokenExpiresAt: expect.any(Number),
+  refreshToken: expect.any(String),
+  refreshTokenExpiresAt: expect.any(Number),
+  userId: expect.any(String),
+};
+
+/** Sign up completely and return the minted userId. */
+async function signUpComplete(t: T, username: string): Promise<string> {
+  const gated = expectIncomplete(await signUp(t, username, PASSWORD));
+  await passMathFactor(t, gated.attemptToken);
+  return expectComplete(await continueSignIn(t, gated.attemptToken)).userId;
+}
+
+describe("sign-up gated by the math factor", () => {
+  test("sign-up parks on the factor, then completes", async () => {
+    const t = await setup();
+    const incomplete = expectIncomplete(await signUp(t, "alice", PASSWORD));
+    // The requirement is bare: the challenge comes from the factor's own
+    // endpoint, not the requirement payload.
+    expect(incomplete.requirements).toEqual([
+      { kind: "mathFactor:problem", data: {} },
+    ]);
+    // The pending state is server-side: a bearer attempt token came back,
+    // and the app's userId did not (it's stripped from client results).
+    expect(typeof incomplete.attemptToken).toBe("string");
+    expect(incomplete.expiresAt).toBeGreaterThan(Date.now());
+    expect(incomplete).not.toHaveProperty("tokens");
+    expect(incomplete).not.toHaveProperty("userId");
+
+    await passMathFactor(t, incomplete.attemptToken);
+    const done = await continueSignIn(t, incomplete.attemptToken);
+    expect(done).toEqual({ status: "complete", tokens: completeTokens });
+  });
+
+  test("continuing before the factor is verified stays incomplete", async () => {
+    const t = await setup();
+    const incomplete = expectIncomplete(await signUp(t, "alice", PASSWORD));
+
+    const still = expectIncomplete(
+      await continueSignIn(t, incomplete.attemptToken),
+    );
+    expect(still.requirements).toEqual([
+      { kind: "mathFactor:problem", data: {} },
+    ]);
+    // Continuing keeps the same attempt (token and expiry are unchanged).
+    expect(still.attemptToken).toBe(incomplete.attemptToken);
+    expect(still.expiresAt).toBe(incomplete.expiresAt);
+
+    await passMathFactor(t, incomplete.attemptToken);
+    expectComplete(await continueSignIn(t, incomplete.attemptToken));
+  });
+
+  test("a wrong answer is metered and the same challenge stands", async () => {
+    const t = await setup();
+    const incomplete = expectIncomplete(await signUp(t, "alice", PASSWORD));
+    const token = incomplete.attemptToken;
+
+    const question = expectStatus(
+      await getMathChallenge(t, token),
+      "challenge",
+    ).question;
+    expect(await verifyMathAnswer(t, token, -1)).toEqual({
+      status: "incorrect",
+    });
+    // The challenge wasn't consumed or reissued by the failure.
+    expect(await getMathChallenge(t, token)).toEqual({
+      status: "challenge",
+      question,
+    });
+
+    await passMathFactor(t, token);
+    expectComplete(await continueSignIn(t, token));
+  });
+
+  test("credentials are stored even while the sign-up is incomplete", async () => {
+    const t = await setup();
+    // Reach the math gate, then abandon the sign-up. The user, account,
+    // username and password all exist — only the session is withheld.
+    expectIncomplete(await signUp(t, "alice", PASSWORD));
+
+    // Self-healing: signing *in* with the right password re-runs the
+    // evaluator (a fresh attempt) and re-prompts; a wrong password is
+    // rejected; re-signing up reports the taken username.
+    expectIncomplete(await signIn(t, "alice", PASSWORD));
+    expect(await signIn(t, "alice", "wrong horse battery staple")).toEqual({
+      status: "error",
+      userError: { error: "INVALID_CREDENTIALS" },
+    });
+    expect(await signUp(t, "alice", PASSWORD)).toEqual({
+      status: "error",
+      userError: { error: "USERNAME_TAKEN" },
+    });
+  });
+});
+
+describe("sign-in requirements", () => {
+  test("every sign-in re-runs the math gate and resolves the same user", async () => {
+    const t = await setup();
+    const userId = await signUpComplete(t, "alice");
+
+    const attempt = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    expect(attempt.requirements).toEqual([
+      { kind: "mathFactor:problem", data: {} },
+    ]);
+    await passMathFactor(t, attempt.attemptToken);
+    const done = expectComplete(await continueSignIn(t, attempt.attemptToken));
+    expect(done.userId).toBe(userId);
+  });
+
+  test("a fresh sign-in supersedes the pending attempt", async () => {
+    const t = await setup();
+    const userId = await signUpComplete(t, "alice");
+
+    const first = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    const second = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    expect(second.attemptToken).not.toBe(first.attemptToken);
+
+    // The superseded attempt is gone — its token opens nothing.
+    expect(await getMathChallenge(t, first.attemptToken)).toEqual({
+      status: "expired",
+    });
+    expect(await continueSignIn(t, first.attemptToken)).toEqual({
+      status: "error",
+      userError: { error: "ATTEMPT_EXPIRED" },
+    });
+    // The live one completes.
+    await passMathFactor(t, second.attemptToken);
+    const done = expectComplete(await continueSignIn(t, second.attemptToken));
+    expect(done.userId).toBe(userId);
+  });
+
+  test("attempts expire", async () => {
+    const t = await setup();
+    await signUpComplete(t, "alice");
+
+    const attempt = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    const answer = await solveMath(t, attempt.attemptToken);
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.now() + 11 * 60 * 1000); // past the 10 min TTL
+
+    expect(await verifyMathAnswer(t, attempt.attemptToken, answer)).toEqual({
+      status: "expired",
+    });
+    expect(await continueSignIn(t, attempt.attemptToken)).toEqual({
+      status: "error",
+      userError: { error: "ATTEMPT_EXPIRED" },
+    });
+  });
+
+  test("repeated failed verifications discard the attempt", async () => {
+    const t = await setup();
+    await signUpComplete(t, "alice");
+
+    const attempt = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    const token = attempt.attemptToken;
+    const answer = await solveMath(t, token);
+
+    // Nine wrong answers fit under the continuation cap of ten...
+    for (let i = 0; i < 9; i++) {
+      expect(await verifyMathAnswer(t, token, -1)).toEqual({
+        status: "incorrect",
+      });
+    }
+    // ...the tenth exhausts it, and even the right answer is refused.
+    expect(await verifyMathAnswer(t, token, -1)).toEqual({
+      status: "expired",
+    });
+    expect(await verifyMathAnswer(t, token, answer)).toEqual({
+      status: "expired",
+    });
+    expect(await continueSignIn(t, token)).toEqual({
+      status: "error",
+      userError: { error: "ATTEMPT_EXPIRED" },
+    });
+  });
+
+  test("a fresh sign-in drops recorded facts and re-proves the factor", async () => {
+    const t = await setup();
+    await signUpComplete(t, "alice");
+
+    // Verify the factor on the first attempt, but don't continue it.
+    const first = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    await passMathFactor(t, first.attemptToken);
+
+    // A fresh sign-in supersedes the attempt and starts with an empty facts
+    // bag: the factor must be proven again.
+    const fresh = expectIncomplete(await signIn(t, "alice", PASSWORD));
+    expect(fresh.requirements.map((r) => r.kind)).toContain(
+      "mathFactor:problem",
+    );
+    expectIncomplete(await continueSignIn(t, fresh.attemptToken));
+  });
+
+  test("an unknown attempt token reports ATTEMPT_EXPIRED", async () => {
+    const t = await setup();
+    expect(await continueSignIn(t, "no-such-token")).toEqual({
+      status: "error",
+      userError: { error: "ATTEMPT_EXPIRED" },
+    });
+  });
+});
+
+describe("input validation", () => {
+  test("a wrong-typed answer is rejected at the factor endpoint", async () => {
+    const t = await setup();
+    const attempt = expectIncomplete(await signUp(t, "alice", PASSWORD));
+
+    // A string answer is a malformed request (a bug or a hostile client),
+    // not a wrong answer — it throws rather than counting as a guess.
+    await expect(
+      t.mutation(api.auth.verifyMathAnswer, {
+        attemptToken: attempt.attemptToken,
+        answer: "9" as unknown as number,
+      }),
+    ).rejects.toThrow(/Validator error: Expected `number`/);
+
+    // The throw aborted that transaction: the attempt is untouched and the
+    // flow still completes.
+    await passMathFactor(t, attempt.attemptToken);
+    expectComplete(await continueSignIn(t, attempt.attemptToken));
+  });
+});

--- a/examples/react-password-requirements/convex/schema.ts
+++ b/examples/react-password-requirements/convex/schema.ts
@@ -1,0 +1,14 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+import { mathFactor } from "./lib/mathFactor";
+
+export default defineSchema({
+  users: defineTable({
+    username: v.string(),
+  }),
+
+  // The math factor owns its challenge table; mounting it here is part of
+  // what the factor's setup value provides (alongside its requirement spec
+  // and its endpoint handlers).
+  ...mathFactor.tables,
+});

--- a/examples/react-password-requirements/convex/tsconfig.json
+++ b/examples/react-password-requirements/convex/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true,
+    // `src/components/testing/**` of @convex-dev/auth ships as source, and its
+    // relative imports use the extension of the file on disk (`.ts`, `.tsx`).
+    "allowImportingTsExtensions": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/react-password-requirements/convex/users.ts
+++ b/examples/react-password-requirements/convex/users.ts
@@ -1,0 +1,65 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requirementValidators } from "@convex-dev/auth/lib/requirements";
+import { mathFactor } from "./lib/mathFactor";
+
+/**
+ * Create the user row for a new password account and return its id. The
+ * provider supplies the username it just registered in `profile`.
+ *
+ * Creation is eager: this runs even when the sign-in then parks as
+ * incomplete (the math factor below) — only the session is withheld.
+ */
+export const createUser = internalMutation({
+  args: {
+    provider: v.literal("password"),
+    providerAccountId: v.string(),
+    profile: v.object({ username: v.string() }),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("users", { username: args.profile.username });
+  },
+});
+
+// The evaluator's `facts` arg and `returns` validators, derived from the
+// same specs registered on `setupUsernamePassword` (auth.ts). Deriving them
+// here — the specs live in lib/mathFactor.ts — keeps this module free of
+// any import from auth.ts, and keeps declaration and enforcement from
+// drifting: a verdict emitting an unregistered kind fails validation (and,
+// via `attachUserCallbacks`, the build).
+const { vFacts, vVerdict } = requirementValidators([mathFactor.requirement]);
+
+/**
+ * The app's sign-in *evaluator*: it runs on every sign-in round — sign-up,
+ * sign-in, and each continuation — blind to which round it is, and judges
+ * only what is in front of it.
+ *
+ * The math factor gate is a pure presence check on the trusted facts bag:
+ * the callback never evaluates the factor itself. Verification happens
+ * out-of-band in the factor's own endpoints (see auth.ts), which record the
+ * `mathVerified` fact on the attempt through the core's server-only
+ * primitive; the next round sees it here and accepts the sign-in.
+ */
+export const evaluateSignIn = internalMutation({
+  args: {
+    provider: v.literal("password"),
+    providerAccountId: v.string(),
+    profile: v.object({ username: v.string() }),
+    userId: v.id("users"),
+    // The accumulated trusted facts (empty on a fresh sign-in; a fresh
+    // sign-in re-proves its factors).
+    facts: vFacts,
+  },
+  returns: vVerdict,
+  handler: async (_ctx, args) => {
+    if (args.facts.mathVerified === undefined) {
+      return {
+        status: "requirements-needed" as const,
+        requirements: [{ kind: "mathFactor:problem" as const, data: {} }],
+      };
+    }
+    // Nothing outstanding: the sign-in completes and a session is minted.
+    return null;
+  },
+});

--- a/examples/react-password-requirements/index.html
+++ b/examples/react-password-requirements/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convex Auth — react-password</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-password-requirements/package.json
+++ b/examples/react-password-requirements/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "example-react-password-requirements",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@convex-dev/auth": "workspace:*",
+    "convex": "^1.43.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.1"
+  },
+  "scripts": {
+    "dev": "convex dev --start vite",
+    "build": "vite build && tsc -p convex --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p convex --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@convex-dev/rate-limiter": "^0.3.2",
+    "@edge-runtime/vm": "^5.0.0",
+    "@types/node": "^24.12.4",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "convex-test": "^0.0.55",
+    "jose": "^5.10.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/react-password-requirements/src/App.tsx
+++ b/examples/react-password-requirements/src/App.tsx
@@ -1,0 +1,72 @@
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+} from "@convex-dev/auth/react";
+import React from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+import { Dashboard } from "./routes/dashboard";
+import { LogIn } from "./routes/logIn";
+import { SignUp } from "./routes/signUp";
+import "./index.css";
+
+export function App() {
+  return (
+    <main>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <Dashboard />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            <RequireNoAuth>
+              <LogIn />
+            </RequireNoAuth>
+          }
+        />
+        <Route
+          path="/signup"
+          element={
+            <RequireNoAuth>
+              <SignUp />
+            </RequireNoAuth>
+          }
+        />
+      </Routes>
+    </main>
+  );
+}
+
+function RequireAuth({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <Navigate to="/login" replace />
+      </Unauthenticated>
+      <Authenticated>{children}</Authenticated>
+    </>
+  );
+}
+
+function RequireNoAuth({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Authenticated>
+        <Navigate to="/" replace />
+      </Authenticated>
+      <Unauthenticated>{children}</Unauthenticated>
+    </>
+  );
+}

--- a/examples/react-password-requirements/src/index.css
+++ b/examples/react-password-requirements/src/index.css
@@ -1,0 +1,35 @@
+body {
+  background-color: oklch(96.8% 0.007 247.896);
+}
+
+main {
+  font-family: system-ui, sans-serif;
+  max-width: 480px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  line-height: 1.5;
+}
+
+/*
+In this demo, we apply a few basic styles on elements themselves
+so that the layout looks okay.
+
+In a real app, you should replace these elements by elements of
+your app’s design system, so that the auth UIs look consistent
+with the rest of your app.
+*/
+
+label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  box-sizing: border-box;
+  font-size: 1rem;
+}

--- a/examples/react-password-requirements/src/main.tsx
+++ b/examples/react-password-requirements/src/main.tsx
@@ -1,0 +1,25 @@
+import { ConvexAuthProvider } from "@convex-dev/auth/react";
+import { ConvexReactClient } from "convex/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { api } from "../convex/_generated/api";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexAuthProvider
+      client={convex}
+      api={{
+        refreshSession: api.auth.refreshSession,
+        signOut: api.auth.signOut,
+      }}
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ConvexAuthProvider>
+  </StrictMode>,
+);

--- a/examples/react-password-requirements/src/routes/dashboard.tsx
+++ b/examples/react-password-requirements/src/routes/dashboard.tsx
@@ -1,0 +1,20 @@
+import { useAuthActions, useAuthToken } from "@convex-dev/auth/react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export function Dashboard() {
+  const user = useQuery(api.currentUser.loggedInUser);
+  const token = useAuthToken();
+  const { signOut } = useAuthActions();
+  return (
+    <>
+      {user && (
+        <p>
+          Signed in as <strong>{user.username}</strong> ({user.id})
+        </p>
+      )}
+      <p>Access token: {token ? `${token.slice(0, 24)}…` : "(none)"}</p>
+      <button onClick={() => signOut()}>Sign out</button>
+    </>
+  );
+}

--- a/examples/react-password-requirements/src/routes/logIn.tsx
+++ b/examples/react-password-requirements/src/routes/logIn.tsx
@@ -1,0 +1,108 @@
+import { useSignInWithPassword } from "@convex-dev/auth/providers/password/react";
+import { useState } from "react";
+import { api } from "../../convex/_generated/api";
+import { RequirementsStep, type IncompleteResult } from "./requirementsStep";
+
+export function LogIn() {
+  const { signIn, pending } = useSignInWithPassword(
+    api.auth.signInWithPassword,
+    api.auth.continueSignInWithPassword,
+  );
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  // An incomplete sign-in parked mid-flow (the math second factor).
+  const [step, setStep] = useState<IncompleteResult | null>(null);
+
+  if (step !== null) {
+    return (
+      <RequirementsStep
+        initial={step}
+        onRestart={(message) => {
+          setStep(null);
+          setError(message);
+        }}
+      />
+    );
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setError(null);
+          const result = await signIn({ username, password });
+          if (result.status === "complete") {
+            return;
+          }
+          if (result.status === "incomplete") {
+            // Credentials are fine, but requirements are outstanding: hand
+            // the flow to the requirements step.
+            setStep(result);
+            return;
+          }
+          setError(() => {
+            switch (result.userError.error) {
+              case "USER_NOT_FOUND":
+                return "No account exists with that username.";
+              case "INVALID_CREDENTIALS":
+                return "Incorrect username or password.";
+              case "PASSWORD_TOO_SHORT":
+                return `Password must be at least ${result.userError.minimumLength} characters.`;
+              case "PASSWORD_TOO_LONG":
+                return `Password must be at most ${result.userError.maximumLength} characters.`;
+              case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                return "Password can't start or end with whitespace.";
+              case "RATE_LIMITED":
+                return `Too many attempts. Try again in ${Math.ceil(result.userError.retryAfterMs / 1000)} seconds.`;
+              case "OTHER_ERROR":
+                // The mutation threw unexpectedly; the original error is
+                // available on `cause` if you want to log or inspect it.
+                console.error("Sign-in failed:", result.userError.cause);
+                return "Something went wrong. Please try again.";
+              default:
+                result.userError satisfies never;
+                return `Unknown error: ` + result.userError;
+            }
+          });
+        }}
+      >
+        <h1>Log in</h1>
+        <label>
+          Username
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+            disabled={pending}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            required
+            disabled={pending}
+          />
+        </label>
+        {error ? (
+          <p role="alert">
+            <strong>{error}</strong>
+          </p>
+        ) : null}
+        <button type="submit" disabled={pending}>
+          {pending ? "Logging in…" : "Log in"}
+        </button>
+      </form>
+      <p>
+        Don't have an account? <a href="/signup">Sign up</a>
+      </p>
+    </>
+  );
+}

--- a/examples/react-password-requirements/src/routes/requirementsStep.tsx
+++ b/examples/react-password-requirements/src/routes/requirementsStep.tsx
@@ -1,0 +1,143 @@
+import {
+  renderRequirements,
+  useRequirementsFlow,
+  type PasswordIncomplete,
+} from "@convex-dev/auth/providers/password/react";
+import { useMutation } from "convex/react";
+import { useEffect, useState } from "react";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * An incomplete flow result — the outstanding requirements, the attempt
+ * token for the factor's endpoints, and the `continueWith` to resume with —
+ * derived from the app's continue reference alone (the incomplete arm is
+ * identical across sign-in, sign-up, and continuation). Both the log-in and
+ * sign-up pages park one of these in state and render this step.
+ */
+export type IncompleteResult = PasswordIncomplete<
+  typeof api.auth.continueSignInWithPassword
+>;
+
+/**
+ * Generic UI for an incomplete sign-in. Requirements are satisfied by
+ * server-verified facts: for the math factor, the client drives the
+ * factor's own endpoints — fetch the challenge, submit the answer — and on
+ * success the server records a fact on the attempt. `useRequirementsFlow`
+ * owns the rest: continuing re-evaluates, a completed sign-in flips the
+ * app's authenticated state (navigation happens on its own), a
+ * still-incomplete round is adopted in place, and an expired attempt hands
+ * control back to the credentials form via `onRestart`.
+ */
+export function RequirementsStep({
+  initial,
+  onRestart,
+}: {
+  initial: IncompleteResult;
+  onRestart: (message: string) => void;
+}) {
+  const flow = useRequirementsFlow(initial, {
+    onExpired: () =>
+      onRestart("Your sign-in attempt expired. Please start over."),
+  });
+  const [answer, setAnswer] = useState("");
+  const [question, setQuestion] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getMathChallenge = useMutation(api.auth.getMathChallenge);
+  const verifyMathAnswer = useMutation(api.auth.verifyMathAnswer);
+
+  const { attemptToken, expire } = flow;
+  const needsMath = flow.requirements.some(
+    (r) => r.kind === "mathFactor:problem",
+  );
+
+  useEffect(() => {
+    if (!needsMath) return;
+    let cancelled = false;
+    getMathChallenge({ attemptToken }).then((challenge) => {
+      if (cancelled) return;
+      if (challenge.status === "expired") {
+        expire();
+        return;
+      }
+      setQuestion(challenge.question);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsMath, attemptToken, getMathChallenge, expire]);
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        setError(null);
+        setPending(true);
+        try {
+          // Verify the factor against its own endpoint first: a correct
+          // answer records the `mathVerified` fact on the attempt,
+          // server-side.
+          if (needsMath) {
+            const verdict = await verifyMathAnswer({
+              attemptToken,
+              answer: Number(answer),
+            });
+            if (verdict.status === "expired") {
+              expire();
+              return;
+            }
+            if (verdict.status === "incorrect") {
+              setAnswer("");
+              setError("That wasn’t right — try again.");
+              return;
+            }
+          }
+          // Then resume the sign-in: the evaluator re-runs against the
+          // freshly recorded facts. "complete" and "expired" are handled by
+          // the flow (auth state / onExpired); "error" renders below from
+          // flow.error.
+          const status = await flow.continueSignIn();
+          if (status === "incomplete") setAnswer("");
+        } finally {
+          setPending(false);
+        }
+      }}
+    >
+      <h1>Almost there</h1>
+      {renderRequirements(flow.requirements, flow, {
+        // The record must name every registered kind: registering a new
+        // requirement on the backend breaks the build here (a missing
+        // property) until the UI handles it.
+        "mathFactor:problem": () => (
+          <label>
+            {question === null ? "Loading challenge…" : `What is ${question}?`}
+            <input
+              type="text"
+              inputMode="numeric"
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              required
+              disabled={pending || question === null}
+            />
+          </label>
+        ),
+        // Runtime backstop for version skew (a stale client bundle against
+        // a backend that registered a kind this build predates).
+        fallback: (req) => (
+          <p role="alert">
+            This app can’t satisfy the requirement: <strong>{req.kind}</strong>
+          </p>
+        ),
+      })}
+      {error !== null || flow.error !== null ? (
+        <p role="alert">
+          <strong>{error ?? "Something went wrong. Please try again."}</strong>
+        </p>
+      ) : null}
+      <button type="submit" disabled={pending}>
+        {pending ? "Checking…" : "Continue"}
+      </button>
+    </form>
+  );
+}

--- a/examples/react-password-requirements/src/routes/signUp.tsx
+++ b/examples/react-password-requirements/src/routes/signUp.tsx
@@ -1,0 +1,112 @@
+import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
+import { useState } from "react";
+import { api } from "../../convex/_generated/api";
+import { RequirementsStep, type IncompleteResult } from "./requirementsStep";
+
+export function SignUp() {
+  const { signUp, pending } = useSignUpWithPassword(
+    api.auth.signUpWithPassword,
+    api.auth.continueSignInWithPassword,
+  );
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  // An incomplete sign-up parked mid-flow (the math second factor).
+  const [step, setStep] = useState<IncompleteResult | null>(null);
+
+  if (step !== null) {
+    return (
+      <RequirementsStep
+        initial={step}
+        onRestart={(message) => {
+          setStep(null);
+          setError(message);
+        }}
+      />
+    );
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setError(null);
+          const result = await signUp({ username, password });
+          if (result.status === "complete") {
+            return;
+          }
+          if (result.status === "incomplete") {
+            // Credentials are fine, but requirements are outstanding: hand
+            // the flow to the requirements step.
+            setStep(result);
+            return;
+          }
+          setError(() => {
+            switch (result.userError.error) {
+              case "USERNAME_TAKEN":
+                return "That username is already taken.";
+              case "USERNAME_TOO_SHORT":
+                return `Username must be at least ${result.userError.minimumLength} characters.`;
+              case "USERNAME_HAS_SURROUNDING_WHITESPACE":
+                return "Username can't start or end with whitespace.";
+              case "USERNAME_HAS_INVALID_CHARACTERS":
+                return "Username contains characters that aren't allowed.";
+              case "PASSWORD_TOO_SHORT":
+                return `Password must be at least ${result.userError.minimumLength} characters.`;
+              case "PASSWORD_TOO_LONG":
+                return `Password must be at most ${result.userError.maximumLength} characters.`;
+              case "PASSWORD_HAS_SURROUNDING_WHITESPACE":
+                return "Password can't start or end with whitespace.";
+              case "PASSWORD_TOO_COMMON":
+                return "This password is one of the most commonly used passwords. Please choose a different one.";
+              case "OTHER_ERROR":
+                // The mutation threw unexpectedly; the original error is
+                // available on `cause` if you want to log or inspect it.
+                console.error("Sign-up failed:", result.userError.cause);
+                return "Something went wrong. Please try again.";
+              default:
+                result.userError satisfies never;
+                return `Unknown error: ` + result.userError;
+            }
+          });
+        }}
+      >
+        <h1>Sign up</h1>
+        <label>
+          Username
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            required
+            disabled={pending}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            required
+            disabled={pending}
+          />
+        </label>
+        {error ? (
+          <p role="alert">
+            <strong>{error}</strong>
+          </p>
+        ) : null}
+        <button type="submit" disabled={pending}>
+          {pending ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+      <p>
+        Already have an account? <a href="/login">Log in</a>
+      </p>
+    </>
+  );
+}

--- a/examples/react-password-requirements/tsconfig.json
+++ b/examples/react-password-requirements/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["convex/**/*", "src/**/*", "vite.config.ts"],
+  "exclude": ["node_modules", "convex/_generated"]
+}

--- a/examples/react-password-requirements/vite.config.ts
+++ b/examples/react-password-requirements/vite.config.ts
@@ -1,0 +1,6 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,55 @@ importers:
         specifier: ^8.0.16
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
+  examples/react-password-requirements:
+    dependencies:
+      '@convex-dev/auth':
+        specifier: workspace:*
+        version: link:../../packages/core
+      convex:
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.18.1
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@convex-dev/rate-limiter':
+        specifier: ^0.3.2
+        version: 0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
+      convex-test:
+        specifier: ^0.0.55
+        version: 0.0.55(convex@1.43.0(react@19.2.7))
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   packages/argon2id-wasm:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
`react-password-requirements` is `react-password` plus a fake second factor,
`mathFactor:problem`, standing in for a real TOTP or passkey verifier.

The point of it is the packaging. `convex/lib/mathFactor.ts` owns everything
about the factor — its table, its challenge and verify endpoints, and its
requirement spec — and hands the app a single value. The spec is only
obtainable by calling `setupMathFactor()`, so an app that can name
`mathFactor:problem` in its `signInRequirements` necessarily holds the thing
that mounts the endpoints which satisfy it.

`convex/users.ts` shows the app side: derive `vFacts` and `vVerdict` from the
same specs, in a module that never imports `auth.ts`, and judge a requirement
satisfied by the presence of its fact. The evaluator never verifies anything
itself — the factor's own endpoint does that out of band and records the fact
through `recordAttemptFacts`, which only server code can reach. Wrong answers
go through `penalizeAttempt`, so the endpoint isn't a free guessing oracle.

`src/routes/requirementsStep.tsx` is the client half, shared by log-in and
sign-up: `useRequirementsFlow` drives the rounds and `renderRequirements`
picks a renderer per kind.

The app joins the codegen CI job, which is what turned up its checked-in
`_generated/api.d.ts` missing the `lib/mathFactor` module — the only example
with a nested `convex/` subdirectory, and the entry was never generated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>