### PR TITLE
usernamePasskey: automatically name new passkeys after the authenticator

### DIFF
--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as aaguids from "../aaguids.js";
 import type * as authentication from "../authentication.js";
 import type * as base64url from "../base64url.js";
 import type * as cleanup from "../cleanup.js";
@@ -36,6 +37,7 @@ import type {
 import { anyApi, componentsGeneric } from "convex/server";
 
 const fullApi: ApiFromModules<{
+  aaguids: typeof aaguids;
   authentication: typeof authentication;
   base64url: typeof base64url;
   cleanup: typeof cleanup;

--- a/packages/core/src/components/passkey/aaguids.ts
+++ b/packages/core/src/components/passkey/aaguids.ts
@@ -1,0 +1,75 @@
+/**
+ * Default display names for new passkeys, from the AAGUID of the
+ * authenticator.
+ *
+ * @module
+ */
+
+// Sourced from https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/774b3cfc940a4138bc451ae4ec9b943bf9a44c1b/aaguid.json
+const WELL_KNOWN_AAGUIDS: Record<string, string> = {
+  "bada5566-a7aa-401f-bd96-45619a55120d": "1Password",
+  "a11a5faa-9f32-4b8c-8c5d-2f7d13e8c942": "AliasVault",
+  "fbfc3007-154e-4ecc-8c0b-6e020557d7bd": "Apple Passwords",
+  "dd4ec289-e01d-41c9-bb89-70fa845d4bf2": "Apple Passwords (Managed)", // managed Apple accounts (work/school)
+  "a4a2d88e-9796-4356-9164-e2a5a8bd019c": "Avast Password Manager",
+  "6bb49926-160a-4306-a100-4eb39ba6ac45": "AVG Password Manager",
+  "e7db2bd3-f2fe-4d71-ad78-7e7aa166cfd1": "Avira Password Manager",
+  "d548826e-79b4-db40-a3d8-11116f7e8349": "Bitwarden",
+  "c9cadfc9-89a9-489e-a25a-c7e86a4d5f15": "Burp Suite Navigation Recorder",
+  "adce0002-35bc-c60a-648b-0b25f1f05503": "Chrome on Mac",
+  "b5397666-4885-aa6b-cebf-e52262a439a2": "Chromium Browser",
+  "531126d6-e717-415c-9320-3d9aa6981239": "Dashlane",
+  "de503f9c-21a4-4f76-b4b7-558eb55c6f89": "Devolutions",
+  "771b48fd-d3d4-4f74-9232-fc157ab0507a": "Edge on Mac",
+  "f3809540-7f14-49c1-a8b3-8f813b225541": "Enpass",
+  "d2717a32-9851-48a8-9961-b264c97a411a": "Fenko Vault",
+  "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4": "Google Password Manager",
+  "d49b2120-b865-4191-8cea-be84a52b0485": "Heimlane Vault",
+  "da583154-ce16-4cdf-9fe6-1dba788c0998": "Hey Be Safe",
+  "39a5647e-1853-446c-a1f6-a79bae9f5bc7": "IDmelon",
+  "6d212b28-a2c1-4638-b375-5932070f62e9": "initial",
+  "cb6f6666-38ea-4873-9161-ff456a82d316": "iPass Secure Auth",
+  "bfc748bb-3429-4faa-b9f9-7cfa9f3b76d0": "iPasswords",
+  "a10c6dd9-465e-4226-8198-c7c44b91c555": "Kaspersky Password Manager",
+  "eaecdef2-1c31-5634-8639-f1cbd9c00a08": "KeePassDX",
+  "9addb28c-b46f-4402-808f-019651441ff3": "KeePassPasskey",
+  "fdb141b2-5d84-443e-8a35-4698c205a502": "KeePassXC",
+  "0ea242b4-43c4-4a1b-8b17-dd6d0b6baec6": "Keeper",
+  "b78a0a55-6ef8-d246-a042-ba0f6d55050c": "LastPass",
+  "22248c4c-7a12-46e2-9a41-44291b373a4d": "LogMeOnce",
+  "d3452668-01fd-4c12-926c-83a4204853aa": "Microsoft Password Manager",
+  "b84e4048-15dc-4dd0-8640-f4f60813c8af": "NordPass",
+  "fa37f553-f9b6-4adb-ac53-8bbb57ebdf0d": "Norton Password Manager",
+  "5ca471bb-a56d-46ad-a496-67e70e9ed9fb": "Parcel",
+  "87f5ec51-f721-4feb-9fe4-be18c4971894": "PassCard",
+  "70617373-7761-6c6c-6669-646f32303236": "Passwall",
+  "53e7a7a5-e75f-4d3d-9483-12fc779cdf23": "Password Depot",
+  "50726f74-6f6e-5061-7373-50726f746f6e": "Proton Pass",
+  "d350af52-0351-4ba2-acd3-dfeeadc3f764": "pwSafe",
+  "65c97700-f5ef-4d5c-8a42-f30e45ac94b7": "Royal Vault",
+  "53414d53-554e-4700-0000-000000000000": "Samsung Pass",
+  "e8b7f4a2-c3d5-e6f7-890a-b1c2d3e4f567": "Sherlocked",
+  "d9be9d39-e6a6-4c28-a581-32b044d986e4": "Sticky Password Manager",
+  "891494da-2c90-4d31-a9cd-4eab0aed1309": "Sésame",
+  "8836336a-f590-0921-301d-46427531eee6": "Thales Bio Android SDK",
+  "66a0ccb3-bd6a-191f-ee06-e375c50b9846": "Thales Bio iOS SDK",
+  "cd69adb5-3c7a-deb9-3177-6800ea6cb72a": "Thales PIN Android SDK",
+  "17290f1e-c212-34d0-1423-365d729f09d9": "Thales PIN iOS SDK",
+  "cc45f64e-52a2-451b-831a-4edd8022a202": "ToothPic Passkey Provider",
+  "9f8a3b2c-1d4e-4f6a-8b0c-2e1d3c4b5a69": "U2 Secured",
+  "45e3057e-b2f9-48ed-912f-9b901e153b16": "Uniqkey",
+  "477b05cd-7f78-4fe7-b629-27247f296138": "WALLIX Vault",
+  "08987058-cadc-4b81-b6e1-30de50dcbe96": "Windows Hello",
+  "6028b017-b1d4-4c02-b4b3-afcdafc96bb2": "Windows Hello",
+  "9ddd1817-af5a-4672-a2b9-3e3dd95000a9": "Windows Hello",
+  "b35a26b2-8f6e-4697-ab1d-d44db4da28c6": "Zoho Vault",
+};
+
+/**
+ * The display name for a new passkey whose authenticator reports `aaguid`,
+ * used when the caller gives no name of its own. `undefined` when the
+ * authenticator model is unknown, which leaves the passkey without a name.
+ */
+export function defaultPasskeyName(aaguid: string): string | undefined {
+  return WELL_KNOWN_AAGUIDS[aaguid];
+}

--- a/packages/core/src/components/passkey/react_impl.tsx
+++ b/packages/core/src/components/passkey/react_impl.tsx
@@ -94,7 +94,7 @@ const FOREIGN_CEREMONY_WARNING =
  * │  └────────────────────────────────────────┘  │
  * │  ╭────────────────────────────────────────────────╮
  * │  │ 🔑  ada                                        │
- * │  │     Passkey · iCloud Keychain                  │
+ * │  │     Passkey · Apple Passwords                  │
  * │  │ 🔑  charles                                    │
  * └──│     Passkey · 1Password                        │
  *    ├────────────────────────────────────────────────┤

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -14,6 +14,7 @@ import {
   generateRS256Credential,
   registrationResponse,
   toBase64URL,
+  aaguidBytes,
 } from "@convex-dev/passkey-test-authenticator";
 import {
   expectProtocolError,
@@ -79,6 +80,7 @@ async function registrationArgs(
     includeCredential?: boolean;
     challenge?: ArrayBuffer;
     startUserId?: string | null;
+    aaguid?: Uint8Array;
   } = {},
 ) {
   const credential = options.credential ?? (await generateES256Credential());
@@ -107,6 +109,7 @@ async function registrationArgs(
     userPresent: options.userPresent,
     userVerified: options.userVerified,
     credential: options.includeCredential === false ? undefined : credential,
+    aaguid: options.aaguid,
   });
   const buildArgs = (extra: { transports?: string[] } = {}) => ({
     expectedRpId: RP_ID,
@@ -986,6 +989,52 @@ describe("checkRegistrationForNewUser", () => {
       ),
     ).toEqual(invalid);
     expect(await finish()).toEqual(invalid);
+  });
+});
+
+describe("default passkey names", () => {
+  const APPLE_PASSWORDS = aaguidBytes("fbfc3007-154e-4ecc-8c0b-6e020557d7bd");
+
+  test("names a new passkey after its authenticator", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      aaguid: APPLE_PASSWORDS,
+    });
+    expect((await finish()).success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBe("Apple Passwords");
+  });
+
+  test("stores no name for an unknown AAGUID", async () => {
+    // `attestation: "none"` lets an authenticator zero its AAGUID; the big
+    // passkey providers report theirs anyway.
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1");
+    expect((await finish()).success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBeUndefined();
+  });
+
+  test("an explicit name wins over the default", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      name: "My security key",
+      aaguid: APPLE_PASSWORDS,
+    });
+    expect((await finish()).success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBe("My security key");
+  });
+
+  test("the new-user flow names its passkey too", async () => {
+    const t = setup();
+    const { finish } = await registrationArgs(t, "user1", {
+      startUserId: null,
+      aaguid: APPLE_PASSWORDS,
+    });
+    expect((await finish()).success).toBe(true);
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBe("Apple Passwords");
   });
 });
 

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -87,6 +87,7 @@ import {
   transportsAreValid,
 } from "./validation.ts";
 import { SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
+import { defaultPasskeyName } from "./aaguids.ts";
 import {
   deleteDeadChallenge,
   findChallenge,
@@ -320,7 +321,7 @@ export const finishRegistrationForNewUser = mutation({
     });
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.newUserId,
-      name: args.name,
+      name: args.name ?? defaultPasskeyName(result.credential.aaguid),
       transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
@@ -363,7 +364,7 @@ export const finishRegistrationForExistingUser = mutation({
     }
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.verifiedUserId,
-      name: args.name,
+      name: args.name ?? defaultPasskeyName(result.credential.aaguid),
       transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
@@ -546,6 +547,9 @@ type VerifiedCredential = {
   // The COSE public key, exactly as `verifyRegistrationResponse` returns it.
   publicKey: ArrayBuffer;
   counter: number;
+  // The authenticator model, for the default passkey name (see
+  // `defaultPasskeyName`).
+  aaguid: string;
 };
 
 /**
@@ -661,6 +665,7 @@ async function verifyAttestation(
       credentialId: storedCredentialId,
       publicKey: toArrayBuffer(credential.publicKey),
       counter: credential.counter,
+      aaguid: verification.registrationInfo.aaguid,
     },
   };
 }

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -145,12 +145,23 @@ export function buildClientDataJSON({
   );
 }
 
+/** Parse an AAGUID in its UUID form into its 16 bytes. */
+export function aaguidBytes(aaguid: string): Uint8Array {
+  const hex = aaguid.replaceAll("-", "");
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    bytes[i] = parseInt(hex.slice(2 * i, 2 * i + 2), 16);
+  }
+  return bytes;
+}
+
 export async function buildAuthenticatorData({
   rpId,
   userPresent = true,
   userVerified = true,
   counter = 0,
   credential,
+  aaguid,
 }: {
   rpId: string;
   userPresent?: boolean;
@@ -158,6 +169,9 @@ export async function buildAuthenticatorData({
   counter?: number;
   // When set, the attested credential data block is included (AT flag).
   credential?: Pick<TestCredential, "credentialId" | "cosePublicKey">;
+  // The authenticator model in the attested credential data. Zeroed by
+  // default, like an authenticator that hides its model.
+  aaguid?: Uint8Array;
 }): Promise<Uint8Array> {
   let flags = 0;
   if (userPresent) flags |= 0x01;
@@ -172,7 +186,7 @@ export async function buildAuthenticatorData({
     counter & 0xff,
   ];
   if (credential !== undefined) {
-    parts.push(...new Array(16).fill(0)); // AAGUID
+    parts.push(...(aaguid ?? new Uint8Array(16))); // AAGUID
     parts.push(
       (credential.credentialId.length >> 8) & 0xff,
       credential.credentialId.length & 0xff,


### PR DESCRIPTION
When registering new passkeys, we now apply a default name depending on the authenticator to make them easier to distinguish.