### PR TITLE
passkey: verify the ceremonies with SimpleWebAuthn alone

### DIFF
--- a/packages/core/src/components/passkey/authentication.test.ts
+++ b/packages/core/src/components/passkey/authentication.test.ts
@@ -247,7 +247,7 @@ describe("finishAuthentication", () => {
             authenticatorData: toBase64URL(new Uint8Array(10)),
           }),
         }),
-      "the authenticator data could not be read",
+      "the assertion did not verify",
     );
   });
 
@@ -293,20 +293,20 @@ describe("finishAuthentication", () => {
           ...EXPECTED,
           ...assertion,
         }),
-      `does not match the expected relying party ID "${RP_ID}"`,
+      "the assertion did not verify",
     );
   });
 
   test("returns PROTOCOL_ERROR when the user is not present or not verified", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
-    const { challenge } = await t.mutation(
-      api.authentication.startAuthentication,
-      { purpose: PURPOSE, userId: "user1" },
-    );
-    // The flag checks run before the challenge is consumed, so the same
-    // challenge can serve both variants.
+    // Each attempt consumes its challenge, so every variant starts a
+    // ceremony of its own.
     for (const flags of [{ userPresent: false }, { userVerified: false }]) {
+      const { challenge } = await t.mutation(
+        api.authentication.startAuthentication,
+        { purpose: PURPOSE, userId: "user1" },
+      );
       const assertion = await buildAssertion(credential, challenge, flags);
       const result = await t.mutation(api.authentication.finishAuthentication, {
         ...EXPECTED,
@@ -335,7 +335,7 @@ describe("finishAuthentication", () => {
           ...EXPECTED,
           ...assertion,
         }),
-      'an authentication ceremony must send "webauthn.get"',
+      "the assertion did not verify",
     );
   });
 
@@ -355,11 +355,11 @@ describe("finishAuthentication", () => {
           ...EXPECTED,
           ...assertion,
         }),
-      'the ceremony ran at the origin "https://evil.example.net"',
+      "the assertion did not verify",
     );
   });
 
-  test("returns PROTOCOL_ERROR for a cross-origin ceremony", async () => {
+  test("returns PROTOCOL_ERROR for a cross-origin ceremony that names its top origin", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
@@ -368,6 +368,7 @@ describe("finishAuthentication", () => {
     );
     const assertion = await buildAssertion(credential, challenge, {
       crossOrigin: true,
+      topOrigin: "https://evil.example.net",
     });
     await expectProtocolError(
       () =>
@@ -375,8 +376,28 @@ describe("finishAuthentication", () => {
           ...EXPECTED,
           ...assertion,
         }),
-      "the ceremony ran in a cross-origin frame",
+      "the assertion did not verify",
     );
+  });
+
+  test("accepts a cross-origin ceremony that names no top origin", async () => {
+    const t = setup();
+    const { credential, passkeyId } = await register(t, "user1");
+    const { challenge } = await t.mutation(
+      api.authentication.startAuthentication,
+      { purpose: PURPOSE, userId: "user1" },
+    );
+    const assertion = await buildAssertion(credential, challenge, {
+      crossOrigin: true,
+    });
+    // `verifyAuthenticationResponse` refuses an embedded ceremony only when
+    // the client sends `topOrigin`, which Safari does not. This test pins
+    // the gap: see the note about `crossOrigin` in `registration.ts`.
+    const result = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...assertion,
+    });
+    expect(result).toEqual({ success: true, userId: "user1", passkeyId });
   });
 
   test("returns CHALLENGE_EXPIRED for an expired challenge", async () => {
@@ -534,40 +555,41 @@ describe("finishAuthentication", () => {
     });
   });
 
