### PR TITLE
password examples: make the forms friendly to password managers

### DIFF
--- a/examples/nextjs/app/signin/page.tsx
+++ b/examples/nextjs/app/signin/page.tsx
@@ -60,9 +60,12 @@ export default function SignIn() {
           });
         }}
       >
-        <label>
+        <label htmlFor="username">
           Username
           <input
+            // Using a static id to help password managers behave correctly
+            id="username"
+            name="username"
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
@@ -71,9 +74,12 @@ export default function SignIn() {
             disabled={pending}
           />
         </label>
-        <label>
+        <label htmlFor="password">
           Password
           <input
+            // Using a static id to help password managers behave correctly
+            id="password"
+            name="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/examples/nextjs/app/signup/page.tsx
+++ b/examples/nextjs/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
+import { MIN_PASSWORD_LENGTH } from "@convex-dev/auth/providers/password/validation";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -59,9 +60,12 @@ export default function SignUp() {
           });
         }}
       >
-        <label>
+        <label htmlFor="username">
           Username
           <input
+            // Using a static id to help password managers behave correctly
+            id="username"
+            name="username"
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
@@ -70,13 +74,17 @@ export default function SignUp() {
             disabled={pending}
           />
         </label>
-        <label>
+        <label htmlFor="password">
           Password
           <input
+            // Using a static id to help password managers behave correctly
+            id="password"
+            name="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
             required
             disabled={pending}
           />

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -47,9 +47,12 @@ export function LogIn() {
         }}
       >
         <h1>Log in</h1>
-        <label>
+        <label htmlFor="username">
           Username
           <input
+            // Using a static id to help password managers behave correctly
+            id="username"
+            name="username"
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
@@ -58,9 +61,12 @@ export function LogIn() {
             disabled={pending}
           />
         </label>
-        <label>
+        <label htmlFor="password">
           Password
           <input
+            // Using a static id to help password managers behave correctly
+            id="password"
+            name="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -1,4 +1,5 @@
 import { useSignUpWithPassword } from "@convex-dev/auth/providers/password/react";
+import { MIN_PASSWORD_LENGTH } from "@convex-dev/auth/providers/password/validation";
 import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 
@@ -51,9 +52,12 @@ export function SignUp() {
         }}
       >
         <h1>Sign up</h1>
-        <label>
+        <label htmlFor="username">
           Username
           <input
+            // Using a static id to help password managers behave correctly
+            id="username"
+            name="username"
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
@@ -62,13 +66,17 @@ export function SignUp() {
             disabled={pending}
           />
         </label>
-        <label>
+        <label htmlFor="password">
           Password
           <input
+            // Using a static id to help password managers behave correctly
+            id="password"
+            name="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
             required
             disabled={pending}
           />


### PR DESCRIPTION
Updates the existing form UIs in the examples to follow the advice from https://www.1password.dev/web/compatible-website-design