### PR TITLE
Update the return shape for sign-in

### DIFF
--- a/examples/nextjs/app/signin/page.tsx
+++ b/examples/nextjs/app/signin/page.tsx
@@ -30,7 +30,7 @@ export default function SignIn() {
           e.preventDefault();
           setError(null);
           const result = await signIn({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             router.push("/");
             return;
           }

--- a/examples/nextjs/app/signup/page.tsx
+++ b/examples/nextjs/app/signup/page.tsx
@@ -28,7 +28,7 @@ export default function SignUp() {
           e.preventDefault();
           setError(null);
           const result = await signUp({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             router.push("/");
             return;
           }

--- a/examples/react-minimal/convex/auth.test.ts
+++ b/examples/react-minimal/convex/auth.test.ts
@@ -39,10 +39,10 @@ describe("anonymous sign in", () => {
   test("returns a token bundle in the shared sign-in envelope", async () => {
     const t = await setup();
     const result = await t.mutation(api.auth.signInAnonymous, {});
-    // Every provider returns the same `{ success, tokens }` envelope. Fixing
+    // Every provider returns the same `{ status, tokens }` envelope. Fixing
     // where the bundle sits is what lets the SSR auth proxy find the refresh
     // token and move it into an httpOnly cookie.
-    expect(result.success).toBe(true);
+    expect(result.status).toBe("complete");
     const { tokens } = result;
     expect(tokens.userId).not.toBe(null);
     expect(tokens.accessToken).not.toBe(null);

--- a/examples/react-passkey-basic/src/routes/logIn.tsx
+++ b/examples/react-passkey-basic/src/routes/logIn.tsx
@@ -38,7 +38,7 @@ export function LogIn() {
         e.preventDefault();
         setError(null);
         const result = await signIn({ username });
-        if (result.success) {
+        if (result.status === "complete") {
           return;
         }
         setError(errorMessage(result.userError));
@@ -74,7 +74,7 @@ export function LogIn() {
 
 function errorMessage(
   userError:
-    | Extract<UsernamePasskeySignInResult, { success: false }>["userError"]
+    | Extract<UsernamePasskeySignInResult, { status: "error" }>["userError"]
     | UsernamePasskeyAutofillError,
 ): string | null {
   switch (userError.error) {

--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -120,7 +120,7 @@ async function signUp(
     username,
     ...(await attest(start.options.challenge, credential, aaguid)),
   });
-  if (!result.success) {
+  if (result.status !== "complete") {
     throw new Error(`The sign-up failed: ${result.userError.error}`);
   }
   return { userId: result.tokens.userId, credential };

--- a/examples/react-passkey/src/routes/logIn.tsx
+++ b/examples/react-passkey/src/routes/logIn.tsx
@@ -38,7 +38,7 @@ export function LogIn() {
         e.preventDefault();
         setError(null);
         const result = await signIn({ username });
-        if (result.success) {
+        if (result.status === "complete") {
           return;
         }
         setError(errorMessage(result.userError));
@@ -74,7 +74,7 @@ export function LogIn() {
 
 function errorMessage(
   userError:
-    | Extract<UsernamePasskeySignInResult, { success: false }>["userError"]
+    | Extract<UsernamePasskeySignInResult, { status: "error" }>["userError"]
     | UsernamePasskeyAutofillError,
 ): string | null {
   switch (userError.error) {

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -57,14 +57,14 @@ const asUser = (t: Awaited<ReturnType<typeof setup>>, userId: string) =>
 
 type PasswordResult =
   Awaited<ReturnType<typeof signUp>> | Awaited<ReturnType<typeof signIn>>;
-type PasswordSuccess = Extract<PasswordResult, { success: true }>;
+type PasswordSuccess = Extract<PasswordResult, { status: "complete" }>;
 
 describe("setupUsernamePassword", () => {
   test("signs up a new user and returns a session", async () => {
     const t = await setup();
     const result = await signUp(t, "alice", PASSWORD);
     expect(result).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -80,7 +80,7 @@ describe("setupUsernamePassword", () => {
     const up = await signUp(t, "alice", PASSWORD);
     const inResult = await signIn(t, "alice", PASSWORD);
     expect(up).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -90,7 +90,7 @@ describe("setupUsernamePassword", () => {
       },
     });
     expect(inResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -109,8 +109,8 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const alice = await signUp(t, "alice", PASSWORD);
     const bob = await signUp(t, "bob", "different horse battery staple");
-    expect(alice).toMatchObject({ success: true });
-    expect(bob).toMatchObject({ success: true });
+    expect(alice).toMatchObject({ status: "complete" });
+    expect(bob).toMatchObject({ status: "complete" });
     expect((bob as PasswordSuccess).tokens.userId).not.toBe(
       (alice as PasswordSuccess).tokens.userId,
     );
@@ -131,7 +131,7 @@ describe("setupUsernamePassword", () => {
     await signUp(t, "alice", PASSWORD);
     const result = await signIn(t, "alice", "wrong horse battery staple");
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "INVALID_CREDENTIALS" },
     });
   });
@@ -140,7 +140,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const result = await signIn(t, "nobody", PASSWORD);
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USER_NOT_FOUND" },
     });
   });
@@ -150,7 +150,7 @@ describe("setupUsernamePassword", () => {
     await signUp(t, "alice", PASSWORD);
     const result = await signUp(t, "alice", PASSWORD);
     expect(result).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TAKEN" },
     });
   });
@@ -159,7 +159,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "Alice", PASSWORD);
     expect(up).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -172,7 +172,7 @@ describe("setupUsernamePassword", () => {
     // A different casing is treated as the same account for both sign-in...
     const inResult = await signIn(t, "ALICE", PASSWORD);
     expect(inResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),
@@ -188,7 +188,7 @@ describe("setupUsernamePassword", () => {
     // ...and the taken-username check.
     const dup = await signUp(t, "alice", PASSWORD);
     expect(dup).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TAKEN" },
     });
   });
@@ -197,7 +197,7 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "", PASSWORD);
     expect(up).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "USERNAME_TOO_SHORT", minimumLength: 1 },
     });
   });
@@ -217,14 +217,14 @@ describe("setupUsernamePassword", () => {
     const t = await setup();
     const up = await signUp(t, "alice", "short");
     expect(up).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "PASSWORD_TOO_SHORT", minimumLength: 10 },
     });
 
     // No account was created, so a later sign-up with a valid password works.
     const retry = await signUp(t, "alice", PASSWORD);
     expect(retry).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: expect.any(String),
         accessTokenExpiresAt: expect.any(Number),

--- a/examples/react-password/convex/password.test.ts
+++ b/examples/react-password/convex/password.test.ts
@@ -255,11 +255,11 @@ describe("changePassword", () => {
     expect(result).toEqual({ success: true });
 
     expect(await signIn(t, "alice", PASSWORD)).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "INVALID_CREDENTIALS" },
     });
     expect(await signIn(t, "alice", NEW_PASSWORD)).toMatchObject({
-      success: true,
+      status: "complete",
     });
   });
 
@@ -286,7 +286,7 @@ describe("changePassword", () => {
       userError: { error: "INVALID_CREDENTIALS" },
     });
     expect(await signIn(t, "alice", PASSWORD)).toMatchObject({
-      success: true,
+      status: "complete",
     });
   });
 
@@ -313,7 +313,7 @@ describe("changePassword", () => {
       userError: { error: "PASSWORD_TOO_COMMON" },
     });
     expect(await signIn(t, "alice", PASSWORD)).toMatchObject({
-      success: true,
+      status: "complete",
     });
   });
 
@@ -337,7 +337,7 @@ describe("changePassword", () => {
     });
     expect(result).toEqual({ success: true });
     expect(await signIn(t, "alice", PASSWORD)).toMatchObject({
-      success: true,
+      status: "complete",
     });
   });
 

