### PR TITLE
Mark the generated files as such in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Files that a code generator writes. Linguist removes them from the language
+# statistics, and GitHub collapses them in the pull request diffs.
+**/_generated/** linguist-generated=true
+*.generated.ts linguist-generated=true
+
+# Lockfiles. Linguist finds them automatically, but some tools (Graphite) only
+# read the .gitattributes.
+pnpm-lock.yaml linguist-generated=true
+Cargo.lock linguist-generated=true


### PR DESCRIPTION
Adds a `.gitattributes` file that marks the generated files with `linguist-generated`, so that GitHub removes them from the language statistics and collapses them in the pull request diffs.

It covers the Convex codegen output (`**/_generated/**`), `commonPasswords.generated.ts` (`*.generated.ts`), and the two lockfiles. Linguist finds the lockfiles automatically, but Graphite currently does not.