### PR TITLE
passkey: accept the SimpleWebAuthn responses unchanged

### DIFF
--- a/packages/core/src/components/passkey/client.test.ts
+++ b/packages/core/src/components/passkey/client.test.ts
@@ -153,7 +153,7 @@ describe("foldClientError", () => {
 });
 
 describe("register", () => {
-  test("hands the options to startRegistration and prunes the response", async () => {
+  test("hands the options to startRegistration and the response back", async () => {
     startRegistration.mockResolvedValue(registrationResponse);
 
     const result = await register(creationOptions);
@@ -161,23 +161,9 @@ describe("register", () => {
     expect(startRegistration).toHaveBeenCalledWith({
       optionsJSON: creationOptions,
     });
-    // The convenience fields (`publicKey`, `publicKeyAlgorithm`,
-    // `authenticatorData`, `authenticatorAttachment`) and the extension
-    // outputs are gone: the exact server validators refuse them.
-    expect(result).toEqual({
-      success: true,
-      response: {
-        id: "credential-id",
-        rawId: "credential-id",
-        response: {
-          clientDataJSON: "client-data",
-          attestationObject: "attestation",
-          transports: ["internal", "hybrid"],
-        },
-        clientExtensionResults: {},
-        type: "public-key",
-      },
-    });
+    // The response reaches the caller unchanged: the server validators
+    // accept the convenience fields and the extension outputs.
+    expect(result).toEqual({ success: true, response: registrationResponse });
   });
 
   test("a response without transports carries none", async () => {
@@ -231,7 +217,7 @@ describe("register", () => {
 });
 
 describe("authenticate", () => {
-  test("hands the options to startAuthentication and prunes the response", async () => {
+  test("hands the options to startAuthentication and the response back", async () => {
     startAuthentication.mockResolvedValue(authenticationResponse);
 
     const result = await authenticate(requestOptions);
@@ -239,21 +225,7 @@ describe("authenticate", () => {
     expect(startAuthentication).toHaveBeenCalledWith({
       optionsJSON: requestOptions,
     });
-    expect(result).toEqual({
-      success: true,
-      response: {
-        id: "credential-id",
-        rawId: "credential-id",
-        response: {
-          clientDataJSON: "client-data",
-          authenticatorData: "auth-data",
-          signature: "signature",
-          userHandle: "user-handle",
-        },
-        clientExtensionResults: {},
-        type: "public-key",
-      },
-    });
+    expect(result).toEqual({ success: true, response: authenticationResponse });
   });
 
   test("a response without userHandle carries none", async () => {

--- a/packages/core/src/components/passkey/client.ts
+++ b/packages/core/src/components/passkey/client.ts
@@ -41,7 +41,7 @@ import { fromBase64URL, toBase64URL } from "./base64url.ts";
 
 // Apps and custom flows read the WebAuthn JSON types from here, so they
 // never depend on `@simplewebauthn/*` directly. The `Wire…` variants are
-// the exact shapes of the provider's mutations.
+// the shapes of the provider's mutations.
 export type {
   AuthenticationResponseJSON,
   PublicKeyCredentialCreationOptionsJSON,
@@ -156,53 +156,6 @@ function foldRegistrationError(cause: unknown): PasskeyClientError {
 }
 
 /**
- * Keep only the fields of a registration response that the finish
- * mutations accept. `@simplewebauthn/browser` adds convenience fields
- * (`publicKey`, `publicKeyAlgorithm`, `authenticatorData`,
- * `authenticatorAttachment`) that duplicate data from the attestation
- * object, and the exact server validators refuse them.
- */
-function pruneRegistrationResponse(
-  response: RegistrationResponseJSON,
-): WireRegistrationResponse {
-  return {
-    id: response.id,
-    rawId: response.rawId,
-    response: {
-      clientDataJSON: response.response.clientDataJSON,
-      attestationObject: response.response.attestationObject,
-      ...(response.response.transports !== undefined
-        ? { transports: response.response.transports }
-        : {}),
-    },
-    // The options request no extensions, so there is nothing to report.
-    clientExtensionResults: {},
-    type: response.type,
-  };
-}
-
-/** Keep only the fields of an authentication response that the finish
- * mutations accept (see {@link pruneRegistrationResponse}). */
-function pruneAuthenticationResponse(
-  response: AuthenticationResponseJSON,
-): WireAuthenticationResponse {
-  return {
-    id: response.id,
-    rawId: response.rawId,
-    response: {
-      clientDataJSON: response.response.clientDataJSON,
-      authenticatorData: response.response.authenticatorData,
-      signature: response.response.signature,
-      ...(response.response.userHandle !== undefined
-        ? { userHandle: response.response.userHandle }
-        : {}),
-    },
-    clientExtensionResults: {},
-    type: response.type,
-  };
-}
-
-/**
  * Run a modal registration ceremony (a WebAuthn `create()` call).
  *
  * `options` comes from a start mutation, ready for the browser. Starting a
@@ -223,7 +176,7 @@ export async function register(
       // not.
       optionsJSON: options as PublicKeyCredentialCreationOptionsJSON,
     });
-    return { success: true, response: pruneRegistrationResponse(response) };
+    return { success: true, response };
   } catch (cause) {
     return { success: false, userError: foldRegistrationError(cause) };
   }
@@ -254,7 +207,7 @@ export async function authenticate(
       // See the `transports` note in `register`.
       optionsJSON: options as PublicKeyCredentialRequestOptionsJSON,
     });
-    return { success: true, response: pruneAuthenticationResponse(response) };
+    return { success: true, response };
   } catch (cause) {
     return { success: false, userError: foldClientError(cause) };
   }

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -218,7 +218,7 @@ const authenticateStart = {
 };
 
 // What the library resolves a `create()` ceremony with, including the
-// convenience fields that the hooks must prune off the wire.
+// convenience fields that the hooks send to the wire unchanged.
 const registrationResponse = {
   id: "cred-1",
   rawId: "cred-1",
@@ -249,19 +249,7 @@ const authenticationResponse = {
   type: "public-key",
 };
 
-// The wire forms of the two responses, as the finish mutations receive them.
-const wireRegistrationResponse = {
-  id: "cred-1",
-  rawId: "cred-1",
-  response: {
-    clientDataJSON: "client-data",
-    attestationObject: "attestation",
-    transports: ["internal", "hybrid"],
-  },
-  clientExtensionResults: {},
-  type: "public-key",
-};
-
+// The wire form of the assertion, as the finish mutations receive it.
 const wireAuthenticationResponse = {
   id: wire("cred-1"),
   rawId: wire("cred-1"),
@@ -341,10 +329,10 @@ describe("useUsernamePasskeySignIn signIn", () => {
     expect(ceremonyCreate).toHaveBeenCalledWith({
       optionsJSON: creationOptions,
     });
-    // The response reaches the finish mutation pruned to the wire shape.
+    // The response reaches the finish mutation unchanged.
     expect(mutations.finishSignUp).toHaveBeenCalledWith({
       username: "alice",
-      response: wireRegistrationResponse,
+      response: registrationResponse,
     });
     expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
     expect(result.current.auth.isAuthenticated).toBe(true);

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -110,11 +110,12 @@ export type CredentialDescriptor = Infer<typeof credentialDescriptor>;
 // on the server by `options.ts`, and responses fed to
 // `verifyRegistrationResponse` / `verifyAuthenticationResponse` unchanged.
 //
-// The validators are exact: they list every field the server produces or
-// reads, and nothing else. A client must prune the convenience fields that
-// `@simplewebauthn/browser` adds to a response (`publicKey`,
-// `publicKeyAlgorithm`, `authenticatorData`, `authenticatorAttachment`)
-// before it calls a mutation; the React hooks do that pruning.
+// The option validators are exact: they list every field the server
+// produces, and nothing else. The response validators accept everything
+// that `startRegistration` / `startAuthentication` of
+// `@simplewebauthn/browser` return, so a client sends the library result
+// to a mutation unchanged. The fields marked "unused" are convenience
+// fields and extension outputs that the server does not read.
 
 /**
  * A library type with every `transports` list widened to plain strings.
@@ -134,6 +135,19 @@ type OpenTransports<T> = T extends readonly (infer E)[]
 
 /** Require `A` to be assignable to `B` (used as a compile-time pin). */
 type Extends<A extends B, B> = A;
+
+/**
+ * `true` when `A` and `B` declare the same keys (used as a compile-time pin).
+ *
+ * `Extends` alone lets `A` miss a key of `B`, because TypeScript allows
+ * extra properties. The response pins add this check so that a new field in
+ * a `@simplewebauthn` response type fails the build here, before the
+ * validator rejects it at runtime.
+ */
+type SameKeys<A, B> =
+  Exclude<keyof A, keyof B> | Exclude<keyof B, keyof A> extends never
+  ? true
+  : false;
 
 /** The JSON form of {@link credentialDescriptor}, for the options objects. */
 const credentialDescriptorJSON = v.object({
@@ -205,12 +219,13 @@ type _RequestOptionsMatch = Extends<
 
 /**
  * The `RegistrationResponseJSON` that the finish mutations of a registration
- * ceremony take, without the convenience fields that duplicate data from the
- * attestation object (`publicKey`, `publicKeyAlgorithm`,
- * `authenticatorData`, `authenticatorAttachment`).
+ * ceremony take, as `startRegistration` of `@simplewebauthn/browser` returns
+ * it.
  *
- * `clientExtensionResults` must be empty because the options request no
- * extensions.
+ * The server reads `attestationObject` and ignores the convenience fields
+ * that duplicate its content (`publicKey`, `publicKeyAlgorithm`,
+ * `authenticatorData`). The options request no extensions, so the server
+ * ignores `clientExtensionResults` too.
  */
 export const vRegistrationResponseJSON = v.object({
   id: v.string(),
@@ -219,8 +234,12 @@ export const vRegistrationResponseJSON = v.object({
     clientDataJSON: v.string(),
     attestationObject: v.string(),
     transports: v.optional(v.array(v.string())),
+    authenticatorData: v.optional(v.any()), // unused
+    publicKey: v.optional(v.any()), // unused
+    publicKeyAlgorithm: v.optional(v.any()), // unused
   }),
-  clientExtensionResults: v.object({}),
+  authenticatorAttachment: v.optional(v.any()), // unused
+  clientExtensionResults: v.any(), // unused
   type: v.literal("public-key"),
 });
 export type WireRegistrationResponse = Infer<typeof vRegistrationResponseJSON>;
@@ -228,11 +247,22 @@ type _RegistrationResponseMatch = Extends<
   WireRegistrationResponse,
   OpenTransports<RegistrationResponseJSON>
 >;
+type _RegistrationResponseKeys = Extends<
+  [
+    SameKeys<WireRegistrationResponse, RegistrationResponseJSON>,
+    SameKeys<
+      WireRegistrationResponse["response"],
+      RegistrationResponseJSON["response"]
+    >,
+  ],
+  [true, true]
+>;
 
 /**
  * The `AuthenticationResponseJSON` that the finish mutations of an
- * authentication ceremony take. `clientExtensionResults` must be empty
- * because the options request no extensions.
+ * authentication ceremony take, as `startAuthentication` of
+ * `@simplewebauthn/browser` returns it. The options request no extensions,
+ * so the server ignores `clientExtensionResults`.
  */
 export const vAuthenticationResponseJSON = v.object({
   id: v.string(),
@@ -243,7 +273,8 @@ export const vAuthenticationResponseJSON = v.object({
     signature: v.string(),
     userHandle: v.optional(v.string()),
   }),
-  clientExtensionResults: v.object({}),
+  authenticatorAttachment: v.optional(v.any()), // unused
+  clientExtensionResults: v.any(), // unused
   type: v.literal("public-key"),
 });
 export type WireAuthenticationResponse = Infer<
@@ -252,6 +283,16 @@ export type WireAuthenticationResponse = Infer<
 type _AuthenticationResponseMatch = Extends<
   WireAuthenticationResponse,
   AuthenticationResponseJSON
+>;
+type _AuthenticationResponseKeys = Extends<
+  [
+    SameKeys<WireAuthenticationResponse, AuthenticationResponseJSON>,
+    SameKeys<
+      WireAuthenticationResponse["response"],
+      AuthenticationResponseJSON["response"]
+    >,
+  ],
+  [true, true]
 >;
 
 /**

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -15,8 +15,8 @@ import { encodeCBOR, type CBORValue } from "./cbor.ts";
 export { encodeCBOR, type CBORValue };
 
 /**
- * The `RegistrationResponseJSON` wire envelope of a `create()` call, pruned
- * to the fields that the exact validators of a relying party accept.
+ * The `RegistrationResponseJSON` wire envelope of a `create()` call, with
+ * only the fields that a relying party reads.
  */
 export type RegistrationResponseEnvelope = {
   id: string;


### PR DESCRIPTION
The finish mutations now take a registration or authentication response
exactly as startRegistration / startAuthentication of @simplewebauthn/browser
return it. The response validators list the convenience fields and the
extension outputs as unused, so the client no longer prunes them.

A SameKeys type pin compares the keys of the wire types with the library
types in both directions, so a new field in a @simplewebauthn response type
fails the build instead of the validator at runtime.