-  // The checks below run before the challenge lookup, so each one keeps the
-  // challenge. This is an ordering of the checks, not a guarantee about
-  // protocol errors: a check that runs after the lookup consumes the
-  // challenge, and a bad signature is one of them.
-  test("the checks before the challenge lookup keep the challenge", async () => {
+  // `expectedChallenge` consumes the row while the verification runs, so
+  // every attempt that names a live challenge burns it, whichever check
+  // then refuses the assertion. Only the credential lookup runs earlier
+  // (see the `UNKNOWN_CREDENTIAL` test above).
+  test("a refused assertion consumes the challenge", async () => {
     const t = setup();
     const { credential } = await register(t, "user1");
     const { challenge } = await t.mutation(
       api.authentication.startAuthentication,
       { purpose: PURPOSE, userId: "user1" },
     );
-    // Each of these checks runs before the challenge is consumed, so the
-    // same challenge serves each variant in turn.
-    const variants = [
-      { rpId: "evil.example.net" },
-      { type: "webauthn.create" as const },
-      { origin: "https://evil.example.net" },
-      { crossOrigin: true },
-    ];
-    for (const variant of variants) {
-      const assertion = await buildAssertion(credential, challenge, variant);
-      await expectProtocolError(
-        () =>
-          t.mutation(api.authentication.finishAuthentication, {
-            ...EXPECTED,
-            ...assertion,
-          }),
-        "Rejected the passkey ceremony",
-      );
-    }
+    const refused = await buildAssertion(credential, challenge, {
+      origin: "https://evil.example.net",
+    });
+    await expectProtocolError(
+      () =>
+        t.mutation(api.authentication.finishAuthentication, {
+          ...EXPECTED,
+          ...refused,
+        }),
+      "the assertion did not verify",
+    );
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
     );
-    expect(challenges).toHaveLength(1);
+    expect(challenges).toEqual([]);
+    // A well-formed retry of the same ceremony finds nothing to redeem.
+    const retry = await t.mutation(api.authentication.finishAuthentication, {
+      ...EXPECTED,
+      ...(await buildAssertion(credential, challenge)),
+    });
+    expect(retry).toEqual({
+      success: false,
+      userError: { error: "CHALLENGE_EXPIRED" },
+    });
   });
 
   test("rejects a replayed assertion with CHALLENGE_EXPIRED", async () => {

--- a/packages/core/src/components/passkey/authentication.ts
+++ b/packages/core/src/components/passkey/authentication.ts
@@ -1,19 +1,14 @@
 import { verifyAuthenticationResponse } from "@simplewebauthn/server";
 import { vAuthenticationResponseJSON } from "./validation.ts";
-import {
-  decodeClientDataJSON,
-  isoBase64URL,
-  parseAuthenticatorData,
-} from "@simplewebauthn/server/helpers";
+import { isoBase64URL } from "@simplewebauthn/server/helpers";
 import { Infer, v } from "convex/values";
 import { mutation } from "./_generated/server.ts";
 import { scheduleChallengeCleanup } from "./cleanup.ts";
 import {
   consumeChallenge,
-  okOrNull,
   randomChallenge,
-  rpIdHashMatches,
   toArrayBuffer,
+  warnRejectedCeremony,
 } from "./helpers.ts";
 import {
   credentialDescriptor,
@@ -144,98 +139,14 @@ export const finishAuthentication = mutation({
       return { success: false, userError: { error: "UNKNOWN_CREDENTIAL" } };
     }
 
-    const authenticatorData = okOrNull(() =>
-      parseAuthenticatorData(
-        isoBase64URL.toBuffer(args.response.response.authenticatorData),
-      ),
-    );
-    if (authenticatorData === null) {
-      console.warn(
-        `Rejected the passkey ceremony: the authenticator data could not be ` +
-          `read.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    if (
-      !(await rpIdHashMatches(authenticatorData.rpIdHash, args.expectedRpId))
-    ) {
-      console.warn(
-        `Rejected the passkey ceremony: the authenticator data does not ` +
-          `match the expected relying party ID ${JSON.stringify(args.expectedRpId)}. ` +
-          `Check that the \`rpId\` of the provider matches the page that ran ` +
-          `the ceremony.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    if (!authenticatorData.flags.up || !authenticatorData.flags.uv) {
-      // The ceremony asks for `userVerification: "required"`, thus
-      // the user present/user verified flags should be set
-      console.warn(
-        `Rejected the passkey ceremony: the authenticator data reports ` +
-          `no user presence or no user verification.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-
-    // This read only supports the tailored diagnostics below and the
-    // component's stricter cross-origin policy. It does not extract the
-    // challenge: `verifyAuthenticationResponse` decodes the client data and
-    // gives the challenge to `expectedChallenge` below. The verifier checks
-    // the type and origin again over the signed bytes.
-    const clientData = okOrNull(() =>
-      decodeClientDataJSON(args.response.response.clientDataJSON),
-    );
-
-    // Here we perform a few checks manually. These checks are also done later by
-    // SimpleWebAuthn’s verifyAuthenticationResponse function, but doing these checks
-    // early allows us to give better error messages.
-    if (clientData === null) {
-      console.warn(
-        `Rejected the passkey ceremony: the client data JSON could not be ` +
-          `read.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    if (clientData.type !== "webauthn.get") {
-      console.warn(
-        `Rejected the passkey ceremony: the client data type is ` +
-          `"webauthn.create", but an authentication ceremony must send ` +
-          `"webauthn.get".`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    if (clientData.origin !== args.expectedOrigin) {
-      // Note: This forces the app to provide a single accepted origin.
-      // In some cases, the server might need to accept multiple origins, for instance:
-      // - a dev server running on localhost might want to accept all ports
-      //   (RP ID = localhost, allowed origin = localhost:*)
-      // - an app might want to use origin verification to only allow a specific list
-      //   of subdomains (RP ID = example.com, allowed origins =
-      //   [auth.example.com, dashboard.example.com] but NOT marketing.example.com)
-      // For these reasons, we will probably want to offer more customization options
-      // for this check in the future. `expectedOrigin` already takes an array
-      // in `@simplewebauthn/server`, so the list case is a small change.
-      console.warn(
-        `Rejected the passkey ceremony: the ceremony ran at the origin ` +
-          `${JSON.stringify(clientData.origin)}, but the expected origin is ` +
-          `${JSON.stringify(args.expectedOrigin)}. Check that the \`origin\` of ` +
-          `the provider matches the page that ran the ceremony.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    if (clientData.crossOrigin === true) {
-      // In the future, we could allow the user to explicitly opt out to this.
-      console.warn(
-        `Rejected the passkey ceremony: the ceremony ran in a cross-origin ` +
-          `frame, which is not allowed.`,
-      );
-      return { success: false, userError: { error: "PROTOCOL_ERROR" } };
-    }
-    // The relying party ID hash, the user-presence and user-verification
-    // flags, and the assertion signature are all checked here. The stored
+    // `verifyAuthenticationResponse` runs every protocol check: the client
+    // data type, the origin, the relying party ID hash, the user-presence
+    // and user-verification flags, and the assertion signature. The stored
     // key is a COSE key, which names its own algorithm, so there is no
-    // ES256/RS256 branch: `verifyAuthenticationResponse` reads the algorithm
-    // out of the key and picks the verifier.
+    // ES256/RS256 branch: the verifier reads the algorithm out of the key
+    // and picks the verifier. It ignores `crossOrigin`, and only refuses an
+    // embedded ceremony when the client sends `topOrigin` (see the note in
+    // `registration.ts`).
     //
     // `expectedChallenge` runs during the verification and records here why
     // it accepted or refused the challenge, because the verifier only
@@ -275,10 +186,10 @@ export const finishAuthentication = mutation({
             // challenge is consumed at this point: a mismatch comes from
             // the code of the app, so the same ceremony would fail again
             // anyway.
-            console.warn(
-              `Rejected the passkey ceremony: the challenge was created for the ` +
-                `purpose ${JSON.stringify(challengeRow.purpose)}, but the ceremony ` +
-                `was finished for the purpose ${JSON.stringify(args.purpose)}.`,
+            warnRejectedCeremony(
+              `the challenge was created for the purpose ` +
+                `${JSON.stringify(challengeRow.purpose)}, but the ceremony was ` +
+                `finished for the purpose ${JSON.stringify(args.purpose)}.`,
             );
             challenge.outcome = "refused";
             return false;
@@ -295,9 +206,9 @@ export const finishAuthentication = mutation({
             // A challenge with a `userId` always carries the passkeys of
             // that user in `allowCredentials`, thus a compliant client
             // cannot send an assertion from a passkey of a different user.
-            console.warn(
-              `Rejected the passkey ceremony: the challenge was created for a ` +
-                `different user than the owner of the credential.`,
+            warnRejectedCeremony(
+              `the challenge was created for a different user than the owner ` +
+                `of the credential.`,
             );
             challenge.outcome = "refused";
             return false;
@@ -333,22 +244,20 @@ export const finishAuthentication = mutation({
         // `expectedChallenge` already logged the reason.
         return { success: false, userError: { error: "PROTOCOL_ERROR" } };
       }
-      // The message names the check that failed: a relying party ID hash
-      // that does not match, a missing user verification, a bad signature,
-      // and so on. It stays in the backend logs, and the client only learns
-      // that the ceremony was refused.
-      console.warn(
-        `Rejected the passkey ceremony: the assertion did not verify. ` +
-          `If this happens for every ceremony, check that the \`rpId\` and ` +
-          `the \`origin\` of the provider match the page that ran it. ` +
-          `${String(cause)}`,
+      // The message of the library names the check that failed: an origin
+      // that does not match, a relying party ID hash that does not match, a
+      // missing user verification, and so on.
+      warnRejectedCeremony(
+        `the assertion did not verify. If this happens for every ceremony, ` +
+          `check that the \`rpId\` and the \`origin\` of the provider match ` +
+          `the page that ran it. ${String(cause)}`,
       );
       return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }
     if (!verification.verified) {
-      console.warn(
-        `Rejected the passkey ceremony: the assertion signature does not ` +
-          `match the public key of the credential.`,
+      warnRejectedCeremony(
+        `the assertion signature does not match the public key of the ` +
+          `credential.`,
       );
       return { success: false, userError: { error: "PROTOCOL_ERROR" } };
     }

--- a/packages/core/src/components/passkey/helpers.ts
+++ b/packages/core/src/components/passkey/helpers.ts
@@ -1,4 +1,3 @@
-import { isoUint8Array, toHash } from "@simplewebauthn/server/helpers";
 import { Doc, Id } from "./_generated/dataModel.ts";
 import { MutationCtx, QueryCtx } from "./_generated/server.ts";
 import { CHALLENGE_TTL_MS } from "./constants.ts";
@@ -15,19 +14,12 @@ export function okOrNull<T>(read: () => T): T | null {
 }
 
 /**
- * Tell whether the relying party ID hash inside authenticator data names the
- * expected relying party.
- *
- * `verifyRegistrationResponse` and `verifyAuthenticationResponse` check this
- * too. It is checked separately, and first, because a mismatch is almost
- * always a misconfigured `rpId`. The message of the library names the check
- * that failed; this one names the setting of the provider to correct.
+ * Log why a ceremony was refused. The client only learns `PROTOCOL_ERROR`,
+ * so the detail stays in the backend logs, where the developer of the app
+ * reads it.
  */
-export async function rpIdHashMatches(
-  rpIdHash: Uint8Array<ArrayBuffer>,
-  expectedRpId: string,
-): Promise<boolean> {
-  return isoUint8Array.areEqual(rpIdHash, await toHash(expectedRpId));
+export function warnRejectedCeremony(detail: string): void {
+  console.warn(`Rejected the passkey ceremony: ${detail}`);
 }
 
 export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -705,37 +705,35 @@ describe("finishRegistration verification", () => {
     const { finish } = await registrationArgs(t, "user1", {
       clientDataType: "webauthn.get",
     });
-    await expectProtocolError(
-      finish,
-      'a registration ceremony must send "webauthn.create"',
-    );
+    await expectProtocolError(finish, "the attestation did not verify");
   });
 
-  test("returns PROTOCOL_ERROR for an unexpected origin without consuming the challenge", async () => {
+  test("returns PROTOCOL_ERROR for an unexpected origin and burns the challenge", async () => {
     const t = setup();
     const { finish } = await registrationArgs(t, "user1", {
       origin: "https://evil.example.net",
     });
-    await expectProtocolError(
-      finish,
-      'the ceremony ran at the origin "https://evil.example.net"',
-    );
-    // The origin check happens before the challenge is consumed.
+    await expectProtocolError(finish, "the attestation did not verify");
+    // The lookup finds the challenge before the verification refuses the
+    // ceremony, so the failed attempt burns it.
     const challenges = await t.run((ctx) =>
       ctx.db.query("challenges").collect(),
     );
-    expect(challenges).toHaveLength(1);
+    expect(challenges).toEqual([]);
   });
 
-  test("returns PROTOCOL_ERROR for a cross-origin ceremony", async () => {
+  test("accepts a cross-origin ceremony", async () => {
     const t = setup();
     const { finish } = await registrationArgs(t, "user1", {
       crossOrigin: true,
     });
-    await expectProtocolError(
-      finish,
-      "the ceremony ran in a cross-origin frame",
-    );
+    // `verifyRegistrationResponse` ignores `crossOrigin` altogether. This
+    // test pins the gap: see the note about `crossOrigin` above
+    // `lookupRegistrationChallenge`.
+    expect(await finish()).toEqual({
+      success: true,
+      passkeyId: expect.any(String),
+    });
   });
 
   test("returns PROTOCOL_ERROR for a relying party ID hash mismatch", async () => {
@@ -743,10 +741,7 @@ describe("finishRegistration verification", () => {
     const { finish } = await registrationArgs(t, "user1", {
       authDataRpId: "evil.example.net",
     });
-    await expectProtocolError(
-      finish,
-      `does not match the expected relying party ID "${RP_ID}"`,
-    );
+    await expectProtocolError(finish, "the attestation did not verify");
   });
 
   test("returns PROTOCOL_ERROR when the user is not present", async () => {
@@ -754,10 +749,7 @@ describe("finishRegistration verification", () => {
     const { finish } = await registrationArgs(t, "user1", {
       userPresent: false,
     });
-    await expectProtocolError(
-      finish,
-      "no user presence or no user verification",
-    );
+    await expectProtocolError(finish, "the attestation did not verify");
   });
 
   test("returns PROTOCOL_ERROR when the user is not verified", async () => {
@@ -765,10 +757,7 @@ describe("finishRegistration verification", () => {
     const { finish } = await registrationArgs(t, "user1", {
       userVerified: false,
     });
-    await expectProtocolError(
-      finish,
-      "no user presence or no user verification",
-    );
+    await expectProtocolError(finish, "the attestation did not verify");
   });
 
   test("returns PROTOCOL_ERROR when the attested credential data is missing", async () => {
@@ -776,7 +765,7 @@ describe("finishRegistration verification", () => {
     const { finish } = await registrationArgs(t, "user1", {
       includeCredential: false,
     });
-    await expectProtocolError(finish, "carries no attested credential data");
+    await expectProtocolError(finish, "the attestation did not verify");
   });
 
   test("returns PROTOCOL_ERROR when the client data JSON carries no challenge", async () => {
@@ -906,7 +895,7 @@ describe("checkRegistrationForNewUser", () => {
     await expectProtocolError(
       () =>
         t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
-      "no user presence or no user verification",
+      "the attestation did not verify",
     );
   });
 
@@ -933,7 +922,7 @@ describe("checkRegistrationForNewUser", () => {
     await expectProtocolError(
       () =>
         t.query(api.registration.checkRegistrationForNewUser, checkArgs(args)),
-      'the ceremony ran at the origin "https://evil.example.net"',
+      "the attestation did not verify",
     );
   });
 

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -70,10 +70,8 @@ import { mutation, MutationCtx, query, QueryCtx } from "./_generated/server.ts";
 import { Doc, Id } from "./_generated/dataModel.ts";
 import { verifyRegistrationResponse } from "@simplewebauthn/server";
 import {
-  decodeAttestationObject,
   decodeClientDataJSON,
   isoBase64URL,
-  parseAuthenticatorData,
 } from "@simplewebauthn/server/helpers";
 import {
   credentialDescriptor,
@@ -91,8 +89,8 @@ import {
   okOrNull,
   randomChallenge,
   randomHandle,
-  rpIdHashMatches,
   toArrayBuffer,
+  warnRejectedCeremony,
 } from "./helpers.ts";
 import { scheduleChallengeCleanup } from "./cleanup.ts";
 
@@ -427,8 +425,9 @@ async function verifyRegistrationAttempt(
 
   const startedBy = handle.userId === null ? "newUser" : "existingUser";
   if (startedBy !== flow.kind) {
-    console.warn(
-      `Rejected the passkey ceremony: the ceremony comes from \`${startedBy}\`, while the function for ${flow.kind} was called.`,
+    warnRejectedCeremony(
+      `the ceremony comes from \`${startedBy}\`, while the function for ` +
+        `${flow.kind} was called.`,
     );
     return { userError: { error: "PROTOCOL_ERROR" }, challengeRow };
   }
@@ -467,8 +466,9 @@ async function lookupRegistrationChallenge(
 
   const { transports } = args.response.response;
   if (!transportsAreValid(transports)) {
-    console.warn(
-      `Rejected the passkey ceremony: the client reported transports that seem invalid. The client sent: ${JSON.stringify(transports).slice(0, 200)}.`,
+    warnRejectedCeremony(
+      `the client reported transports that seem invalid. The client sent: ` +
+        `${JSON.stringify(transports).slice(0, 200)}.`,
     );
     return PROTOCOL_ERROR;
   }
@@ -476,43 +476,22 @@ async function lookupRegistrationChallenge(
     decodeClientDataJSON(args.response.response.clientDataJSON),
   );
   if (clientData === null) {
-    console.warn(
-      `Rejected the passkey ceremony: the client data JSON could not be read.`,
-    );
+    warnRejectedCeremony(`the client data JSON could not be read.`);
     return PROTOCOL_ERROR;
   }
-  if (clientData.type !== "webauthn.create") {
-    console.warn(
-      `Rejected the passkey ceremony: the client data type is ` +
-        `"webauthn.get", but a registration ceremony must send ` +
-        `"webauthn.create".`,
-    );
-    return PROTOCOL_ERROR;
-  }
-  if (clientData.origin !== args.expectedOrigin) {
-    // We could allow this verification to be less strict in the future
-    // (see the comment in `finishAuthentication`).
-    console.warn(
-      `Rejected the passkey ceremony: the ceremony ran at the origin ` +
-        `${JSON.stringify(clientData.origin)}, but the expected origin is ` +
-        `${JSON.stringify(args.expectedOrigin)}. Check that the \`origin\` of ` +
-        `the provider matches the page that ran the ceremony.`,
-    );
-    return PROTOCOL_ERROR;
-  }
-  if (clientData.crossOrigin === true) {
-    // In the future, we could allow the user to explicitly opt out to this.
-    console.warn(
-      `Rejected the passkey ceremony: the ceremony ran in a cross-origin ` +
-        `frame, which is not allowed.`,
-    );
-    return PROTOCOL_ERROR;
-  }
+  // TODO(nicolas) Refuse a ceremony that ran inside a cross-origin frame.
+  // The WebAuthn spec asks the relying party to check
+  // `clientData.crossOrigin` (w3c/webauthn#2113), but
+  // `@simplewebauthn/server` does not: `verifyRegistrationResponse` ignores
+  // the field, and `verifyAuthenticationResponse` only refuses an embedded
+  // ceremony when the client also sends `topOrigin`, which Safari does not
+  // (MasterKale/SimpleWebAuthn#613, #759). Until the library covers
+  // registration, an app that must never be embedded has to send
+  // `Content-Security-Policy: frame-ancestors` for the page that runs the
+  // ceremony.
   const challenge = okOrNull(() => isoBase64URL.toBuffer(clientData.challenge));
   if (challenge === null) {
-    console.warn(
-      `Rejected the passkey ceremony: the client data JSON carries no challenge.`,
-    );
+    warnRejectedCeremony(`the client data JSON carries no challenge.`);
     return PROTOCOL_ERROR;
   }
   const challengeRow = await findChallenge(ctx, "registration", challenge);
@@ -552,48 +531,6 @@ async function verifyAttestation(
 > {
   const PROTOCOL_ERROR = { userError: { error: "PROTOCOL_ERROR" } } as const;
 
-  // `verifyRegistrationResponse` runs all of these checks again.
-  // We still perform them manually so that we can log error messages
-  // that are more helpful.
-  const authenticatorData = okOrNull(() => {
-    const attestation = decodeAttestationObject(
-      isoBase64URL.toBuffer(args.response.response.attestationObject),
-    );
-    return parseAuthenticatorData(attestation.get("authData"));
-  });
-  if (authenticatorData === null) {
-    console.warn(
-      `Rejected the passkey ceremony: the attestation object could not be ` +
-        `read.`,
-    );
-    return PROTOCOL_ERROR;
-  }
-  if (!(await rpIdHashMatches(authenticatorData.rpIdHash, args.expectedRpId))) {
-    console.warn(
-      `Rejected the passkey ceremony: the authenticator data does not match ` +
-        `the expected relying party ID ${JSON.stringify(args.expectedRpId)}. ` +
-        `Check that the \`rpId\` of the provider matches the page that ran ` +
-        `the ceremony.`,
-    );
-    return PROTOCOL_ERROR;
-  }
-  if (!authenticatorData.flags.up || !authenticatorData.flags.uv) {
-    // The ceremony asks for `userVerification: "required"`, thus
-    // the user present/user verified flags should be set
-    console.warn(
-      `Rejected the passkey ceremony: the authenticator data reports no ` +
-        `user presence or no user verification.`,
-    );
-    return PROTOCOL_ERROR;
-  }
-  if (authenticatorData.credentialID === undefined) {
-    console.warn(
-      `Rejected the passkey ceremony: the authenticator data carries no ` +
-        `attested credential data.`,
-    );
-    return PROTOCOL_ERROR;
-  }
-
   let verification;
   try {
     verification = await verifyRegistrationResponse({
@@ -605,18 +542,19 @@ async function verifyAttestation(
       supportedAlgorithmIDs: SUPPORTED_ALGORITHM_IDS,
     });
   } catch (cause) {
-    // Logging the rejection cause to help debugging, but not exposing it
-    // to the client.
-    console.warn(
-      `Rejected the passkey ceremony: the attestation did not verify. ` +
-        `If this happens for every ceremony, check that the \`rpId\` and the ` +
-        `\`origin\` of the provider match the page that ran it. ` +
-        `${String(cause)}`,
+    // The message of the library names the check that failed: an origin
+    // that does not match, a relying party ID hash that does not match, a
+    // missing user verification, and so on. It stays in the backend logs,
+    // and the client only learns that the ceremony was refused.
+    warnRejectedCeremony(
+      `the attestation did not verify. If this happens for every ceremony, ` +
+        `check that the \`rpId\` and the \`origin\` of the provider match ` +
+        `the page that ran it. ${String(cause)}`,
     );
     return PROTOCOL_ERROR;
   }
   if (!verification.verified) {
-    console.warn(`Rejected the passkey ceremony: the attestation is invalid.`);
+    warnRejectedCeremony(`the attestation is invalid.`);
     return PROTOCOL_ERROR;
   }
   const { credential } = verification.registrationInfo;
@@ -635,9 +573,7 @@ async function verifyAttestation(
     // random credential ID for each ceremony, and `excludeCredentials`
     // makes the authenticator refuse a duplicate for this RP. A duplicate
     // here shows a replayed or tampered registration.
-    console.warn(
-      `Rejected the passkey ceremony: the credential is already registered.`,
-    );
+    warnRejectedCeremony(`the credential is already registered.`);
     return PROTOCOL_ERROR;
   }
 

--- a/packages/docs/content/docs/login-providers/passkey.mdx
+++ b/packages/docs/content/docs/login-providers/passkey.mdx
@@ -166,3 +166,15 @@ Copy the following code block inside of your app:
 </Step>
 
 </Steps>
+
+## Ceremonies inside a frame
+
+The component does not refuse a ceremony that runs inside a frame of a
+different site. `@simplewebauthn/server`, which does the WebAuthn
+verification, ignores the `crossOrigin` field of the client data during a
+registration. During an authentication, it uses the field only when the
+browser also sends a top origin, which Safari does not send.
+
+If a page of your app runs a ceremony, and no other site must embed that
+page, send the `Content-Security-Policy: frame-ancestors 'none'` header for
+it.

--- a/packages/passkey-test-authenticator/src/index.ts
+++ b/packages/passkey-test-authenticator/src/index.ts
@@ -126,12 +126,16 @@ export function buildClientDataJSON({
   challenge,
   origin,
   crossOrigin,
+  topOrigin,
 }: {
   type: "webauthn.create" | "webauthn.get";
   // Raw challenge bytes, or the base64url string of an options object.
   challenge: ArrayBuffer | Uint8Array | string;
   origin: string;
   crossOrigin?: boolean;
+  // The origin of the top-level page. A browser sends it only for a
+  // cross-origin ceremony, and Safari never sends it.
+  topOrigin?: string;
 }): Uint8Array {
   const base64url =
     typeof challenge === "string" ? challenge : toBase64URL(challenge);
@@ -141,6 +145,7 @@ export function buildClientDataJSON({
       challenge: base64url,
       origin,
       ...(crossOrigin !== undefined ? { crossOrigin } : {}),
+      ...(topOrigin !== undefined ? { topOrigin } : {}),
     }),
   );
 }
@@ -253,6 +258,7 @@ export async function buildAssertion(
     type?: "webauthn.create" | "webauthn.get";
     origin?: string;
     crossOrigin?: boolean;
+    topOrigin?: string;
     rpId?: string;
     counter?: number;
     userPresent?: boolean;
@@ -266,6 +272,7 @@ export async function buildAssertion(
     challenge,
     origin: options.origin ?? ORIGIN,
     crossOrigin: options.crossOrigin,
+    topOrigin: options.topOrigin,
   });
   const authenticatorData = await buildAuthenticatorData({
     rpId: options.rpId ?? RP_ID,


### PR DESCRIPTION
The component checked the client data type, the origin, the relying party
ID hash, and the user-presence and user-verification flags by hand before
it called `verifyAuthenticationResponse` or `verifyRegistrationResponse`.
The library runs every one of those checks, and the rejection message of
the library is already in the log line, so the copies only added lines.

The cross-origin check goes with them. The library ignores `crossOrigin`
during a registration, and reads it during an authentication only when the
client also sends `topOrigin`, which Safari does not. A note above
`lookupRegistrationChallenge` and a section of the passkey documentation
name the gap, and the header that closes it.

`finishAuthentication` now reads the client data only through the library.
One consequence: every attempt that names a live challenge burns it,
because `expectedChallenge` consumes the row before the other checks of
the library run.