### PR TITLE
Add renamePasskey function to passkey provider

### DIFF
--- a/packages/core/src/components/passkey/_generated/api.ts
+++ b/packages/core/src/components/passkey/_generated/api.ts
@@ -20,6 +20,7 @@ import type * as management_flows from "../management/flows.js";
 import type * as management_list from "../management/list.js";
 import type * as management_react from "../management/react.js";
 import type * as management_remove from "../management/remove.js";
+import type * as management_rename from "../management/rename.js";
 import type * as options from "../options.js";
 import type * as purposes from "../purposes.js";
 import type * as react from "../react.js";
@@ -48,6 +49,7 @@ const fullApi: ApiFromModules<{
   "management/list": typeof management_list;
   "management/react": typeof management_react;
   "management/remove": typeof management_remove;
+  "management/rename": typeof management_rename;
   options: typeof options;
   purposes: typeof purposes;
   react: typeof react;

--- a/packages/core/src/components/passkey/management/rename.ts
+++ b/packages/core/src/components/passkey/management/rename.ts
@@ -1,0 +1,46 @@
+/**
+ * Renaming a passkey of a signed-in account.
+ *
+ * A rename changes only the display label of the passkey in the settings
+ * list, so no re-authentication ceremony guards it: the session of the
+ * caller is enough.
+ *
+ * @module
+ */
+import { mutationGeneric } from "convex/server";
+import { Infer, v } from "convex/values";
+import { getAuthUserId } from "../../core/userId.ts";
+import type { UsernamePasskeyConfig } from "../setup.ts";
+import { notSignedInUserError, renamePasskeyUserError } from "../validation.ts";
+
+const renamePasskeyResult = v.union(
+  v.object({ success: v.literal(true) }),
+  v.object({
+    success: v.literal(false),
+    userError: v.union(notSignedInUserError, renamePasskeyUserError),
+  }),
+);
+
+export type RenamePasskeyResult = Infer<typeof renamePasskeyResult>;
+
+export function renamePasskey(config: UsernamePasskeyConfig) {
+  return mutationGeneric({
+    args: {
+      passkeyId: v.string(),
+      // A short label for the settings list ("MacBook Touch ID"); at most
+      // 50 characters (see `passkeyNameIsValid`).
+      name: v.string(),
+    },
+    returns: renamePasskeyResult,
+    handler: async (ctx, args): Promise<RenamePasskeyResult> => {
+      const userId = await getAuthUserId(ctx);
+      if (userId === null) {
+        return { success: false, userError: { error: "NOT_SIGNED_IN" } };
+      }
+      return await ctx.runMutation(
+        config.component.registration.renamePasskey,
+        { userId, passkeyId: args.passkeyId, name: args.name },
+      );
+    },
+  });
+}

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -34,6 +34,7 @@ import {
   finishRemovePasskey,
   startRemovePasskey,
 } from "./management/remove.ts";
+import { renamePasskey } from "./management/rename.ts";
 import { SIGN_IN_PURPOSE } from "./purposes.ts";
 
 /**
@@ -171,6 +172,7 @@ export type FinishSignInResult = Infer<typeof finishSignInResult>;
  *   finishSignIn,
  *
  *   listPasskeys,
+ *   renamePasskey,
  *
  *   startAddPasskey,
  *   verifyAddPasskey,
@@ -486,6 +488,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
         // the request and refuses a signed-out caller. Each mutation
         // composes the functions of the component in one transaction.
         listPasskeys: listPasskeys(config),
+        renamePasskey: renamePasskey(config),
         startAddPasskey: startAddPasskey(config),
         verifyAddPasskey: verifyAddPasskey(config),
         finishAddPasskey: finishAddPasskey(config),


### PR DESCRIPTION
The provider mutation takes `{ passkeyId, name }` and guards a signed-out
caller with `NOT_SIGNED_IN`, like `listPasskeys`. It calls the component
mutation, which checks the owner of the passkey, thus a passkey id that
comes from the client is safe.