--- a/examples/react-password/src/routes/logIn.tsx
+++ b/examples/react-password/src/routes/logIn.tsx
@@ -17,7 +17,7 @@ export function LogIn() {
           e.preventDefault();
           setError(null);
           const result = await signIn({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             return;
           }
           setError(() => {

--- a/examples/react-password/src/routes/signUp.tsx
+++ b/examples/react-password/src/routes/signUp.tsx
@@ -18,7 +18,7 @@ export function SignUp() {
           e.preventDefault();
           setError(null);
           const result = await signUp({ username, password });
-          if (result.success) {
+          if (result.status === "complete") {
             return;
           }
           setError(() => {

--- a/packages/core/src/components/anonymous/react.test.tsx
+++ b/packages/core/src/components/anonymous/react.test.tsx
@@ -60,7 +60,7 @@ describe("useAnonymousAuth", () => {
   });
 
   test("signIn adopts the envelope's bundle from signInAnonymous into the core client", async () => {
-    runSignIn.mockResolvedValue({ success: true, tokens: bundle });
+    runSignIn.mockResolvedValue({ status: "complete", tokens: bundle });
     const { result } = renderAnonymousAuth();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
     expect(result.current.auth.isAuthenticated).toBe(false);

--- a/packages/core/src/components/anonymous/react.tsx
+++ b/packages/core/src/components/anonymous/react.tsx
@@ -16,7 +16,7 @@
 
 import { FunctionReference } from "convex/server";
 import { useCallback } from "react";
-import type { ClientView, SignInSuccess } from "../../lib/types.ts";
+import type { ClientView, SignInComplete } from "../../lib/types.ts";
 import { useAuthActions, useAuthSignInApi } from "../../react/index.tsx";
 
 /**
@@ -29,7 +29,7 @@ export type SignInAnonymousMutation = FunctionReference<
   "mutation",
   "public",
   Record<string, never>,
-  ClientView<SignInSuccess>
+  ClientView<SignInComplete>
 >;
 
 /**

--- a/packages/core/src/components/anonymous/setup.ts
+++ b/packages/core/src/components/anonymous/setup.ts
@@ -1,6 +1,6 @@
 import {
-  vSignInSuccess,
-  type SignInSuccess,
+  vSignInComplete,
+  type SignInComplete,
   type UserCallbacks,
 } from "../../lib/types.ts";
 import type { AuthCore } from "../core/setup.ts";
@@ -57,15 +57,15 @@ export function setupAnonymous<UsersTable extends string>(
 
       return {
         // Anonymous sign-in cannot fail per-user, so this only ever produces
-        // the success arm. It still returns the shared envelope rather than a
+        // the complete arm. It still returns the shared envelope rather than a
         // bare bundle: that is the shape the SSR auth proxy recognizes (and
         // validates before moving the refresh token into its cookie), and it
         // leaves room for a `userError` arm later without another breaking
         // change.
         signInAnonymous: authMutation({
           args: {},
-          returns: vSignInSuccess,
-          handler: async (ctx): Promise<SignInSuccess> => {
+          returns: vSignInComplete,
+          handler: async (ctx): Promise<SignInComplete> => {
             const anonymousId = await ctx.runMutation(
               component.provider.createAnonymousAccount,
               {},
@@ -74,7 +74,7 @@ export function setupAnonymous<UsersTable extends string>(
               providerAccountId: anonymousId,
               profile: {},
             });
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
       };

--- a/packages/core/src/components/passkey/flows.ts
+++ b/packages/core/src/components/passkey/flows.ts
@@ -10,6 +10,7 @@ import type { FunctionReference } from "convex/server";
 import type { AuthSignInApi } from "../../browser/ambientSignInClient.ts";
 import type {
   ClientView,
+  SignInError,
   SlimTokenBundle,
   TokenBundle,
 } from "../../lib/types.ts";
@@ -18,7 +19,6 @@ import {
   register,
   supportsWebAuthn,
   type PasskeyClientError,
-  type PasskeyClientFailure,
 } from "./client.ts";
 import type {
   FinishSignInResult,
@@ -85,26 +85,36 @@ export type SignInFlowContext = {
 };
 
 /**
+ * The user-facing failures the ceremony protocol reports. `startSignIn` and
+ * the browser ceremonies answer with their own `success` boolean rather than
+ * the shared envelope, so this flow re-wraps their payloads as error arms and
+ * callers only ever see the one discriminant.
+ */
+type ProtocolUserError =
+  | Extract<StartSignInResult, { success: false }>["userError"]
+  | PasskeyClientError;
+
+/**
  * The result of {@link runSignInOrSignUpFlow}.
  *
- * A success carries a `flow` discriminant: `"signUp"` when the ceremony
- * created a new account, `"signIn"` when it authenticated an existing one.
+ * A completed sign-in carries a `flow` discriminant: `"signUp"` when the
+ * ceremony created a new account, `"signIn"` when it authenticated an existing
+ * one.
  */
 export type SignInFlowResult =
-  | (Extract<ClientView<FinishSignUpResult>, { success: true }> & {
+  | (Extract<ClientView<FinishSignUpResult>, { status: "complete" }> & {
       flow: "signUp";
     })
-  | (Extract<ClientView<FinishSignInResult>, { success: true }> & {
+  | (Extract<ClientView<FinishSignInResult>, { status: "complete" }> & {
       flow: "signIn";
     })
-  | Extract<ClientView<FinishSignUpResult>, { success: false }>
-  | Extract<ClientView<FinishSignInResult>, { success: false }>
-  | Extract<StartSignInResult, { success: false }>
-  | PasskeyClientFailure;
+  | Extract<ClientView<FinishSignUpResult>, { status: "error" }>
+  | Extract<ClientView<FinishSignInResult>, { status: "error" }>
+  | SignInError<ProtocolUserError>;
 
 /** The errors the autofill sign-in flow reports. */
 export type UsernamePasskeyAutofillError =
-  | Extract<FinishSignInResult, { success: false }>["userError"]
+  | Extract<FinishSignInResult, { status: "error" }>["userError"]
   | PasskeyClientError;
 
 /**
@@ -118,12 +128,12 @@ export async function runSignInOrSignUpFlow(
   const { convex, api, signInApi, setSession } = ctx;
 
   if (!supportsWebAuthn()) {
-    return { success: false, userError: { error: "WEBAUTHN_UNSUPPORTED" } };
+    return { status: "error", userError: { error: "WEBAUTHN_UNSUPPORTED" } };
   }
 
   const start = await convex.mutation(api.startSignIn, { username });
   if (!start.success) {
-    return start;
+    return { status: "error", userError: start.userError };
   }
 
   if (start.step === "register") {
@@ -132,13 +142,13 @@ export async function runSignInOrSignUpFlow(
     // and suggest creating one.
     const ceremony = await register(start.options);
     if (!ceremony.success) {
-      return ceremony;
+      return { status: "error", userError: ceremony.userError };
     }
     const result = await signInApi.mutation(api.finishSignUp, {
       username,
       response: ceremony.response,
     });
-    if (!result.success) {
+    if (result.status !== "complete") {
       return result;
     }
     await setSession(result.tokens);
@@ -147,12 +157,12 @@ export async function runSignInOrSignUpFlow(
 
   const ceremony = await authenticate(start.options);
   if (!ceremony.success) {
-    return ceremony;
+    return { status: "error", userError: ceremony.userError };
   }
   const result = await signInApi.mutation(api.finishSignIn, {
     response: ceremony.response,
   });
-  if (!result.success) {
+  if (result.status !== "complete") {
     return result;
   }
   await setSession(result.tokens);

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -327,7 +327,10 @@ describe("useUsernamePasskeySignIn signIn", () => {
   test("sign-up success runs the registration ceremony and adopts the session", async () => {
     mutations.startSignIn.mockResolvedValue(registerStart);
     ceremonyCreate.mockResolvedValue(registrationResponse);
-    mutations.finishSignUp.mockResolvedValue({ success: true, tokens: bundle });
+    mutations.finishSignUp.mockResolvedValue({
+      status: "complete",
+      tokens: bundle,
+    });
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
@@ -346,7 +349,11 @@ describe("useUsernamePasskeySignIn signIn", () => {
       username: "alice",
       response: wireRegistrationResponse,
     });
-    expect(returned).toEqual({ success: true, tokens: bundle, flow: "signUp" });
+    expect(returned).toEqual({
+      status: "complete",
+      tokens: bundle,
+      flow: "signUp",
+    });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("access-1");
   });
@@ -355,7 +362,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     ceremonyGet.mockResolvedValue(authenticationResponse);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -374,7 +381,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
       response: wireAuthenticationResponse,
     });
     expect(returned).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",
@@ -382,12 +389,11 @@ describe("useUsernamePasskeySignIn signIn", () => {
     expect(result.current.auth.isAuthenticated).toBe(true);
   });
 
-  test("a server userError passes through without a ceremony", async () => {
-    const failure = {
+  test("a startSignIn userError becomes an error arm without a ceremony", async () => {
+    mutations.startSignIn.mockResolvedValue({
       success: false,
       userError: { error: "USERNAME_INVALID" },
-    };
-    mutations.startSignIn.mockResolvedValue(failure);
+    });
     const { result } = renderPasskey();
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
 
@@ -396,7 +402,12 @@ describe("useUsernamePasskeySignIn signIn", () => {
       returned = await result.current.passkey.signIn({ username: "no" });
     });
 
-    expect(returned).toEqual(failure);
+    // `startSignIn` answers with its own `success` boolean; the flow re-wraps
+    // the failure so callers see the envelope's one discriminant.
+    expect(returned).toEqual({
+      status: "error",
+      userError: { error: "USERNAME_INVALID" },
+    });
     expect(ceremonyCreate).not.toHaveBeenCalled();
     expect(ceremonyGet).not.toHaveBeenCalled();
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -416,7 +427,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
     });
 
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "CEREMONY_ABORTED" },
     });
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -432,7 +443,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
       }),
     );
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -452,7 +463,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
       second = await result.current.passkey.signIn({ username: "alice" });
     });
     expect(second).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "ALREADY_PENDING" },
     });
     expect(mutations.startSignIn).toHaveBeenCalledTimes(1);
@@ -464,7 +475,7 @@ describe("useUsernamePasskeySignIn signIn", () => {
       firstResult = await first;
     });
     expect(firstResult).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",
@@ -524,7 +535,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
     });
     conditionalGet.mockResolvedValue(conditionalCredential);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -558,11 +569,11 @@ describe("useUsernamePasskeySignIn autofill", () => {
     // fresh challenge and the second one succeeds.
     mutations.finishSignIn
       .mockResolvedValueOnce({
-        success: false,
+        status: "error",
         userError: { error: "CHALLENGE_EXPIRED" },
       })
       .mockResolvedValueOnce({
-        success: true,
+        status: "complete",
         tokens: bundle,
         username: "alice",
       });
@@ -602,7 +613,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
     });
     mutations.startSignIn.mockResolvedValue(authenticateStart);
     mutations.finishSignIn.mockResolvedValue({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
     });
@@ -618,7 +629,7 @@ describe("useUsernamePasskeySignIn autofill", () => {
     });
 
     expect(returned).toEqual({
-      success: true,
+      status: "complete",
       tokens: bundle,
       username: "alice",
       flow: "signIn",
@@ -645,7 +656,7 @@ describe("usePasskeyCeremonySlot", () => {
     expect(result.current.pending).toBe(false);
 
     let resolveCeremony!: (value: string) => void;
-    let running!: Promise<string | { success: false }>;
+    let running!: Promise<string | { status: "error" }>;
     act(() => {
       running = result.current.run(
         () =>
@@ -656,7 +667,7 @@ describe("usePasskeyCeremonySlot", () => {
     });
     await waitFor(() => expect(result.current.pending).toBe(true));
 
-    let returned!: string | { success: false };
+    let returned!: string | { status: "error" };
     await act(async () => {
       resolveCeremony("done");
       returned = await running;
@@ -682,12 +693,12 @@ describe("usePasskeyCeremonySlot", () => {
     await waitFor(() => expect(result.current.pending).toBe(true));
 
     const second = vi.fn(async () => "second");
-    let returned!: string | { success: false; userError: unknown };
+    let returned!: string | { status: "error"; userError: unknown };
     await act(async () => {
       returned = await result.current.run(second);
     });
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "ALREADY_PENDING" },
     });
     expect(second).not.toHaveBeenCalled();
@@ -703,14 +714,14 @@ describe("usePasskeyCeremonySlot", () => {
       usePasskeyCeremonySlot({ autofill: noopAutofill }),
     );
     const cause = new Error("boom");
-    let returned!: never | { success: false; userError: unknown };
+    let returned!: never | { status: "error"; userError: unknown };
     await act(async () => {
       returned = await result.current.run(async () => {
         throw cause;
       });
     });
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "OTHER_ERROR", cause },
     });
     expect(result.current.pending).toBe(false);
@@ -892,7 +903,7 @@ describe("usePasskeyAutofill", () => {
     await waitFor(() => expect(result.current.autofill.status).toBe("waiting"));
 
     let finishCeremony!: () => void;
-    let running!: Promise<string | { success: false }>;
+    let running!: Promise<string | { status: "error" }>;
     act(() => {
       running = result.current.modal.run(
         () =>
@@ -912,7 +923,7 @@ describe("usePasskeyAutofill", () => {
     await act(async () => {});
     expect(start).toHaveBeenCalledTimes(1);
 
-    let returned!: string | { success: false };
+    let returned!: string | { status: "error" };
     await act(async () => {
       finishCeremony();
       returned = await running;
@@ -943,7 +954,7 @@ describe("usePasskeyAutofill", () => {
     // and is over before that abort settles. The loop then sees its own
     // abort with the pause already retracted: it must not read that as a
     // foreign ceremony that displaced it and park for good.
-    let returned!: string | { success: false };
+    let returned!: string | { status: "error" };
     await act(async () => {
       returned = await result.current.modal.run(async () => "done");
     });

--- a/packages/core/src/components/passkey/react.test.tsx
+++ b/packages/core/src/components/passkey/react.test.tsx
@@ -656,7 +656,7 @@ describe("usePasskeyCeremonySlot", () => {
     expect(result.current.pending).toBe(false);
 
     let resolveCeremony!: (value: string) => void;
-    let running!: Promise<string | { status: "error" }>;
+    let running!: Promise<string | { success: false }>;
     act(() => {
       running = result.current.run(
         () =>
@@ -667,7 +667,7 @@ describe("usePasskeyCeremonySlot", () => {
     });
     await waitFor(() => expect(result.current.pending).toBe(true));
 
-    let returned!: string | { status: "error" };
+    let returned!: string | { success: false };
     await act(async () => {
       resolveCeremony("done");
       returned = await running;
@@ -693,12 +693,12 @@ describe("usePasskeyCeremonySlot", () => {
     await waitFor(() => expect(result.current.pending).toBe(true));
 
     const second = vi.fn(async () => "second");
-    let returned!: string | { status: "error"; userError: unknown };
+    let returned!: string | { success: false; userError: unknown };
     await act(async () => {
       returned = await result.current.run(second);
     });
     expect(returned).toEqual({
-      status: "error",
+      success: false,
       userError: { error: "ALREADY_PENDING" },
     });
     expect(second).not.toHaveBeenCalled();
@@ -714,14 +714,14 @@ describe("usePasskeyCeremonySlot", () => {
       usePasskeyCeremonySlot({ autofill: noopAutofill }),
     );
     const cause = new Error("boom");
-    let returned!: never | { status: "error"; userError: unknown };
+    let returned!: never | { success: false; userError: unknown };
     await act(async () => {
       returned = await result.current.run(async () => {
         throw cause;
       });
     });
     expect(returned).toEqual({
-      status: "error",
+      success: false,
       userError: { error: "OTHER_ERROR", cause },
     });
     expect(result.current.pending).toBe(false);
@@ -903,7 +903,7 @@ describe("usePasskeyAutofill", () => {
     await waitFor(() => expect(result.current.autofill.status).toBe("waiting"));
 
     let finishCeremony!: () => void;
-    let running!: Promise<string | { status: "error" }>;
+    let running!: Promise<string | { success: false }>;
     act(() => {
       running = result.current.modal.run(
         () =>
@@ -923,7 +923,7 @@ describe("usePasskeyAutofill", () => {
     await act(async () => {});
     expect(start).toHaveBeenCalledTimes(1);
 
-    let returned!: string | { status: "error" };
+    let returned!: string | { success: false };
     await act(async () => {
       finishCeremony();
       returned = await running;
@@ -954,7 +954,7 @@ describe("usePasskeyAutofill", () => {
     // and is over before that abort settles. The loop then sees its own
     // abort with the pause already retracted: it must not read that as a
     // foreign ceremony that displaced it and park for good.
-    let returned!: string | { status: "error" };
+    let returned!: string | { success: false };
     await act(async () => {
       returned = await result.current.modal.run(async () => "done");
     });

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -28,10 +28,13 @@ import {
   type SignInFlowResult,
 } from "./flows.ts";
 import {
+  AlreadyPendingError,
+  AlreadyPendingFailure,
   usePasskeyAutofill,
   usePasskeyCeremonySlot,
-  type AlreadyPendingFailure,
 } from "./react_impl.tsx";
+import { PasskeyClientError, PasskeyClientFailure } from "./client.ts";
+import { SignInError } from "../../lib/types.ts";
 
 export {
   useAddPasskey,
@@ -67,13 +70,13 @@ export type {
 /**
  * The result of the `signIn` callback from {@link useUsernamePasskeySignIn}.
  *
- * A success carries a `flow` discriminant: `"signUp"` when the ceremony
- * created a new account, `"signIn"` when it authenticated an existing one.
- * `ALREADY_PENDING` comes back when a `signIn` call runs while the
+ * A completed sign-in carries a `flow` discriminant: `"signUp"` when the
+ * ceremony created a new account, `"signIn"` when it authenticated an existing
+ * one. `ALREADY_PENDING` comes back when a `signIn` call runs while the
  * previous one still does.
  */
 export type UsernamePasskeySignInResult =
-  SignInFlowResult | AlreadyPendingFailure;
+  SignInFlowResult | SignInError<PasskeyClientError | AlreadyPendingError>;
 
 /**
  * Client for the log in page in the “username + passkey” auth flow.
@@ -100,7 +103,7 @@ export type UsernamePasskeySignInResult =
  *       onSubmit={async (e) => {
  *         e.preventDefault();
  *         const result = await signIn({ username });
- *         if (!result.success) {
+ *         if (result.status === "error") {
  *           // map result.userError to a message
  *         }
  *       }}
@@ -164,12 +167,25 @@ export function useUsernamePasskeySignIn(
   const { run, pending } = usePasskeyCeremonySlot({ autofill });
 
   const signIn = useCallback(
-    ({
+    async ({
       username,
     }: {
       username: string;
-    }): Promise<UsernamePasskeySignInResult> =>
-      run(() => runSignInOrSignUpFlow(ctxRef.current, { username })),
+    }): Promise<UsernamePasskeySignInResult> => {
+      const signInResult = await run(() =>
+        runSignInOrSignUpFlow(ctxRef.current, { username }),
+      );
+      if ("status" in signInResult) {
+        // This is the result of `runSignInOrSignUpFlow`. It can be directly
+        // returned.
+        return signInResult;
+      }
+      // The `run` wrapper is generic and can return a `success: false` error.
+      // We handle that here and package it as a sign-in failure with
+      // `status: "error"`.
+      signInResult satisfies PasskeyClientFailure | AlreadyPendingFailure;
+      return { status: "error", userError: signInResult.userError };
+    },
     [run],
   );
 

--- a/packages/core/src/components/passkey/react.tsx
+++ b/packages/core/src/components/passkey/react.tsx
@@ -144,8 +144,11 @@ export function useUsernamePasskeySignIn(
     onAssertion: async (response) => {
       const { api, signInApi, setSession } = ctxRef.current;
       const result = await signInApi.mutation(api.finishSignIn, { response });
-      if (!result.success) {
-        return result;
+      if (result.status !== "complete") {
+        // The autofill loop takes its own `success` boolean, not the
+        // envelope: it retries on a failed assertion rather than handing
+        // the arm back to the caller.
+        return { success: false, userError: result.userError };
       }
 
       // There’s a small race with the modal flow here. When the user resolves the
@@ -175,15 +178,15 @@ export function useUsernamePasskeySignIn(
       /**
        * Runs the identifier-first passkey flow for the given username.
        *
-       * Returns an object with a `success` boolean flag.
+       * Returns an object with a `status` field.
        *
-       * If it is `true` the sign-in (or the account creation) was
+       * If it is `"complete"` the sign-in (or the account creation) was
        * successful and the client will establish an authenticated session
        * with the Convex backend server. The `flow` field tells which one
        * it was: `"signUp"` created a new account, `"signIn"` authenticated
        * an existing one.
        *
-       * If it is `false` the returned object will have a `userError` field
+       * If it is `"error"` the returned object will have a `userError` field
        * with additional details about why sign-in failed.
        */
       signIn,

--- a/packages/core/src/components/passkey/react_impl.tsx
+++ b/packages/core/src/components/passkey/react_impl.tsx
@@ -9,10 +9,10 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { SignInError } from "../../lib/types.ts";
 import {
   authenticateWithAutofill,
   foldClientError,
+  type PasskeyClientFailure,
   supportsWebAuthn,
   type PasskeyClientError,
   type WireRequestOptions,
@@ -384,7 +384,15 @@ export function usePasskeyAutofill<E = never>(options: {
  * its browser dialog and resolves as usual, thus a caller that gets this
  * shows nothing.
  */
-export type AlreadyPendingFailure = SignInError<{ error: "ALREADY_PENDING" }>;
+export type AlreadyPendingError = { error: "ALREADY_PENDING" };
+
+/**
+ * Failure shape for {@link AlreadyPendingError}.
+ */
+export type AlreadyPendingFailure = {
+  success: false;
+  userError: AlreadyPendingError;
+};
 
 /**
  * Building block for modal passkey flows: a `run` callback that runs one
@@ -435,12 +443,12 @@ export function usePasskeyCeremonySlot(options: {
     // file.
     async <T,>(
       fn: () => Promise<T>,
-    ): Promise<T | SignInError<PasskeyClientError> | AlreadyPendingFailure> => {
+    ): Promise<T | PasskeyClientFailure | AlreadyPendingFailure> => {
       if (pendingRef.current) {
         // TODO(nicolas): Consider a different behavior here. The caller has
         // nothing to show for this error, since the first ceremony keeps its
         // dialog and resolves as usual.
-        return { status: "error", userError: { error: "ALREADY_PENDING" } };
+        return { success: false, userError: { error: "ALREADY_PENDING" } };
       }
       pendingRef.current = true;
       setPending(true);
@@ -453,7 +461,7 @@ export function usePasskeyCeremonySlot(options: {
       try {
         return await fn();
       } catch (cause) {
-        return { status: "error", userError: foldClientError(cause) };
+        return { success: false, userError: foldClientError(cause) };
       } finally {
         resumeAutofillFlow?.();
         pendingRef.current = false;

--- a/packages/core/src/components/passkey/react_impl.tsx
+++ b/packages/core/src/components/passkey/react_impl.tsx
@@ -9,12 +9,12 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SignInError } from "../../lib/types.ts";
 import {
   authenticateWithAutofill,
   foldClientError,
   supportsWebAuthn,
   type PasskeyClientError,
-  type PasskeyClientFailure,
   type WireRequestOptions,
 } from "./client.ts";
 import { CHALLENGE_TTL_MS } from "./constants.ts";
@@ -384,10 +384,7 @@ export function usePasskeyAutofill<E = never>(options: {
  * its browser dialog and resolves as usual, thus a caller that gets this
  * shows nothing.
  */
-export type AlreadyPendingFailure = {
-  success: false;
-  userError: { error: "ALREADY_PENDING" };
-};
+export type AlreadyPendingFailure = SignInError<{ error: "ALREADY_PENDING" }>;
 
 /**
  * Building block for modal passkey flows: a `run` callback that runs one
@@ -404,8 +401,8 @@ export type AlreadyPendingFailure = {
  *   ceremony of `fn` displaces the pending conditional request anyway (the browser runs one ceremony at a
  *   time per page); the pause keeps the autofill loop from starting a new
  *   request mid-ceremony, and the resume restarts it.
- * - It folds every value `fn` throws into a {@link PasskeyClientFailure},
- *   so callers handle every failure through one `userError` switch.
+ * - It folds every value `fn` throws into the envelope's error arm, so
+ *   callers handle every failure through one `userError` switch.
  *
  * `pause()` returns at once and needs no acknowledgement, because the
  * autofill hook aborts its request through an `AbortSignal` it owns, and an
@@ -438,12 +435,12 @@ export function usePasskeyCeremonySlot(options: {
     // file.
     async <T,>(
       fn: () => Promise<T>,
-    ): Promise<T | PasskeyClientFailure | AlreadyPendingFailure> => {
+    ): Promise<T | SignInError<PasskeyClientError> | AlreadyPendingFailure> => {
       if (pendingRef.current) {
         // TODO(nicolas): Consider a different behavior here. The caller has
         // nothing to show for this error, since the first ceremony keeps its
         // dialog and resolves as usual.
-        return { success: false, userError: { error: "ALREADY_PENDING" } };
+        return { status: "error", userError: { error: "ALREADY_PENDING" } };
       }
       pendingRef.current = true;
       setPending(true);
@@ -456,7 +453,7 @@ export function usePasskeyCeremonySlot(options: {
       try {
         return await fn();
       } catch (cause) {
-        return { success: false, userError: foldClientError(cause) };
+        return { status: "error", userError: foldClientError(cause) };
       } finally {
         resumeAutofillFlow?.();
         pendingRef.current = false;

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -84,11 +84,6 @@ export type UsernamePasskeyConfig = Required<UsernamePasskeyOptions>;
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "passkey";
 
-// `startSignIn` opens passkey's own ceremony protocol rather than returning a
-// sign-in result: it mints no session, and the client always has a `finish*`
-// call to make after it. So it keeps a plain `success` boolean, and `status`
-// stays reserved for the shared envelope the SSR proxy reads. The hook folds a
-// failure here into the envelope's error arm before callers see it.
 const startSignInResult = v.union(
   // The username has an account: authenticate with a passkey of that
   // account. The challenge is bound to the user.

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -1,7 +1,8 @@
 import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import {
-  vSignInSuccess,
+  vSignInComplete,
+  vSignInError,
   USE_USER_ID_AS_ACCOUNT_ID,
   type UserCallbacks,
 } from "../../lib/types.ts";
@@ -83,6 +84,11 @@ export type UsernamePasskeyConfig = Required<UsernamePasskeyOptions>;
 // TODO: derive this from the component mount path rather than hardcoding it.
 const PROVIDER_NAME = "passkey";
 
+// `startSignIn` opens passkey's own ceremony protocol rather than returning a
+// sign-in result: it mints no session, and the client always has a `finish*`
+// call to make after it. So it keeps a plain `success` boolean, and `status`
+// stays reserved for the shared envelope the SSR proxy reads. The hook folds a
+// failure here into the envelope's error arm before callers see it.
 const startSignInResult = v.union(
   // The username has an account: authenticate with a passkey of that
   // account. The challenge is bound to the user.
@@ -117,37 +123,31 @@ const startAutofillSignInResult = v.object({
 export type StartAutofillSignInResult = Infer<typeof startAutofillSignInResult>;
 
 const finishSignUpResult = v.union(
-  vSignInSuccess,
-  v.object({
-    success: v.literal(false),
-    userError: v.union(finishRegistrationUserError, setUsernameUserError),
-  }),
+  vSignInComplete,
+  vSignInError(v.union(finishRegistrationUserError, setUsernameUserError)),
 );
 
 /**
  * The result of `finishSignUp`.
  *
- * On success the minted session tokens, otherwise a user-facing `userError`.
+ * When complete the minted session tokens, otherwise a user-facing `userError`.
  */
 export type FinishSignUpResult = Infer<typeof finishSignUpResult>;
 
 const finishSignInResult = v.union(
   v.object({
-    ...vSignInSuccess.fields,
+    ...vSignInComplete.fields,
     // The username of the account, for display. `null` when the app
     // removed the username of the user.
     username: v.union(v.string(), v.null()),
   }),
-  v.object({
-    success: v.literal(false),
-    userError: finishAuthenticationUserError,
-  }),
+  vSignInError(finishAuthenticationUserError),
 );
 
 /**
  * The result of `finishSignIn`.
  *
- * On success the minted session tokens and the username of the account,
+ * When complete the minted session tokens and the username of the account,
  * otherwise a user-facing `userError`.
  */
 export type FinishSignInResult = Infer<typeof finishSignInResult>;
@@ -336,7 +336,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             const { username } = args;
             const usernameError = validateUsernameFormat(username);
             if (usernameError !== null) {
-              return { success: false, userError: usernameError };
+              return { status: "error", userError: usernameError };
             }
 
             // Fail early if the username is taken
@@ -345,7 +345,10 @@ export function setupUsernamePasskey<UsersTable extends string>(
               { username },
             );
             if (existing !== null) {
-              return { success: false, userError: { error: "USERNAME_TAKEN" } };
+              return {
+                status: "error",
+                userError: { error: "USERNAME_TAKEN" },
+              };
             }
 
             // The app does not name a new passkey yet, thus the provider
@@ -375,7 +378,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                   { cause: userError },
                 );
               }
-              return { success: false, userError };
+              return { status: "error", userError };
             }
 
             // Create the account + app user (via the app's createUser) and
@@ -429,7 +432,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               );
             }
 
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
 
@@ -463,7 +466,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
             );
             if (!authenticationResult.success) {
               return {
-                success: false,
+                status: "error",
                 userError: authenticationResult.userError,
               };
             }
@@ -478,7 +481,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
               providerAccountId: userId,
               profile: { username },
             });
-            return { success: true, tokens, username };
+            return { status: "complete", tokens, username };
           },
         }),
 

--- a/packages/core/src/components/password/react.test.tsx
+++ b/packages/core/src/components/password/react.test.tsx
@@ -85,7 +85,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
   });
 
   test("success adopts the session and returns the result", async () => {
-    runMutation.mockResolvedValue({ success: true, tokens: bundle });
+    runMutation.mockResolvedValue({ status: "complete", tokens: bundle });
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -96,13 +96,13 @@ describe.each(flows)("$name", ({ useFlow }) => {
     });
 
     expect(runMutation).toHaveBeenCalledWith(credentials);
-    expect(returned).toEqual({ success: true, tokens: bundle });
+    expect(returned).toEqual({ status: "complete", tokens: bundle });
     expect(result.current.auth.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("access-1");
   });
 
   test("user error is returned without adopting a session", async () => {
-    const failure = { success: false, userError: { error: "USER_NOT_FOUND" } };
+    const failure = { status: "error", userError: { error: "USER_NOT_FOUND" } };
     runMutation.mockResolvedValue(failure);
     const { result } = renderFlow(useFlow);
     await waitFor(() => expect(result.current.auth.isLoading).toBe(false));
@@ -128,7 +128,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     });
 
     expect(returned).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "OTHER_ERROR", cause },
     });
     expect(result.current.auth.isAuthenticated).toBe(false);
@@ -152,7 +152,7 @@ describe.each(flows)("$name", ({ useFlow }) => {
     await waitFor(() => expect(result.current.flow.pending).toBe(true));
 
     await act(async () => {
-      resolveMutation!({ success: true, tokens: bundle });
+      resolveMutation!({ status: "complete", tokens: bundle });
       await pending;
     });
     expect(result.current.flow.pending).toBe(false);

--- a/packages/core/src/components/password/react.tsx
+++ b/packages/core/src/components/password/react.tsx
@@ -59,7 +59,7 @@ type SignUpWithPasswordMutation = FunctionReference<
  * on `cause` for callers that want to inspect or log it.
  */
 type UnexpectedFailure = {
-  success: false;
+  status: "error";
   userError: { error: "OTHER_ERROR"; cause: unknown };
 };
 
@@ -81,7 +81,7 @@ export type SignUpWithPasswordResult =
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signIn`, check the `success` flag on the return value to see
+ * After calling `signIn`, check the `status` field on the return value to see
  * whether the sign-in was successful or if you need to handle an error.
  *
  * ```tsx
@@ -95,7 +95,7 @@ export type SignUpWithPasswordResult =
  *       onSubmit={async (e) => {
  *         e.preventDefault();
  *         const result = await signIn({ username, password });
- *         if (!result.success) {
+ *         if (result.status !== "complete") {
  *           // map result.userError to a message
  *         }
  *       }}
@@ -116,12 +116,12 @@ export function useSignInWithPassword(
     /**
      * Passes up the given crendentials to perform a username/password sign in.
      *
-     * Returns an object with a `success` boolean flag.
+     * Returns an object with a `status` field.
      *
-     * If it is `true` the sign-in was successful and the client will establish
-     * an authenticated session with the Convex backend server.
+     * If it is `"complete"` the sign-in was successful and the client will
+     * establish an authenticated session with the Convex backend server.
      *
-     * If it is `false` the returned object will have a `userError` field with
+     * If it is `"error"` the returned object will have a `userError` field with
      * additional details about why sign-in failed.
      */
     signIn: run,
@@ -140,7 +140,7 @@ export function useSignInWithPassword(
  * The `pending` flag returned will let you know if the credentials are
  * currently being validated.
  *
- * After calling `signUp`, check the `success` flag on the return value to see
+ * After calling `signUp`, check the `status` field on the return value to see
  * whether the sign-up was successful or if you need to handle an error.
  *
  * ```tsx
@@ -163,12 +163,12 @@ export function useSignUpWithPassword(
     /**
      * Passes up the given crendentials to perform a username/password sign up.
      *
-     * Returns an object with a `success` boolean flag.
+     * Returns an object with a `status` field.
      *
-     * If it is `true` the sign-up was successful and the client will establish
-     * an authenticated session with the Convex backend server.
+     * If it is `"complete"` the sign-up was successful and the client will
+     * establish an authenticated session with the Convex backend server.
      *
-     * If it is `false` the returned object will have a `userError` field with
+     * If it is `"error"` the returned object will have a `userError` field with
      * additional details about why sign-up failed.
      */
     signUp: run,
@@ -197,7 +197,7 @@ function usePasswordFlow<
       setPending(true);
       try {
         const result = await signInApi.mutation(mutation, credentials);
-        if (result.success) {
+        if (result.status === "complete") {
           await setSession(result.tokens);
         }
         return result;
@@ -206,7 +206,7 @@ function usePasswordFlow<
         // the same discriminated result as `OTHER_ERROR`, preserving the thrown
         // value on `cause`, so the caller handles it alongside every other
         // failure and can still inspect or log the original error if it wants.
-        return { success: false, userError: { error: "OTHER_ERROR", cause } };
+        return { status: "error", userError: { error: "OTHER_ERROR", cause } };
       } finally {
         // Reset even when the mutation throws.
         setPending(false);

--- a/packages/core/src/components/password/setup.ts
+++ b/packages/core/src/components/password/setup.ts
@@ -2,7 +2,8 @@ import { mutationGeneric } from "convex/server";
 import { Infer, v } from "convex/values";
 import { getAuthUserId } from "../core/userId.ts";
 import {
-  vSignInSuccess,
+  vSignInComplete,
+  vSignInError,
   USE_USER_ID_AS_ACCOUNT_ID,
   type UserCallbacks,
 } from "../../lib/types.ts";
@@ -40,35 +41,31 @@ export type UsernamePasswordOptions = {
 };
 
 const signInResult = v.union(
-  vSignInSuccess,
-  v.object({
-    success: v.literal(false),
-    userError: v.union(
+  vSignInComplete,
+  vSignInError(
+    v.union(
       verifyPasswordUserError,
       v.object({ error: v.literal("USER_NOT_FOUND") }),
     ),
-  }),
+  ),
 );
 
 /**
  * The result of `signInWithPassword`.
  *
- * On success the minted session tokens, otherwise a user-facing `userError`.
+ * When complete the minted session tokens, otherwise a user-facing `userError`.
  */
 export type SignInResult = Infer<typeof signInResult>;
 
 const signUpResult = v.union(
-  vSignInSuccess,
-  v.object({
-    success: v.literal(false),
-    userError: v.union(setPasswordUserError, setUsernameUserError),
-  }),
+  vSignInComplete,
+  vSignInError(v.union(setPasswordUserError, setUsernameUserError)),
 );
 
 /**
  * The result of `signUpWithPassword`.
  *
- * On success the minted session tokens, otherwise a user-facing `userError`.
+ * When complete the minted session tokens, otherwise a user-facing `userError`.
  */
 export type SignUpResult = Infer<typeof signUpResult>;
 
@@ -157,11 +154,11 @@ export function setupUsernamePassword<UsersTable extends string>(
             // TODO(nicolas) Make the first-party providers apply stronger validation rules by default
             const usernameError = validateUsernameFormat(username);
             if (usernameError !== null) {
-              return { success: false, userError: usernameError };
+              return { status: "error", userError: usernameError };
             }
             const userError = validateNewPassword(password);
             if (userError !== null) {
-              return { success: false, userError };
+              return { status: "error", userError };
             }
 
             const existing = await ctx.runQuery(
@@ -169,7 +166,10 @@ export function setupUsernamePassword<UsersTable extends string>(
               { username },
             );
             if (existing !== null) {
-              return { success: false, userError: { error: "USERNAME_TAKEN" } };
+              return {
+                status: "error",
+                userError: { error: "USERNAME_TAKEN" },
+              };
             }
 
             // Create the account + app user (via the app's createUser) and
@@ -223,7 +223,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               );
             }
 
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
 
@@ -247,7 +247,7 @@ export function setupUsernamePassword<UsersTable extends string>(
             );
             if (userId === null) {
               return {
-                success: false,
+                status: "error",
                 userError: { error: "USER_NOT_FOUND" },
               };
             }
@@ -257,7 +257,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               { userId, password },
             );
             if (!verifyResult.success) {
-              return { success: false, userError: verifyResult.userError };
+              return { status: "error", userError: verifyResult.userError };
             }
 
             // The username resolved to a user id and its password verified, so
@@ -267,7 +267,7 @@ export function setupUsernamePassword<UsersTable extends string>(
               providerAccountId: userId,
               profile: { username },
             });
-            return { success: true, tokens };
+            return { status: "complete", tokens };
           },
         }),
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,6 +1,6 @@
 import { FunctionReference } from "convex/server";
 
-import { GenericId, Infer, v } from "convex/values";
+import { GenericId, Infer, v, type Validator } from "convex/values";
 
 /**
  * Shared contracts that cross a module boundary within Convex Auth. That includes
@@ -31,20 +31,58 @@ export const vTokenBundle = v.object({
 export type TokenBundle = Infer<typeof vTokenBundle>;
 
 /**
- * The success arm of every provider's sign-in result.
+ * A complete sign-in result.
  *
  * Providers compose this into their result union rather than declaring the
- * success arm themselves. Fixing where the minted bundle sits is what lets the
+ * complete arm themselves. Fixing where the minted bundle sits is what lets the
  * SSR auth proxy find the refresh token without knowing which provider produced
  * the response, and lets it reject a shape it doesn't recognize instead of
  * forwarding tokens to the browser.
  */
-export const vSignInSuccess = v.object({
-  success: v.literal(true),
+export const vSignInComplete = v.object({
+  status: v.literal("complete"),
   tokens: vTokenBundle,
 });
 
-export type SignInSuccess = Infer<typeof vSignInSuccess>;
+export type SignInComplete = Infer<typeof vSignInComplete>;
+
+/**
+ * A sign-in that resulted in an error, carrying that provider's own
+ * `userError` codes.
+ *
+ * The `status` is shared so every arm of every provider is discriminated the
+ * same way; the payload is not, because what can go wrong is provider-specific.
+ *
+ * ```ts
+ * const signInResult = v.union(
+ *   vSignInComplete,
+ *   vSignInError(v.object({ error: v.literal("USER_NOT_FOUND") })),
+ * );
+ * ```
+ */
+export function vSignInError<
+  UserError extends Validator<unknown, "required", string>,
+>(userError: UserError) {
+  return v.object({ status: v.literal("error"), userError });
+}
+
+/** The inferred shape of a {@link vSignInError} arm. */
+export type SignInError<UserError> = {
+  status: "error";
+  userError: UserError;
+};
+
+/**
+ * The full shared sign-in envelope.
+ *
+ * Represents sign-ins that ran to completion and those that hit an error.
+ *
+ * `userError` is `unknown` here because each provider declares its own codes.
+ */
+export type SignInEnvelope = SignInComplete | SignInError<unknown>;
+
+/** The `status` discriminant of every {@link SignInEnvelope}. */
+export type SignInStatus = SignInEnvelope["status"];
 
 /**
  * The token bundle that an SSR route hands back to the client. It is a slimmed

--- a/packages/core/src/oauth/client.test.ts
+++ b/packages/core/src/oauth/client.test.ts
@@ -4,14 +4,14 @@ import { ConvexError } from "convex/values";
 import type { AuthSignInApi } from "../browser/ambientSignInClient.ts";
 import { AuthClient, type AuthState } from "../browser/sessionManager.ts";
 import { InMemoryStorage, type TokenStorage } from "../browser/storage.ts";
-import type { TokenBundle } from "../lib/types.ts";
 import { oauth } from "./client.ts";
 import {
   ACME_REFS,
   NAMESPACE,
-  bundle,
   calledPath,
+  completed,
   flowStorage,
+  invalidCode,
   readFlow,
   restoreNavigatorProduct,
   seedPendingFlow,
@@ -57,7 +57,7 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client, mutation, flowError } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(bundle);
+    mutation.mockResolvedValueOnce(completed);
 
     await client.init();
 
@@ -83,7 +83,7 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client, mutation } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(bundle);
+    mutation.mockResolvedValueOnce(completed);
 
     await client.init();
 
@@ -99,7 +99,7 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client, mutation } = setupOAuth({ storage });
-    const { promise, resolve } = Promise.withResolvers<TokenBundle>();
+    const { promise, resolve } = Promise.withResolvers<typeof completed>();
     mutation.mockReturnValueOnce(promise);
 
     // The session load finishes long before the redemption does. Any snapshot
@@ -116,7 +116,7 @@ describe("OAuth client", () => {
     await client.init();
     expect(client.getSnapshot().isLoading).toBe(true);
 
-    resolve(bundle);
+    resolve(completed);
     await vi.waitFor(() =>
       expect(client.getSnapshot().isAuthenticated).toBe(true),
     );
@@ -130,7 +130,7 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client: first, mutation: firstMutation } = setupOAuth({ storage });
-    firstMutation.mockResolvedValueOnce(bundle);
+    firstMutation.mockResolvedValueOnce(completed);
 
     await first.init();
     await vi.waitFor(() =>
@@ -216,12 +216,12 @@ describe("OAuth client", () => {
     expect(mutation).not.toHaveBeenCalled();
   });
 
-  test("a null bundle sets expired", async () => {
+  test("an INVALID_CODE error sets expired", async () => {
     window.history.replaceState(null, "", "/?convexAuthCode=code-1");
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client, mutation, flowError } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(null);
+    mutation.mockResolvedValueOnce(invalidCode);
 
     await client.init();
 
@@ -349,7 +349,7 @@ describe("OAuth client", () => {
     const storage = new InMemoryStorage();
     seedPendingFlow(storage);
     const { client, mutation, actions } = setupOAuth({ storage });
-    mutation.mockResolvedValueOnce(bundle);
+    mutation.mockResolvedValueOnce(completed);
 
     const outcome = await actions.signIn(ACME_REFS, { code: "code-1" });
 

--- a/packages/core/src/oauth/client.ts
+++ b/packages/core/src/oauth/client.ts
@@ -19,7 +19,8 @@ import type { AmbientSignInClient } from "../browser/ambientSignInClient.ts";
 import { retryOnNetworkError } from "../browser/retry.ts";
 import type { SignInStorage } from "../browser/storage.ts";
 import { OAUTH_CODE_PARAM, OAUTH_ERROR_PARAM } from "../lib/oauthParams.ts";
-import type { TokenBundle } from "../lib/types.ts";
+import type { ClientView } from "../lib/types.ts";
+import type { CompleteSignInResult } from "./component/setup.ts";
 
 /**
  * The mutations an OAuth provider adds to the app's API. Passed as
@@ -38,7 +39,7 @@ export type OauthProviderApi = {
     "mutation",
     "public",
     { code: string; state: string },
-    TokenBundle | null
+    ClientView<CompleteSignInResult>
   >;
 };
 
@@ -277,16 +278,16 @@ export function oauth(): AmbientSignInClient {
           const completeSignIn = makeFunctionReference<"mutation">(
             pending.completeSignIn,
           ) as OauthProviderApi["completeSignIn"];
-          const bundle = await retryOnNetworkError(() =>
+          const result = await retryOnNetworkError(() =>
             signInApi.mutation(completeSignIn, { code, state: pending.state }),
           );
-          if (bundle === null) {
+          if (result.status === "error") {
             // The server can't tell unknown, already redeemed, expired, and
             // mismatched state apart, so they all land here.
             setFlowError("expired");
             return false;
           }
-          await client.setSession(bundle);
+          await client.setSession(result.tokens);
           return true;
         } catch (error) {
           setThrownFlowError(error);

--- a/packages/core/src/oauth/component/redemption.test.ts
+++ b/packages/core/src/oauth/component/redemption.test.ts
@@ -58,6 +58,15 @@ const FAKE_BUNDLE: TokenBundle = {
   userId: "user-1",
 };
 
+/** The envelope a redemption that reached the helpers returns. */
+const COMPLETED = { status: "complete", tokens: FAKE_BUNDLE };
+
+/**
+ * The envelope every unredeemable code returns: unknown, already spent,
+ * expired, and mismatched state are one code by design.
+ */
+const INVALID_CODE = { status: "error", userError: { error: "INVALID_CODE" } };
+
 /**
  * A fake core whose builders inject fake {@link BoundAuthHelpers}.
  * `signUpWithoutSession` is never reached by redemption.
@@ -281,16 +290,16 @@ afterEach(() => {
 });
 
 describe("completeSignIn", () => {
-  test("redeems a minted ticket into a session bundle via the profile mapping", async () => {
+  test("redeems a minted ticket into a session via the profile mapping", async () => {
     const t = setup();
     const code = await mintTicket(t);
 
-    const bundle = await t.mutation(completeSignInAcme, {
+    const result = await t.mutation(completeSignInAcme, {
       code,
       state: "state-1",
     });
 
-    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(result).toEqual(COMPLETED);
     // The decrypted payload flowed through the catalog's profile mapping
     // into the fake helpers. The identity is unknown to the core, so
     // redemption took the sign-up path.
@@ -312,12 +321,12 @@ describe("completeSignIn", () => {
 
     // Only the core knows the account has been seen before.
     resolvedUserId.value = "user-1";
-    const bundle = await t.mutation(completeSignInAcme, {
+    const result = await t.mutation(completeSignInAcme, {
       code,
       state: "state-1",
     });
 
-    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(result).toEqual(COMPLETED);
     expect(helperCalls).toEqual([
       {
         kind: "signIn",
@@ -337,12 +346,12 @@ describe("completeSignIn", () => {
       payload: { userInfoResponses: { user: { id: 42, login: "octocat" } } },
     });
 
-    const bundle = await t.mutation(completeSignInAcmeInfo, {
+    const result = await t.mutation(completeSignInAcmeInfo, {
       code,
       state: "state-1",
     });
 
-    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(result).toEqual(COMPLETED);
     expect(helperCalls).toEqual([
       {
         kind: "signUp",
@@ -355,17 +364,17 @@ describe("completeSignIn", () => {
     ]);
   });
 
-  test("an unknown code returns null", async () => {
+  test("an unknown code reports INVALID_CODE", async () => {
     const t = setup();
     const result = await t.mutation(completeSignInAcme, {
       code: "never-minted",
       state: "state-1",
     });
-    expect(result).toBeNull();
+    expect(result).toEqual(INVALID_CODE);
     expect(helperCalls).toHaveLength(0);
   });
 
-  test("a wrong state returns null and preserves the ticket", async () => {
+  test("a wrong state reports INVALID_CODE and preserves the ticket", async () => {
     const t = setup();
     const code = await mintTicket(t);
 
@@ -373,15 +382,15 @@ describe("completeSignIn", () => {
       code,
       state: "someone-elses-state",
     });
-    expect(mismatched).toBeNull();
+    expect(mismatched).toEqual(INVALID_CODE);
 
     // The ticket survives a mismatched attempt, so the initiating client can
     // still complete.
-    const bundle = await t.mutation(completeSignInAcme, {
+    const result = await t.mutation(completeSignInAcme, {
       code,
       state: "state-1",
     });
-    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(result).toEqual(COMPLETED);
   });
 
   test("a code redeems exactly once", async () => {
@@ -392,17 +401,17 @@ describe("completeSignIn", () => {
       code,
       state: "state-1",
     });
-    expect(first).toEqual(FAKE_BUNDLE);
+    expect(first).toEqual(COMPLETED);
 
     const second = await t.mutation(completeSignInAcme, {
       code,
       state: "state-1",
     });
-    expect(second).toBeNull();
+    expect(second).toEqual(INVALID_CODE);
     expect(helperCalls).toHaveLength(1);
   });
 
-  test("an expired ticket returns null", async () => {
+  test("an expired ticket reports INVALID_CODE", async () => {
     vi.useFakeTimers();
     const t = setup();
     const code = await mintTicket(t);
@@ -412,7 +421,7 @@ describe("completeSignIn", () => {
       code,
       state: "state-1",
     });
-    expect(result).toBeNull();
+    expect(result).toEqual(INVALID_CODE);
     expect(helperCalls).toHaveLength(0);
   });
 
@@ -447,10 +456,10 @@ describe("completeSignIn", () => {
     // ...and the claim rolled back with the rest of the mutation, so the
     // ticket is not burned by the failed attempt.
     helperFailure.error = undefined;
-    const bundle = await t.mutation(completeSignInAcme, {
+    const result = await t.mutation(completeSignInAcme, {
       code,
       state: "state-1",
     });
-    expect(bundle).toEqual(FAKE_BUNDLE);
+    expect(result).toEqual(COMPLETED);
   });
 });

--- a/packages/core/src/oauth/component/setup.ts
+++ b/packages/core/src/oauth/component/setup.ts
@@ -1,8 +1,8 @@
 import { mutationGeneric } from "convex/server";
-import { v } from "convex/values";
+import { Infer, v } from "convex/values";
 import {
-  vTokenBundle,
-  type TokenBundle,
+  vSignInComplete,
+  vSignInError,
   type UserCallbacks,
 } from "../../lib/types.ts";
 import type { AuthCore } from "../../components/core/setup.ts";
@@ -119,6 +119,21 @@ export type OauthProviderOptions = {
    */
   allowedRedirectOrigins: string[];
 };
+
+const completeSignInResult = v.union(
+  vSignInComplete,
+  // The one-time code did not redeem: unknown, already spent, expired, or
+  // paired with a state this browser never held. The server cannot tell those
+  // apart and deliberately does not try, so they share one code.
+  vSignInError(v.object({ error: v.literal("INVALID_CODE") })),
+);
+
+/**
+ * The result of `completeSignIn`.
+ *
+ * When complete the minted session tokens, otherwise a user-facing `userError`.
+ */
+export type CompleteSignInResult = Infer<typeof completeSignInResult>;
 
 /** `new URL` without the exception: returns null on unparseable input. */
 function parseUrl(value: string): URL | null {
@@ -271,24 +286,23 @@ export function setupOauth<
   /**
    * Complete an OAuth sign-in by redeeming the one-time `code` from
    * the callback redirect together with the state held since
-   * `startSignIn`. Returns the session token bundle, or null when
-   * the code is unknown, already redeemed, expired, or the state
-   * doesn't match: all indistinguishable to the caller.
+   * `startSignIn`. Returns the shared sign-in envelope: the session
+   * token bundle, or an `INVALID_CODE` error when the code is unknown,
+   * already redeemed, expired, or the state doesn't match: all
+   * indistinguishable to the caller.
    *
    * The component calls are subtransactions of this mutation, so a
    * failure anywhere (including the app rejecting the sign-in from
    * `createUser` / `onSignIn`) rolls back the ticket claim. Only a
    * successful redemption consumes the ticket.
    */
-  // TODO: dowski - return the shared `vSignInSuccess` envelope like the other
-  // providers do, instead of a bare bundle or null.
   const completeSignIn = authMutation({
     args: {
       code: v.string(),
       state: v.string(),
     },
-    returns: v.union(vTokenBundle, v.null()),
-    handler: async (ctx, args): Promise<TokenBundle | null> => {
+    returns: completeSignInResult,
+    handler: async (ctx, args): Promise<CompleteSignInResult> => {
       const ticket = await ctx.runMutation(
         options.component.provider.claimTicket,
         {
@@ -298,7 +312,7 @@ export function setupOauth<
         },
       );
       if (ticket === null) {
-        return null;
+        return { status: "error", userError: { error: "INVALID_CODE" } };
       }
 
       // Finding the ticket by hash proves `code` is the value the
@@ -322,15 +336,17 @@ export function setupOauth<
       // resolve the identity to pick a path. This handler is a mutation, so the
       // lookup and the write it decides on are one transaction.
       const existingUserId = await ctx.convexAuth.resolveUserId(profile.id);
-      return existingUserId === null
-        ? await ctx.convexAuth.completeSignUp({
-            providerAccountId: profile.id,
-            profile,
-          })
-        : await ctx.convexAuth.completeSignIn({
-            providerAccountId: profile.id,
-            profile,
-          });
+      const tokens =
+        existingUserId === null
+          ? await ctx.convexAuth.completeSignUp({
+              providerAccountId: profile.id,
+              profile,
+            })
+          : await ctx.convexAuth.completeSignIn({
+              providerAccountId: profile.id,
+              profile,
+            });
+      return { status: "complete", tokens };
     },
   });
 

--- a/packages/core/src/oauth/react.test.tsx
+++ b/packages/core/src/oauth/react.test.tsx
@@ -19,8 +19,8 @@ import {
 import {
   ACME_REFS,
   NAMESPACE,
-  bundle,
   calledPath,
+  completed,
   oauthClient,
   readFlow,
   restoreNavigatorProduct,
@@ -136,7 +136,7 @@ describe("OAuth React client", () => {
     const { result, mutation } = renderOAuth(useGoogleFlow, {
       storage,
       strictMode: true,
-      onMutation: (mutation) => mutation.mockResolvedValueOnce(bundle),
+      onMutation: (mutation) => mutation.mockResolvedValueOnce(completed),
     });
 
     await waitFor(() => expect(result.current.auth.isAuthenticated).toBe(true));

--- a/packages/core/src/oauth/testFlow.ts
+++ b/packages/core/src/oauth/testFlow.ts
@@ -36,6 +36,18 @@ export const bundle: TokenBundle = {
   userId: "user-1",
 };
 
+/** The envelope `completeSignIn` returns once a code redeems. */
+export const completed = { status: "complete" as const, tokens: bundle };
+
+/**
+ * The envelope `completeSignIn` returns for a code that cannot be redeemed:
+ * unknown, already spent, expired, or paired with someone else's state.
+ */
+export const invalidCode = {
+  status: "error" as const,
+  userError: { error: "INVALID_CODE" as const },
+};
+
 /**
  * A stand-in provider, for tests that don't care which provider ran. The refs
  * have paths that look like an app's because `signIn` saves the completeSignIn

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -60,9 +60,12 @@ export type {
   ConvexAuthApi,
   IsAuthenticatedFn,
   RefreshSessionFn,
-  SignInSuccess,
+  SignInComplete,
+  SignInEnvelope,
+  SignInError,
+  SignInStatus,
   SignOutFn,
   SlimTokenBundle,
   TokenBundle,
 } from "../lib/types.ts";
-export { makeSlimBundle, vSignInSuccess } from "../lib/types.ts";
+export { makeSlimBundle, vSignInComplete, vSignInError } from "../lib/types.ts";

--- a/packages/core/src/server/signInProxy.test.ts
+++ b/packages/core/src/server/signInProxy.test.ts
@@ -75,14 +75,17 @@ afterEach(() => vi.restoreAllMocks());
 
 describe("token interception", () => {
   test("moves the refresh token into an httpOnly cookie and slims the body", async () => {
-    upstream({ status: "success", value: { success: true, tokens: bundle() } });
+    upstream({
+      status: "success",
+      value: { status: "complete", tokens: bundle() },
+    });
 
     const response = await handler(call(envelope()));
     expect(response.status).toBe(200);
 
     const body = await response.json();
     // The envelope survives; only the refresh half of the bundle is removed.
-    expect(body.value.success).toBe(true);
+    expect(body.value.status).toBe("complete");
     expect(body.value.tokens).toEqual({
       accessToken: "access-1",
       accessTokenExpiresAt: 1_000,
@@ -101,7 +104,7 @@ describe("token interception", () => {
     // tokens. The refresh token is the only thing the proxy removes.
     upstream({
       status: "success",
-      value: { success: true, tokens: bundle(), username: "alice" },
+      value: { status: "complete", tokens: bundle(), username: "alice" },
     });
 
     const body = await (await handler(call(envelope()))).json();
@@ -112,13 +115,13 @@ describe("token interception", () => {
   test("passes a failure arm through untouched and writes no cookies", async () => {
     upstream({
       status: "success",
-      value: { success: false, userError: { error: "INVALID_CREDENTIALS" } },
+      value: { status: "error", userError: { error: "INVALID_CREDENTIALS" } },
     });
 
     const response = await handler(call(envelope()));
     const body = await response.json();
     expect(body.value).toEqual({
-      success: false,
+      status: "error",
       userError: { error: "INVALID_CREDENTIALS" },
     });
     // A failed sign-in is a successful call: the transport says 200 and the
@@ -139,6 +142,21 @@ describe("token interception", () => {
     const response = await handler(call(envelope()));
     expect(response.status).toBe(500);
     expect(await response.text()).toContain("did not return a sign-in result");
+  });
+
+  test("refuses a status this handler does not know", async () => {
+    // A deployment running a provider newer than the handler serving it. The
+    // arm may well carry no tokens, but the proxy does not guess: forwarding an
+    // arm it cannot classify is how a refresh token reaches browser JS.
+    upstream({
+      status: "success",
+      value: { status: "requires-second-factor", challenge: "abc" },
+    });
+
+    const response = await handler(call(envelope()));
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain("did not return a sign-in result");
+    expect(setCookies(response)).toBe("");
   });
 
   test("fails closed when an exposed function returns an unrecognized shape", async () => {
@@ -216,7 +234,7 @@ describe("forwarding", () => {
   test("forwards args in the caller's encoding, and the caller's auth header", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
 
     await handler(
@@ -241,7 +259,7 @@ describe("forwarding", () => {
   test("routes each endpoint to its counterpart on the deployment", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
     await handler(call(envelope(), { kind: "mutation" }));
     expect(fetchSpy.mock.calls[0][0]).toBe(`${CONVEX_URL}/api/mutation`);
@@ -250,7 +268,7 @@ describe("forwarding", () => {
   test("never forwards the browser's cookies to the deployment", async () => {
     const fetchSpy = upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
     });
     await handler(
       call(envelope(), {
@@ -266,7 +284,7 @@ describe("forwarding", () => {
   test("forwards server log lines so a proxied call logs like a direct one", async () => {
     upstream({
       status: "success",
-      value: { success: true, tokens: bundle() },
+      value: { status: "complete", tokens: bundle() },
       logLines: ["from the function's console.log"],
     });
     const body = await (await handler(call(envelope()))).json();
@@ -335,7 +353,7 @@ describe("ConvexHttpClient wire contract", () => {
       return new Response(
         JSON.stringify({
           status: "success",
-          value: { success: true, tokens: bundle() },
+          value: { status: "complete", tokens: bundle() },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
@@ -354,7 +372,7 @@ describe("ConvexHttpClient wire contract", () => {
 
     // The client parsed the proxy's reply, and the refresh token is gone.
     expect(result).toEqual({
-      success: true,
+      status: "complete",
       tokens: {
         accessToken: "access-1",
         accessTokenExpiresAt: 1_000,

--- a/packages/core/src/server/signInProxy.ts
+++ b/packages/core/src/server/signInProxy.ts
@@ -164,7 +164,9 @@ function classifyResult(
   // An arm that mints nothing has no tokens to intercept, so it goes back as
   // the provider wrote it. On the arms that do mint, a bundle that isn't a
   // bundle is a wiring bug rather than something to forward.
-  if (!MINTS_SESSION[status as SignInStatus]) return { kind: "forward" };
+  if (!MINTS_SESSION[status as SignInStatus]) {
+    return Object.hasOwn(value, "tokens") ? null : { kind: "forward" };
+  }
   return isEncodedTokenBundle(tokens) ? { kind: "mint", tokens } : null;
 }
 

--- a/packages/core/src/server/signInProxy.ts
+++ b/packages/core/src/server/signInProxy.ts
@@ -30,7 +30,8 @@ import {
 } from "convex/server";
 import {
   makeSlimBundle,
-  type SignInSuccess,
+  type SignInEnvelope,
+  type SignInStatus,
   type TokenBundle,
 } from "../lib/types.ts";
 import type { AuthCookieOptions } from "./cookies.ts";
@@ -42,15 +43,15 @@ import { forbiddenOriginResponse, isTrustedOrigin } from "./origin.ts";
 /**
  * A sign-in function exposed through the proxy.
  *
- * Any public mutation or action returning the shared {@link SignInSuccess}
- * envelope. Args are typed loosely because the proxy never inspects them; it
- * forwards the caller's encoded args untouched.
+ * Any public mutation or action returning the shared {@link SignInEnvelope}.
+ * Args are typed loosely because the proxy never inspects them; it forwards the
+ * caller's encoded args untouched.
  */
 export type ExposedSignInFn = FunctionReference<
   "mutation" | "action",
   "public",
   DefaultFunctionArgs,
-  SignInSuccess | { success: false }
+  SignInEnvelope
 >;
 
 /** Configuration for {@link convexProxyHandler}. */
@@ -132,23 +133,39 @@ function isEncodedTokenBundle(value: unknown): value is TokenBundle {
 }
 
 /**
+ * Whether each arm of the envelope carries a bundle whose refresh token has to
+ * move into the cookie. Keyed by {@link SignInStatus}, so a new status has to
+ * answer that question here before it compiles.
+ */
+const MINTS_SESSION: Record<SignInStatus, boolean> = {
+  complete: true,
+  error: false,
+};
+
+/**
  * Classify a sign-in function's return value.
  *
  * `null` means "not the envelope this proxy knows how to handle", which the
- * caller turns into a 500 rather than forwarding.
+ * caller turns into a 500 rather than forwarding. A status missing from
+ * {@link MINTS_SESSION} lands there too: a deployment running a provider newer
+ * than this handler is not something to guess at, because guessing wrong is how
+ * a refresh token reaches browser JS.
  */
 function classifyResult(
   value: unknown,
-): { kind: "success"; tokens: TokenBundle } | { kind: "failure" } | null {
+): { kind: "mint"; tokens: TokenBundle } | { kind: "forward" } | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
   }
-  const result = value as Record<string, unknown>;
-  if (result.success === false) return { kind: "failure" };
-  if (result.success !== true) return null;
-  return isEncodedTokenBundle(result.tokens)
-    ? { kind: "success", tokens: result.tokens }
-    : null;
+  const { status, tokens } = value as Record<string, unknown>;
+  if (typeof status !== "string" || !Object.hasOwn(MINTS_SESSION, status)) {
+    return null;
+  }
+  // An arm that mints nothing has no tokens to intercept, so it goes back as
+  // the provider wrote it. On the arms that do mint, a bundle that isn't a
+  // bundle is a wiring bug rather than something to forward.
+  if (!MINTS_SESSION[status as SignInStatus]) return { kind: "forward" };
+  return isEncodedTokenBundle(tokens) ? { kind: "mint", tokens } : null;
 }
 
 /** A plain-text error. `ConvexHttpClient` throws its body as an `Error`. */
@@ -251,12 +268,12 @@ export function convexProxyHandler(config: ConvexProxyConfig): RequestHandler {
       return textError(
         500,
         `${envelope.path} did not return a sign-in result. Provider sign-in ` +
-          `functions must return the shared envelope (see vSignInSuccess).`,
+          `functions must return the shared envelope (see vSignInComplete).`,
       );
     }
 
     const cookies = httpCookies(request);
-    if (result.kind === "success") {
+    if (result.kind === "mint") {
       await writeAuthCookies(cookies, result.tokens, config.cookieOptions);
       // The refresh token goes to the cookie and gets removed from the tokens.
       (payload.value as Record<string, unknown>).tokens = makeSlimBundle(

--- a/packages/core/src/server/signInProxy.ts
+++ b/packages/core/src/server/signInProxy.ts
@@ -133,23 +133,9 @@ function isEncodedTokenBundle(value: unknown): value is TokenBundle {
 }
 
 /**
- * Whether each arm of the envelope carries a bundle whose refresh token has to
- * move into the cookie. Keyed by {@link SignInStatus}, so a new status has to
- * answer that question here before it compiles.
- */
-const MINTS_SESSION: Record<SignInStatus, boolean> = {
-  complete: true,
-  error: false,
-};
-
-/**
- * Classify a sign-in function's return value.
- *
- * `null` means "not the envelope this proxy knows how to handle", which the
- * caller turns into a 500 rather than forwarding. A status missing from
- * {@link MINTS_SESSION} lands there too: a deployment running a provider newer
- * than this handler is not something to guess at, because guessing wrong is how
- * a refresh token reaches browser JS.
+ * Classify a sign-in function's return value: which arm of the envelope it is,
+ * and whether it carries a bundle whose refresh token has to move into the
+ * cookie.
  */
 function classifyResult(
   value: unknown,
@@ -157,17 +143,22 @@ function classifyResult(
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
   }
-  const { status, tokens } = value as Record<string, unknown>;
-  if (typeof status !== "string" || !Object.hasOwn(MINTS_SESSION, status)) {
-    return null;
+  // `status` is asserted rather than checked so the `default` arm can assert
+  // exhaustiveness; that arm is also what catches a value whose status is
+  // nothing of the sort.
+  const { status, tokens } = value as { status: SignInStatus; tokens: unknown };
+  switch (status) {
+    case "complete":
+      // A complete sign-in that should include a token bundle.
+      return isEncodedTokenBundle(tokens) ? { kind: "mint", tokens } : null;
+    case "error":
+      // A sign-in error that should be passed along (unless it mistakenly
+      // carries tokens, in which case it gets erased).
+      return tokens === undefined ? { kind: "forward" } : null;
+    default:
+      status satisfies never;
+      return null;
   }
-  // An arm that mints nothing has no tokens to intercept, so it goes back as
-  // the provider wrote it. On the arms that do mint, a bundle that isn't a
-  // bundle is a wiring bug rather than something to forward.
-  if (!MINTS_SESSION[status as SignInStatus]) {
-    return Object.hasOwn(value, "tokens") ? null : { kind: "forward" };
-  }
-  return isEncodedTokenBundle(tokens) ? { kind: "mint", tokens } : null;
 }
 
 /** A plain-text error. `ConvexHttpClient` throws its body as an `Error`. */
@@ -274,14 +265,16 @@ export function convexProxyHandler(config: ConvexProxyConfig): RequestHandler {
       );
     }
 
-    const cookies = httpCookies(request);
-    if (result.kind === "mint") {
-      await writeAuthCookies(cookies, result.tokens, config.cookieOptions);
-      // The refresh token goes to the cookie and gets removed from the tokens.
-      (payload.value as Record<string, unknown>).tokens = makeSlimBundle(
-        result.tokens,
-      );
+    if (result.kind === "forward") {
+      return Response.json(payload, { status: upstream.status });
     }
+
+    const cookies = httpCookies(request);
+    await writeAuthCookies(cookies, result.tokens, config.cookieOptions);
+    // The refresh token goes to the cookie and gets removed from the tokens.
+    (payload.value as Record<string, unknown>).tokens = makeSlimBundle(
+      result.tokens,
+    );
 
     const response = Response.json(payload, { status: upstream.status });
     cookies.applyTo(response.headers);


### PR DESCRIPTION
It now carries a status "complete" | "error" in preparation for a future where we have an "incomplete" status that needs to be resolved before it eventually completes.

Also closes a gap where the OAuth provider didn't conform to the standard sign-in success shape.