### PR TITLE
Add passkey renaming to the full passkey demo

### DIFF
--- a/examples/react-passkey/convex/auth.ts
+++ b/examples/react-passkey/convex/auth.ts
@@ -12,6 +12,7 @@ export const {
   finishSignIn,
 
   listPasskeys,
+  renamePasskey,
 
   startAddPasskey,
   verifyAddPasskey,

--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -381,6 +381,50 @@ describe("adding a passkey", () => {
   });
 });
 
+describe("renaming a passkey", () => {
+  test("renames a passkey of the caller and refuses bad input", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const caller = as(t, alice.userId);
+    const list = await caller.query(api.auth.listPasskeys, {});
+    if (!list.success) throw new Error("The caller is signed in.");
+    const { passkeyId } = list.passkeys[0];
+
+    expect(
+      await caller.mutation(api.auth.renamePasskey, {
+        passkeyId,
+        name: "My security key",
+      }),
+    ).toEqual({ success: true });
+    const after = await caller.query(api.auth.listPasskeys, {});
+    if (!after.success) throw new Error("The caller is signed in.");
+    expect(after.passkeys[0].name).toBe("My security key");
+
+    expect(
+      await caller.mutation(api.auth.renamePasskey, { passkeyId, name: "" }),
+    ).toEqual({ success: false, userError: { error: "INVALID_NAME" } });
+  });
+
+  test("refuses a passkey of another account and a signed-out caller", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    const bob = await signUp(t, "bob");
+    const bobList = await as(t, bob.userId).query(api.auth.listPasskeys, {});
+    if (!bobList.success) throw new Error("The caller is signed in.");
+    const { passkeyId } = bobList.passkeys[0];
+
+    expect(
+      await as(t, alice.userId).mutation(api.auth.renamePasskey, {
+        passkeyId,
+        name: "Not mine",
+      }),
+    ).toEqual({ success: false, userError: { error: "PASSKEY_NOT_FOUND" } });
+    expect(
+      await t.mutation(api.auth.renamePasskey, { passkeyId, name: "Mine" }),
+    ).toEqual({ success: false, userError: { error: "NOT_SIGNED_IN" } });
+  });
+});
+
 describe("removing a passkey", () => {
   test("removes a passkey through the whole flow", async () => {
     const t = await setup();

--- a/examples/react-passkey/src/routes/dashboard.tsx
+++ b/examples/react-passkey/src/routes/dashboard.tsx
@@ -2,10 +2,11 @@ import { useAuthActions } from "@convex-dev/auth/react";
 import {
   AddPasskeyResult,
   RemovePasskeyResult,
+  RenamePasskeyResult,
   useAddPasskey,
   useRemovePasskey,
 } from "@convex-dev/auth/providers/passkey/react";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
@@ -94,10 +95,34 @@ function PasskeyRow({
   // Each row has its own remove hook, so `pending` drives only the spinner
   // of this row.
   const { removePasskey, pending: removing } = useRemovePasskey(api.auth);
+  const renamePasskey = useMutation(api.auth.renamePasskey);
   return (
     <li>
       <em>{passkey.name ?? "Unnamed passkey"}</em>, added{" "}
       {new Date(passkey.createdAt).toLocaleString()}{" "}
+      <button
+        onClick={async () => {
+          const name = window.prompt("New name for this passkey?");
+          if (name === null) {
+            return;
+          }
+          onError(null);
+          try {
+            const result = await renamePasskey({
+              passkeyId: passkey.passkeyId,
+              name,
+            });
+            if (!result.success) {
+              onError(errorMessage(result.userError));
+            }
+          } catch (cause) {
+            console.error("Passkey rename failed:", cause);
+            onError("Something went wrong. Please try again.");
+          }
+        }}
+      >
+        Rename
+      </button>{" "}
       <button
         disabled={removing || !canRemove}
         onClick={async () => {
@@ -120,7 +145,8 @@ function PasskeyRow({
 function errorMessage(
   userError:
     | Extract<AddPasskeyResult, { success: false }>["userError"]
-    | Extract<RemovePasskeyResult, { success: false }>["userError"],
+    | Extract<RemovePasskeyResult, { success: false }>["userError"]
+    | Extract<RenamePasskeyResult, { success: false }>["userError"],
 ): string | null {
   switch (userError.error) {
     case "CEREMONY_ABORTED":
@@ -142,6 +168,8 @@ function errorMessage(
       return "You have too many passkeys. Remove one before you add another.";
     case "PASSKEY_NOT_FOUND":
       return "This passkey no longer exists.";
+    case "INVALID_NAME":
+      return "A passkey name must be 1 to 50 characters on one line.";
     case "CHALLENGE_EXPIRED":
       return "The passkey dialog stayed open for too long. Please try again.";
     case "UNKNOWN_CREDENTIAL":

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -33,6 +33,7 @@ import {
   type AlreadyPendingFailure,
 } from "./react_impl.tsx";
 
+export type { RenamePasskeyResult } from "./management/rename.ts";
 export {
   useAddPasskey,
   useRemovePasskey,

--- a/packages/docs/content/docs/login-providers/passkey.mdx
+++ b/packages/docs/content/docs/login-providers/passkey.mdx
@@ -180,7 +180,7 @@ When your app supports passkeys, it is highly recommended to allow users to add 
 #### Make sure the Convex functions for passkey managements are exposed
 
 In `convex/auth.ts`, make sure the following functions are exported:
-`listPasskeys`, `startAddPasskey`, `verifyAddPasskey`,
+`listPasskeys`, `renamePasskey`, `startAddPasskey`, `verifyAddPasskey`,
 `finishAddPasskey`, `startRemovePasskey`, and `finishRemovePasskey`.
 
 <include
@@ -196,7 +196,7 @@ In `convex/auth.ts`, make sure the following functions are exported:
 
 #### Build the passkey management page
 
-In your app’s settings page, add the UI code for adding and removing passkeys. This code will use the `useAddPasskey` and `useRemovePasskey` hooks provided by Convex Auth.
+In your app’s settings page, add the UI code for adding, renaming, and removing passkeys. This code uses the `useAddPasskey` and `useRemovePasskey` hooks provided by Convex Auth, and the `renamePasskey` mutation.
 
 We recommend copying and pasting the following code sample, and adapting it to your app’s design system:
 


### PR DESCRIPTION
Follow-up to #584, on top of #605 (`renamePasskey`). The rename pieces of the example lived in #584 before the stack was reordered; they move here because they need the mutation from #605.

- Each passkey row gets a "Rename" button: a `window.prompt` on the plain `renamePasskey` mutation, exported from the example's `convex/auth.ts`.
- The error-copy switch covers `INVALID_NAME`, and the passkey React entry point exports `RenamePasskeyResult` so the example can name the error union.
- `passkeyManagement.test.ts` covers a rename by the owner, an empty name, another user's passkey, and a signed-out caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)