### PR TITLE
Add renamePasskey component function

### DIFF
--- a/packages/core/src/components/passkey/_generated/component.ts
+++ b/packages/core/src/components/passkey/_generated/component.ts
@@ -185,6 +185,18 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         }>,
         Name
       >;
+      renamePasskey: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string; passkeyId: string; userId: string },
+        | { success: true }
+        | {
+            success: false;
+            userError:
+              { error: "PASSKEY_NOT_FOUND" } | { error: "INVALID_NAME" };
+          },
+        Name
+      >;
       startRegistrationForExistingUser: FunctionReference<
         "mutation",
         "internal",

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -1059,6 +1059,69 @@ describe("passkey names at registration", () => {
   });
 });
 
+describe("renamePasskey", () => {
+  test("renames the user's own passkey", async () => {
+    const t = setup();
+    const { passkeyId } = await register(t, "user1", { name: "Old name" });
+    const result = await t.mutation(api.registration.renamePasskey, {
+      userId: "user1",
+      passkeyId,
+      name: "New name",
+    });
+    expect(result).toEqual({ success: true });
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBe("New name");
+  });
+
+  test("refuses a passkey of another user", async () => {
+    const t = setup();
+    const { passkeyId } = await register(t, "user1", { name: "Old name" });
+    const result = await t.mutation(api.registration.renamePasskey, {
+      userId: "user2",
+      passkeyId,
+      name: "New name",
+    });
+    expect(result).toEqual({
+      success: false,
+      userError: { error: "PASSKEY_NOT_FOUND" },
+    });
+    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
+    expect(row.name).toBe("Old name");
+  });
+
+  test("refuses an unknown passkey id", async () => {
+    const t = setup();
+    await register(t, "user1");
+    expect(
+      await t.mutation(api.registration.renamePasskey, {
+        userId: "user1",
+        passkeyId: "not a passkey id",
+        name: "New name",
+      }),
+    ).toEqual({ success: false, userError: { error: "PASSKEY_NOT_FOUND" } });
+  });
+
+  test("refuses names that are not short labels", async () => {
+    const t = setup();
+    const { passkeyId } = await register(t, "user1", { name: "Old name" });
+    const rename = (name: string) =>
+      t.mutation(api.registration.renamePasskey, {
+        userId: "user1",
+        passkeyId,
+        name,
+      });
+    const invalid = { success: false, userError: { error: "INVALID_NAME" } };
+    expect(await rename("")).toEqual(invalid);
+    expect(await rename("   ")).toEqual(invalid);
+    expect(await rename("x".repeat(51))).toEqual(invalid);
+    expect(await rename("line\nbreak")).toEqual(invalid);
+    // A C1 control, which the C0 range does not cover.
+    expect(await rename("os\u009dcontrol")).toEqual(invalid);
+    // 50 code points are the limit, also for astral characters.
+    expect(await rename("\u{1f511}".repeat(50))).toEqual({ success: true });
+  });
+});
+
 describe("listPasskeys", () => {
   test("returns an empty array for an unknown user", async () => {
     const t = setup();

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -81,6 +81,7 @@ import {
   finishRegistrationUserError,
   FinishRegistrationUserError,
   deletePasskeyUserError,
+  renamePasskeyUserError,
   invalidNameUserError,
   passkeyNameIsValid,
   transportsAreValid,
@@ -733,6 +734,46 @@ export const deletePasskey = mutation({
       return { success: false, userError: { error: "PASSKEY_NOT_FOUND" } };
     }
     await ctx.db.delete("passkeys", id);
+    return { success: true };
+  },
+});
+
+//------------------------------------------------------------------------------
+// Rename passkey
+//------------------------------------------------------------------------------
+
+const renamePasskeyResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({ success: v.literal(false), userError: renamePasskeyUserError }),
+);
+type RenamePasskeyResult = Infer<typeof renamePasskeyResult>;
+
+/**
+ * Rename one passkey of `userId`, for example from a settings page.
+ *
+ * The `userId` check makes the function safe for an ID that comes directly
+ * from the client: a user can only rename their own passkeys. The name must
+ * be a short label (see {@link passkeyNameIsValid}).
+ */
+export const renamePasskey = mutation({
+  args: { userId: v.string(), passkeyId: v.string(), name: v.string() },
+  returns: renamePasskeyResult,
+  handler: async (
+    ctx,
+    { userId, passkeyId, name },
+  ): Promise<RenamePasskeyResult> => {
+    if (!passkeyNameIsValid(name)) {
+      return { success: false, userError: { error: "INVALID_NAME" } };
+    }
+    const id = ctx.db.normalizeId("passkeys", passkeyId);
+    if (id === null) {
+      return { success: false, userError: { error: "PASSKEY_NOT_FOUND" } };
+    }
+    const row = await ctx.db.get("passkeys", id);
+    if (row === null || row.userId !== userId) {
+      return { success: false, userError: { error: "PASSKEY_NOT_FOUND" } };
+    }
+    await ctx.db.patch("passkeys", id, { name });
     return { success: true };
   },
 });

--- a/packages/core/src/components/passkey/validation.ts
+++ b/packages/core/src/components/passkey/validation.ts
@@ -351,6 +351,17 @@ export const invalidNameUserError = v.object({
 });
 
 /**
+ * The user-facing errors for `renamePasskey`. An app can show these errors
+ * to the end user.
+ */
+export const renamePasskeyUserError = v.union(
+  // The passkey does not exist, or it is the passkey of a different user.
+  v.object({ error: v.literal("PASSKEY_NOT_FOUND") }),
+  invalidNameUserError,
+);
+export type RenamePasskeyUserError = Infer<typeof renamePasskeyUserError>;
+
+/**
  * The user-facing errors for `deletePasskey`. An app can show these errors
  * to the end user.
  */


### PR DESCRIPTION
This PR adds a new `renamePasskey` component function that renames an existing passkey.