### PR TITLE
Move “default passkey name” behavior (component → provider)

### DIFF
--- a/examples/react-passkey/convex/passkeyManagement.test.ts
+++ b/examples/react-passkey/convex/passkeyManagement.test.ts
@@ -15,6 +15,7 @@ import { registerPasskeyProvider } from "@convex-dev/auth/providers/testing/pass
 // part of the public API of `@convex-dev/auth`. An app writes an authenticator
 // of its own, or it drives a real one.
 import {
+  aaguidBytes,
   buildAssertion,
   buildAttestationObject,
   buildAuthenticatorData,
@@ -71,14 +72,21 @@ afterEach(() => {
 /** The caller as a signed-in user, the way a real access token identifies one. */
 const as = (t: T, userId: string) => t.withIdentity({ subject: userId });
 
-/** Build the `response` of a `create()` ceremony, spreadable into args. */
+/**
+ * Build the `response` of a `create()` ceremony, spreadable into args.
+ *
+ * `aaguid` is the authenticator model that the attestation reports. It is
+ * zeroed by default, like an authenticator that hides its model.
+ */
 async function attest(
   challenge: string,
   credential: TestCredential,
+  aaguid?: Uint8Array,
 ): Promise<{ response: ReturnType<typeof registrationResponse> }> {
   const authenticatorData = await buildAuthenticatorData({
     rpId: RP_ID,
     credential,
+    aaguid,
   });
   return {
     response: registrationResponse({
@@ -101,6 +109,7 @@ const assertWith = (credential: TestCredential, challenge: string) =>
 async function signUp(
   t: T,
   username: string,
+  aaguid?: Uint8Array,
 ): Promise<{ userId: string; credential: TestCredential }> {
   const start = await t.mutation(api.auth.startSignIn, { username });
   if (!start.success || start.step !== "register") {
@@ -109,7 +118,7 @@ async function signUp(
   const credential = await generateES256Credential();
   const result = await t.mutation(api.auth.finishSignUp, {
     username,
-    ...(await attest(start.options.challenge, credential)),
+    ...(await attest(start.options.challenge, credential, aaguid)),
   });
   if (!result.success) {
     throw new Error(`The sign-up failed: ${result.userError.error}`);
@@ -122,6 +131,7 @@ async function addPasskey(
   t: T,
   userId: string,
   authorizeWith: TestCredential,
+  aaguid?: Uint8Array,
 ): Promise<{ passkeyId: string; credential: TestCredential }> {
   const caller = as(t, userId);
   const start = await caller.mutation(api.auth.startAddPasskey, {});
@@ -140,7 +150,7 @@ async function addPasskey(
   const credential = await generateES256Credential();
   const finished = await caller.mutation(
     api.auth.finishAddPasskey,
-    await attest(verified.options.challenge, credential),
+    await attest(verified.options.challenge, credential, aaguid),
   );
   if (!finished.success) {
     throw new Error(`The add failed: ${finished.userError.error}`);
@@ -179,6 +189,42 @@ describe("listPasskeys", () => {
       success: false,
       userError: { error: "NOT_SIGNED_IN" },
     });
+  });
+});
+
+describe("default passkey names", () => {
+  const APPLE_PASSWORDS = aaguidBytes("fbfc3007-154e-4ecc-8c0b-6e020557d7bd");
+
+  /** The names of the passkeys of `userId`, in the order of the list. */
+  async function names(t: T, userId: string): Promise<(string | undefined)[]> {
+    const list = await as(t, userId).query(api.auth.listPasskeys, {});
+    if (!list.success) throw new Error("The caller is signed in.");
+    return list.passkeys.map((passkey) => passkey.name);
+  }
+
+  test("names the passkey of a sign-up after its authenticator", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice", APPLE_PASSWORDS);
+    expect(await names(t, alice.userId)).toEqual(["Apple Passwords"]);
+  });
+
+  test("names an added passkey after its authenticator", async () => {
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    await addPasskey(t, alice.userId, alice.credential, APPLE_PASSWORDS);
+    expect(await names(t, alice.userId)).toEqual([
+      undefined,
+      "Apple Passwords",
+    ]);
+  });
+
+  test("stores no name for an authenticator that reports no model", async () => {
+    // `attestation: "none"` lets an authenticator zero its AAGUID; the big
+    // passkey providers report theirs anyway.
+    const t = await setup();
+    const alice = await signUp(t, "alice");
+    await addPasskey(t, alice.userId, alice.credential);
+    expect(await names(t, alice.userId)).toEqual([undefined, undefined]);
   });
 });
 

--- a/packages/core/src/components/passkey/aaguids.test.ts
+++ b/packages/core/src/components/passkey/aaguids.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+  RP_ID,
+  aaguidBytes,
+  buildAttestationObject,
+  buildAuthenticatorData,
+  buildClientDataJSON,
+  generateES256Credential,
+  registrationResponse,
+  toBase64URL,
+} from "@convex-dev/passkey-test-authenticator";
+import { defaultPasskeyName } from "./aaguids.ts";
+import type { WireRegistrationResponse } from "./validation.ts";
+
+/** The response of a `create()` ceremony that reports `aaguid`. */
+async function response(options: {
+  aaguid?: Uint8Array;
+  includeCredential?: boolean;
+}): Promise<WireRegistrationResponse> {
+  const credential = await generateES256Credential();
+  return registrationResponse({
+    credential,
+    attestationObject: buildAttestationObject(
+      await buildAuthenticatorData({
+        rpId: RP_ID,
+        credential:
+          options.includeCredential === false ? undefined : credential,
+        aaguid: options.aaguid,
+      }),
+    ),
+    clientDataJSON: buildClientDataJSON({
+      type: "webauthn.create",
+      challenge: toBase64URL(new ArrayBuffer(32)),
+      origin: "https://app.example.com",
+    }),
+  });
+}
+
+describe("defaultPasskeyName", () => {
+  test("names a well-known authenticator", async () => {
+    const apple = aaguidBytes("fbfc3007-154e-4ecc-8c0b-6e020557d7bd");
+    expect(defaultPasskeyName(await response({ aaguid: apple }))).toBe(
+      "Apple Passwords",
+    );
+  });
+
+  test("gives no name for an unknown AAGUID", async () => {
+    // `attestation: "none"` lets an authenticator zero its AAGUID; the big
+    // passkey providers report theirs anyway.
+    expect(defaultPasskeyName(await response({}))).toBeUndefined();
+  });
+
+  test("gives no name when the attestation carries no credential data", async () => {
+    expect(
+      defaultPasskeyName(await response({ includeCredential: false })),
+    ).toBeUndefined();
+  });
+
+  test("gives no name for an attestation that does not parse", async () => {
+    const unreadable = await response({});
+    unreadable.response.attestationObject = "not an attestation object";
+    expect(defaultPasskeyName(unreadable)).toBeUndefined();
+  });
+});

--- a/packages/core/src/components/passkey/aaguids.ts
+++ b/packages/core/src/components/passkey/aaguids.ts
@@ -4,6 +4,13 @@
  *
  * @module
  */
+import {
+  convertAAGUIDToString,
+  decodeAttestationObject,
+  isoBase64URL,
+  parseAuthenticatorData,
+} from "@simplewebauthn/server/helpers";
+import type { WireRegistrationResponse } from "./validation.ts";
 
 // Sourced from https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/774b3cfc940a4138bc451ae4ec9b943bf9a44c1b/aaguid.json
 const WELL_KNOWN_AAGUIDS: Record<string, string> = {
@@ -66,10 +73,36 @@ const WELL_KNOWN_AAGUIDS: Record<string, string> = {
 };
 
 /**
- * The display name for a new passkey whose authenticator reports `aaguid`,
- * used when the caller gives no name of its own. `undefined` when the
- * authenticator model is unknown, which leaves the passkey without a name.
+ * The display name for a new passkey, from the authenticator model that the
+ * attestation of the ceremony reports. `undefined` when the authenticator
+ * model is unknown, or when the attestation carries none, which leaves the
+ * passkey without a name.
+ *
+ * The name is cosmetic, thus the caller does not have to verify the
+ * attestation first: bytes that do not parse give no name.
  */
-export function defaultPasskeyName(aaguid: string): string | undefined {
-  return WELL_KNOWN_AAGUIDS[aaguid];
+export function defaultPasskeyName(
+  response: WireRegistrationResponse,
+): string | undefined {
+  const aaguid = attestedAaguid(response);
+  return aaguid === undefined ? undefined : WELL_KNOWN_AAGUIDS[aaguid];
+}
+
+/**
+ * The AAGUID that the attested credential data of the response carries, in
+ * its UUID form. `undefined` when the attestation does not parse, or when it
+ * carries no attested credential data.
+ */
+function attestedAaguid(
+  response: WireRegistrationResponse,
+): string | undefined {
+  try {
+    const attestation = decodeAttestationObject(
+      isoBase64URL.toBuffer(response.response.attestationObject),
+    );
+    const { aaguid } = parseAuthenticatorData(attestation.get("authData"));
+    return aaguid === undefined ? undefined : convertAAGUIDToString(aaguid);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/core/src/components/passkey/management/add.ts
+++ b/packages/core/src/components/passkey/management/add.ts
@@ -45,6 +45,7 @@ import {
   buildAuthenticationOptions,
   buildRegistrationOptions,
 } from "../options.ts";
+import { defaultPasskeyName } from "../aaguids.ts";
 
 /**
  * The largest number of passkeys that one user can hold.
@@ -253,15 +254,18 @@ export function finishAddPasskey(config: UsernamePasskeyConfig) {
           expectedOrigin: config.origin,
           verifiedUserId: userId,
           response: args.response,
+          // The app does not name a new passkey yet, thus the provider names
+          // it after the authenticator model.
+          // TODO(nicolas) Allow the user to provide a custom name when creating a passkey
+          name: defaultPasskeyName(args.response),
         },
       );
       if (!registrationResult.success) {
         const { userError } = registrationResult;
         if (userError.error === "INVALID_NAME") {
-          // Not possible: this function passes no `name`, thus the component
-          // stores its default name. The provider does not let an app name a
-          // passkey at registration yet.
-          // TODO(nicolas) Allow the user to provide a custom name when creating a passkey
+          // Not possible: the only name that this function passes is a
+          // default name, and every default name is a short label that the
+          // component stores.
           throw new Error(
             "Unexpected error when storing the passkey: INVALID_NAME",
             { cause: userError },

--- a/packages/core/src/components/passkey/registration.test.ts
+++ b/packages/core/src/components/passkey/registration.test.ts
@@ -14,7 +14,6 @@ import {
   generateRS256Credential,
   registrationResponse,
   toBase64URL,
-  aaguidBytes,
 } from "@convex-dev/passkey-test-authenticator";
 import {
   expectProtocolError,
@@ -80,7 +79,6 @@ async function registrationArgs(
     includeCredential?: boolean;
     challenge?: ArrayBuffer;
     startUserId?: string | null;
-    aaguid?: Uint8Array;
   } = {},
 ) {
   const credential = options.credential ?? (await generateES256Credential());
@@ -109,7 +107,6 @@ async function registrationArgs(
     userPresent: options.userPresent,
     userVerified: options.userVerified,
     credential: options.includeCredential === false ? undefined : credential,
-    aaguid: options.aaguid,
   });
   const buildArgs = (extra: { transports?: string[] } = {}) => ({
     expectedRpId: RP_ID,
@@ -989,52 +986,6 @@ describe("checkRegistrationForNewUser", () => {
       ),
     ).toEqual(invalid);
     expect(await finish()).toEqual(invalid);
-  });
-});
-
-describe("default passkey names", () => {
-  const APPLE_PASSWORDS = aaguidBytes("fbfc3007-154e-4ecc-8c0b-6e020557d7bd");
-
-  test("names a new passkey after its authenticator", async () => {
-    const t = setup();
-    const { finish } = await registrationArgs(t, "user1", {
-      aaguid: APPLE_PASSWORDS,
-    });
-    expect((await finish()).success).toBe(true);
-    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
-    expect(row.name).toBe("Apple Passwords");
-  });
-
-  test("stores no name for an unknown AAGUID", async () => {
-    // `attestation: "none"` lets an authenticator zero its AAGUID; the big
-    // passkey providers report theirs anyway.
-    const t = setup();
-    const { finish } = await registrationArgs(t, "user1");
-    expect((await finish()).success).toBe(true);
-    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
-    expect(row.name).toBeUndefined();
-  });
-
-  test("an explicit name wins over the default", async () => {
-    const t = setup();
-    const { finish } = await registrationArgs(t, "user1", {
-      name: "My security key",
-      aaguid: APPLE_PASSWORDS,
-    });
-    expect((await finish()).success).toBe(true);
-    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
-    expect(row.name).toBe("My security key");
-  });
-
-  test("the new-user flow names its passkey too", async () => {
-    const t = setup();
-    const { finish } = await registrationArgs(t, "user1", {
-      startUserId: null,
-      aaguid: APPLE_PASSWORDS,
-    });
-    expect((await finish()).success).toBe(true);
-    const [row] = await t.run((ctx) => ctx.db.query("passkeys").collect());
-    expect(row.name).toBe("Apple Passwords");
   });
 });
 

--- a/packages/core/src/components/passkey/registration.ts
+++ b/packages/core/src/components/passkey/registration.ts
@@ -87,7 +87,6 @@ import {
   transportsAreValid,
 } from "./validation.ts";
 import { SUPPORTED_ALGORITHM_IDS } from "./constants.ts";
-import { defaultPasskeyName } from "./aaguids.ts";
 import {
   deleteDeadChallenge,
   findChallenge,
@@ -224,7 +223,8 @@ type RegistrationCheckArgs = Infer<typeof _vRegistrationCheckArgs>;
 
 const finishRegistrationArgs = {
   ...registrationCheckArgs,
-  // The name of the passkey, for display in a settings list. See
+  // The name of the passkey, for display in a settings list. The passkey
+  // stays without a name when the caller gives none. See
   // {@link passkeyNameIsValid}.
   name: v.optional(v.string()),
 };
@@ -321,7 +321,7 @@ export const finishRegistrationForNewUser = mutation({
     });
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.newUserId,
-      name: args.name ?? defaultPasskeyName(result.credential.aaguid),
+      name: args.name,
       transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
@@ -364,7 +364,7 @@ export const finishRegistrationForExistingUser = mutation({
     }
     const passkeyId = await ctx.db.insert("passkeys", {
       userId: args.verifiedUserId,
-      name: args.name ?? defaultPasskeyName(result.credential.aaguid),
+      name: args.name,
       transports: args.response.response.transports,
       credentialId: result.credential.credentialId,
       publicKey: result.credential.publicKey,
@@ -547,9 +547,6 @@ type VerifiedCredential = {
   // The COSE public key, exactly as `verifyRegistrationResponse` returns it.
   publicKey: ArrayBuffer;
   counter: number;
-  // The authenticator model, for the default passkey name (see
-  // `defaultPasskeyName`).
-  aaguid: string;
 };
 
 /**
@@ -665,7 +662,6 @@ async function verifyAttestation(
       credentialId: storedCredentialId,
       publicKey: toArrayBuffer(credential.publicKey),
       counter: credential.counter,
-      aaguid: verification.registrationInfo.aaguid,
     },
   };
 }

--- a/packages/core/src/components/passkey/setup.ts
+++ b/packages/core/src/components/passkey/setup.ts
@@ -36,6 +36,7 @@ import {
 } from "./management/remove.ts";
 import { renamePasskey } from "./management/rename.ts";
 import { SIGN_IN_PURPOSE } from "./purposes.ts";
+import { defaultPasskeyName } from "./aaguids.ts";
 
 /**
  * Options for {@link setupUsernamePasskey}.
@@ -347,6 +348,11 @@ export function setupUsernamePasskey<UsersTable extends string>(
               return { success: false, userError: { error: "USERNAME_TAKEN" } };
             }
 
+            // The app does not name a new passkey yet, thus the provider
+            // names it after the authenticator model.
+            // TODO(nicolas) Allow the user to provide a custom name when creating a passkey
+            const passkeyName = defaultPasskeyName(args.response);
+
             // Fail early if the passkey registration fails
             const checkResult = await ctx.runQuery(
               component.registration.checkRegistrationForNewUser,
@@ -354,13 +360,15 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 expectedRpId: rpId,
                 expectedOrigin: origin,
                 response: args.response,
+                name: passkeyName,
               },
             );
             if (!checkResult.success) {
               const { userError } = checkResult;
               if (userError.error === "INVALID_NAME") {
-                // Not possible: this function passes no `name`, thus the
-                // component stores its default name. See the same case in
+                // Not possible: the only name that this function passes is a
+                // default name, and every default name is a short label that
+                // the component stores. See the same case in
                 // `finishAddPasskey`.
                 throw new Error(
                   "Unexpected error when storing the passkey: INVALID_NAME",
@@ -407,6 +415,7 @@ export function setupUsernamePasskey<UsersTable extends string>(
                 expectedOrigin: origin,
                 newUserId: tokens.userId,
                 response: args.response,
+                name: passkeyName,
               },
             );
             if (!registrationResult.success) {


### PR DESCRIPTION
I realized that the implementation of the “default passkey name” behavior introduced in #592 was done in the component instead of the provider function. This is probably too opinionated and it’s better to move it to the provider function, so that a custom implementation can change the behavior if it wants.