### PR TITLE
passkey: use SimpleWebAuthn on the frontend

### DIFF
--- a/examples/react-passkey-basic/src/routes/logIn.tsx
+++ b/examples/react-passkey-basic/src/routes/logIn.tsx
@@ -102,9 +102,11 @@ function errorMessage(
       // The Convex logs contain more information about the source of the error.
       return "This passkey request could not be verified. Please try again, or contact support if the problem persists.";
     case "PASSKEY_ALREADY_REGISTERED":
-      // The authenticator refused to make a second passkey for this
-      // account (usually via `excludeCredentials`).
-      return "You already have a passkey for this account on this device. Sign in with it instead.";
+      // The authenticator refused to make a second passkey (usually
+      // because `excludeCredentials` names one it already holds). The
+      // message stays account-neutral: this switch also serves the sign-up
+      // flow, where no account exists yet.
+      return "This device already holds a passkey for this site. Try signing in with it instead.";
     case "CEREMONY_ABORTED":
       // The most common failure: the user closed the passkey dialog.
       return "Sign-in was cancelled. Please try again.";

--- a/examples/react-passkey-basic/src/routes/logIn.tsx
+++ b/examples/react-passkey-basic/src/routes/logIn.tsx
@@ -101,6 +101,10 @@ function errorMessage(
       // This might be caused by a misbehaving client, or by a configuration error.
       // The Convex logs contain more information about the source of the error.
       return "This passkey request could not be verified. Please try again, or contact support if the problem persists.";
+    case "PASSKEY_ALREADY_REGISTERED":
+      // The authenticator refused to make a second passkey for this
+      // account (usually via `excludeCredentials`).
+      return "You already have a passkey for this account on this device. Sign in with it instead.";
     case "CEREMONY_ABORTED":
       // The most common failure: the user closed the passkey dialog.
       return "Sign-in was cancelled. Please try again.";

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -101,6 +101,12 @@ function errorMessage(
       // This might be caused by a misbehaving client, or by a configuration error.
       // The Convex logs contain more information about the source of the error.
       return "This passkey request could not be verified. Please try again, or contact support if the problem persists.";
+    case "PASSKEY_ALREADY_REGISTERED":
+      // The authenticator refused to make a second passkey (usually
+      // because `excludeCredentials` names one it already holds). The
+      // message stays account-neutral: this switch also serves the sign-up
+      // flow, where no account exists yet.
+      return "This device already holds a passkey for this site. Try signing in with it instead.";
     case "CEREMONY_ABORTED":
       // The most common failure: the user closed the passkey dialog.
       return "Sign-in was cancelled. Please try again.";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -170,6 +170,7 @@
     "@babel/code-frame": "^7.29.7",
     "@convex-dev/batch-worker": "^0.3.0",
     "@convex-dev/rate-limiter": "^0.3.2",
+    "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.2",
     "argon2id-wasm": "0.0.0-alpha.2",
     "chalk": "^5.6.2",

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -3,61 +3,65 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   authenticate,
   authenticateWithAutofill,
+  cancelPendingCeremony,
   foldClientError,
   register,
   supportsWebAuthn,
 } from "./client.ts";
 import { fromBase64URL, toBase64URL } from "./base64url.ts";
 
-// The ceremonies run through `navigator.credentials`, which jsdom has not.
-// The tests stub it and check what the wrappers add on top: the support
-// check, the decoding of the options, the encoding of the response, and
-// the error fold.
-const credentialsCreate = vi.fn();
-const credentialsGet = vi.fn();
+// The ceremonies run through `@simplewebauthn/browser`; the tests mock its
+// module surface and check what the wrappers add on top: the support
+// check, the error fold, and the pruning of the response.
+const startRegistration = vi.fn();
+const startAuthentication = vi.fn();
+const cancelCeremony = vi.fn();
+
+vi.mock("@simplewebauthn/browser", () => ({
+  startRegistration: (...args: unknown[]) => startRegistration(...args),
+  startAuthentication: (...args: unknown[]) => startAuthentication(...args),
+  WebAuthnAbortService: { cancelCeremony: () => cancelCeremony() },
+}));
 
 class FakePublicKeyCredential {}
 
-const bytes = (text: string) =>
-  Uint8Array.from(text, (character) => character.charCodeAt(0)).buffer;
-
-/**
- * base64url of a short ASCII string. The ceremonies decode the options they
- * are given, so the fixtures have to be real base64url.
- */
-const wire = (text: string) => toBase64URL(bytes(text));
-
-// An attestation credential the way `navigator.credentials.create()`
-// returns one.
-const attestationCredential = {
-  id: wire("credential-id"),
-  rawId: bytes("credential-id"),
+// A registration response as the library returns it, with the convenience
+// fields that the wire must not carry.
+const registrationResponse = {
+  id: "credential-id",
+  rawId: "credential-id",
   response: {
-    clientDataJSON: bytes("client-data"),
-    attestationObject: bytes("attestation"),
-    getTransports: () => ["internal", "hybrid"],
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
+    transports: ["internal", "hybrid"],
+    authenticatorData: "auth-data",
+    publicKey: "public-key",
+    publicKeyAlgorithm: -7,
   },
+  authenticatorAttachment: "platform",
+  clientExtensionResults: { credProps: { rk: true } },
   type: "public-key",
 };
 
-// An assertion credential the way `navigator.credentials.get()` returns
-// one.
-const assertionCredential = {
-  id: wire("credential-id"),
-  rawId: bytes("credential-id"),
+// An authentication response as the library returns it.
+const authenticationResponse = {
+  id: "credential-id",
+  rawId: "credential-id",
   response: {
-    clientDataJSON: bytes("client-data"),
-    authenticatorData: bytes("auth-data"),
-    signature: bytes("signature"),
-    userHandle: bytes("user-handle"),
+    clientDataJSON: "client-data",
+    authenticatorData: "auth-data",
+    signature: "signature",
+    userHandle: "user-handle",
   },
+  authenticatorAttachment: "platform",
+  clientExtensionResults: {},
   type: "public-key",
 };
 
 const creationOptions = {
   rp: { id: "localhost", name: "Test app" },
-  user: { id: wire("handle"), name: "alice", displayName: "alice" },
-  challenge: wire("challenge"),
+  user: { id: "handle", name: "alice", displayName: "alice" },
+  challenge: "challenge",
   pubKeyCredParams: [{ alg: -7, type: "public-key" as const }],
   timeout: 600000,
   excludeCredentials: [],
@@ -70,6 +74,15 @@ const creationOptions = {
   extensions: {},
 };
 
+/**
+ * base64url of a short ASCII string. The conditional path decodes the
+ * challenge it is given, so the fixtures have to be real base64url.
+ */
+const wire = (text: string) =>
+  toBase64URL(
+    Uint8Array.from(text, (character) => character.charCodeAt(0)).buffer,
+  );
+
 const requestOptions = {
   challenge: wire("challenge"),
   timeout: 600000,
@@ -78,18 +91,23 @@ const requestOptions = {
   userVerification: "required" as const,
 };
 
+/** An error the way `WebAuthnError` wraps it: the `name` is preserved. */
+function browserError(name: string) {
+  const error = new Error(`wrapped ${name}`);
+  error.name = name;
+  return error;
+}
+
 beforeEach(() => {
   vi.stubGlobal("PublicKeyCredential", FakePublicKeyCredential);
   vi.stubGlobal("isSecureContext", true);
-  vi.stubGlobal("navigator", {
-    credentials: { create: credentialsCreate, get: credentialsGet },
-  });
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  credentialsCreate.mockReset();
-  credentialsGet.mockReset();
+  startRegistration.mockReset();
+  startAuthentication.mockReset();
+  cancelCeremony.mockReset();
 });
 
 describe("supportsWebAuthn", () => {
@@ -121,6 +139,18 @@ describe("foldClientError", () => {
     });
   });
 
+  test("a wrapped WebAuthnError folds by its preserved name", () => {
+    expect(foldClientError(browserError("NotAllowedError"))).toEqual({
+      error: "CEREMONY_ABORTED",
+    });
+  });
+
+  test("InvalidStateError folds into PASSKEY_ALREADY_REGISTERED", () => {
+    expect(foldClientError(browserError("InvalidStateError"))).toEqual({
+      error: "PASSKEY_ALREADY_REGISTERED",
+    });
+  });
+
   test("everything else folds into OTHER_ERROR with the cause", () => {
     const cause = new Error("network blip");
     expect(foldClientError(cause)).toEqual({ error: "OTHER_ERROR", cause });
@@ -128,33 +158,25 @@ describe("foldClientError", () => {
 });
 
 describe("register", () => {
-  test("decodes the options for create() and encodes the response", async () => {
-    credentialsCreate.mockResolvedValue(attestationCredential);
+  test("hands the options to startRegistration and prunes the response", async () => {
+    startRegistration.mockResolvedValue(registrationResponse);
 
     const result = await register(creationOptions);
 
-    // The wire carries base64url; the WebAuthn API takes bytes. Everything
-    // else reaches the browser as the server built it.
-    const [call] = credentialsCreate.mock.calls[0];
-    expect(call.publicKey.challenge).toEqual(
-      fromBase64URL(creationOptions.challenge),
-    );
-    expect(call.publicKey.user.id).toEqual(
-      fromBase64URL(creationOptions.user.id),
-    );
-    expect(call.publicKey.rp).toEqual(creationOptions.rp);
-    expect(call.publicKey.attestation).toBe("none");
-    expect(call.publicKey.authenticatorSelection).toEqual(
-      creationOptions.authenticatorSelection,
-    );
+    expect(startRegistration).toHaveBeenCalledWith({
+      optionsJSON: creationOptions,
+    });
+    // The convenience fields (`publicKey`, `publicKeyAlgorithm`,
+    // `authenticatorData`, `authenticatorAttachment`) and the extension
+    // outputs are gone: the exact server validators refuse them.
     expect(result).toEqual({
       success: true,
       response: {
-        id: wire("credential-id"),
-        rawId: wire("credential-id"),
+        id: "credential-id",
+        rawId: "credential-id",
         response: {
-          clientDataJSON: wire("client-data"),
-          attestationObject: wire("attestation"),
+          clientDataJSON: "client-data",
+          attestationObject: "attestation",
           transports: ["internal", "hybrid"],
         },
         clientExtensionResults: {},
@@ -163,12 +185,12 @@ describe("register", () => {
     });
   });
 
-  test("a browser without getTransports reports no transports", async () => {
-    credentialsCreate.mockResolvedValue({
-      ...attestationCredential,
+  test("a response without transports carries none", async () => {
+    startRegistration.mockResolvedValue({
+      ...registrationResponse,
       response: {
-        clientDataJSON: bytes("client-data"),
-        attestationObject: bytes("attestation"),
+        clientDataJSON: "client-data",
+        attestationObject: "attestation",
       },
     });
     const result = await register(creationOptions);
@@ -178,27 +200,25 @@ describe("register", () => {
     );
   });
 
-  test("a null credential folds into CEREMONY_ABORTED", async () => {
-    credentialsCreate.mockResolvedValue(null);
+  test("a thrown NotAllowedError folds into CEREMONY_ABORTED", async () => {
+    startRegistration.mockRejectedValue(browserError("NotAllowedError"));
     expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
     });
   });
 
-  test("a thrown NotAllowedError folds into CEREMONY_ABORTED", async () => {
-    credentialsCreate.mockRejectedValue(
-      new DOMException("cancelled", "NotAllowedError"),
-    );
+  test("an excluded credential folds into PASSKEY_ALREADY_REGISTERED", async () => {
+    startRegistration.mockRejectedValue(browserError("InvalidStateError"));
     expect(await register(creationOptions)).toEqual({
       success: false,
-      userError: { error: "CEREMONY_ABORTED" },
+      userError: { error: "PASSKEY_ALREADY_REGISTERED" },
     });
   });
 
   test("an unexpected throw folds into OTHER_ERROR with the cause", async () => {
     const cause = new Error("boom");
-    credentialsCreate.mockRejectedValue(cause);
+    startRegistration.mockRejectedValue(cause);
     expect(await register(creationOptions)).toEqual({
       success: false,
       userError: { error: "OTHER_ERROR", cause },
@@ -211,44 +231,29 @@ describe("register", () => {
       success: false,
       userError: { error: "WEBAUTHN_UNSUPPORTED" },
     });
-    expect(credentialsCreate).not.toHaveBeenCalled();
+    expect(startRegistration).not.toHaveBeenCalled();
   });
 });
 
 describe("authenticate", () => {
-  test("decodes the options for get() and encodes the response", async () => {
-    credentialsGet.mockResolvedValue(assertionCredential);
+  test("hands the options to startAuthentication and prunes the response", async () => {
+    startAuthentication.mockResolvedValue(authenticationResponse);
 
-    const result = await authenticate({
-      ...requestOptions,
-      allowCredentials: [
-        { id: wire("credential-id"), type: "public-key", transports: ["usb"] },
-      ],
+    const result = await authenticate(requestOptions);
+
+    expect(startAuthentication).toHaveBeenCalledWith({
+      optionsJSON: requestOptions,
     });
-
-    const [call] = credentialsGet.mock.calls[0];
-    expect(call.publicKey.challenge).toEqual(
-      fromBase64URL(requestOptions.challenge),
-    );
-    expect(call.publicKey.rpId).toBe(requestOptions.rpId);
-    expect(call.publicKey.userVerification).toBe("required");
-    expect(call.publicKey.allowCredentials).toEqual([
-      {
-        id: fromBase64URL(wire("credential-id")),
-        type: "public-key",
-        transports: ["usb"],
-      },
-    ]);
     expect(result).toEqual({
       success: true,
       response: {
-        id: wire("credential-id"),
-        rawId: wire("credential-id"),
+        id: "credential-id",
+        rawId: "credential-id",
         response: {
-          clientDataJSON: wire("client-data"),
-          authenticatorData: wire("auth-data"),
-          signature: wire("signature"),
-          userHandle: wire("user-handle"),
+          clientDataJSON: "client-data",
+          authenticatorData: "auth-data",
+          signature: "signature",
+          userHandle: "user-handle",
         },
         clientExtensionResults: {},
         type: "public-key",
@@ -256,14 +261,13 @@ describe("authenticate", () => {
     });
   });
 
-  test("an assertion without a user handle carries none", async () => {
-    credentialsGet.mockResolvedValue({
-      ...assertionCredential,
+  test("a response without userHandle carries none", async () => {
+    startAuthentication.mockResolvedValue({
+      ...authenticationResponse,
       response: {
-        clientDataJSON: bytes("client-data"),
-        authenticatorData: bytes("auth-data"),
-        signature: bytes("signature"),
-        userHandle: null,
+        clientDataJSON: "client-data",
+        authenticatorData: "auth-data",
+        signature: "signature",
       },
     });
     const result = await authenticate(requestOptions);
@@ -273,16 +277,8 @@ describe("authenticate", () => {
     );
   });
 
-  test("a null credential folds into CEREMONY_ABORTED", async () => {
-    credentialsGet.mockResolvedValue(null);
-    expect(await authenticate(requestOptions)).toEqual({
-      success: false,
-      userError: { error: "CEREMONY_ABORTED" },
-    });
-  });
-
   test("an aborted ceremony folds into CEREMONY_ABORTED", async () => {
-    credentialsGet.mockRejectedValue(new DOMException("aborted", "AbortError"));
+    startAuthentication.mockRejectedValue(browserError("AbortError"));
     expect(await authenticate(requestOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
@@ -295,7 +291,7 @@ describe("authenticate", () => {
       success: false,
       userError: { error: "WEBAUTHN_UNSUPPORTED" },
     });
-    expect(credentialsGet).not.toHaveBeenCalled();
+    expect(startAuthentication).not.toHaveBeenCalled();
   });
 });
 
@@ -393,7 +389,7 @@ describe("authenticateWithAutofill", () => {
 
   test("an abort folds into CEREMONY_ABORTED", async () => {
     stubCredentials();
-    credentialsGet.mockRejectedValue(new DOMException("aborted", "AbortError"));
+    credentialsGet.mockRejectedValue(browserError("AbortError"));
 
     expect(
       await authenticateWithAutofill(
@@ -426,5 +422,12 @@ describe("authenticateWithAutofill", () => {
       ),
     ).toEqual({ success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } });
     expect(credentialsGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelPendingCeremony", () => {
+  test("delegates to the ceremony slot of the library", () => {
+    cancelPendingCeremony();
+    expect(cancelCeremony).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   authenticate,
   authenticateWithAutofill,
-  cancelPendingCeremony,
   foldClientError,
   register,
   supportsWebAuthn,
@@ -15,12 +14,10 @@ import { fromBase64URL, toBase64URL } from "./base64url.ts";
 // check, the error fold, and the pruning of the response.
 const startRegistration = vi.fn();
 const startAuthentication = vi.fn();
-const cancelCeremony = vi.fn();
 
 vi.mock("@simplewebauthn/browser", () => ({
   startRegistration: (...args: unknown[]) => startRegistration(...args),
   startAuthentication: (...args: unknown[]) => startAuthentication(...args),
-  WebAuthnAbortService: { cancelCeremony: () => cancelCeremony() },
 }));
 
 class FakePublicKeyCredential {}
@@ -107,7 +104,6 @@ afterEach(() => {
   vi.unstubAllGlobals();
   startRegistration.mockReset();
   startAuthentication.mockReset();
-  cancelCeremony.mockReset();
 });
 
 describe("supportsWebAuthn", () => {
@@ -145,10 +141,9 @@ describe("foldClientError", () => {
     });
   });
 
-  test("InvalidStateError folds into PASSKEY_ALREADY_REGISTERED", () => {
-    expect(foldClientError(browserError("InvalidStateError"))).toEqual({
-      error: "PASSKEY_ALREADY_REGISTERED",
-    });
+  test("InvalidStateError folds into OTHER_ERROR outside a registration", () => {
+    const cause = browserError("InvalidStateError");
+    expect(foldClientError(cause)).toEqual({ error: "OTHER_ERROR", cause });
   });
 
   test("everything else folds into OTHER_ERROR with the cause", () => {
@@ -282,6 +277,15 @@ describe("authenticate", () => {
     expect(await authenticate(requestOptions)).toEqual({
       success: false,
       userError: { error: "CEREMONY_ABORTED" },
+    });
+  });
+
+  test("an InvalidStateError is not a duplicate registration", async () => {
+    const cause = browserError("InvalidStateError");
+    startAuthentication.mockRejectedValue(cause);
+    expect(await authenticate(requestOptions)).toEqual({
+      success: false,
+      userError: { error: "OTHER_ERROR", cause },
     });
   });
 
@@ -422,12 +426,5 @@ describe("authenticateWithAutofill", () => {
       ),
     ).toEqual({ success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } });
     expect(credentialsGet).not.toHaveBeenCalled();
-  });
-});
-
-describe("cancelPendingCeremony", () => {
-  test("delegates to the ceremony slot of the library", () => {
-    cancelPendingCeremony();
-    expect(cancelCeremony).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import {
   authenticate,
   authenticateWithAutofill,
@@ -153,7 +153,7 @@ describe("foldClientError", () => {
 });
 
 describe("register", () => {
-  test("hands the options to startRegistration and prunes the response", async () => {
+  it("hands the options to startRegistration and prunes the response", async () => {
     startRegistration.mockResolvedValue(registrationResponse);
 
     const result = await register(creationOptions);
@@ -232,7 +232,7 @@ describe("register", () => {
 });
 
 describe("authenticate", () => {
-  test("hands the options to startAuthentication and prunes the response", async () => {
+  it("hands the options to startAuthentication and prunes the response", async () => {
     startAuthentication.mockResolvedValue(authenticationResponse);
 
     const result = await authenticate(requestOptions);
@@ -257,7 +257,7 @@ describe("authenticate", () => {
     });
   });
 
-  test("a response without userHandle carries none", async () => {
+  it("doesn’t include userHandle in the return value when the authenticator doesn’t set it", async () => {
     startAuthentication.mockResolvedValue({
       ...authenticationResponse,
       response: {

--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -161,9 +161,10 @@ describe("register", () => {
     expect(startRegistration).toHaveBeenCalledWith({
       optionsJSON: creationOptions,
     });
-    // The convenience fields (`publicKey`, `publicKeyAlgorithm`,
-    // `authenticatorData`, `authenticatorAttachment`) and the extension
-    // outputs are gone: the exact server validators refuse them.
+    // Some of the fields (e.g. `publicKey`, `publicKeyAlgorithm`,
+    // `authenticatorData`, `authenticatorAttachment`) are not used
+    // on the server, so it’s expected that we strip them before
+    // calling the server function.
     expect(result).toEqual({
       success: true,
       response: {
@@ -180,7 +181,7 @@ describe("register", () => {
     });
   });
 
-  test("a response without transports carries none", async () => {
+  test("`transports` is undefined in the `register` output when using a browser that doesn’t support `transports`", async () => {
     startRegistration.mockResolvedValue({
       ...registrationResponse,
       response: {

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -7,11 +7,10 @@
  * file. It becomes a public entry point only when a real non-React consumer
  * asks for one.
  *
- * These functions wrap the WebAuthn ceremonies (`navigator.credentials`),
- * modal and conditional. They do not depend on React and they do not call
- * any Convex function: a flow starts a ceremony with data from its start
- * mutation, runs the ceremony here, and sends the result to its finish
- * mutation.
+ * These functions wrap the modal WebAuthn ceremonies through
+ * `@simplewebauthn/browser`. They do not call any Convex function: a flow
+ * gets an `options` object from its start mutation, runs the ceremony here,
+ * and sends the response to its finish mutation.
  *
  * The functions never throw. They return discriminated unions, and they
  * fold every failure into the {@link PasskeyClientError} shape, so callers
@@ -22,6 +21,17 @@
  * @module
  */
 
+import {
+  startAuthentication,
+  startRegistration,
+  WebAuthnAbortService,
+} from "@simplewebauthn/browser";
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from "@simplewebauthn/browser";
 import type {
   WireAuthenticationResponse,
   WireCreationOptions,
@@ -30,8 +40,15 @@ import type {
 } from "./validation.ts";
 import { fromBase64URL, toBase64URL } from "./base64url.ts";
 
-// Apps and custom flows read the wire shapes from here: they are the exact
-// shapes of the provider's mutations.
+// Apps and custom flows read the WebAuthn JSON types from here, so they
+// never depend on `@simplewebauthn/*` directly. The `Wire…` variants are
+// the exact shapes of the provider's mutations.
+export type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+};
 export type {
   WireAuthenticationResponse,
   WireCreationOptions,
@@ -43,9 +60,13 @@ export type {
  * The failures the browser side produces (the server never returns these):
  *
  * - `CEREMONY_ABORTED`: the user dismissed the passkey dialog, the browser
- *   refused the ceremony (`NotAllowedError`), or the caller aborted it
- *   through an `AbortSignal`. This is the most common failure; show a calm
- *   "sign-in was cancelled" message.
+ *   refused the ceremony (`NotAllowedError`), or another ceremony displaced
+ *   this one. This is the most common failure; show a calm "sign-in was
+ *   cancelled" message.
+ * - `PASSKEY_ALREADY_REGISTERED`: the authenticator refused a registration
+ *   because it already holds a passkey for this account
+ *   (`InvalidStateError`, usually via `excludeCredentials`). Tell the user
+ *   they can sign in with the passkey they already have.
  * - `WEBAUTHN_UNSUPPORTED`: the browser has no WebAuthn support, or the
  *   page is not a secure context.
  * - `OTHER_ERROR`: everything else thrown (a network blip, a bug, an
@@ -54,6 +75,7 @@ export type {
  */
 export type PasskeyClientError =
   | { error: "CEREMONY_ABORTED" }
+  | { error: "PASSKEY_ALREADY_REGISTERED" }
   | { error: "WEBAUTHN_UNSUPPORTED" }
   | { error: "OTHER_ERROR"; cause: unknown };
 
@@ -97,112 +119,86 @@ export function supportsWebAuthn(): boolean {
 
 /**
  * Fold a thrown value into the {@link PasskeyClientError} shape, so callers
- * handle every failure through one `userError` switch. Useful for custom
- * flows that call `navigator.credentials` or a mutation themselves.
+ * handle every failure through one `userError` switch.
+ *
+ * The browser errors keep their `name` when `@simplewebauthn/browser` wraps
+ * them in a `WebAuthnError`, so one check covers both the wrapped and the
+ * raw form:
+ *
+ * - `NotAllowedError` is what the browser throws when the user dismisses
+ *   the dialog, when the ceremony times out, and when the page is not
+ *   allowed to run one. `AbortError` is a ceremony that another one
+ *   displaced (see {@link cancelPendingCeremony}). A `null` credential
+ *   cannot happen through `@simplewebauthn/browser` (it throws instead).
+ * - `InvalidStateError` is the authenticator refusing to make a second
+ *   passkey for a credential in `excludeCredentials`.
  */
 export function foldClientError(cause: unknown): PasskeyClientError {
-  // `NotAllowedError` is what the browser throws when the user dismisses
-  // the dialog, when the ceremony times out, and when the page is not
-  // allowed to run one. `AbortError` is what an `AbortSignal` produces.
-  // A `null` credential is handled separately.
-  if (
-    cause instanceof DOMException &&
-    (cause.name === "NotAllowedError" || cause.name === "AbortError")
-  ) {
-    return { error: "CEREMONY_ABORTED" };
+  // `DOMException` does not extend `Error` in every runtime.
+  if (cause instanceof Error || cause instanceof DOMException) {
+    if (cause.name === "NotAllowedError" || cause.name === "AbortError") {
+      return { error: "CEREMONY_ABORTED" };
+    }
+    if (cause.name === "InvalidStateError") {
+      return { error: "PASSKEY_ALREADY_REGISTERED" };
+    }
   }
   return { error: "OTHER_ERROR", cause };
 }
 
 /**
- * Turn the JSON credential descriptors of the wire into the DOM shape of
- * `allowCredentials` and `excludeCredentials`.
+ * Keep only the fields of a registration response that the finish
+ * mutations accept. `@simplewebauthn/browser` adds convenience fields
+ * (`publicKey`, `publicKeyAlgorithm`, `authenticatorData`,
+ * `authenticatorAttachment`) that duplicate data from the attestation
+ * object, and the exact server validators refuse them.
  */
-function descriptorsFromJSON(
-  descriptors: WireRequestOptions["allowCredentials"],
-): PublicKeyCredentialDescriptor[] {
-  return descriptors.map(({ id, type, transports }) => ({
-    id: fromBase64URL(id),
-    type,
-    // The wire keeps `transports` as free-form strings, because the
-    // WebAuthn spec lets new transports appear; the DOM type does not.
-    transports: transports as AuthenticatorTransport[] | undefined,
-  }));
-}
-
-/**
- * Turn the creation options of the wire into the DOM shape that
- * `navigator.credentials.create()` takes: every binary field is base64url
- * on the wire and a `BufferSource` in the API.
- */
-function creationOptionsFromJSON(
-  options: WireCreationOptions,
-): PublicKeyCredentialCreationOptions {
-  return {
-    rp: options.rp,
-    user: {
-      id: fromBase64URL(options.user.id),
-      name: options.user.name,
-      displayName: options.user.displayName,
-    },
-    challenge: fromBase64URL(options.challenge),
-    pubKeyCredParams: options.pubKeyCredParams,
-    timeout: options.timeout,
-    excludeCredentials: descriptorsFromJSON(options.excludeCredentials),
-    authenticatorSelection: options.authenticatorSelection,
-    attestation: options.attestation,
-    extensions: options.extensions,
-  };
-}
-
-/** Turn the request options of the wire into the DOM shape that
- * `navigator.credentials.get()` takes (see
- * {@link creationOptionsFromJSON}). */
-function requestOptionsFromJSON(
-  options: WireRequestOptions,
-): PublicKeyCredentialRequestOptions {
-  return {
-    challenge: fromBase64URL(options.challenge),
-    timeout: options.timeout,
-    rpId: options.rpId,
-    allowCredentials: descriptorsFromJSON(options.allowCredentials),
-    userVerification: options.userVerification,
-  };
-}
-
-/**
- * Put an attestation credential from a `create()` call into the wire
- * shape.
- */
-function attestationToJSON(
-  credential: PublicKeyCredential,
+function pruneRegistrationResponse(
+  response: RegistrationResponseJSON,
 ): WireRegistrationResponse {
-  const response = credential.response as AuthenticatorAttestationResponse;
-  // Older browsers have no `getTransports`. Then the server stores no
-  // transports for this credential.
-  const transports =
-    typeof response.getTransports === "function"
-      ? response.getTransports()
-      : undefined;
   return {
-    id: credential.id,
-    rawId: toBase64URL(credential.rawId),
+    id: response.id,
+    rawId: response.rawId,
     response: {
-      clientDataJSON: toBase64URL(response.clientDataJSON),
-      attestationObject: toBase64URL(response.attestationObject),
-      ...(transports !== undefined ? { transports } : {}),
+      clientDataJSON: response.response.clientDataJSON,
+      attestationObject: response.response.attestationObject,
+      ...(response.response.transports !== undefined
+        ? { transports: response.response.transports }
+        : {}),
     },
     // The options request no extensions, so there is nothing to report.
     clientExtensionResults: {},
-    type: "public-key",
+    type: response.type,
+  };
+}
+
+/** Keep only the fields of an authentication response that the finish
+ * mutations accept (see {@link pruneRegistrationResponse}). */
+function pruneAuthenticationResponse(
+  response: AuthenticationResponseJSON,
+): WireAuthenticationResponse {
+  return {
+    id: response.id,
+    rawId: response.rawId,
+    response: {
+      clientDataJSON: response.response.clientDataJSON,
+      authenticatorData: response.response.authenticatorData,
+      signature: response.response.signature,
+      ...(response.response.userHandle !== undefined
+        ? { userHandle: response.response.userHandle }
+        : {}),
+    },
+    clientExtensionResults: {},
+    type: response.type,
   };
 }
 
 /**
  * Run a modal registration ceremony (a WebAuthn `create()` call).
  *
- * `options` comes from a start mutation, ready for the browser: this
- * function only decodes its binary fields.
+ * `options` comes from a start mutation, ready for the browser. Starting a
+ * ceremony displaces a pending one anywhere on the page (they share one
+ * browser-level slot; see {@link cancelPendingCeremony}).
  */
 export async function register(
   options: WireCreationOptions,
@@ -211,13 +207,13 @@ export async function register(
     return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
   try {
-    const credential = (await navigator.credentials.create({
-      publicKey: creationOptionsFromJSON(options),
-    })) as PublicKeyCredential | null; // navigator.credentials.get is typed as returning `Credential | null`, but with these arguments it returns a PublicKeyCredential
-    if (credential === null) {
-      return { success: false, userError: { error: "CEREMONY_ABORTED" } };
-    }
-    return { success: true, response: attestationToJSON(credential) };
+    const response = await startRegistration({
+      // The wire keeps `transports` as free-form strings, because the
+      // WebAuthn spec lets new transports appear; the library type does
+      // not.
+      optionsJSON: options as PublicKeyCredentialCreationOptionsJSON,
+    });
+    return { success: true, response: pruneRegistrationResponse(response) };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }
@@ -227,8 +223,9 @@ export async function register(
  * Run a modal authentication ceremony
  * (a WebAuthn `navigator.credentials.get()` call).
  *
- * `options` comes from a start mutation, ready for the browser: this
- * function only decodes its binary fields.
+ * `options` comes from a start mutation, ready for the browser. Starting a
+ * ceremony displaces a pending one anywhere on the page (they share one
+ * browser-level slot; see {@link cancelPendingCeremony}).
  *
  * For the conditional-mediation flow, which stays pending until the user
  * picks a passkey in the autocompletion list of an
@@ -242,13 +239,11 @@ export async function authenticate(
     return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
   try {
-    const credential = (await navigator.credentials.get({
-      publicKey: requestOptionsFromJSON(options),
-    })) as PublicKeyCredential | null; // navigator.credentials.get is typed as returning `Credential | null`, but with these arguments it returns a PublicKeyCredential
-    if (credential === null) {
-      return { success: false, userError: { error: "CEREMONY_ABORTED" } };
-    }
-    return { success: true, response: assertionToJSON(credential) };
+    const response = await startAuthentication({
+      // See the `transports` note in `register`.
+      optionsJSON: options as PublicKeyCredentialRequestOptionsJSON,
+    });
+    return { success: true, response: pruneAuthenticationResponse(response) };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }
@@ -261,6 +256,19 @@ export async function authenticate(
  *
  * `signal` aborts it. This is required because the caller is expected to
  * periodically recreate a new ceremony (because every ceremony has a timeout).
+ *
+ * This one call does not go through `@simplewebauthn/browser`, and the
+ * reason is `signal`. `startAuthentication` always overwrites the abort
+ * signal with one from its own singleton, which it creates *after* it
+ * awaits its autofill-support probe. A caller that aborts in that window
+ * aborts nothing, and the request then takes the ceremony slot from
+ * whoever the caller was making room for. An `AbortSignal` the caller owns
+ * has neither problem: it latches, so `get()` refuses an already-aborted
+ * one on entry, and no ordering matters.
+ *
+ * The caller feature-detects conditional mediation once, so this function
+ * does not repeat the probe (which is the `await` that opens that window
+ * in the library).
  */
 export async function authenticateWithAutofill(
   options: WireRequestOptions,
@@ -319,4 +327,18 @@ function assertionToJSON(
     clientExtensionResults: {},
     type: "public-key",
   };
+}
+
+/**
+ * Cancel the pending WebAuthn ceremony of this page, if one exists. The
+ * pending request rejects with an `AbortError`, which
+ * {@link foldClientError} folds into `CEREMONY_ABORTED`.
+ *
+ * The browser runs one ceremony at a time per page, and
+ * `@simplewebauthn/browser` manages that slot with a singleton: starting a
+ * new ceremony displaces the pending one the same way. The singleton stays
+ * an implementation detail behind this function.
+ */
+export function cancelPendingCeremony(): void {
+  WebAuthnAbortService.cancelCeremony();
 }

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -24,7 +24,6 @@
 import {
   startAuthentication,
   startRegistration,
-  WebAuthnAbortService,
 } from "@simplewebauthn/browser";
 import type {
   AuthenticationResponseJSON,
@@ -123,15 +122,11 @@ export function supportsWebAuthn(): boolean {
  *
  * The browser errors keep their `name` when `@simplewebauthn/browser` wraps
  * them in a `WebAuthnError`, so one check covers both the wrapped and the
- * raw form:
- *
- * - `NotAllowedError` is what the browser throws when the user dismisses
- *   the dialog, when the ceremony times out, and when the page is not
- *   allowed to run one. `AbortError` is a ceremony that another one
- *   displaced (see {@link cancelPendingCeremony}). A `null` credential
- *   cannot happen through `@simplewebauthn/browser` (it throws instead).
- * - `InvalidStateError` is the authenticator refusing to make a second
- *   passkey for a credential in `excludeCredentials`.
+ * raw form. `NotAllowedError` is what the browser throws when the user
+ * dismisses the dialog, when the ceremony times out, and when the page is
+ * not allowed to run one. `AbortError` is a ceremony that another one
+ * displaced. A `null` credential cannot happen through
+ * `@simplewebauthn/browser` (it throws instead).
  */
 export function foldClientError(cause: unknown): PasskeyClientError {
   // `DOMException` does not extend `Error` in every runtime.
@@ -139,11 +134,25 @@ export function foldClientError(cause: unknown): PasskeyClientError {
     if (cause.name === "NotAllowedError" || cause.name === "AbortError") {
       return { error: "CEREMONY_ABORTED" };
     }
-    if (cause.name === "InvalidStateError") {
-      return { error: "PASSKEY_ALREADY_REGISTERED" };
-    }
   }
   return { error: "OTHER_ERROR", cause };
+}
+
+/**
+ * Fold a thrown value from a registration ceremony, which has one failure
+ * that no other ceremony produces: `InvalidStateError`, the authenticator
+ * refusing to make a second passkey for a credential in
+ * `excludeCredentials`. An authentication ceremony that somehow throws it
+ * means something else, so that fold stays in {@link foldClientError}.
+ */
+function foldRegistrationError(cause: unknown): PasskeyClientError {
+  if (
+    (cause instanceof Error || cause instanceof DOMException) &&
+    cause.name === "InvalidStateError"
+  ) {
+    return { error: "PASSKEY_ALREADY_REGISTERED" };
+  }
+  return foldClientError(cause);
 }
 
 /**
@@ -197,8 +206,9 @@ function pruneAuthenticationResponse(
  * Run a modal registration ceremony (a WebAuthn `create()` call).
  *
  * `options` comes from a start mutation, ready for the browser. Starting a
- * ceremony displaces a pending one anywhere on the page (they share one
- * browser-level slot; see {@link cancelPendingCeremony}).
+ * ceremony displaces a pending one anywhere on the page: the browser runs
+ * one ceremony at a time, and the pending one rejects with an
+ * `AbortError`.
  */
 export async function register(
   options: WireCreationOptions,
@@ -215,7 +225,7 @@ export async function register(
     });
     return { success: true, response: pruneRegistrationResponse(response) };
   } catch (cause) {
-    return { success: false, userError: foldClientError(cause) };
+    return { success: false, userError: foldRegistrationError(cause) };
   }
 }
 
@@ -224,8 +234,9 @@ export async function register(
  * (a WebAuthn `navigator.credentials.get()` call).
  *
  * `options` comes from a start mutation, ready for the browser. Starting a
- * ceremony displaces a pending one anywhere on the page (they share one
- * browser-level slot; see {@link cancelPendingCeremony}).
+ * ceremony displaces a pending one anywhere on the page: the browser runs
+ * one ceremony at a time, and the pending one rejects with an
+ * `AbortError`.
  *
  * For the conditional-mediation flow, which stays pending until the user
  * picks a passkey in the autocompletion list of an
@@ -257,18 +268,9 @@ export async function authenticate(
  * `signal` aborts it. This is required because the caller is expected to
  * periodically recreate a new ceremony (because every ceremony has a timeout).
  *
- * This one call does not go through `@simplewebauthn/browser`, and the
- * reason is `signal`. `startAuthentication` always overwrites the abort
- * signal with one from its own singleton, which it creates *after* it
- * awaits its autofill-support probe. A caller that aborts in that window
- * aborts nothing, and the request then takes the ceremony slot from
- * whoever the caller was making room for. An `AbortSignal` the caller owns
- * has neither problem: it latches, so `get()` refuses an already-aborted
- * one on entry, and no ordering matters.
- *
- * The caller feature-detects conditional mediation once, so this function
- * does not repeat the probe (which is the `await` that opens that window
- * in the library).
+ * This one call does not go through `@simplewebauthn/browser`, because its
+ * autofill integration doesn’t handle correctly restarting autofill requests
+ * after modal passkey ceremonies failed.
  */
 export async function authenticateWithAutofill(
   options: WireRequestOptions,
@@ -327,18 +329,4 @@ function assertionToJSON(
     clientExtensionResults: {},
     type: "public-key",
   };
-}
-
-/**
- * Cancel the pending WebAuthn ceremony of this page, if one exists. The
- * pending request rejects with an `AbortError`, which
- * {@link foldClientError} folds into `CEREMONY_ABORTED`.
- *
- * The browser runs one ceremony at a time per page, and
- * `@simplewebauthn/browser` manages that slot with a singleton: starting a
- * new ceremony displaces the pending one the same way. The singleton stays
- * an implementation detail behind this function.
- */
-export function cancelPendingCeremony(): void {
-  WebAuthnAbortService.cancelCeremony();
 }

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -16,7 +16,7 @@ import {
 } from "./react.tsx";
 import { usePasskeyAutofill, usePasskeyCeremonySlot } from "./react_impl.tsx";
 
-import { fromBase64URL, toBase64URL } from "./base64url.ts";
+import { toBase64URL } from "./base64url.ts";
 
 const noopAutofill = {
   pauseAutofillFlow: () => {},
@@ -53,24 +53,28 @@ const passkeyApi = {
 // The fake browser ceremonies
 //------------------------------------------------------------------------------
 //
-// jsdom has no WebAuthn, so the tests stub `navigator.credentials`. The
-// modal and the conditional ceremonies share one ceremony slot, the way the
-// browser does: starting any ceremony displaces a pending one, which
-// rejects with an `AbortError`. The tests own what each ceremony resolves
-// with through `ceremonyCreate` / `ceremonyGet` / `conditionalGet`.
+// Modal ceremonies run through `@simplewebauthn/browser`, which the tests
+// mock; the conditional request runs through `navigator.credentials`, which
+// they stub. Both share one ceremony slot, the way the browser does:
+// starting any ceremony displaces a pending one, which rejects with an
+// `AbortError`. The tests own what each ceremony resolves with through
+// `ceremonyCreate` / `ceremonyGet` / `conditionalGet`.
 
 const ceremonyCreate = vi.fn();
 const ceremonyGet = vi.fn();
-// The conditional request has its own control: the hook drives it with an
-// `AbortSignal` it owns, which the modal ceremonies do not take.
+// The conditional request does not go through the library (the hook owns
+// its `AbortSignal`), so it has its own control. It resolves with a
+// `PublicKeyCredential`, the way `navigator.credentials.get` does, rather
+// than with the JSON the library returns.
 const conditionalGet = vi.fn();
 
-// What a browser rejects an aborted ceremony with.
 function abortError() {
-  return new DOMException("Ceremony was aborted", "AbortError");
+  const error = new Error("Ceremony was aborted");
+  error.name = "AbortError";
+  return error;
 }
 
-let abortPending: ((reason: DOMException) => void) | null = null;
+let abortPending: ((reason: Error) => void) | null = null;
 
 function runInCeremonySlot<T>(run: () => Promise<T>): Promise<T> {
   abortPending?.(abortError());
@@ -91,39 +95,46 @@ function runInCeremonySlot<T>(run: () => Promise<T>): Promise<T> {
 }
 
 /**
- * The fake `navigator.credentials`. Every ceremony goes through the slot,
- * and the conditional request honours the caller's signal: an
- * already-aborted one is refused on entry, which is the property the hook
- * relies on.
+ * The fake `navigator.credentials`, which the conditional path calls. It
+ * shares the ceremony slot with the library fake, the way the browser does,
+ * and it honours the caller's signal: an already-aborted one is refused on
+ * entry, which is the property the hook relies on.
  */
 function stubCredentials() {
   Object.defineProperty(globalThis.navigator, "credentials", {
     configurable: true,
     value: {
-      create: (options: unknown) =>
-        runInCeremonySlot(() => ceremonyCreate(options)),
-      get: (options: { mediation?: string; signal?: AbortSignal }) =>
-        options.mediation !== "conditional"
-          ? runInCeremonySlot(() => ceremonyGet(options))
-          : runInCeremonySlot(
-              () =>
-                new Promise((resolve, reject) => {
-                  const signal = options.signal;
-                  if (signal?.aborted) {
-                    reject(abortError());
-                    return;
-                  }
-                  signal?.addEventListener(
-                    "abort",
-                    () => reject(abortError()),
-                    { once: true },
-                  );
-                  conditionalGet(options).then(resolve, reject);
-                }),
-            ),
+      get: (options: { signal?: AbortSignal }) =>
+        runInCeremonySlot(
+          () =>
+            new Promise((resolve, reject) => {
+              const signal = options.signal;
+              if (signal?.aborted) {
+                reject(abortError());
+                return;
+              }
+              signal?.addEventListener("abort", () => reject(abortError()), {
+                once: true,
+              });
+              conditionalGet(options).then(resolve, reject);
+            }),
+        ),
     },
   });
 }
+
+vi.mock("@simplewebauthn/browser", () => ({
+  startRegistration: (options: unknown) =>
+    runInCeremonySlot(() => ceremonyCreate(options)),
+  startAuthentication: (options: unknown) =>
+    runInCeremonySlot(() => ceremonyGet(options)),
+  WebAuthnAbortService: {
+    cancelCeremony: () => {
+      abortPending?.(abortError());
+      abortPending = null;
+    },
+  },
+}));
 
 /** A ceremony that stays pending until the slot aborts it, like a real
  * conditional-mediation request until the user picks a passkey. */
@@ -179,8 +190,8 @@ const requestOptions = {
   userVerification: "required" as const,
 };
 
-// A stand-in for the credential `navigator.credentials.get()` returns, for
-// the modal and the conditional path alike. It encodes back to
+// The same assertion in the shape `navigator.credentials.get` resolves
+// with: bytes rather than base64url. It encodes back to
 // `wireAuthenticationResponse`.
 const conditionalCredential = {
   id: wire("cred-1"),
@@ -206,36 +217,45 @@ const authenticateStart = {
   options: requestOptions,
 };
 
-// A stand-in for the credential `navigator.credentials.create()` returns.
-// It encodes back to `wireRegistrationResponse`.
-const attestationCredential = {
-  id: wire("cred-1"),
-  rawId: bytes("cred-1"),
+// What the library resolves a `create()` ceremony with, including the
+// convenience fields that the hooks must prune off the wire.
+const registrationResponse = {
+  id: "cred-1",
+  rawId: "cred-1",
   response: {
-    clientDataJSON: bytes("client-data"),
-    attestationObject: bytes("attestation"),
-    getTransports: () => ["internal", "hybrid"],
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
+    transports: ["internal", "hybrid"],
+    publicKey: "public-key",
+    publicKeyAlgorithm: -7,
+    authenticatorData: "auth-data",
   },
+  authenticatorAttachment: "platform",
+  clientExtensionResults: { credProps: { rk: true } },
   type: "public-key",
 };
 
-// A stand-in for an older browser, whose attestation response has no
-// `getTransports` method.
-const attestationCredentialWithoutTransports = {
-  ...attestationCredential,
-  response: {
-    clientDataJSON: bytes("client-data"),
-    attestationObject: bytes("attestation"),
-  },
-};
-
-// The wire forms of the two responses, as the finish mutations receive them.
-const wireRegistrationResponse = {
+// What the library resolves a `get()` ceremony with.
+const authenticationResponse = {
   id: wire("cred-1"),
   rawId: wire("cred-1"),
   response: {
     clientDataJSON: wire("client-data"),
-    attestationObject: wire("attestation"),
+    authenticatorData: wire("auth-data"),
+    signature: wire("signature"),
+    userHandle: wire("handle-1"),
+  },
+  clientExtensionResults: {},
+  type: "public-key",
+};
+
+// The wire forms of the two responses, as the finish mutations receive them.
+const wireRegistrationResponse = {
+  id: "cred-1",
+  rawId: "cred-1",
+  response: {
+    clientDataJSON: "client-data",
+    attestationObject: "attestation",
     transports: ["internal", "hybrid"],
   },
   clientExtensionResults: {},
@@ -306,7 +326,7 @@ function renderPasskey() {
 describe("useUsernamePasskeySignIn signIn", () => {
   test("sign-up success runs the registration ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(registerStart);
-    ceremonyCreate.mockResolvedValue(attestationCredential);
+    ceremonyCreate.mockResolvedValue(registrationResponse);
     mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
@@ -317,20 +337,11 @@ describe("useUsernamePasskeySignIn signIn", () => {
     });
 
     expect(mutations.startSignIn).toHaveBeenCalledWith({ username: "alice" });
-    // The server-built options reach the browser with their binary fields
-    // decoded and everything else untouched.
-    const [createCall] = ceremonyCreate.mock.calls[0] as [
-      { publicKey: PublicKeyCredentialCreationOptions },
-    ];
-    expect(createCall.publicKey.challenge).toEqual(
-      fromBase64URL(creationOptions.challenge),
-    );
-    expect(createCall.publicKey.user.id).toEqual(
-      fromBase64URL(creationOptions.user.id),
-    );
-    expect(createCall.publicKey.rp).toEqual(creationOptions.rp);
-    expect(createCall.publicKey.attestation).toBe("none");
-    // The response reaches the finish mutation in the wire shape.
+    // The server-built options go to the browser untouched.
+    expect(ceremonyCreate).toHaveBeenCalledWith({
+      optionsJSON: creationOptions,
+    });
+    // The response reaches the finish mutation pruned to the wire shape.
     expect(mutations.finishSignUp).toHaveBeenCalledWith({
       username: "alice",
       response: wireRegistrationResponse,
@@ -340,28 +351,9 @@ describe("useUsernamePasskeySignIn signIn", () => {
     expect(result.current.token).toBe("access-1");
   });
 
-  test("sends no transports when the browser has no getTransports", async () => {
-    mutations.startSignIn.mockResolvedValue(registerStart);
-    ceremonyCreate.mockResolvedValue(attestationCredentialWithoutTransports);
-    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
-    const { result } = renderPasskey();
-    await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
-
-    let returned!: UsernamePasskeySignInResult;
-    await act(async () => {
-      returned = await result.current.passkey.signIn({ username: "alice" });
-    });
-
-    expect(returned.success).toBe(true);
-    const [args] = mutations.finishSignUp.mock.calls[0] as [
-      { response: { response: { transports?: string[] } } },
-    ];
-    expect(args.response.response).not.toHaveProperty("transports");
-  });
-
   test("sign-in success runs the authentication ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(authenticateStart);
-    ceremonyGet.mockResolvedValue(conditionalCredential);
+    ceremonyGet.mockResolvedValue(authenticationResponse);
     mutations.finishSignIn.mockResolvedValue({
       success: true,
       tokens: bundle,
@@ -375,19 +367,9 @@ describe("useUsernamePasskeySignIn signIn", () => {
       returned = await result.current.passkey.signIn({ username: "alice" });
     });
 
-    const [getCall] = ceremonyGet.mock.calls[0] as [
-      { publicKey: PublicKeyCredentialRequestOptions },
-    ];
-    expect(getCall.publicKey.challenge).toEqual(
-      fromBase64URL(requestOptions.challenge),
-    );
-    expect(getCall.publicKey.rpId).toBe(requestOptions.rpId);
-    expect(getCall.publicKey.allowCredentials).toEqual(
-      requestOptions.allowCredentials.map((descriptor) => ({
-        ...descriptor,
-        id: fromBase64URL(descriptor.id),
-      })),
-    );
+    expect(ceremonyGet).toHaveBeenCalledWith({
+      optionsJSON: requestOptions,
+    });
     expect(mutations.finishSignIn).toHaveBeenCalledWith({
       response: wireAuthenticationResponse,
     });
@@ -478,7 +460,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
     // The first call still completes normally.
     let firstResult!: UsernamePasskeySignInResult;
     await act(async () => {
-      resolveCeremony(conditionalCredential);
+      resolveCeremony(authenticationResponse);
       firstResult = await first;
     });
     expect(firstResult).toEqual({
@@ -616,7 +598,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
       // ceremony started. The signal latches, thus this holds whether the
       // pause landed while the request was pending or still starting.
       expect(conditionalSignal?.aborted).toBe(true);
-      return Promise.resolve(conditionalCredential);
+      return Promise.resolve(authenticationResponse);
     });
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     mutations.finishSignIn.mockResolvedValue({

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -4,10 +4,11 @@
  *
  * {@link useUsernamePasskeySignIn} is the batteries-included hook for the
  * username + passkey login form. It drives the browser-side WebAuthn
- * ceremonies (see `@convex-dev/auth/providers/passkey/client`) against the
- * mutations of a passkey recipe, and it handles both the identifier-first
- * modal flow and passkey autofill (conditional mediation), where the user
- * selects an account directly in the autocompletion list.
+ * ceremonies (through the internal client module built on
+ * `@simplewebauthn/browser`) against the mutations of a passkey recipe,
+ * and it handles both the identifier-first modal flow and passkey autofill
+ * (conditional mediation), where the user selects an account directly in
+ * the autocompletion list.
  *
  * @module
  */
@@ -28,10 +29,15 @@ import {
   type AlreadyPendingFailure,
 } from "./react_impl.tsx";
 
-// Apps read the wire shapes and the browser-side failure shapes from here.
+// Apps read the WebAuthn JSON types and the browser-side failure shapes
+// from here, so they never depend on `@simplewebauthn/*` directly.
 export type {
+  AuthenticationResponseJSON,
   PasskeyClientError,
   PasskeyClientFailure,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
   WireAuthenticationResponse,
   WireCreationOptions,
   WireRegistrationResponse,

--- a/packages/core/src/components/passkey/react_impl.tsx
+++ b/packages/core/src/components/passkey/react_impl.tsx
@@ -153,12 +153,12 @@ export function usePasskeyAutofill<E = never>(options: {
   const wakeRef = useRef<(() => void) | null>(null);
   // The `AbortController` of the conditional request that this hook has in
   // flight, or `null` when it has none. The hook owns it, rather than
-  // letting the request loop own it, because an `AbortSignal` latches: an
-  // abort holds whether it arrives before, during, or after the `get()`
-  // call, so `pause` needs no acknowledgement from the loop and no ordering
-  // rule. It is also how the loop knows *who* ended a request: this hook
-  // aborts this controller and nobody else does, so an abort here is never
-  // another ceremony taking the browser's ceremony slot.
+  // letting `@simplewebauthn/browser` own the ceremony slot, because an
+  // `AbortSignal` latches: an abort holds whether it arrives before, during,
+  // or after the `get()` call, so `pause` needs no acknowledgement from the
+  // loop and no ordering rule. It is also how the loop knows *who* ended a
+  // request: this hook aborts this controller and nobody else does, so an
+  // abort here is never another ceremony taking the browser's ceremony slot.
   const controllerRef = useRef<AbortController | null>(null);
 
   // The loop reads the options through a ref: the callback identities

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@convex-dev/rate-limiter':
         specifier: ^0.3.2
         version: 0.3.2(convex@1.43.0(react@19.2.7))(react@19.2.7)
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@simplewebauthn/server':
         specifier: ^13.3.2
         version: 13.3.2
@@ -1509,6 +1512,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
   '@simplewebauthn/server@13.3.2':
     resolution: {integrity: sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ==}
@@ -4232,6 +4238,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simplewebauthn/browser@13.3.0': {}
 
   '@simplewebauthn/server@13.3.2':
     dependencies:


### PR DESCRIPTION
This updates the implementation of the passkey client to use `@simplewebauthn/browser` instead of our custom code.
